### PR TITLE
Clean up tests

### DIFF
--- a/packages/framework/tests/Feature/Actions/PublishesHomepageViewTest.php
+++ b/packages/framework/tests/Feature/Actions/PublishesHomepageViewTest.php
@@ -12,13 +12,11 @@ use Hyde\Testing\TestCase;
  */
 class PublishesHomepageViewTest extends TestCase
 {
-    // Test that the class implements the ActionContract
     public function test_implements_action_contract()
     {
         $this->assertInstanceOf(ActionContract::class, new PublishesHomepageView('foo'));
     }
 
-    // Test that the $homePages array contains all the available home pages
     public function test_home_pages_array_contains_all_available_home_pages()
     {
         $array = PublishesHomepageView::$homePages;
@@ -36,7 +34,6 @@ class PublishesHomepageViewTest extends TestCase
         $this->assertEquals(404, $action->execute());
     }
 
-    // Test execute method can publish the selected home page
     public function test_execute_method_can_publish_home_page()
     {
         unlink(Hyde::path('_pages/index.blade.php'));

--- a/packages/framework/tests/Feature/Concerns/HasPageMetadataTest.php
+++ b/packages/framework/tests/Feature/Concerns/HasPageMetadataTest.php
@@ -285,7 +285,6 @@ class HasPageMetadataTest extends TestCase
         $this->assertFalse($page->hasOpenGraphTitleInConfig());
     }
 
-    // Test meta titles can be dynamically added and override defaults
     public function test_get_dynamic_metadata_adds_twitter_and_open_graph_title_when_conditions_are_met()
     {
         config(['hyde.meta' => [

--- a/packages/framework/tests/Feature/ConfigurableFeaturesTest.php
+++ b/packages/framework/tests/Feature/ConfigurableFeaturesTest.php
@@ -11,7 +11,7 @@ use Illuminate\Support\Facades\Config;
  */
 class ConfigurableFeaturesTest extends TestCase
 {
-    public function testHasFeatureReturnsFalseWhenFeatureIsNotEnabled()
+    public function test_has_feature_returns_false_when_feature_is_not_enabled()
     {
         Config::set('hyde.features', []);
         // Foreach method in Features class that begins with "has"
@@ -23,7 +23,7 @@ class ConfigurableFeaturesTest extends TestCase
         }
     }
 
-    public function testHasFeatureReturnsTrueWhenFeatureIsEnabled()
+    public function test_has_feature_returns_true_when_feature_is_enabled()
     {
         $features = [];
         foreach (get_class_methods(Features::class) as $method) {

--- a/packages/framework/tests/Feature/ConfigurableFeaturesTest.php
+++ b/packages/framework/tests/Feature/ConfigurableFeaturesTest.php
@@ -11,7 +11,6 @@ use Illuminate\Support\Facades\Config;
  */
 class ConfigurableFeaturesTest extends TestCase
 {
-    // Test HasFeature methods return false when feature is not enabled
     public function testHasFeatureReturnsFalseWhenFeatureIsNotEnabled()
     {
         Config::set('hyde.features', []);
@@ -24,7 +23,6 @@ class ConfigurableFeaturesTest extends TestCase
         }
     }
 
-    // Test HasFeature methods return true when feature is enabled
     public function testHasFeatureReturnsTrueWhenFeatureIsEnabled()
     {
         $features = [];

--- a/packages/framework/tests/Feature/DocumentationPageParserTest.php
+++ b/packages/framework/tests/Feature/DocumentationPageParserTest.php
@@ -9,7 +9,7 @@ use Hyde\Framework\Models\Parsers\DocumentationPageParser;
 use Hyde\Framework\Services\CollectionService;
 use Hyde\Testing\TestCase;
 
-class DocumentationPageTest extends TestCase
+class DocumentationPageParserTest extends TestCase
 {
     /**
      * Test the Parser.

--- a/packages/framework/tests/Feature/FindsContentLengthForImageObjectTest.php
+++ b/packages/framework/tests/Feature/FindsContentLengthForImageObjectTest.php
@@ -24,7 +24,6 @@ class FindsContentLengthForImageObjectTest extends TestCase
         );
     }
 
-    // Test it can find the content length for a local image stored in the _media directory
     public function test_it_can_find_the_content_length_for_a_local_image_stored_in_the_media_directory()
     {
         $image = new Image();
@@ -38,7 +37,6 @@ class FindsContentLengthForImageObjectTest extends TestCase
         unlink($image->path);
     }
 
-    // Test it can find the content length for a remote image
     public function test_it_can_find_the_content_length_for_a_remote_image()
     {
         Http::fake(function (Request $request) {
@@ -55,7 +53,6 @@ class FindsContentLengthForImageObjectTest extends TestCase
         );
     }
 
-    // Test it returns 0 if local image is missing
     public function test_it_returns_0_if_local_image_is_missing()
     {
         $image = new Image();
@@ -66,7 +63,6 @@ class FindsContentLengthForImageObjectTest extends TestCase
         );
     }
 
-    // Test it returns 0 if remote image is missing
     public function test_it_returns_0_if_remote_image_is_missing()
     {
         Http::fake(function (Request $request) {

--- a/packages/framework/tests/Feature/HydeHelperFacadeTest.php
+++ b/packages/framework/tests/Feature/HydeHelperFacadeTest.php
@@ -11,7 +11,7 @@ use Hyde\Testing\TestCase;
  */
 class HydeHelperFacadeTest extends TestCase
 {
-    public function testFeaturesFacadeReturnsInstanceOfFeaturesClass()
+    public function test_features_facade_returns_instance_of_features_class()
     {
         $this->assertInstanceOf(
             Features::class,
@@ -19,14 +19,14 @@ class HydeHelperFacadeTest extends TestCase
         );
     }
 
-    public function testFeaturesFacadeCanBeUsedToCallStaticMethodsOnFeaturesClass()
+    public function test_features_facade_can_be_used_to_call_static_methods_on_features_class()
     {
         $this->assertTrue(
             Hyde::features()->hasBlogPosts()
         );
     }
 
-    public function testHydeHasFeatureShorthandCallsStaticMethodOnFeaturesClass()
+    public function test_hyde_has_feature_shorthand_calls_static_method_on_features_class()
     {
         $this->assertTrue(
             Hyde::hasFeature('blog-posts')

--- a/packages/framework/tests/Feature/HydeHelperFacadeTest.php
+++ b/packages/framework/tests/Feature/HydeHelperFacadeTest.php
@@ -11,7 +11,6 @@ use Hyde\Testing\TestCase;
  */
 class HydeHelperFacadeTest extends TestCase
 {
-    // Test Hyde::features() facade returns an instance of Features::class
     public function testFeaturesFacadeReturnsInstanceOfFeaturesClass()
     {
         $this->assertInstanceOf(
@@ -20,7 +19,6 @@ class HydeHelperFacadeTest extends TestCase
         );
     }
 
-    // Test Hyde::features() facade can be used to call static methods on Features::class
     public function testFeaturesFacadeCanBeUsedToCallStaticMethodsOnFeaturesClass()
     {
         $this->assertTrue(
@@ -28,7 +26,6 @@ class HydeHelperFacadeTest extends TestCase
         );
     }
 
-    // Test Hyde::hasFeature() shorthand calls the static method on Features::class
     public function testHydeHasFeatureShorthandCallsStaticMethodOnFeaturesClass()
     {
         $this->assertTrue(

--- a/packages/framework/tests/Feature/ImageModelTest.php
+++ b/packages/framework/tests/Feature/ImageModelTest.php
@@ -59,7 +59,6 @@ class ImageModelTest extends TestCase
 
     public function test_get_image_author_attribution_string_method()
     {
-        // Test with author and credit set
         $image = new Image([
             'author' => 'John Doe',
             'credit' => 'https://example.com/',
@@ -71,14 +70,12 @@ class ImageModelTest extends TestCase
         $this->assertStringContainsString('<span itemprop="name">John Doe</span>', $string);
         $this->assertStringContainsString('<a href="https://example.com/"', $string);
 
-        // Test with author set
         $image = new Image(['author' => 'John Doe']);
         $string = $image->getImageAuthorAttributionString();
         $this->assertStringContainsString('itemprop="creator"', $string);
         $this->assertStringContainsString('itemtype="http://schema.org/Person"', $string);
         $this->assertStringContainsString('<span itemprop="name">John Doe</span>', $string);
 
-        // Test with nothing set
         $image = new Image();
         $this->assertNull($image->getImageAuthorAttributionString());
     }
@@ -94,7 +91,6 @@ class ImageModelTest extends TestCase
 
     public function test_get_license_string()
     {
-        // Test with license and url set
         $image = new Image([
             'license' => 'foo',
             'licenseUrl' => 'https://example.com/bar.html',
@@ -102,40 +98,33 @@ class ImageModelTest extends TestCase
         $this->assertEquals('<a href="https://example.com/bar.html" rel="license nofollow noopener" '.
                 'itemprop="license">foo</a>', $image->getLicenseString());
 
-        // Test with license set
         $image = new Image(['license' => 'foo']);
         $this->assertEquals('<span itemprop="license">foo</span>', $image->getLicenseString());
 
-        // Test with url set
         $image = new Image(['licenseUrl' => 'https://example.com/bar.html']);
         $this->assertNull($image->getLicenseString());
 
-        // Test with nothing set
         $image = new Image();
         $this->assertNull($image->getLicenseString());
     }
 
     public function test_get_fluent_attribution_method()
     {
-        // Test it contains the Author string
         $image = new Image(['author' => 'John Doe']);
         $string = $image->getFluentAttribution();
 
         $this->assertStringContainsString('Image by ', $string);
 
-        // Test it contains the Copyright string
         $image = new Image(['copyright' => 'foo']);
         $string = $image->getFluentAttribution();
 
         $this->assertStringContainsString('<span itemprop="copyrightNotice">foo</span>', $string);
 
-        // Test it contains the License string
         $image = new Image(['license' => 'foo']);
 
         $string = $image->getFluentAttribution();
         $this->assertStringContainsString('License <span itemprop="license">foo</span>', $string);
 
-        // Test with nothing set
         $image = new Image();
         $this->assertEquals('', $image->getFluentAttribution());
     }

--- a/packages/framework/tests/Feature/MetadataHelperTest.php
+++ b/packages/framework/tests/Feature/MetadataHelperTest.php
@@ -17,7 +17,6 @@ class MetadataHelperTest extends TestCase
         config(['hyde.meta' => []]);
     }
 
-    // Test name method returns a valid HTML meta string
     public function test_name_method_returns_a_valid_html_meta_string()
     {
         $this->assertEquals(
@@ -26,7 +25,6 @@ class MetadataHelperTest extends TestCase
         );
     }
 
-    // Test property method returns a valid HTML meta string
     public function test_property_method_returns_a_valid_html_meta_string()
     {
         $this->assertEquals(
@@ -35,7 +33,6 @@ class MetadataHelperTest extends TestCase
         );
     }
 
-    // Test property method accepts property with og prefix
     public function test_property_method_accepts_property_with_og_prefix()
     {
         $this->assertEquals(
@@ -44,7 +41,6 @@ class MetadataHelperTest extends TestCase
         );
     }
 
-    // Test property method accepts property without og prefix
     public function test_property_method_accepts_property_without_og_prefix()
     {
         $this->assertEquals(
@@ -53,7 +49,6 @@ class MetadataHelperTest extends TestCase
         );
     }
 
-    // Test render method implodes an array of meta tags into a formatted string
     public function test_render_method_implodes_an_array_of_meta_tags_into_a_formatted_string()
     {
         $this->assertEquals(
@@ -67,7 +62,6 @@ class MetadataHelperTest extends TestCase
         );
     }
 
-    // Test render method returns an empty string if no meta tags are supplied
     public function test_render_method_returns_an_empty_string_if_no_meta_tags_are_supplied()
     {
         $this->assertEquals(
@@ -76,7 +70,6 @@ class MetadataHelperTest extends TestCase
         );
     }
 
-    // Test render method returns config defined tags if no meta tags are supplied
     public function test_render_method_returns_config_defined_tags_if_no_meta_tags_are_supplied()
     {
         config(['hyde.meta' => [
@@ -92,7 +85,6 @@ class MetadataHelperTest extends TestCase
         );
     }
 
-    // Test render method merges config defined tags with supplied meta tags
     public function test_render_method_merges_config_defined_tags_with_supplied_meta_tags()
     {
         config(['hyde.meta' => [
@@ -109,7 +101,6 @@ class MetadataHelperTest extends TestCase
         );
     }
 
-    // Test render method returns unique meta tags
     public function test_render_method_returns_unique_meta_tags()
     {
         config(['hyde.meta' => [
@@ -124,7 +115,6 @@ class MetadataHelperTest extends TestCase
         );
     }
 
-    // Test render method gives precedence to supplied meta tags
     public function test_render_method_gives_precedence_to_supplied_meta_tags()
     {
         config(['hyde.meta' => [

--- a/packages/framework/tests/Feature/Services/BladeDownProcessorTest.php
+++ b/packages/framework/tests/Feature/Services/BladeDownProcessorTest.php
@@ -12,13 +12,11 @@ use Hyde\Testing\TestCase;
  */
 class BladeDownProcessorTest extends TestCase
 {
-    // Test it renders Blade echo syntax
     public function test_it_renders_blade_echo_syntax()
     {
         $this->assertEquals('Hello World!', BladeDownProcessor::render('[Blade]: {{ "Hello World!" }}'));
     }
 
-    // Test it renders Blade within multiline Markdown
     public function test_it_renders_blade_within_multiline_markdown()
     {
         $this->assertEquals(
@@ -28,7 +26,6 @@ class BladeDownProcessorTest extends TestCase
         );
     }
 
-    // Test it renders Blade views
     public function test_it_renders_blade_views()
     {
         file_put_contents(resource_path(
@@ -40,26 +37,22 @@ class BladeDownProcessorTest extends TestCase
         unlink(resource_path('views/hello.blade.php'));
     }
 
-    // Test directive is case-insensitive
     public function test_directive_is_case_insensitive()
     {
         $this->assertEquals('Hello World!', BladeDownProcessor::render('[blade]: {{ "Hello World!" }}'));
     }
 
-    // Test directive is ignored if it's not at the start of a line
     public function test_directive_is_ignored_if_it_is_not_at_the_start_of_a_line()
     {
         $this->assertEquals('Example: [Blade]: {{ "Hello World!" }}',
             BladeDownProcessor::render('Example: [Blade]: {{ "Hello World!" }}'));
     }
 
-    // Test it renders Blade echo syntax with variables
     public function test_it_renders_blade_echo_syntax_with_variables()
     {
         $this->assertEquals('Hello World!', BladeDownProcessor::render('[Blade]: {{ $foo }}', ['foo' => 'Hello World!']));
     }
 
-    // Test it renders Blade views with variables
     public function test_it_renders_blade_views_with_variables()
     {
         file_put_contents(resource_path(

--- a/packages/framework/tests/Feature/Services/FileCacheServiceTest.php
+++ b/packages/framework/tests/Feature/Services/FileCacheServiceTest.php
@@ -11,7 +11,6 @@ use Hyde\Testing\TestCase;
  */
 class FileCacheServiceTest extends TestCase
 {
-    // Test getFilecache() method returns array containing checksums for vendor files
     public function testGetFilecache()
     {
         $fileCacheService = new FileCacheService();
@@ -23,7 +22,6 @@ class FileCacheServiceTest extends TestCase
         $this->assertEquals(32, strlen($fileCache['/resources/views/layouts/app.blade.php']['unixsum']));
     }
 
-    // Test getChecksums() method returns array with just the checksums
     public function testGetChecksums()
     {
         $fileCacheService = new FileCacheService();
@@ -33,7 +31,6 @@ class FileCacheServiceTest extends TestCase
         $this->assertEquals(32, strlen($checksums[0]));
     }
 
-    // Test checksumMatchesAny() method returns true if a supplied checksum matches any of the checksums in array
     public function testChecksumMatchesAny()
     {
         $fileCacheService = new FileCacheService();
@@ -43,7 +40,6 @@ class FileCacheServiceTest extends TestCase
         ));
     }
 
-    // Test checksumMatchesAny() method returns false if a supplied checksum does not match any of the checksums in array
     public function testChecksumMatchesAnyFalse()
     {
         $fileCacheService = new FileCacheService();

--- a/packages/framework/tests/Feature/Services/FileCacheServiceTest.php
+++ b/packages/framework/tests/Feature/Services/FileCacheServiceTest.php
@@ -11,7 +11,7 @@ use Hyde\Testing\TestCase;
  */
 class FileCacheServiceTest extends TestCase
 {
-    public function testGetFilecache()
+    public function test_get_filecache()
     {
         $fileCacheService = new FileCacheService();
         $fileCache = $fileCacheService->getFilecache();
@@ -22,7 +22,7 @@ class FileCacheServiceTest extends TestCase
         $this->assertEquals(32, strlen($fileCache['/resources/views/layouts/app.blade.php']['unixsum']));
     }
 
-    public function testGetChecksums()
+    public function test_get_checksums()
     {
         $fileCacheService = new FileCacheService();
         $checksums = $fileCacheService->getChecksums();
@@ -31,7 +31,7 @@ class FileCacheServiceTest extends TestCase
         $this->assertEquals(32, strlen($checksums[0]));
     }
 
-    public function testChecksumMatchesAny()
+    public function test_checksum_matches_any()
     {
         $fileCacheService = new FileCacheService();
 
@@ -40,7 +40,7 @@ class FileCacheServiceTest extends TestCase
         ));
     }
 
-    public function testChecksumMatchesAnyFalse()
+    public function test_checksum_matches_any_false()
     {
         $fileCacheService = new FileCacheService();
 

--- a/packages/framework/tests/Feature/Services/HasConfigurableMarkdownFeaturesTest.php
+++ b/packages/framework/tests/Feature/Services/HasConfigurableMarkdownFeaturesTest.php
@@ -21,79 +21,68 @@ class HasConfigurableMarkdownFeaturesTest extends TestCase
         $this->assertIsArray($this->features);
     }
 
-    // Test that the features array is empty by default
-    public function test_has_features_array_empty()
+    public function test_the_features_array_is_empty_by_default()
     {
         $this->assertEmpty($this->features);
     }
 
-    // Test that features can be added to the array
-    public function test_has_features_array_add()
+    public function test_features_can_be_added_to_the_array()
     {
         $this->addFeature('test');
         $this->assertContains('test', $this->features);
     }
 
-    // Test that features can be removed from the array
-    public function test_has_features_array_remove()
+    public function test_features_can_be_removed_from_the_array()
     {
         $this->addFeature('test');
         $this->removeFeature('test');
         $this->assertNotContains('test', $this->features);
     }
 
-    // Test that method chaining can be used to programmatically add features to the array
-    public function test_has_features_array_add_chain()
+    public function test_method_chaining_can_be_used_to_programmatically_add_features_to_the_array()
     {
         $this->addFeature('test')->addFeature('test2');
         $this->assertContains('test', $this->features);
         $this->assertContains('test2', $this->features);
     }
 
-    // Test that method chaining can be used to programmatically remove features from the array
-    public function test_has_features_array_remove_chain()
+    public function test_method_chaining_can_be_used_to_programmatically_remove_features_from_the_array()
     {
         $this->addFeature('test')->addFeature('test2')->removeFeature('test');
         $this->assertNotContains('test', $this->features);
         $this->assertContains('test2', $this->features);
     }
 
-    // Test that method withTableOfContents method chain adds the table-of-contents feature
-    public function test_has_features_array_add_toc()
+    public function test_method_with_table_of_contents_method_chain_adds_the_table-of-contents_feature()
     {
         $this->withTableOfContents();
         $this->assertContains('table-of-contents', $this->features);
     }
 
-    // Test that method withPermalinks method chain adds the permalinks feature
-    public function test_has_features_array_add_permalinks()
+    public function test_method_with_permalinks_method_chain_adds_the_permalinks_feature()
     {
         $this->withPermalinks();
         $this->assertContains('permalinks', $this->features);
     }
 
-    // Test that hasFeature() returns true if the feature is in the array
-    public function test_has_features_array_has()
+    public function test_has_feature_returns_true_if_the_feature_is_in_the_array()
     {
         $this->addFeature('test');
         $this->assertTrue($this->hasFeature('test'));
     }
 
-    // Test that hasFeature() returns false if the feature is not in the array
-    public function test_has_features_array_has_not()
+    public function test_has_feature_returns_false_if_the_feature_is_not_in_the_array()
     {
         $this->assertFalse($this->hasFeature('test'));
     }
 
-    // Test that method canEnablePermalinks returns true if the permalinks feature is in the array
-    public function test_has_features_array_can_enable_permalinks()
+    public function test_method_can_enable_permalinks_returns_true_if_the_permalinks_feature_is_in_the_array()
     {
         $this->addFeature('permalinks');
         $this->assertTrue($this->canEnablePermalinks());
     }
 
-    // Test that method canEnablePermalinks is automatically for DocumentationPages
-    public function test_has_features_array_can_enable_permalinks_auto()
+    public function test_method_can_enable_permalinks_is_automatically_for_documentation_pages()
     {
         Config::set('docs.table_of_contents.enabled', true);
         $this->sourceModel = DocumentationPage::class;
@@ -101,21 +90,18 @@ class HasConfigurableMarkdownFeaturesTest extends TestCase
         $this->assertTrue($this->canEnablePermalinks());
     }
 
-    // Test that method canEnablePermalinks returns false if the permalinks feature is not in the array
-    public function test_has_features_array_can_enable_permalinks_not()
+    public function test_method_can_enable_permalinks_returns_false_if_the_permalinks_feature_is_not_in_the_array()
     {
         $this->assertFalse($this->canEnablePermalinks());
     }
 
-    // Test that method canEnableTorchlight returns true if the torchlight feature is in the array
-    public function test_has_features_array_can_enable_torchlight()
+    public function test_method_can_enable_torchlight_returns_true_if_the_torchlight_feature_is_in_the_array()
     {
         $this->addFeature('torchlight');
         $this->assertTrue($this->canEnableTorchlight());
     }
 
-    // Test that method canEnableTorchlight returns false if the torchlight feature is not in the array
-    public function test_has_features_array_can_enable_torchlight_not()
+    public function test_method_can_enable_torchlight_returns_false_if_the_torchlight_feature_is_not_in_the_array()
     {
         $this->assertFalse($this->canEnableTorchlight());
     }

--- a/packages/framework/tests/Feature/Services/HasConfigurableMarkdownFeaturesTest.php
+++ b/packages/framework/tests/Feature/Services/HasConfigurableMarkdownFeaturesTest.php
@@ -53,7 +53,7 @@ class HasConfigurableMarkdownFeaturesTest extends TestCase
         $this->assertContains('test2', $this->features);
     }
 
-    public function test_method_with_table_of_contents_method_chain_adds_the_table-of-contents_feature()
+    public function test_method_with_table_of_contents_method_chain_adds_the_table_of_contents_feature()
     {
         $this->withTableOfContents();
         $this->assertContains('table-of-contents', $this->features);

--- a/packages/framework/tests/Feature/Services/HydeSmartDocsTest.php
+++ b/packages/framework/tests/Feature/Services/HydeSmartDocsTest.php
@@ -49,7 +49,6 @@ class HydeSmartDocsTest extends TestCase
         config(['torchlight.token' => '12345']);
     }
 
-    // test facade create helper creates a new instance and processes it
     public function test_create_helper_creates_new_instance_and_processes_it()
     {
         $page = HydeSmartDocs::create($this->mock, $this->html);
@@ -59,7 +58,6 @@ class HydeSmartDocsTest extends TestCase
         $this->assertEqualsIgnoringNewlines('<p>Hello world.</p>', $page->renderBody());
     }
 
-    // Test instance can be constructed directly with same result as facade
     public function test_instance_can_be_constructed_directly_with_same_result_as_facade()
     {
         $class = new HydeSmartDocs($this->mock, $this->html);
@@ -74,7 +72,6 @@ class HydeSmartDocsTest extends TestCase
         $this->assertEquals($class, $facade);
     }
 
-    // Test renderHeader returns the extracted header
     public function test_render_header_returns_the_extracted_header()
     {
         $page = HydeSmartDocs::create($this->mock, $this->html);
@@ -82,7 +79,6 @@ class HydeSmartDocsTest extends TestCase
         $this->assertEqualsIgnoringNewlines('<h1>Foo</h1>', $page->renderHeader());
     }
 
-    // Test renderHeader returns the extracted header with varying newlines
     public function test_render_header_returns_the_extracted_header_with_varying_newlines()
     {
         $tests = [
@@ -97,7 +93,6 @@ class HydeSmartDocsTest extends TestCase
         }
     }
 
-    // Test renderBody returns the extracted body
     public function test_render_body_returns_the_extracted_body()
     {
         $page = HydeSmartDocs::create($this->mock, $this->html);
@@ -105,7 +100,6 @@ class HydeSmartDocsTest extends TestCase
         $this->assertEqualsIgnoringNewlines('<p>Hello world.</p>', $page->renderBody());
     }
 
-    // Test renderBody returns the extracted body with varying newlines
     public function test_render_body_returns_the_extracted_body_with_varying_newlines()
     {
         $tests = [
@@ -120,7 +114,6 @@ class HydeSmartDocsTest extends TestCase
         }
     }
 
-    // Test renderFooter is empty by default
     public function test_render_footer_is_empty_by_default()
     {
         $page = HydeSmartDocs::create($this->mock, $this->html);
@@ -128,7 +121,6 @@ class HydeSmartDocsTest extends TestCase
         $this->assertEqualsIgnoringNewlines('', $page->renderFooter());
     }
 
-    // Test addDynamicHeaderContent adds source link when conditions are met
     public function test_add_dynamic_header_content_adds_source_link_when_conditions_are_met()
     {
         config(['docs.source_file_location_base' => 'https://example.com/']);
@@ -138,7 +130,6 @@ class HydeSmartDocsTest extends TestCase
         $this->assertEqualsIgnoringNewlines('<h1>Foo</h1><p class="edit-page-link"><a href="https://example.com/foo.md">Edit Source</a></p>', $page->renderHeader());
     }
 
-    // Test edit source link is added to footer when conditions are met
     public function test_edit_source_link_is_added_to_footer_when_conditions_are_met()
     {
         config(['docs.source_file_location_base' => 'https://example.com/']);
@@ -148,7 +139,6 @@ class HydeSmartDocsTest extends TestCase
         $this->assertEqualsIgnoringNewlines('<p class="edit-page-link"><a href="https://example.com/foo.md">Edit Source</a></p>', $page->renderFooter());
     }
 
-    // Test edit source link can be added to both header and footer
     public function test_edit_source_link_can_be_added_to_both_header_and_footer()
     {
         config(['docs.source_file_location_base' => 'https://example.com/']);
@@ -159,7 +149,6 @@ class HydeSmartDocsTest extends TestCase
         $this->assertEqualsIgnoringNewlines('<p class="edit-page-link"><a href="https://example.com/foo.md">Edit Source</a></p>', $page->renderFooter());
     }
 
-    // Test edit source link text can be customized
     public function test_edit_source_link_text_can_be_customized()
     {
         config(['docs.source_file_location_base' => 'https://example.com/']);
@@ -171,7 +160,6 @@ class HydeSmartDocsTest extends TestCase
         $this->assertEqualsIgnoringNewlines('<p class="edit-page-link"><a href="https://example.com/foo.md">Go to Source</a></p>', $page->renderFooter());
     }
 
-    // Test addDynamicFooterContent adds torchlight attribution when conditions are met
     public function test_add_dynamic_footer_content_adds_torchlight_attribution_when_conditions_are_met()
     {
         $this->mockTorchlight();

--- a/packages/framework/tests/Feature/Services/Markdown/CodeblockFilepathProcessorTest.php
+++ b/packages/framework/tests/Feature/Services/Markdown/CodeblockFilepathProcessorTest.php
@@ -10,7 +10,6 @@ use Hyde\Testing\TestCase;
  */
 class CodeblockFilepathProcessorTest extends TestCase
 {
-    // Test preprocess method expands filepath
     public function test_preprocess_expands_filepath()
     {
         $markdown = "\n```php\n// filepath: foo.php\necho 'Hello World';\n```";
@@ -19,7 +18,6 @@ class CodeblockFilepathProcessorTest extends TestCase
         $this->assertEquals($expected, CodeblockFilepathProcessor::preprocess($markdown));
     }
 
-    // Test preprocess method accepts multiple filepath formats
     public function test_preprocess_accepts_multiple_filepath_formats()
     {
         $patterns = [
@@ -41,7 +39,6 @@ class CodeblockFilepathProcessorTest extends TestCase
         }
     }
 
-    // Test preprocess method accepts multiple languages
     public function test_preprocess_accepts_multiple_languages()
     {
         $languages = [
@@ -62,7 +59,6 @@ class CodeblockFilepathProcessorTest extends TestCase
         $this->assertEquals($expected, CodeblockFilepathProcessor::preprocess($markdown));
     }
 
-    // Test preprocess method accepts multiple input blocks
     public function test_preprocess_accepts_multiple_input_blocks()
     {
         $markdown = <<<'MD'
@@ -94,7 +90,6 @@ class CodeblockFilepathProcessorTest extends TestCase
         $this->assertEqualsIgnoringLineReturnType($expected, CodeblockFilepathProcessor::preprocess($markdown));
     }
 
-    // Test preprocess method accepts multi-line codeblocks
     public function test_preprocess_accepts_multi_line_codeblocks()
     {
         $markdown = <<<'MD'
@@ -120,7 +115,6 @@ class CodeblockFilepathProcessorTest extends TestCase
         $this->assertEqualsIgnoringLineReturnType($expected, CodeblockFilepathProcessor::preprocess($markdown));
     }
 
-    // Test space after filepath is optional
     public function test_space_after_filepath_is_optional()
     {
         $markdown = <<<'MD'
@@ -144,7 +138,6 @@ class CodeblockFilepathProcessorTest extends TestCase
             CodeblockFilepathProcessor::preprocess($markdown));
     }
 
-    // Test processor expands filepath directive in standard codeblock
     public function test_processor_expands_filepath_directive_in_standard_codeblock()
     {
         $html = <<<'HTML'
@@ -159,7 +152,6 @@ class CodeblockFilepathProcessorTest extends TestCase
         $this->assertEqualsIgnoringLineReturnType($expected, CodeblockFilepathProcessor::process($html));
     }
 
-    // Test processor expands filepath directive in Torchlight codeblock
     public function test_processor_expands_filepath_directive_in_torchlight_codeblock()
     {
         $html = <<<'HTML'

--- a/packages/framework/tests/Feature/Services/Markdown/ShortcodeProcessorTest.php
+++ b/packages/framework/tests/Feature/Services/Markdown/ShortcodeProcessorTest.php
@@ -11,7 +11,6 @@ use Hyde\Testing\TestCase;
  */
 class ShortcodeProcessorTest extends TestCase
 {
-    // Test constructor discovers default shortcodes
     public function test_constructor_discovers_default_shortcodes()
     {
         $shortcodes = (new ShortcodeProcessor('foo'))->shortcodes;
@@ -20,7 +19,6 @@ class ShortcodeProcessorTest extends TestCase
         $this->assertContainsOnlyInstancesOf(MarkdownShortcodeContract::class, $shortcodes);
     }
 
-    // Test discovered shortcodes are used to process input
     public function test_discovered_shortcodes_are_used_to_process_input()
     {
         $processor = new ShortcodeProcessor('>info foo');
@@ -29,7 +27,6 @@ class ShortcodeProcessorTest extends TestCase
             $processor->run());
     }
 
-    // Test string not matching shortcode is not modified
     public function test_string_without_shortcode_is_not_modified()
     {
         $processor = new ShortcodeProcessor('foo');
@@ -37,14 +34,12 @@ class ShortcodeProcessorTest extends TestCase
         $this->assertEquals('foo', $processor->run());
     }
 
-    // Test the static process() shorthand method
     public function test_process_static_shorthand()
     {
         $this->assertEquals('<blockquote class="info">foo</blockquote>',
             ShortcodeProcessor::process('>info foo'));
     }
 
-    // Test shortcodes can be added to the processor
     public function test_shortcodes_can_be_added_to_processor()
     {
         $processor = new ShortcodeProcessor('foo');

--- a/packages/framework/tests/Feature/Services/RssFeedServiceTest.php
+++ b/packages/framework/tests/Feature/Services/RssFeedServiceTest.php
@@ -11,14 +11,12 @@ use Hyde\Testing\TestCase;
  */
 class RssFeedServiceTest extends TestCase
 {
-    // Test service instantiates the XML element
     public function test_service_instantiates_xml_element()
     {
         $service = new RssFeedService();
         $this->assertInstanceOf('SimpleXMLElement', $service->feed);
     }
 
-    // Test XML root element is set to RSS 2.0
     public function test_xml_root_element_is_set_to_rss_2_0()
     {
         $service = new RssFeedService();
@@ -26,14 +24,12 @@ class RssFeedServiceTest extends TestCase
         $this->assertEquals('2.0', $service->feed->attributes()->version);
     }
 
-    // Test XML element has channel element
     public function test_xml_element_has_channel_element()
     {
         $service = new RssFeedService();
         $this->assertObjectHasAttribute('channel', $service->feed);
     }
 
-    // Test XML channel element has required elements
     public function test_xml_channel_element_has_required_elements()
     {
         config(['hyde.name' => 'Test Blog']);
@@ -49,7 +45,6 @@ class RssFeedServiceTest extends TestCase
         $this->assertEquals('Test Blog RSS Feed', $service->feed->channel->description);
     }
 
-    // Test XML channel element has additional elements
     public function test_xml_channel_element_has_additional_elements()
     {
         config(['hyde.site_url' => 'https://example.com']);
@@ -65,7 +60,6 @@ class RssFeedServiceTest extends TestCase
         $this->assertObjectHasAttribute('lastBuildDate', $service->feed->channel);
     }
 
-    // Test XML channel data can be customized
     public function test_xml_channel_data_can_be_customized()
     {
         config(['hyde.name' => 'Foo']);
@@ -78,7 +72,6 @@ class RssFeedServiceTest extends TestCase
         $this->assertEquals('Foo is a web log about stuff', $service->feed->channel->description);
     }
 
-    // Test Markdown blog posts are added to RSS feed through autodiscovery
     public function test_markdown_blog_posts_are_added_to_rss_feed_through_autodiscovery()
     {
         file_put_contents(Hyde::path('_posts/rss.md'), <<<'MD'
@@ -122,14 +115,12 @@ class RssFeedServiceTest extends TestCase
         unlink(Hyde::path('_media/rss-test.jpg'));
     }
 
-    // Test getXML method returns XML string
     public function test_get_xml_method_returns_xml_string()
     {
         $service = new RssFeedService();
         $this->assertStringStartsWith('<?xml version="1.0" encoding="UTF-8"?>', ($service->getXML()));
     }
 
-    // Test generateFeed helper returns XML string
     public function test_generate_feed_helper_returns_xml_string()
     {
         $this->assertStringStartsWith('<?xml version="1.0" encoding="UTF-8"?>', (RssFeedService::generateFeed()));

--- a/packages/framework/tests/Feature/Services/SitemapServiceTest.php
+++ b/packages/framework/tests/Feature/Services/SitemapServiceTest.php
@@ -33,7 +33,7 @@ class SitemapServiceTest extends TestCase
         $service = new SitemapService();
         $service->generate();
 
-        // Test runner has an index and 404 page, so we are using that as a baseline
+        // The test runner has an index and 404 page, so we are using that as a baseline
         $this->assertCount(2, $service->xmlElement->url);
     }
 

--- a/packages/framework/tests/Unit/AuthorGetNameTest.php
+++ b/packages/framework/tests/Unit/AuthorGetNameTest.php
@@ -12,7 +12,6 @@ use Hyde\Testing\TestCase;
  */
 class AuthorGetNameTest extends TestCase
 {
-    // Test get name helper returns name if set
     public function test_get_name_helper_returns_name_if_set()
     {
         $author = new Author('username');
@@ -21,7 +20,6 @@ class AuthorGetNameTest extends TestCase
         $this->assertEquals('John Doe', $author->getName());
     }
 
-    // Test get name helper returns username if name is not set
     public function test_get_name_helper_returns_username_if_name_is_not_set()
     {
         $author = new Author('username');

--- a/packages/framework/tests/Unit/BlogPostFrontMatterIsOptionalTest.php
+++ b/packages/framework/tests/Unit/BlogPostFrontMatterIsOptionalTest.php
@@ -8,7 +8,6 @@ use Illuminate\Support\Facades\Artisan;
 
 class BlogPostFrontMatterIsOptionalTest extends TestCase
 {
-    // Test blog posts can be created without having any front matter
     public function testBlogPostCanBeCreatedWithoutFrontMatter()
     {
         file_put_contents(Hyde::path('_posts/test-post.md'), '# My New Post');
@@ -21,7 +20,6 @@ class BlogPostFrontMatterIsOptionalTest extends TestCase
         unlink(Hyde::path('_site/posts/test-post.html'));
     }
 
-    // Test blog post feed can be rendered when having post without front matter
     public function testBlogPostFeedCanBeRenderedWhenPostHasNoFrontMatter()
     {
         file_put_contents(Hyde::path('_posts/test-post.md'), '# My New Post');

--- a/packages/framework/tests/Unit/BlogPostFrontMatterIsOptionalTest.php
+++ b/packages/framework/tests/Unit/BlogPostFrontMatterIsOptionalTest.php
@@ -8,7 +8,7 @@ use Illuminate\Support\Facades\Artisan;
 
 class BlogPostFrontMatterIsOptionalTest extends TestCase
 {
-    public function testBlogPostCanBeCreatedWithoutFrontMatter()
+    public function test_blog_post_can_be_created_without_front_matter()
     {
         file_put_contents(Hyde::path('_posts/test-post.md'), '# My New Post');
 
@@ -20,7 +20,7 @@ class BlogPostFrontMatterIsOptionalTest extends TestCase
         unlink(Hyde::path('_site/posts/test-post.html'));
     }
 
-    public function testBlogPostFeedCanBeRenderedWhenPostHasNoFrontMatter()
+    public function test_blog_post_feed_can_be_rendered_when_post_has_no_front_matter()
     {
         file_put_contents(Hyde::path('_posts/test-post.md'), '# My New Post');
 

--- a/packages/framework/tests/Unit/DateStringTest.php
+++ b/packages/framework/tests/Unit/DateStringTest.php
@@ -12,42 +12,36 @@ use PHPUnit\Framework\TestCase;
  */
 class DateStringTest extends TestCase
 {
-    // Test it can parse a date string
     public function test_it_can_parse_date_string()
     {
         $dateString = new DateString('2020-01-01');
         $this->assertEquals('2020-01-01', $dateString->string);
     }
 
-    // Test it can parse date string into datetime object
     public function test_it_can_parse_date_string_into_datetime_object()
     {
         $dateString = new DateString('2020-01-01 UTC');
         $this->assertInstanceOf(DateTime::class, $dateString->dateTimeObject);
     }
 
-    // Test it can format date string into a machine-readable string
     public function test_it_can_format_date_string_into_machine_readable_string()
     {
         $dateString = new DateString('2020-01-01 UTC');
         $this->assertEquals('2020-01-01T00:00:00+00:00', $dateString->datetime);
     }
 
-    // Test it can format date string into a human-readable string
     public function test_it_can_format_date_string_into_human_readable_string()
     {
         $dateString = new DateString('2020-01-01 UTC');
         $this->assertEquals('Wednesday Jan 1st, 2020, at 12:00am', $dateString->sentence);
     }
 
-    // Test it can format date string into a short human-readable string
     public function test_it_can_format_date_string_into_short_human_readable_string()
     {
         $dateString = new DateString('2020-01-01 UTC');
         $this->assertEquals('Jan 1st, 2020', $dateString->short);
     }
 
-    // Test it handles invalid date strings
     public function test_it_handles_invalid_date_strings()
     {
         $this->expectException(CouldNotParseDateStringException::class);

--- a/packages/framework/tests/Unit/DocumentationPageTest.php
+++ b/packages/framework/tests/Unit/DocumentationPageTest.php
@@ -12,13 +12,13 @@ class DocumentationPageTest extends TestCase
 {
     public function test_can_generate_table_of_contents()
     {
-        $page = (new DocumentationPage([], "# Foo"));
+        $page = (new DocumentationPage([], '# Foo'));
         $this->assertIsString($page->tableOfContents);
     }
 
     public function test_can_get_current_page_path()
     {
-        $page = (new DocumentationPage([], "", "", "foo"));
+        $page = (new DocumentationPage([], '', '', 'foo'));
         $this->assertEquals('docs/foo', $page->getCurrentPagePath());
 
         config(['docs.output_directory' => 'documentation/latest/']);
@@ -27,14 +27,14 @@ class DocumentationPageTest extends TestCase
 
     public function test_can_get_online_source_path()
     {
-        $page = (new DocumentationPage([], ""));
+        $page = (new DocumentationPage([], ''));
         $this->assertFalse($page->getOnlineSourcePath());
     }
 
     public function test_can_get_online_source_path_with_source_file_location_base()
     {
         config(['docs.source_file_location_base' => 'docs.example.com/edit']);
-        $page = (new DocumentationPage([], "", "", "foo"));
+        $page = (new DocumentationPage([], '', '', 'foo'));
         $this->assertEquals('docs.example.com/edit/foo.md', $page->getOnlineSourcePath());
     }
 

--- a/packages/framework/tests/Unit/DocumentationPageTest.php
+++ b/packages/framework/tests/Unit/DocumentationPageTest.php
@@ -10,15 +10,13 @@ use Hyde\Testing\TestCase;
  */
 class DocumentationPageTest extends TestCase
 {
-    // Test documentation page table of contents is generated automatically.
-    public function testCanGenerateTableOfContents()
+    public function test_can_generate_table_of_contents()
     {
         $page = (new DocumentationPage([], "# Foo"));
         $this->assertIsString($page->tableOfContents);
     }
 
-    // Test getCurrentPagePath returns trimmed path to current page slug in documentation output directory.
-    public function testCanGetCurrentPagePath()
+    public function test_can_get_current_page_path()
     {
         $page = (new DocumentationPage([], "", "", "foo"));
         $this->assertEquals('docs/foo', $page->getCurrentPagePath());
@@ -27,23 +25,20 @@ class DocumentationPageTest extends TestCase
         $this->assertEquals('documentation/latest/foo', $page->getCurrentPagePath());
     }
 
-    // Test getOnlineSourcePath returns false if source file location base is not set.
-    public function testCanGetOnlineSourcePath()
+    public function test_can_get_online_source_path()
     {
         $page = (new DocumentationPage([], ""));
         $this->assertFalse($page->getOnlineSourcePath());
     }
 
-    // Test getOnlineSourcePath returns proper source path to current page
-    public function testCanGetOnlineSourcePathWithSourceFileLocationBase()
+    public function test_can_get_online_source_path_with_source_file_location_base()
     {
         config(['docs.source_file_location_base' => 'docs.example.com/edit']);
         $page = (new DocumentationPage([], "", "", "foo"));
         $this->assertEquals('docs.example.com/edit/foo.md', $page->getOnlineSourcePath());
     }
 
-    // Test getOnlineSourcePath trims base input to avoid trailing slash.
-    public function testCanGetOnlineSourcePathWithTrailingSlash()
+    public function test_can_get_online_source_path_with_trailing_slash()
     {
         $page = (new DocumentationPage([], '', '', 'foo'));
 
@@ -54,21 +49,18 @@ class DocumentationPageTest extends TestCase
         $this->assertEquals('edit/foo.md', $page->getOnlineSourcePath());
     }
 
-    // Test getDocumentationOutputPath helper returns path to documentation output directory.
-    public function testCanGetDocumentationOutputPath()
+    public function test_can_get_documentation_output_path()
     {
         $this->assertEquals('docs', DocumentationPage::getDocumentationOutputPath());
     }
 
-    // Test getDocumentationOutputPath helper can be customized.
-    public function testCanGetDocumentationOutputPathWithCustomOutputDirectory()
+    public function test_can_get_documentation_output_path_with_custom_output_directory()
     {
         config(['docs.output_directory' => 'foo']);
         $this->assertEquals('foo', DocumentationPage::getDocumentationOutputPath());
     }
 
-    // Test getDocumentationOutputPath helper trims trailing slashes.
-    public function testCanGetDocumentationOutputPathWithTrailingSlashes()
+    public function test_can_get_documentation_output_path_with_trailing_slashes()
     {
         $tests = [
             'foo',

--- a/packages/framework/tests/Unit/FileHelperRelativeLinkTest.php
+++ b/packages/framework/tests/Unit/FileHelperRelativeLinkTest.php
@@ -12,50 +12,42 @@ use Hyde\Testing\TestCase;
  */
 class FileHelperRelativeLinkTest extends TestCase
 {
-    // Test helper returns string as is when $current is not set
     public function test_helper_returns_string_as_is_if_current_is_not_set()
     {
         $this->assertEquals('foo/bar.html', Hyde::relativeLink('foo/bar.html'));
     }
 
-    // Test helper injects the proper number of `../`
     public function test_helper_injects_proper_number_of_doubles_slash()
     {
         $this->assertEquals('../foo.html', Hyde::relativeLink('foo.html', 'foo/bar.html'));
     }
 
-    // Test helper injects the proper number of `../` for deeply nested $current paths
     public function test_helper_injects_proper_number_of_doubles_slash_for_deeply_nested_paths()
     {
         $this->assertEquals('../../../foo.html', Hyde::relativeLink('foo.html', 'foo/bar/baz/qux.html'));
     }
 
-    // Test helper handles destination without file extension
     public function test_helper_handles_destination_without_file_extension()
     {
         $this->assertEquals('../foo', Hyde::relativeLink('foo', 'foo/bar.html'));
     }
 
-    // Test helper handles $current without file extension
     public function test_helper_handles_current_without_file_extension()
     {
         $this->assertEquals('../foo.html', Hyde::relativeLink('foo.html', 'foo/bar'));
     }
 
-    // Test helper handles case without any file extensions
     public function test_helper_handles_case_without_any_file_extensions()
     {
         $this->assertEquals('../foo', Hyde::relativeLink('foo', 'foo/bar'));
     }
 
-    // Test helper handles case with mixed file extensions
     public function test_helper_handles_case_with_mixed_file_extensions()
     {
         $this->assertEquals('../foo.md', Hyde::relativeLink('foo.md', 'foo/bar.md'));
         $this->assertEquals('../foo.txt', Hyde::relativeLink('foo.txt', 'foo/bar.txt'));
     }
 
-    // Test helper handles different file extensions
     public function test_helper_handles_different_file_extensions()
     {
         $this->assertEquals('../foo.png', Hyde::relativeLink('foo.png', 'foo/bar'));
@@ -63,21 +55,18 @@ class FileHelperRelativeLinkTest extends TestCase
         $this->assertEquals('../foo.js', Hyde::relativeLink('foo.js', 'foo/bar'));
     }
 
-    // Test helper returns pretty URL if enabled and destination is a HTML file
     public function test_helper_returns_pretty_url_if_enabled_and_destination_is_a_html_file()
     {
         config(['hyde.pretty_urls' => true]);
         $this->assertEquals('../foo', Hyde::relativeLink('foo.html', 'foo/bar.html'));
     }
 
-    // Test helper method does not require current path to be HTML to use pretty URLs
     public function test_helper_method_does_not_require_current_path_to_be_html_to_use_pretty_urls()
     {
         config(['hyde.pretty_urls' => true]);
         $this->assertEquals('../foo', Hyde::relativeLink('foo.html', 'foo/bar'));
     }
 
-    // Test helper returns does not return pretty URL if when enabled but and destination is not a HTML file
     public function test_helper_returns_does_not_return_pretty_url_if_when_enabled_but_and_destination_is_not_a_html_file()
     {
         config(['hyde.pretty_urls' => true]);

--- a/packages/framework/tests/Unit/HasAuthorTest.php
+++ b/packages/framework/tests/Unit/HasAuthorTest.php
@@ -17,7 +17,6 @@ class HasAuthorTest extends TestCase
 
     protected array $matter;
 
-    // Test it can create a new author instance from username string
     public function test_it_can_create_a_new_author_instance_from_username_string()
     {
         $this->matter = [
@@ -31,7 +30,6 @@ class HasAuthorTest extends TestCase
         $this->assertNull($this->author->website);
     }
 
-    // Test it can create a new author instance from user array
     public function test_it_can_create_a_new_author_instance_from_user_array()
     {
         $this->matter['author'] = [

--- a/packages/framework/tests/Unit/HasDynamicTitleTest.php
+++ b/packages/framework/tests/Unit/HasDynamicTitleTest.php
@@ -14,8 +14,7 @@ class HasDynamicTitleTest extends TestCase
 {
     protected array $matter;
 
-    // Test it can find title from front matter.
-    public function testFindTitleFromFrontMatter()
+    public function testCanFindTitleFromFrontMatter()
     {
         $document = new MarkdownDocument([
             'title' => 'My Title',
@@ -24,16 +23,14 @@ class HasDynamicTitleTest extends TestCase
         $this->assertEquals('My Title', $document->findTitleForDocument());
     }
 
-    // Test it can find title from H1 tag.
-    public function testFindTitleFromH1Tag()
+    public function testCanFindTitleFromH1Tag()
     {
         $document = new MarkdownDocument([], body: '# My Title');
 
         $this->assertEquals('My Title', $document->findTitleForDocument());
     }
 
-    // Test it can find title from slug.
-    public function testFindTitleFromSlug()
+    public function testCanFindTitleFromSlug()
     {
         $document = new MarkdownDocument([], body: '', slug: 'my-title');
         $this->assertEquals('My Title', $document->findTitleForDocument());

--- a/packages/framework/tests/Unit/HasDynamicTitleTest.php
+++ b/packages/framework/tests/Unit/HasDynamicTitleTest.php
@@ -14,7 +14,7 @@ class HasDynamicTitleTest extends TestCase
 {
     protected array $matter;
 
-    public function testCanFindTitleFromFrontMatter()
+    public function test_can_find_title_from_front_matter()
     {
         $document = new MarkdownDocument([
             'title' => 'My Title',
@@ -23,14 +23,14 @@ class HasDynamicTitleTest extends TestCase
         $this->assertEquals('My Title', $document->findTitleForDocument());
     }
 
-    public function testCanFindTitleFromH1Tag()
+    public function test_can_find_title_from_h1_tag()
     {
         $document = new MarkdownDocument([], body: '# My Title');
 
         $this->assertEquals('My Title', $document->findTitleForDocument());
     }
 
-    public function testCanFindTitleFromSlug()
+    public function test_can_find_title_from_slug()
     {
         $document = new MarkdownDocument([], body: '', slug: 'my-title');
         $this->assertEquals('My Title', $document->findTitleForDocument());

--- a/packages/framework/tests/Unit/HasFeaturedImageTest.php
+++ b/packages/framework/tests/Unit/HasFeaturedImageTest.php
@@ -17,7 +17,6 @@ class HasFeaturedImageTest extends TestCase
 
     protected array $matter;
 
-    // Test it can create a new Image instance from a string
     public function test_it_can_create_a_new_image_instance_from_a_string()
     {
         $this->matter = [
@@ -29,7 +28,6 @@ class HasFeaturedImageTest extends TestCase
         $this->assertEquals('https://example.com/image.jpg', $this->image->uri);
     }
 
-    // Test it can create a new Image instance from an array
     public function test_it_can_create_a_new_image_instance_from_an_array()
     {
         $this->matter = [
@@ -43,27 +41,23 @@ class HasFeaturedImageTest extends TestCase
         $this->assertEquals('https://example.com/image.jpg', $this->image->uri);
     }
 
-    // Test constructBaseImage() sets the source to the image's uri when supplied path is an uri
     public function test_construct_base_image_sets_the_source_to_the_image_uri_when_supplied_path_is_an_uri()
     {
         $image = $this->constructBaseImage('https://example.com/image.jpg');
         $this->assertEquals('https://example.com/image.jpg', $image->getSource());
     }
 
-    // Test constructBaseImage() sets the source to the image's path when supplied path is a local path
     public function test_construct_base_image_sets_the_source_to_the_image_path_when_supplied_path_is_a_local_path()
     {
         $image = $this->constructBaseImage('/path/to/image.jpg');
         $this->assertEquals('/path/to/image.jpg', $image->getSource());
     }
 
-    // Test constructBaseImage() returns an Image instance created from a string
     public function test_construct_base_image_returns_an_image_instance_created_from_a_string()
     {
         $this->assertInstanceOf(Image::class, $this->constructBaseImage(''));
     }
 
-    // Test constructFullImage() returns an Image instance created from an array
     public function test_construct_full_image_returns_an_image_instance_created_from_an_array()
     {
         $this->assertInstanceOf(Image::class, $this->constructFullImage([]));

--- a/packages/framework/tests/Unit/HasPageMetadataRssFeedLinkTest.php
+++ b/packages/framework/tests/Unit/HasPageMetadataRssFeedLinkTest.php
@@ -93,7 +93,6 @@ class HasPageMetadataRssFeedLinkTest extends TestCase
         );
     }
 
-    // Test link is not added if site url is not set
     public function test_link_is_not_added_if_site_url_is_not_set()
     {
         config(['hyde.site_url' => '']);


### PR DESCRIPTION
Removes Copilot comments and renames test method names to snake_case to match the convention