### PR TITLE
Change priority of the automatic docs link in the navbar so it is after standard pages 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ This serves two purposes:
 ### Changed
 - Changed welcome page title https://github.com/hydephp/develop/issues/52
 - Add `rel="nofollow"` to the image author links https://github.com/hydephp/develop/issues/19
+- Changed the default position of the automatic navigation menu link to the right, also making it configurable.
 
 ### Deprecated
 - for soon-to-be removed features.

--- a/docs/documentation-pages.md
+++ b/docs/documentation-pages.md
@@ -177,7 +177,7 @@ In version v0.38.0-beta and lower, this link had the internal priority of 500 pu
 You can customize the priority using the following config value in the `config/docs.php` file:
 
 ```php
-'navigation_menu_priority' => 500
+'navigation_link_priority' => 500
 ```
 
 ### Sidebar header name

--- a/docs/documentation-pages.md
+++ b/docs/documentation-pages.md
@@ -169,6 +169,17 @@ for example to specify a version like the Hyde docs does, you can specify the ou
 'output_directory' => 'docs/master' // What the Hyde docs use
 ```
 
+### Automatic navigation menu
+
+By default, a link to the documentation page is added to the navigation menu when an index.md or readme.md file is found in the `_docs` directory.
+In version v0.38.0-beta and lower, this link had the internal priority of 500 putting it to the left of the automatic menu. In v0.39.0-beta and higher, the priority is set to 1000 to be placed at the end of the menu. See the reasoning behind this in [this GitHub issue](https://github.com/hydephp/develop/issues/24).
+
+You can customize the priority using the following config value in the `config/docs.php` file:
+
+```php
+'navigation_menu_priority' => 500
+```
+
 ### Sidebar header name
 
 By default, the site title shown in the sidebar header is generated from the configured site name suffixed with "docs".

--- a/packages/framework/src/Actions/GeneratesNavigationMenu.php
+++ b/packages/framework/src/Actions/GeneratesNavigationMenu.php
@@ -85,7 +85,7 @@ class GeneratesNavigationMenu
                                 : Hyde::docsDirectory().'/readme'
                         ),
                         'current' => false,
-                        'priority' => 1000,
+                        'priority' => config('docs.navigation_link_priority', 1000),
                     ];
                 }
             }

--- a/packages/framework/src/Actions/GeneratesNavigationMenu.php
+++ b/packages/framework/src/Actions/GeneratesNavigationMenu.php
@@ -85,7 +85,7 @@ class GeneratesNavigationMenu
                                 : Hyde::docsDirectory().'/readme'
                         ),
                         'current' => false,
-                        'priority' => 500,
+                        'priority' => 1000,
                     ];
                 }
             }


### PR DESCRIPTION
Changed the default position of the automatic navigation menu link to the right, also making it configurable.

You can customize the priority using the following config value in the `config/docs.php` file:

```php
'navigation_link_priority' => 500 // Default value before this change
```