### PR TITLE
Make page model constructor parameters optional

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ This serves two purposes:
 ### Added
 - Added a helper to all page models to get an array of all its source files https://github.com/hydephp/develop/issues/44
 - Added a helper to all page models to parse source files directly into an object https://github.com/hydephp/develop/issues/40
+- Adds the MarkdownDocumentContract interface to markdown based pages to keep a consistent and predictable state
 - internal: Add more tests
 
 ### Changed
@@ -31,7 +32,9 @@ This serves two purposes:
 - Add `rel="nofollow"` to the image author links https://github.com/hydephp/develop/issues/19
 - Changed the default position of the automatic navigation menu link to the right, also making it configurable.
 - Renamed deprecated Hyde::docsDirectory() helper to suggested Hyde::getDocumentationOutputDirectory()
+- Makes the constructor arguments for Markdown page models optional https://github.com/hydephp/develop/issues/65
 - internal: Add back codecov.io to pull request tests https://github.com/hydephp/develop/issues/37
+
 
 ### Deprecated
 - for soon-to-be removed features.

--- a/packages/framework/src/Contracts/MarkdownDocumentContract.php
+++ b/packages/framework/src/Contracts/MarkdownDocumentContract.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace Hyde\Framework\Contracts;
+
+interface MarkdownDocumentContract
+{
+    public function __construct(array $matter = [], string $body = '', string $title = '', string $slug = '');
+}

--- a/packages/framework/src/Contracts/MarkdownDocumentContract.php
+++ b/packages/framework/src/Contracts/MarkdownDocumentContract.php
@@ -4,5 +4,13 @@ namespace Hyde\Framework\Contracts;
 
 interface MarkdownDocumentContract
 {
+    /**
+     * Construct the class.
+     *
+     * @param array $matter The parsed front matter.
+     * @param string $body The parsed markdown body.
+     * @param string $title The page title used in the HTML.
+     * @param string $slug The page slug for internal reference.
+     */
     public function __construct(array $matter = [], string $body = '', string $title = '', string $slug = '');
 }

--- a/packages/framework/src/Contracts/MarkdownDocumentContract.php
+++ b/packages/framework/src/Contracts/MarkdownDocumentContract.php
@@ -7,10 +7,10 @@ interface MarkdownDocumentContract
     /**
      * Construct the class.
      *
-     * @param array $matter The parsed front matter.
-     * @param string $body The parsed markdown body.
-     * @param string $title The page title used in the HTML.
-     * @param string $slug The page slug for internal reference.
+     * @param  array  $matter  The parsed front matter.
+     * @param  string  $body  The parsed markdown body.
+     * @param  string  $title  The page title used in the HTML.
+     * @param  string  $slug  The page slug for internal reference.
      */
     public function __construct(array $matter = [], string $body = '', string $title = '', string $slug = '');
 }

--- a/packages/framework/src/Models/DocumentationPage.php
+++ b/packages/framework/src/Models/DocumentationPage.php
@@ -13,7 +13,7 @@ class DocumentationPage extends MarkdownDocument
     public static string $sourceDirectory = '_docs';
     public static string $parserClass = DocumentationPageParser::class;
 
-    public function __construct(array $matter, string $body, string $title = '', string $slug = '')
+    public function __construct(array $matter = [], string $body = '', string $title = '', string $slug = '')
     {
         parent::__construct($matter, $body, $title, $slug);
 

--- a/packages/framework/src/Models/MarkdownDocument.php
+++ b/packages/framework/src/Models/MarkdownDocument.php
@@ -11,6 +11,10 @@ use Hyde\Framework\Contracts\MarkdownDocumentContract;
  *
  * It is, in itself an intermediate object model created by the MarkdownFileService
  * and contains the Front Matter and Markdown body found in a document processed by the service.
+ *
+ * @see \Hyde\Framework\Models\MarkdownPage
+ * @see \Hyde\Framework\Models\MarkdownPost
+ * @see \Hyde\Framework\Models\DocumentationPage
  */
 class MarkdownDocument extends AbstractPage implements MarkdownDocumentContract
 {

--- a/packages/framework/src/Models/MarkdownDocument.php
+++ b/packages/framework/src/Models/MarkdownDocument.php
@@ -4,6 +4,7 @@ namespace Hyde\Framework\Models;
 
 use Hyde\Framework\Concerns\HasDynamicTitle;
 use Hyde\Framework\Contracts\AbstractPage;
+use Hyde\Framework\Contracts\MarkdownDocumentContract;
 
 /**
  * The base class for all Markdown-based Page Models.
@@ -11,7 +12,7 @@ use Hyde\Framework\Contracts\AbstractPage;
  * It is, in itself an intermediate object model created by the MarkdownFileService
  * and contains the Front Matter and Markdown body found in a document processed by the service.
  */
-class MarkdownDocument extends AbstractPage
+class MarkdownDocument extends AbstractPage implements MarkdownDocumentContract
 {
     use HasDynamicTitle;
 
@@ -22,15 +23,7 @@ class MarkdownDocument extends AbstractPage
 
     public static string $fileExtension = '.md';
 
-    /**
-     * Construct the class.
-     *
-     * @param  array  $matter
-     * @param  string  $body
-     * @param  string  $title
-     * @param  string  $slug
-     */
-    public function __construct(array $matter, string $body, string $title = '', string $slug = '')
+    public function __construct(array $matter = [], string $body = '', string $title = '', string $slug = '')
     {
         $this->matter = $matter;
         $this->body = $body;

--- a/packages/framework/src/Models/MarkdownPost.php
+++ b/packages/framework/src/Models/MarkdownPost.php
@@ -25,7 +25,7 @@ class MarkdownPost extends MarkdownDocument
     /**
      * @throws \Hyde\Framework\Exceptions\CouldNotParseDateStringException
      */
-    public function __construct(array $matter, string $body, string $title = '', string $slug = '')
+    public function __construct(array $matter = [], string $body = '', string $title = '', string $slug = '')
     {
         parent::__construct($matter, $body, $title, $slug);
 

--- a/packages/framework/tests/Unit/MarkdownPageModelConstructorArgumentsAreOptionalTest.php
+++ b/packages/framework/tests/Unit/MarkdownPageModelConstructorArgumentsAreOptionalTest.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Hyde\Testing\Framework\Unit;
+
+use Hyde\Framework\Models\DocumentationPage;
+use Hyde\Framework\Models\MarkdownPage;
+use Hyde\Framework\Models\MarkdownPost;
+use Hyde\Testing\TestCase;
+
+class MarkdownPageModelConstructorArgumentsAreOptionalTest extends TestCase
+{
+    public function test_markdown_page_model_constructor_arguments_are_optional()
+    {
+        $models = [
+            MarkdownPage::class,
+            MarkdownPost::class,
+            DocumentationPage::class,
+        ];
+
+        foreach ($models as $model) {
+            $this->assertInstanceOf($model, new $model());
+        }
+    }
+}


### PR DESCRIPTION
Adds the MarkdownDocumentContract interface to markdown based pages to keep a consistent and predictable state and makes the constructor arguments for Markdown page models optional to fix https://github.com/hydephp/develop/issues/65