### PR TITLE
Deprecate ChecksIfConfigIsUpToDate.php

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,9 +35,8 @@ This serves two purposes:
 - Makes the constructor arguments for Markdown page models optional https://github.com/hydephp/develop/issues/65
 - internal: Add back codecov.io to pull request tests https://github.com/hydephp/develop/issues/37
 
-
 ### Deprecated
-- for soon-to-be removed features.
+- ChecksIfConfigIsUpToDate.php - Will be replaced by checking the version instead.
 
 ### Removed
 - Removed the Hyde::getLatestPosts() helper which was deprecated in v0.34.x and was replaced with MarkdownPost::getLatestPosts()

--- a/packages/framework/src/Actions/ChecksIfConfigIsUpToDate.php
+++ b/packages/framework/src/Actions/ChecksIfConfigIsUpToDate.php
@@ -10,6 +10,7 @@ use Hyde\Framework\Hyde;
  * Works by comparing the number of title blocks, which is a crude but fast way to check.
  *
  * @see \Hyde\Testing\Framework\Feature\Actions\ChecksIfConfigIsUpToDateTest
+ * @deprecated v0.39.0-beta - Will be replaced by checking the version instead.
  */
 class ChecksIfConfigIsUpToDate implements ActionContract
 {


### PR DESCRIPTION
Will be replaced by checking the version instead.
