### PR TITLE
Fix #44 Add ModelClass::files() helper

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,7 @@ This serves two purposes:
 2. At release time, you can move the Unreleased section changes into a new release version section.
 
 ### Added
-- for new features.
+- Added a helper to all page models to get an array of all its source files https://github.com/hydephp/develop/issues/44
 
 ### Changed
 - Changed welcome page title https://github.com/hydephp/develop/issues/52

--- a/packages/framework/src/Contracts/AbstractPage.php
+++ b/packages/framework/src/Contracts/AbstractPage.php
@@ -37,4 +37,9 @@ abstract class AbstractPage implements PageContract
 
         return $collection;
     }
+
+    public static function files(): array
+    {
+        return CollectionService::getSourceFileListForModel(static::class);
+    }
 }

--- a/packages/framework/src/Contracts/PageContract.php
+++ b/packages/framework/src/Contracts/PageContract.php
@@ -14,4 +14,14 @@ interface PageContract
      * @see \Tests\Unit\PageModelGetHelperTest
      */
     public static function all(): Collection;
+
+    /**
+     * Get an array of all the source file slugs for the model.
+     * Essentially an alias of CollectionService::getAbstractPageList().
+     *
+     * @return array<string>
+     *
+     * @see \Tests\Unit\PageModelGetAllFilesHelperTest
+     */
+    public static function files(): array;
 }

--- a/packages/framework/tests/Unit/PageModelGetAllFilesHelperTest.php
+++ b/packages/framework/tests/Unit/PageModelGetAllFilesHelperTest.php
@@ -8,7 +8,6 @@ use Hyde\Framework\Models\DocumentationPage;
 use Hyde\Framework\Models\MarkdownPage;
 use Hyde\Framework\Models\MarkdownPost;
 use Hyde\Testing\TestCase;
-use Illuminate\Support\Collection;
 
 /**
  * @see \Hyde\Framework\Concerns\AbstractPage::files()

--- a/packages/framework/tests/Unit/PageModelGetAllFilesHelperTest.php
+++ b/packages/framework/tests/Unit/PageModelGetAllFilesHelperTest.php
@@ -1,0 +1,61 @@
+<?php
+
+namespace Hyde\Testing\Framework\Unit;
+
+use Hyde\Framework\Hyde;
+use Hyde\Framework\Models\BladePage;
+use Hyde\Framework\Models\DocumentationPage;
+use Hyde\Framework\Models\MarkdownPage;
+use Hyde\Framework\Models\MarkdownPost;
+use Hyde\Testing\TestCase;
+use Illuminate\Support\Collection;
+
+/**
+ * @see \Hyde\Framework\Concerns\AbstractPage::files()
+ */
+class PageModelGetAllFilesHelperTest extends TestCase
+{
+    public function test_blade_page_get_helper_returns_blade_page_array()
+    {
+        $array = BladePage::files();
+        $this->assertCount(2, $array);
+        $this->assertIsArray($array);
+        $this->assertEquals(['404', 'index'], $array);
+    }
+
+    public function test_markdown_page_get_helper_returns_markdown_page_array()
+    {
+        touch(Hyde::path('_pages/test-page.md'));
+
+        $array = MarkdownPage::files();
+        $this->assertCount(1, $array);
+        $this->assertIsArray($array);
+        $this->assertEquals(['test-page'], $array);
+
+        unlink(Hyde::path('_pages/test-page.md'));
+    }
+
+    public function test_markdown_post_get_helper_returns_markdown_post_array()
+    {
+        touch(Hyde::path('_posts/test-post.md'));
+
+        $array = MarkdownPost::files();
+        $this->assertCount(1, $array);
+        $this->assertIsArray($array);
+        $this->assertEquals(['test-post'], $array);
+
+        unlink(Hyde::path('_posts/test-post.md'));
+    }
+
+    public function test_documentation_page_get_helper_returns_documentation_page_array()
+    {
+        touch(Hyde::path('_docs/test-page.md'));
+
+        $array = DocumentationPage::files();
+        $this->assertCount(1, $array);
+        $this->assertIsArray($array);
+        $this->assertEquals(['test-page'], $array);
+
+        unlink(Hyde::path('_docs/test-page.md'));
+    }
+}


### PR DESCRIPTION
Adds a helper to get an array of all the source file slugs for the model.
Essentially an alias of CollectionService::getAbstractPageList().

Example:
```php
MarkdownPost::all() = ['hello-world']
```