### PR TITLE
Improve transformation of the hyde/hyde composer.json in the monorepo split job

### DIFF
--- a/.github/workflows/split-monorepo.yml
+++ b/.github/workflows/split-monorepo.yml
@@ -87,12 +87,14 @@ jobs:
     - name: Load persisted data
       run: wget https://raw.githubusercontent.com/hydephp/develop/${{ github.sha }}/build/monorepo/persist/hyde/README.md -O README.md
 
-    - name: Download composer fix script
-      run: wget https://gist.githubusercontent.com/caendesilva/8528ef3ab2f5d116c2b58af9ff1c211b/raw/01fcae28cdec1d26b0494331175b301a4e5b2852/fixcomposer.json.php -O fixcomposer.php
-    - name: Remove packages from composer.json
-      run: php fixcomposer.php
+    - name: Download composer update script
+      run: wget https://raw.githubusercontent.com/hydephp/develop/${{ github.sha }}/build/tools/update-composer.php -O update-composer.php
+    - name: Verify checksum matches
+      run: echo '25f06588b0e513532b446e7a305f0e7b91601abf  update-composer.php' | shasum -c
+    - name: Update composer.json
+      run: php update-compose.php
     - name: Delete script
-      run: rm fixcomposer.php
+      run: rm update-compose.php
     - name: Remove composer.lock
       run: rm -f composer.lock
 

--- a/build/tools/checksums.txt
+++ b/build/tools/checksums.txt
@@ -1,1 +1,1 @@
-9c67273b63614931ae0808e5eb9080b293932bcc  update-composer.php
+25f06588b0e513532b446e7a305f0e7b91601abf  update-composer.php

--- a/build/tools/checksums.txt
+++ b/build/tools/checksums.txt
@@ -1,0 +1,1 @@
+9c67273b63614931ae0808e5eb9080b293932bcc  update-composer.php

--- a/build/tools/update-composer.php
+++ b/build/tools/update-composer.php
@@ -1,0 +1,28 @@
+<?php
+
+// Script to use in the Monorepo split action to update the root Composer.json
+// creating one that works for the hyde/hyde project.
+
+// We do two main things:
+// 1. Replace dev-master versions with the configured versions.
+// 2. Remove the package entries from the repositories configuration.
+
+// Usage:
+// This script is intended to be downloaded and run in split-monorepo.yml
+// where it follows roughly the flow below:
+// 1. Checkout ref readonly-hyde-mirror
+// 2. Download the script to the root
+// 3. Run the script, then delete it
+
+// Configuration settings
+const frameworkVersion = '^0.35';
+const rcVersion = '^2.1';
+
+$json = json_decode(file_get_contents('composer.json'), true);
+
+$json['require']['hyde/framework'] = frameworkVersion;
+$json['require-dev']['hyde/realtime-compiler'] = rcVersion;
+
+unset($json['repositories']);
+
+file_put_contents('composer.json', json_encode($json, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES));

--- a/build/tools/update-composer.php
+++ b/build/tools/update-composer.php
@@ -14,6 +14,10 @@
 // 2. Download the script to the root
 // 3. Run the script, then delete it
 
+// Checking the integrity of the script
+// a) Generate the checksum file with shasum update-composer.php > checksums.txt
+// b) Check that the checksums match with shasum -c checksums.txt
+
 // Configuration settings
 const frameworkVersion = '^0.35';
 const rcVersion = '^2.1';

--- a/build/tools/update-composer.php
+++ b/build/tools/update-composer.php
@@ -30,3 +30,4 @@ unset($json['repositories']);
 file_put_contents('composer.json', json_encode($json, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES));
 
 echo "Done. Finished in " . number_format((microtime(true) - $time_start) * 1000, 2) . "ms\n";
+exit(0);

--- a/build/tools/update-composer.php
+++ b/build/tools/update-composer.php
@@ -17,6 +17,8 @@
 // Configuration settings
 const frameworkVersion = '^0.35';
 const rcVersion = '^2.1';
+$time_start = microtime(true);
+echo "Transforming composer.json\n";
 
 $json = json_decode(file_get_contents('composer.json'), true);
 
@@ -26,3 +28,5 @@ $json['require-dev']['hyde/realtime-compiler'] = rcVersion;
 unset($json['repositories']);
 
 file_put_contents('composer.json', json_encode($json, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES));
+
+echo "Done. Finished in " . number_format((microtime(true) - $time_start) * 1000, 2) . "ms\n";


### PR DESCRIPTION
Creates an improved update-composer.php script that removes the packages entry as well as replaces dev-master version requirements with configured constants. Also updates the actual script, together with the checksums as an added security.