### PR TITLE
Skip documentation index validation test if the _docs directory is empty

### DIFF
--- a/packages/framework/src/Services/ValidationService.php
+++ b/packages/framework/src/Services/ValidationService.php
@@ -66,6 +66,10 @@ class ValidationService
             return $result->skip('The documentation page feature is disabled in config');
         }
 
+        if (count(CollectionService::getDocumentationPageList()) === 0) {
+            return $result->skip('There are no documentation pages');
+        }
+
         if (file_exists('_docs/index.md')) {
             return $result->pass('Your documentation site has an index page');
         }

--- a/tests/Feature/Commands/HydeValidateCommandTest.php
+++ b/tests/Feature/Commands/HydeValidateCommandTest.php
@@ -25,7 +25,7 @@ class HydeValidateCommandTest extends TestCase
 
     public function test_validate_command_can_run_with_skips()
     {
-        // Trigger skipping of Torchlight check$
+        // Trigger skipping of Torchlight and documentation index check
         config(['hyde.features' => []]);
 
         $this->artisan('validate')

--- a/tests/Feature/Services/ValidationServiceTest.php
+++ b/tests/Feature/Services/ValidationServiceTest.php
@@ -81,7 +81,14 @@ class ValidationServiceTest extends TestCase
 
     public function test_check_documentation_site_has_an_index_page_can_fail()
     {
+        touch('_docs/foo.md');
         $this->test('check_documentation_site_has_an_index_page', 2);
+        unlink('_docs/foo.md');
+    }
+
+    public function test_check_documentation_site_has_an_index_page_be_skipped()
+    {
+        $this->test('check_documentation_site_has_an_index_page', 1);
     }
 
     public function test_check_site_has_an_index_page_can_pass()


### PR DESCRIPTION
If there are no documentation pages there is no need for an index page, and the test can safely be skipped.