### PR TITLE
Add package auto-discovery

### DIFF
--- a/app/bootstrap.php
+++ b/app/bootstrap.php
@@ -11,7 +11,7 @@
 |
 */
 
-$app = new LaravelZero\Framework\Application(
+$app = new Hyde\Framework\Application(
     dirname(__DIR__)
 );
 

--- a/bootstrap/app.php
+++ b/bootstrap/app.php
@@ -17,7 +17,7 @@
 |
 */
 
-$app = new LaravelZero\Framework\Application(
+$app = new Hyde\Framework\Application(
     dirname(__DIR__)
 );
 

--- a/composer.json
+++ b/composer.json
@@ -36,6 +36,11 @@
             "Hyde\\Testing\\": "tests/"
         }
     },
+    "scripts": {
+        "post-autoload-dump": [
+            "@php hyde package:discover --ansi"
+        ]
+    },
     "config": {
         "preferred-install": "dist",
         "sort-packages": true,

--- a/packages/framework/src/Application.php
+++ b/packages/framework/src/Application.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Hyde\Framework;
+
+use Illuminate\Filesystem\Filesystem;
+use Illuminate\Foundation\PackageManifest;
+
+class Application extends \LaravelZero\Framework\Application
+{
+    /**
+     * {@inheritdoc}
+     */
+    protected function registerBaseBindings(): void
+    {
+        parent::registerBaseBindings();
+
+        /*
+         * Enable auto-discovery.
+         */
+        $this->app->singleton(PackageManifest::class, function () {
+            return new PackageManifest(
+                new Filesystem, $this->basePath(), $this->basePath('storage/framework/cache/packages.php')
+            );
+        });
+    }
+}

--- a/packages/framework/src/Commands/PackageDiscoverCommand.php
+++ b/packages/framework/src/Commands/PackageDiscoverCommand.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Hyde\Framework\Commands;
+
+use Hyde\Framework\Hyde;
+use Illuminate\Foundation\PackageManifest;
+use Illuminate\Foundation\Console\PackageDiscoverCommand as BaseCommand;
+
+class PackageDiscoverCommand extends BaseCommand
+{
+    protected $hidden = true;
+
+    public function handle(PackageManifest $manifest)
+    {
+        $manifest->manifestPath = Hyde::path('storage/framework/cache/packages.php');
+        parent::handle($manifest);
+    }
+}

--- a/packages/framework/src/HydeServiceProvider.php
+++ b/packages/framework/src/HydeServiceProvider.php
@@ -77,6 +77,8 @@ class HydeServiceProvider extends ServiceProvider
             Commands\HydeInstallCommand::class,
             Commands\HydeDebugCommand::class,
             Commands\HydeServeCommand::class,
+
+            Commands\PackageDiscoverCommand::class,
         ]);
     }
 


### PR DESCRIPTION
Package auto-discovery (and subsequently autoloading of service providers) are disabled in Laravel Zero, which the Hyde internals are based on. This update adds Hyde/Framework/Application to re-enable the Laravel functionality. It also ports the package:discover command from Laravel. The composer.json is updated to automatically run the discover command.