### PR TITLE
Change Framework testing namespace

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ This serves two purposes:
 - Renamed deprecated Hyde::docsDirectory() helper to suggested Hyde::getDocumentationOutputDirectory()
 - Makes the constructor arguments for Markdown page models optional https://github.com/hydephp/develop/issues/65
 - Added the Hyde/Framework composer.lock to .gitignore as we keep a master lock file in the monorepo.
+- Changed namespace for Hyde/Framework tests from `Hyde\Testing\Framework` to `Hyde\Framework\Testing`
 - internal: Add back codecov.io to pull request tests https://github.com/hydephp/develop/issues/37
 
 ### Deprecated

--- a/composer.lock
+++ b/composer.lock
@@ -903,7 +903,7 @@
             },
             "autoload-dev": {
                 "psr-4": {
-                    "Hyde\\Testing\\Framework\\": "tests/"
+                    "Hyde\\Framework\\Testing\\": "tests/"
                 }
             },
             "license": [

--- a/packages/framework/composer.json
+++ b/packages/framework/composer.json
@@ -9,7 +9,7 @@
     },
     "autoload-dev": {
         "psr-4": {
-            "Hyde\\Testing\\Framework\\": "tests/"
+            "Hyde\\Framework\\Testing\\": "tests/"
         }
     },
     "authors": [

--- a/packages/framework/src/Actions/ChecksIfConfigIsUpToDate.php
+++ b/packages/framework/src/Actions/ChecksIfConfigIsUpToDate.php
@@ -9,7 +9,7 @@ use Hyde\Framework\Hyde;
  * Checks if the installed config is up-to-date with the Framework's config.
  * Works by comparing the number of title blocks, which is a crude but fast way to check.
  *
- * @see \Hyde\Testing\Framework\Feature\Actions\ChecksIfConfigIsUpToDateTest
+ * @see \Hyde\Framework\Testing\Feature\Actions\ChecksIfConfigIsUpToDateTest
  * @deprecated v0.39.0-beta - Will be replaced by checking the version instead.
  */
 class ChecksIfConfigIsUpToDate implements ActionContract

--- a/packages/framework/src/Actions/CreatesNewPageSourceFile.php
+++ b/packages/framework/src/Actions/CreatesNewPageSourceFile.php
@@ -13,7 +13,7 @@ use Illuminate\Support\Str;
 /**
  * Scaffold a new Markdown, Blade, or documentation page.
  *
- * @see \Hyde\Testing\Framework\Feature\Actions\CreatesNewPageSourceFileTest
+ * @see \Hyde\Framework\Testing\Feature\Actions\CreatesNewPageSourceFileTest
  */
 class CreatesNewPageSourceFile
 {

--- a/packages/framework/src/Actions/FindsContentLengthForImageObject.php
+++ b/packages/framework/src/Actions/FindsContentLengthForImageObject.php
@@ -9,7 +9,7 @@ use Symfony\Component\Console\Output\ConsoleOutput;
 use Symfony\Component\Console\Output\OutputInterface;
 
 /**
- * @see \Hyde\Testing\Framework\Feature\FindsContentLengthForImageObjectTest
+ * @see \Hyde\Framework\Testing\Feature\FindsContentLengthForImageObjectTest
  */
 class FindsContentLengthForImageObject implements ActionContract
 {

--- a/packages/framework/src/Actions/GeneratesDocumentationSearchIndexFile.php
+++ b/packages/framework/src/Actions/GeneratesDocumentationSearchIndexFile.php
@@ -16,7 +16,7 @@ use Illuminate\Support\Str;
  * @todo Convert into Service, and add more strategies, such as slug-only (no file parsing)
  *        search which while dumber, would be much faster to compile and take way less space.
  *
- * @see \Hyde\Testing\Framework\Feature\Actions\GeneratesDocumentationSearchIndexFileTest
+ * @see \Hyde\Framework\Testing\Feature\Actions\GeneratesDocumentationSearchIndexFileTest
  */
 class GeneratesDocumentationSearchIndexFile implements ActionContract
 {

--- a/packages/framework/src/Actions/GeneratesTableOfContents.php
+++ b/packages/framework/src/Actions/GeneratesTableOfContents.php
@@ -12,7 +12,7 @@ use League\CommonMark\MarkdownConverter;
 /**
  * Generates a table of contents for the Markdown document.
  *
- * @see \Hyde\Testing\Framework\Feature\Actions\GeneratesTableOfContentsTest
+ * @see \Hyde\Framework\Testing\Feature\Actions\GeneratesTableOfContentsTest
  */
 class GeneratesTableOfContents implements ActionContract
 {

--- a/packages/framework/src/Actions/PublishesHomepageView.php
+++ b/packages/framework/src/Actions/PublishesHomepageView.php
@@ -8,7 +8,7 @@ use Hyde\Framework\Hyde;
 /**
  * Publish one of the Hyde homepages.
  *
- * @see \Hyde\Testing\Framework\Feature\Actions\PublishesHomepageViewTest
+ * @see \Hyde\Framework\Testing\Feature\Actions\PublishesHomepageViewTest
  */
 class PublishesHomepageView implements ActionContract
 {

--- a/packages/framework/src/Actions/PublishesHydeViews.php
+++ b/packages/framework/src/Actions/PublishesHydeViews.php
@@ -9,7 +9,7 @@ use Illuminate\Support\Facades\File;
 /*
 * Publish one or more of the Hyde Blade views.
 *
-* @see \Hyde\Testing\Framework\Feature\Actions\PublishesHomepageViewTest
+* @see \Hyde\Framework\Testing\Feature\Actions\PublishesHomepageViewTest
 */
 class PublishesHydeViews implements ActionContract
 {

--- a/packages/framework/src/Commands/HydeBuildRssFeedCommand.php
+++ b/packages/framework/src/Commands/HydeBuildRssFeedCommand.php
@@ -9,7 +9,7 @@ use LaravelZero\Framework\Commands\Command;
 /**
  * Hyde Command to run the Build Process for the RSS Feed.
  *
- * @see \Hyde\Testing\Framework\Feature\Commands\HydeBuildRssFeedCommandTest
+ * @see \Hyde\Framework\Testing\Feature\Commands\HydeBuildRssFeedCommandTest
  */
 class HydeBuildRssFeedCommand extends Command
 {

--- a/packages/framework/src/Commands/HydeBuildSearchCommand.php
+++ b/packages/framework/src/Commands/HydeBuildSearchCommand.php
@@ -13,7 +13,7 @@ use LaravelZero\Framework\Commands\Command;
  *
  * @todo Add configuration option to enable/disable this feature.
  *
- * @see \Hyde\Testing\Framework\Feature\Commands\HydeBuildSearchCommandTest
+ * @see \Hyde\Framework\Testing\Feature\Commands\HydeBuildSearchCommandTest
  */
 class HydeBuildSearchCommand extends Command
 {

--- a/packages/framework/src/Commands/HydeBuildSitemapCommand.php
+++ b/packages/framework/src/Commands/HydeBuildSitemapCommand.php
@@ -9,7 +9,7 @@ use LaravelZero\Framework\Commands\Command;
 /**
  * Hyde Command to run the Build Process for the Sitemap.
  *
- * @see \Hyde\Testing\Framework\Feature\Commands\HydeBuildSitemapCommandTest
+ * @see \Hyde\Framework\Testing\Feature\Commands\HydeBuildSitemapCommandTest
  */
 class HydeBuildSitemapCommand extends Command
 {

--- a/packages/framework/src/Commands/HydeBuildStaticSiteCommand.php
+++ b/packages/framework/src/Commands/HydeBuildStaticSiteCommand.php
@@ -24,7 +24,7 @@ use LaravelZero\Framework\Commands\Command;
 /**
  * Hyde Command to run the Build Process.
  *
- * @see \Hyde\Testing\Framework\Feature\Commands\BuildStaticSiteCommandTest
+ * @see \Hyde\Framework\Testing\Feature\Commands\BuildStaticSiteCommandTest
  */
 class HydeBuildStaticSiteCommand extends Command
 {

--- a/packages/framework/src/Commands/HydeInstallCommand.php
+++ b/packages/framework/src/Commands/HydeInstallCommand.php
@@ -10,7 +10,7 @@ use LaravelZero\Framework\Commands\Command;
 /**
  * Initialize a new Hyde project.
  *
- * @see \Hyde\Testing\Framework\Feature\Commands\HydeInstallCommandTest
+ * @see \Hyde\Framework\Testing\Feature\Commands\HydeInstallCommandTest
  */
 class HydeInstallCommand extends Command
 {

--- a/packages/framework/src/Commands/HydeMakePageCommand.php
+++ b/packages/framework/src/Commands/HydeMakePageCommand.php
@@ -12,7 +12,7 @@ use LaravelZero\Framework\Commands\Command;
 /**
  * Hyde Command to scaffold a new Markdown or Blade page file.
  *
- * @see \Hyde\Testing\Framework\Feature\Commands\HydeMakePageCommandTest
+ * @see \Hyde\Framework\Testing\Feature\Commands\HydeMakePageCommandTest
  */
 class HydeMakePageCommand extends Command
 {

--- a/packages/framework/src/Commands/HydePublishHomepageCommand.php
+++ b/packages/framework/src/Commands/HydePublishHomepageCommand.php
@@ -11,7 +11,7 @@ use LaravelZero\Framework\Commands\Command;
 /**
  * Publish one of the default homepages.
  *
- * @see \Hyde\Testing\Framework\Feature\Commands\HydePublishHomepageCommandTest
+ * @see \Hyde\Framework\Testing\Feature\Commands\HydePublishHomepageCommandTest
  */
 class HydePublishHomepageCommand extends Command
 {

--- a/packages/framework/src/Commands/HydeUpdateConfigsCommand.php
+++ b/packages/framework/src/Commands/HydeUpdateConfigsCommand.php
@@ -10,7 +10,7 @@ use LaravelZero\Framework\Commands\Command;
 /**
  * Publish the Hyde Config Files.
  *
- * @see \Hyde\Testing\Framework\Feature\Commands\HydeUpdateConfigsCommandTest
+ * @see \Hyde\Framework\Testing\Feature\Commands\HydeUpdateConfigsCommandTest
  */
 class HydeUpdateConfigsCommand extends Command
 {

--- a/packages/framework/src/Concerns/FacadeHelpers/HydeSmartDocsFacade.php
+++ b/packages/framework/src/Concerns/FacadeHelpers/HydeSmartDocsFacade.php
@@ -9,7 +9,7 @@ use Hyde\Framework\Models\DocumentationPage;
  * Provide static facade methods, and instance helpers for HydeSmartDocs.
  *
  * @see \Hyde\Framework\Services\HydeSmartDocs
- * @see \Hyde\Testing\Framework\Feature\Services\HydeSmartDocsTest
+ * @see \Hyde\Framework\Testing\Feature\Services\HydeSmartDocsTest
  */
 trait HydeSmartDocsFacade
 {

--- a/packages/framework/src/Concerns/GeneratesPageMetadata.php
+++ b/packages/framework/src/Concerns/GeneratesPageMetadata.php
@@ -9,7 +9,7 @@ use Hyde\Framework\Models\MarkdownPost;
  * Generates metadata for page models that have front matter.
  *
  * @see \Hyde\Framework\Models\Metadata
- * @see \Hyde\Testing\Framework\Feature\Concerns\GeneratesPageMetadataTest
+ * @see \Hyde\Framework\Testing\Feature\Concerns\GeneratesPageMetadataTest
  */
 trait GeneratesPageMetadata
 {

--- a/packages/framework/src/Concerns/HasAuthor.php
+++ b/packages/framework/src/Concerns/HasAuthor.php
@@ -9,7 +9,7 @@ use Hyde\Framework\Models\Author;
  * Handle logic for Page models that have an Author.
  *
  * @see \Hyde\Framework\Models\Author
- * @see \Hyde\Testing\Framework\Unit\HasAuthorTest
+ * @see \Hyde\Framework\Testing\Unit\HasAuthorTest
  */
 trait HasAuthor
 {

--- a/packages/framework/src/Concerns/HasPageMetadata.php
+++ b/packages/framework/src/Concerns/HasPageMetadata.php
@@ -11,7 +11,7 @@ use Hyde\Framework\Services\SitemapService;
 /**
  * @todo Move logic into service class to make it easier to test.
  *
- * @see \Hyde\Testing\Framework\Feature\Concerns\HasPageMetadataTest
+ * @see \Hyde\Framework\Testing\Feature\Concerns\HasPageMetadataTest
  */
 trait HasPageMetadata
 {

--- a/packages/framework/src/Concerns/HasTableOfContents.php
+++ b/packages/framework/src/Concerns/HasTableOfContents.php
@@ -7,7 +7,7 @@ use Hyde\Framework\Actions\GeneratesTableOfContents;
 /**
  * Generate Table of Contents as HTML from a Markdown document body.
  *
- * @see \Hyde\Testing\Framework\Unit\HasTableOfContentsTest
+ * @see \Hyde\Framework\Testing\Unit\HasTableOfContentsTest
  */
 trait HasTableOfContents
 {

--- a/packages/framework/src/Concerns/InteractsWithDirectories.php
+++ b/packages/framework/src/Concerns/InteractsWithDirectories.php
@@ -3,7 +3,7 @@
 namespace Hyde\Framework\Concerns;
 
 /**
- * @see \Hyde\Testing\Framework\Unit\InteractsWithDirectoriesConcernTest
+ * @see \Hyde\Framework\Testing\Unit\InteractsWithDirectoriesConcernTest
  */
 trait InteractsWithDirectories
 {

--- a/packages/framework/src/Concerns/Internal/FileHelpers.php
+++ b/packages/framework/src/Concerns/Internal/FileHelpers.php
@@ -78,7 +78,7 @@ trait FileHelpers
     /**
      * Format a link to an HTML file, allowing for pretty URLs, if enabled.
      *
-     * @see \Hyde\Testing\Framework\Unit\FileHelperPageLinkPrettyUrlTest
+     * @see \Hyde\Framework\Testing\Unit\FileHelperPageLinkPrettyUrlTest
      */
     public static function pageLink(string $destination): string
     {
@@ -101,7 +101,7 @@ trait FileHelpers
     /**
      * Inject the proper number of `../` before the links in Blade templates.
      *
-     * @see \Hyde\Testing\Framework\Unit\FileHelperRelativeLinkTest
+     * @see \Hyde\Framework\Testing\Unit\FileHelperRelativeLinkTest
      *
      * @param  string  $destination  relative to output directory on compiled site
      * @param  string  $current  the current URI path relative to the site root

--- a/packages/framework/src/Concerns/Internal/FluentPathHelpers.php
+++ b/packages/framework/src/Concerns/Internal/FluentPathHelpers.php
@@ -19,7 +19,7 @@ use Hyde\Framework\StaticPageBuilder;
  * Hyde::path('_pages/foo') becomes Hyde::getBladePagePath('foo')
  *
  * @see \Hyde\Framework\Hyde
- * @see \Hyde\Testing\Framework\Unit\FluentPathHelpersTest
+ * @see \Hyde\Framework\Testing\Unit\FluentPathHelpersTest
  */
 trait FluentPathHelpers
 {

--- a/packages/framework/src/Concerns/ValidatesExistence.php
+++ b/packages/framework/src/Concerns/ValidatesExistence.php
@@ -8,7 +8,7 @@ use Hyde\Framework\Hyde;
 /**
  * Validate the existence of a Page model's source file.
  *
- * @see \Hyde\Testing\Framework\Unit\ValidatesExistenceTest
+ * @see \Hyde\Framework\Testing\Unit\ValidatesExistenceTest
  */
 trait ValidatesExistence
 {

--- a/packages/framework/src/Contracts/PageContract.php
+++ b/packages/framework/src/Contracts/PageContract.php
@@ -11,7 +11,7 @@ interface PageContract
      *
      * @return \Illuminate\Support\Collection<\Hyde\Framework\Contracts\PageContract>
      *
-     * @see \Hyde\Testing\Framework\Unit\PageModelGetHelperTest
+     * @see \Hyde\Framework\Testing\Unit\PageModelGetHelperTest
      */
     public static function all(): Collection;
 
@@ -21,7 +21,7 @@ interface PageContract
      *
      * @return array<string>
      *
-     * @see \Hyde\Testing\Framework\Unit\PageModelGetAllFilesHelperTest
+     * @see \Hyde\Framework\Testing\Unit\PageModelGetAllFilesHelperTest
      */
     public static function files(): array;
 
@@ -31,7 +31,7 @@ interface PageContract
      * @param  string  $slug
      * @return \Hyde\Framework\Contracts\AbstractPage
      *
-     * @see \Hyde\Testing\Framework\Unit\PageModelParseHelperTest
+     * @see \Hyde\Framework\Testing\Unit\PageModelParseHelperTest
      */
     public static function parse(string $slug): AbstractPage;
 }

--- a/packages/framework/src/Helpers/Author.php
+++ b/packages/framework/src/Helpers/Author.php
@@ -6,7 +6,7 @@ use Hyde\Framework\Models\Author as AuthorModel;
 use Illuminate\Support\Collection;
 
 /**
- * @see \Hyde\Testing\Framework\Feature\AuthorHelperTest
+ * @see \Hyde\Framework\Testing\Feature\AuthorHelperTest
  */
 class Author
 {

--- a/packages/framework/src/Helpers/HydeHelperFacade.php
+++ b/packages/framework/src/Helpers/HydeHelperFacade.php
@@ -5,7 +5,7 @@ namespace Hyde\Framework\Helpers;
 /**
  * Provides convenient access to Hyde helpers, through the main Hyde facade.
  *
- * @see \Hyde\Testing\Framework\Feature\HydeHelperFacadeTest
+ * @see \Hyde\Framework\Testing\Feature\HydeHelperFacadeTest
  */
 trait HydeHelperFacade
 {

--- a/packages/framework/src/Helpers/Meta.php
+++ b/packages/framework/src/Helpers/Meta.php
@@ -5,7 +5,7 @@ namespace Hyde\Framework\Helpers;
 /**
  * Helpers to fluently declare HTML meta tags.
  *
- * @see \Hyde\Testing\Framework\Feature\MetadataHelperTest
+ * @see \Hyde\Framework\Testing\Feature\MetadataHelperTest
  */
 class Meta
 {

--- a/packages/framework/src/Models/Author.php
+++ b/packages/framework/src/Models/Author.php
@@ -55,7 +55,7 @@ class Author
     /**
      * Get the author's preferred name.
      *
-     * @see \Hyde\Testing\Framework\Unit\AuthorGetNameTest
+     * @see \Hyde\Framework\Testing\Unit\AuthorGetNameTest
      *
      * @return string
      */

--- a/packages/framework/src/Models/DateString.php
+++ b/packages/framework/src/Models/DateString.php
@@ -8,7 +8,7 @@ use Hyde\Framework\Exceptions\CouldNotParseDateStringException;
 /**
  * Parse a date string and create normalized formats.
  *
- * @see \Hyde\Testing\Framework\Unit\DateStringTest
+ * @see \Hyde\Framework\Testing\Unit\DateStringTest
  */
 class DateString
 {

--- a/packages/framework/src/Models/DocumentationSidebar.php
+++ b/packages/framework/src/Models/DocumentationSidebar.php
@@ -12,7 +12,7 @@ use Illuminate\Support\Collection;
  * methods to fluently add DocumentationSidebarItems to the
  * collection using method chaining.
  *
- * @see \Hyde\Testing\Framework\Feature\Services\DocumentationSidebarServiceTest
+ * @see \Hyde\Framework\Testing\Feature\Services\DocumentationSidebarServiceTest
  */
 class DocumentationSidebar extends Collection implements DocumentationSidebarContract
 {

--- a/packages/framework/src/Models/DocumentationSidebarItem.php
+++ b/packages/framework/src/Models/DocumentationSidebarItem.php
@@ -9,7 +9,7 @@ use Spatie\YamlFrontMatter\YamlFrontMatter;
 /**
  * Object containing information for a sidebar item.
  *
- * @see \Hyde\Testing\Framework\Feature\Services\DocumentationSidebarServiceTest
+ * @see \Hyde\Framework\Testing\Feature\Services\DocumentationSidebarServiceTest
  */
 class DocumentationSidebarItem
 {

--- a/packages/framework/src/Services/CollectionService.php
+++ b/packages/framework/src/Services/CollectionService.php
@@ -11,7 +11,7 @@ use Hyde\Framework\Models\MarkdownPost;
 /**
  * Contains service methods to return helpful collections of arrays and lists.
  *
- * @see \Hyde\Testing\Framework\Feature\Services\CollectionServiceTest
+ * @see \Hyde\Framework\Testing\Feature\Services\CollectionServiceTest
  */
 class CollectionService
 {

--- a/packages/framework/src/Services/DiscoveryService.php
+++ b/packages/framework/src/Services/DiscoveryService.php
@@ -61,7 +61,7 @@ class DiscoveryService
      * @param  string  $filepath
      * @return string|false The model class constant, or false if none was found.
      *
-     * @see \Hyde\Testing\Framework\Unit\DiscoveryServiceCanFindModelFromCustomSourceFilePathTest
+     * @see \Hyde\Framework\Testing\Unit\DiscoveryServiceCanFindModelFromCustomSourceFilePathTest
      */
     public static function findModelFromFilePath(string $filepath): string|false
     {

--- a/packages/framework/src/Services/DocumentationSidebarService.php
+++ b/packages/framework/src/Services/DocumentationSidebarService.php
@@ -10,7 +10,7 @@ use Hyde\Framework\Models\DocumentationSidebarItem;
 /**
  * Service class to create and manage the sidebar collection object.
  *
- * @see \Hyde\Testing\Framework\Feature\Services\DocumentationSidebarServiceTest
+ * @see \Hyde\Framework\Testing\Feature\Services\DocumentationSidebarServiceTest
  */
 class DocumentationSidebarService implements DocumentationSidebarServiceContract
 {

--- a/packages/framework/src/Services/FileCacheService.php
+++ b/packages/framework/src/Services/FileCacheService.php
@@ -7,8 +7,8 @@ use Hyde\Framework\Hyde;
 /**
  * Helper methods to interact with the filecache.
  *
- * @see \Hyde\Testing\Framework\Feature\Services\FileCacheServiceTest
- * @see \Hyde\Testing\Framework\Unit\FileCacheServiceUnixsumMethodTest
+ * @see \Hyde\Framework\Testing\Feature\Services\FileCacheServiceTest
+ * @see \Hyde\Framework\Testing\Unit\FileCacheServiceUnixsumMethodTest
  */
 class FileCacheService
 {

--- a/packages/framework/src/Services/HydeSmartDocs.php
+++ b/packages/framework/src/Services/HydeSmartDocs.php
@@ -12,7 +12,7 @@ use Illuminate\Support\Str;
  *
  * @experimental 🧪 Subject to change without notice.
  *
- * @see \Hyde\Testing\Framework\Feature\Services\HydeSmartDocsTest
+ * @see \Hyde\Framework\Testing\Feature\Services\HydeSmartDocsTest
  */
 class HydeSmartDocs
 {

--- a/packages/framework/src/Services/Markdown/BladeDownProcessor.php
+++ b/packages/framework/src/Services/Markdown/BladeDownProcessor.php
@@ -13,7 +13,7 @@ use Illuminate\Support\Facades\Blade;
  * @example: [Blade]: {{ time() }}
  * @example: [Blade]: @include('path/to/view.blade.php')
  *
- * @see \Hyde\Testing\Framework\Feature\Services\BladeDownProcessorTest
+ * @see \Hyde\Framework\Testing\Feature\Services\BladeDownProcessorTest
  */
 class BladeDownProcessor
 {

--- a/packages/framework/src/Services/Markdown/CodeblockFilepathProcessor.php
+++ b/packages/framework/src/Services/Markdown/CodeblockFilepathProcessor.php
@@ -3,7 +3,7 @@
 namespace Hyde\Framework\Services\Markdown;
 
 /**
- * @see \Hyde\Testing\Framework\Feature\Services\Markdown\CodeblockFilepathProcessorTest
+ * @see \Hyde\Framework\Testing\Feature\Services\Markdown\CodeblockFilepathProcessorTest
  */
 class CodeblockFilepathProcessor
 {

--- a/packages/framework/src/Services/Markdown/ShortcodeProcessor.php
+++ b/packages/framework/src/Services/Markdown/ShortcodeProcessor.php
@@ -20,7 +20,7 @@ use Hyde\Framework\Services\Markdown\Shortcodes\AbstractColoredBlockquote;
  * @todo Refactor shortcode manager to singleton as it does not need to be re-instantiated
  *      for each Markdown conversion.
  *
- * @see \Hyde\Testing\Framework\Feature\Services\Markdown\ShortcodeProcessorTest
+ * @see \Hyde\Framework\Testing\Feature\Services\Markdown\ShortcodeProcessorTest
  */
 class ShortcodeProcessor implements MarkdownProcessorContract
 {

--- a/packages/framework/src/Services/Markdown/Shortcodes/AbstractColoredBlockquote.php
+++ b/packages/framework/src/Services/Markdown/Shortcodes/AbstractColoredBlockquote.php
@@ -5,7 +5,7 @@ namespace Hyde\Framework\Services\Markdown\Shortcodes;
 use Hyde\Framework\Contracts\MarkdownShortcodeContract;
 
 /**
- * @see \Hyde\Testing\Framework\Feature\ColoredBlockquoteShortcodesTest
+ * @see \Hyde\Framework\Testing\Feature\ColoredBlockquoteShortcodesTest
  */
 abstract class AbstractColoredBlockquote implements MarkdownShortcodeContract
 {

--- a/packages/framework/src/Services/MarkdownConverterService.php
+++ b/packages/framework/src/Services/MarkdownConverterService.php
@@ -15,8 +15,8 @@ use Torchlight\Commonmark\V2\TorchlightExtension;
  * Interface for the CommonMarkConverter,
  * allowing for easy configuration of extensions.
  *
- * @see \Hyde\Testing\Framework\Feature\MarkdownConverterServiceTest
- * @see \Hyde\Testing\Framework\Feature\Services\HasConfigurableMarkdownFeaturesTest
+ * @see \Hyde\Framework\Testing\Feature\MarkdownConverterServiceTest
+ * @see \Hyde\Framework\Testing\Feature\Services\HasConfigurableMarkdownFeaturesTest
  */
 class MarkdownConverterService
 {

--- a/packages/framework/src/Services/RssFeedService.php
+++ b/packages/framework/src/Services/RssFeedService.php
@@ -8,7 +8,7 @@ use Hyde\Framework\Models\MarkdownPost;
 use SimpleXMLElement;
 
 /**
- * @see \Hyde\Testing\Framework\Feature\Services\RssFeedServiceTest
+ * @see \Hyde\Framework\Testing\Feature\Services\RssFeedServiceTest
  * @see https://validator.w3.org/feed/docs/rss2.html
  */
 class RssFeedService

--- a/packages/framework/src/Services/SitemapService.php
+++ b/packages/framework/src/Services/SitemapService.php
@@ -11,7 +11,7 @@ use Hyde\Framework\Models\MarkdownPost;
 use SimpleXMLElement;
 
 /**
- * @see \Hyde\Testing\Framework\Feature\Services\SitemapServiceTest
+ * @see \Hyde\Framework\Testing\Feature\Services\SitemapServiceTest
  * @see https://www.sitemaps.org/protocol.html
  */
 class SitemapService

--- a/packages/framework/tests/Feature/Actions/ChecksIfConfigIsUpToDateTest.php
+++ b/packages/framework/tests/Feature/Actions/ChecksIfConfigIsUpToDateTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Hyde\Testing\Framework\Feature\Actions;
+namespace Hyde\Framework\Testing\Feature\Actions;
 
 use Hyde\Framework\Actions\ChecksIfConfigIsUpToDate;
 use Hyde\Testing\TestCase;

--- a/packages/framework/tests/Feature/Actions/CreatesNewPageSourceFileTest.php
+++ b/packages/framework/tests/Feature/Actions/CreatesNewPageSourceFileTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Hyde\Testing\Framework\Feature\Actions;
+namespace Hyde\Framework\Testing\Feature\Actions;
 
 use Hyde\Framework\Actions\CreatesNewPageSourceFile;
 use Hyde\Framework\Exceptions\FileConflictException;

--- a/packages/framework/tests/Feature/Actions/GeneratesDocumentationSearchIndexFileTest.php
+++ b/packages/framework/tests/Feature/Actions/GeneratesDocumentationSearchIndexFileTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Hyde\Testing\Framework\Feature\Actions;
+namespace Hyde\Framework\Testing\Feature\Actions;
 
 use Hyde\Framework\Actions\GeneratesDocumentationSearchIndexFile as Action;
 use Hyde\Framework\Hyde;

--- a/packages/framework/tests/Feature/Actions/GeneratesTableOfContentsTest.php
+++ b/packages/framework/tests/Feature/Actions/GeneratesTableOfContentsTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Hyde\Testing\Framework\Feature\Actions;
+namespace Hyde\Framework\Testing\Feature\Actions;
 
 use Hyde\Framework\Actions\GeneratesTableOfContents;
 use Hyde\Testing\TestCase;

--- a/packages/framework/tests/Feature/Actions/PublishesHomepageViewTest.php
+++ b/packages/framework/tests/Feature/Actions/PublishesHomepageViewTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Hyde\Testing\Framework\Feature\Actions;
+namespace Hyde\Framework\Testing\Feature\Actions;
 
 use Hyde\Framework\Actions\PublishesHomepageView;
 use Hyde\Framework\Contracts\ActionContract;

--- a/packages/framework/tests/Feature/Actions/PublishesHydeViewsTest.php
+++ b/packages/framework/tests/Feature/Actions/PublishesHydeViewsTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Hyde\Testing\Framework\Feature\Actions;
+namespace Hyde\Framework\Testing\Feature\Actions;
 
 use Hyde\Framework\Actions\PublishesHydeViews;
 use Hyde\Framework\Hyde;

--- a/packages/framework/tests/Feature/AssetServiceTest.php
+++ b/packages/framework/tests/Feature/AssetServiceTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Hyde\Testing\Framework\Feature;
+namespace Hyde\Framework\Testing\Feature;
 
 use Hyde\Framework\Services\AssetService;
 use Hyde\Testing\TestCase;

--- a/packages/framework/tests/Feature/AuthorHelperTest.php
+++ b/packages/framework/tests/Feature/AuthorHelperTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Hyde\Testing\Framework\Feature;
+namespace Hyde\Framework\Testing\Feature;
 
 use Hyde\Framework\Helpers\Author as AuthorHelper;
 use Hyde\Framework\Models\Author as AuthorModel;

--- a/packages/framework/tests/Feature/AuthorPostsIntegrationTest.php
+++ b/packages/framework/tests/Feature/AuthorPostsIntegrationTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Hyde\Testing\Framework\Feature;
+namespace Hyde\Framework\Testing\Feature;
 
 use Hyde\Framework\Actions\CreatesNewMarkdownPostFile;
 use Hyde\Framework\Helpers\Author;

--- a/packages/framework/tests/Feature/BuildOutputDirectoryCanBeChangedTest.php
+++ b/packages/framework/tests/Feature/BuildOutputDirectoryCanBeChangedTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Hyde\Testing\Framework\Feature;
+namespace Hyde\Framework\Testing\Feature;
 
 use Hyde\Framework\Hyde;
 use Hyde\Framework\Services\RebuildService;

--- a/packages/framework/tests/Feature/ColoredBlockquoteShortcodesTest.php
+++ b/packages/framework/tests/Feature/ColoredBlockquoteShortcodesTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Hyde\Testing\Framework\Feature;
+namespace Hyde\Framework\Testing\Feature;
 
 use Hyde\Framework\Services\Markdown\Shortcodes\AbstractColoredBlockquote;
 use Hyde\Testing\TestCase;

--- a/packages/framework/tests/Feature/Commands/BuildStaticSiteCommandTest.php
+++ b/packages/framework/tests/Feature/Commands/BuildStaticSiteCommandTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Hyde\Testing\Framework\Feature\Commands;
+namespace Hyde\Framework\Testing\Feature\Commands;
 
 use Hyde\Framework\Actions\CreatesDefaultDirectories;
 use Hyde\Framework\Hyde;

--- a/packages/framework/tests/Feature/Commands/DebugCommandTest.php
+++ b/packages/framework/tests/Feature/Commands/DebugCommandTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Hyde\Testing\Framework\Feature\Commands;
+namespace Hyde\Framework\Testing\Feature\Commands;
 
 use Hyde\Testing\TestCase;
 

--- a/packages/framework/tests/Feature/Commands/HydeBuildRssFeedCommandTest.php
+++ b/packages/framework/tests/Feature/Commands/HydeBuildRssFeedCommandTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Hyde\Testing\Framework\Feature\Commands;
+namespace Hyde\Framework\Testing\Feature\Commands;
 
 use Hyde\Framework\Hyde;
 use Hyde\Testing\TestCase;

--- a/packages/framework/tests/Feature/Commands/HydeBuildSearchCommandTest.php
+++ b/packages/framework/tests/Feature/Commands/HydeBuildSearchCommandTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Hyde\Testing\Framework\Feature\Commands;
+namespace Hyde\Framework\Testing\Feature\Commands;
 
 use Hyde\Framework\Hyde;
 use Hyde\Testing\TestCase;

--- a/packages/framework/tests/Feature/Commands/HydeBuildSitemapCommandTest.php
+++ b/packages/framework/tests/Feature/Commands/HydeBuildSitemapCommandTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Hyde\Testing\Framework\Feature\Commands;
+namespace Hyde\Framework\Testing\Feature\Commands;
 
 use Hyde\Framework\Hyde;
 use Hyde\Testing\TestCase;

--- a/packages/framework/tests/Feature/Commands/HydeInstallCommandTest.php
+++ b/packages/framework/tests/Feature/Commands/HydeInstallCommandTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Hyde\Testing\Framework\Feature\Commands;
+namespace Hyde\Framework\Testing\Feature\Commands;
 
 use Hyde\Framework\Hyde;
 use Hyde\Testing\TestCase;

--- a/packages/framework/tests/Feature/Commands/HydeMakePageCommandTest.php
+++ b/packages/framework/tests/Feature/Commands/HydeMakePageCommandTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Hyde\Testing\Framework\Feature\Commands;
+namespace Hyde\Framework\Testing\Feature\Commands;
 
 use Exception;
 use Hyde\Framework\Exceptions\FileConflictException;

--- a/packages/framework/tests/Feature/Commands/HydePublishHomepageCommandTest.php
+++ b/packages/framework/tests/Feature/Commands/HydePublishHomepageCommandTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Hyde\Testing\Framework\Feature\Commands;
+namespace Hyde\Framework\Testing\Feature\Commands;
 
 use Hyde\Framework\Hyde;
 use Hyde\Testing\TestCase;

--- a/packages/framework/tests/Feature/Commands/HydePublishViewsCommandTest.php
+++ b/packages/framework/tests/Feature/Commands/HydePublishViewsCommandTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Hyde\Testing\Framework\Feature\Commands;
+namespace Hyde\Framework\Testing\Feature\Commands;
 
 use Hyde\Framework\Hyde;
 use Hyde\Testing\TestCase;

--- a/packages/framework/tests/Feature/Commands/HydeRebuildStaticSiteCommandTest.php
+++ b/packages/framework/tests/Feature/Commands/HydeRebuildStaticSiteCommandTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Hyde\Testing\Framework\Feature\Commands;
+namespace Hyde\Framework\Testing\Feature\Commands;
 
 use Hyde\Framework\Commands\HydeRebuildStaticSiteCommand;
 use Hyde\Framework\Hyde;

--- a/packages/framework/tests/Feature/Commands/HydeServeCommandTest.php
+++ b/packages/framework/tests/Feature/Commands/HydeServeCommandTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Hyde\Testing\Framework\Feature\Commands;
+namespace Hyde\Framework\Testing\Feature\Commands;
 
 use Hyde\Testing\TestCase;
 

--- a/packages/framework/tests/Feature/Commands/HydeUpdateConfigsCommandTest.php
+++ b/packages/framework/tests/Feature/Commands/HydeUpdateConfigsCommandTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Hyde\Testing\Framework\Feature\Commands;
+namespace Hyde\Framework\Testing\Feature\Commands;
 
 use Hyde\Framework\Commands\HydeUpdateConfigsCommand;
 use Hyde\Framework\Hyde;

--- a/packages/framework/tests/Feature/Commands/HydeValidateCommandTest.php
+++ b/packages/framework/tests/Feature/Commands/HydeValidateCommandTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Hyde\Testing\Framework\Feature\Commands;
+namespace Hyde\Framework\Testing\Feature\Commands;
 
 use Hyde\Testing\TestCase;
 
@@ -9,7 +9,7 @@ use Hyde\Testing\TestCase;
  * @covers \Hyde\Framework\Services\ValidationService
  * @covers \Hyde\Framework\Models\ValidationResult
  *
- * @see \Hyde\Testing\Framework\Feature\Services\ValidationServiceTest
+ * @see \Hyde\Framework\Testing\Feature\Services\ValidationServiceTest
  */
 class HydeValidateCommandTest extends TestCase
 {

--- a/packages/framework/tests/Feature/Commands/MakePostCommandTest.php
+++ b/packages/framework/tests/Feature/Commands/MakePostCommandTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Hyde\Testing\Framework\Feature\Commands;
+namespace Hyde\Framework\Testing\Feature\Commands;
 
 use Hyde\Framework\Hyde;
 use Hyde\Testing\TestCase;

--- a/packages/framework/tests/Feature/Commands/StaticSiteBuilderPostModuleTest.php
+++ b/packages/framework/tests/Feature/Commands/StaticSiteBuilderPostModuleTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Hyde\Testing\Framework\Feature\Commands;
+namespace Hyde\Framework\Testing\Feature\Commands;
 
 use Hyde\Framework\Hyde;
 use Hyde\Framework\Models\MarkdownPost;
@@ -10,7 +10,7 @@ use Hyde\Testing\TestCase;
 /**
  * Test the post compiler module.
  *
- * @see \Hyde\Testing\Framework\Unit\MarkdownPostParserTest for the Markdown parser test.
+ * @see \Hyde\Framework\Testing\Unit\MarkdownPostParserTest for the Markdown parser test.
  */
 class StaticSiteBuilderPostModuleTest extends TestCase
 {

--- a/packages/framework/tests/Feature/Concerns/GeneratesPageMetadataTest.php
+++ b/packages/framework/tests/Feature/Concerns/GeneratesPageMetadataTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Hyde\Testing\Framework\Feature\Concerns;
+namespace Hyde\Framework\Testing\Feature\Concerns;
 
 use Hyde\Framework\Concerns\GeneratesPageMetadata;
 use Hyde\Testing\TestCase;

--- a/packages/framework/tests/Feature/Concerns/HasPageMetadataTest.php
+++ b/packages/framework/tests/Feature/Concerns/HasPageMetadataTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Hyde\Testing\Framework\Feature\Concerns;
+namespace Hyde\Framework\Testing\Feature\Concerns;
 
 use Hyde\Framework\Concerns\HasPageMetadata;
 use Hyde\Framework\Contracts\AbstractPage;
@@ -10,7 +10,7 @@ use Hyde\Testing\TestCase;
 /**
  * @covers \Hyde\Framework\Concerns\HasPageMetadata
  *
- * @see \Hyde\Testing\Framework\Unit\HasPageMetadataRssFeedLinkTest
+ * @see \Hyde\Framework\Testing\Unit\HasPageMetadataRssFeedLinkTest
  */
 class HasPageMetadataTest extends TestCase
 {

--- a/packages/framework/tests/Feature/ConfigurableFeaturesTest.php
+++ b/packages/framework/tests/Feature/ConfigurableFeaturesTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Hyde\Testing\Framework\Feature;
+namespace Hyde\Framework\Testing\Feature;
 
 use Hyde\Framework\Helpers\Features;
 use Hyde\Testing\TestCase;

--- a/packages/framework/tests/Feature/DarkmodeFeatureTest.php
+++ b/packages/framework/tests/Feature/DarkmodeFeatureTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Hyde\Testing\Framework\Feature;
+namespace Hyde\Framework\Testing\Feature;
 
 use Hyde\Framework\Helpers\Features;
 use Hyde\Framework\Models\DocumentationPage;

--- a/packages/framework/tests/Feature/DiscoveryServiceTest.php
+++ b/packages/framework/tests/Feature/DiscoveryServiceTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Hyde\Testing\Framework\Feature;
+namespace Hyde\Framework\Testing\Feature;
 
 use Hyde\Framework\Hyde;
 use Hyde\Framework\Models\BladePage;

--- a/packages/framework/tests/Feature/DocumentationPageParserTest.php
+++ b/packages/framework/tests/Feature/DocumentationPageParserTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Hyde\Testing\Framework\Feature;
+namespace Hyde\Framework\Testing\Feature;
 
 use Exception;
 use Hyde\Framework\Hyde;

--- a/packages/framework/tests/Feature/FindsContentLengthForImageObjectTest.php
+++ b/packages/framework/tests/Feature/FindsContentLengthForImageObjectTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Hyde\Testing\Framework\Feature;
+namespace Hyde\Framework\Testing\Feature;
 
 use Hyde\Framework\Models\Image;
 use Hyde\Testing\TestCase;

--- a/packages/framework/tests/Feature/GeneratesNavigationMenuTest.php
+++ b/packages/framework/tests/Feature/GeneratesNavigationMenuTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Hyde\Testing\Framework\Feature;
+namespace Hyde\Framework\Testing\Feature;
 
 use Hyde\Framework\Actions\GeneratesNavigationMenu;
 use Hyde\Framework\Hyde;

--- a/packages/framework/tests/Feature/HydeDocsIndexPathTest.php
+++ b/packages/framework/tests/Feature/HydeDocsIndexPathTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Hyde\Testing\Framework\Feature;
+namespace Hyde\Framework\Testing\Feature;
 
 use Hyde\Framework\Hyde;
 use Hyde\Testing\TestCase;

--- a/packages/framework/tests/Feature/HydeHelperFacadeTest.php
+++ b/packages/framework/tests/Feature/HydeHelperFacadeTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Hyde\Testing\Framework\Feature;
+namespace Hyde\Framework\Testing\Feature;
 
 use Hyde\Framework\Helpers\Features;
 use Hyde\Framework\Hyde;

--- a/packages/framework/tests/Feature/ImageModelTest.php
+++ b/packages/framework/tests/Feature/ImageModelTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Hyde\Testing\Framework\Feature;
+namespace Hyde\Framework\Testing\Feature;
 
 use Hyde\Framework\Models\Image;
 use Hyde\Testing\TestCase;

--- a/packages/framework/tests/Feature/MarkdownConverterServiceTest.php
+++ b/packages/framework/tests/Feature/MarkdownConverterServiceTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Hyde\Testing\Framework\Feature;
+namespace Hyde\Framework\Testing\Feature;
 
 use Hyde\Framework\Services\MarkdownConverterService;
 use Hyde\Testing\TestCase;

--- a/packages/framework/tests/Feature/MarkdownFileServiceTest.php
+++ b/packages/framework/tests/Feature/MarkdownFileServiceTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Hyde\Testing\Framework\Feature;
+namespace Hyde\Framework\Testing\Feature;
 
 use Hyde\Framework\Hyde;
 use Hyde\Framework\Models\MarkdownDocument;

--- a/packages/framework/tests/Feature/MarkdownPageTest.php
+++ b/packages/framework/tests/Feature/MarkdownPageTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Hyde\Testing\Framework\Feature;
+namespace Hyde\Framework\Testing\Feature;
 
 use Exception;
 use Hyde\Framework\Hyde;

--- a/packages/framework/tests/Feature/MetadataHelperTest.php
+++ b/packages/framework/tests/Feature/MetadataHelperTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Hyde\Testing\Framework\Feature;
+namespace Hyde\Framework\Testing\Feature;
 
 use Hyde\Framework\Helpers\Meta;
 use Hyde\Testing\TestCase;

--- a/packages/framework/tests/Feature/RebuildServiceTest.php
+++ b/packages/framework/tests/Feature/RebuildServiceTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Hyde\Testing\Framework\Feature;
+namespace Hyde\Framework\Testing\Feature;
 
 use Hyde\Framework\Hyde;
 use Hyde\Framework\Services\RebuildService;

--- a/packages/framework/tests/Feature/Services/BladeDownProcessorTest.php
+++ b/packages/framework/tests/Feature/Services/BladeDownProcessorTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Hyde\Testing\Framework\Feature\Services;
+namespace Hyde\Framework\Testing\Feature\Services;
 
 use Hyde\Framework\Services\Markdown\BladeDownProcessor;
 use Hyde\Testing\TestCase;

--- a/packages/framework/tests/Feature/Services/CollectionServiceTest.php
+++ b/packages/framework/tests/Feature/Services/CollectionServiceTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Hyde\Testing\Framework\Feature\Services;
+namespace Hyde\Framework\Testing\Feature\Services;
 
 use Hyde\Framework\Hyde;
 use Hyde\Framework\Models\BladePage;

--- a/packages/framework/tests/Feature/Services/DocumentationSidebarServiceTest.php
+++ b/packages/framework/tests/Feature/Services/DocumentationSidebarServiceTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Hyde\Testing\Framework\Feature\Services;
+namespace Hyde\Framework\Testing\Feature\Services;
 
 use Hyde\Framework\Actions\ConvertsArrayToFrontMatter;
 use Hyde\Framework\Hyde;

--- a/packages/framework/tests/Feature/Services/FileCacheServiceTest.php
+++ b/packages/framework/tests/Feature/Services/FileCacheServiceTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Hyde\Testing\Framework\Feature\Services;
+namespace Hyde\Framework\Testing\Feature\Services;
 
 use Hyde\Framework\Hyde;
 use Hyde\Framework\Services\FileCacheService;

--- a/packages/framework/tests/Feature/Services/HasConfigurableMarkdownFeaturesTest.php
+++ b/packages/framework/tests/Feature/Services/HasConfigurableMarkdownFeaturesTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Hyde\Testing\Framework\Feature\Services;
+namespace Hyde\Framework\Testing\Feature\Services;
 
 use Hyde\Framework\Concerns\Markdown\HasConfigurableMarkdownFeatures;
 use Hyde\Framework\Models\DocumentationPage;

--- a/packages/framework/tests/Feature/Services/HydeSmartDocsTest.php
+++ b/packages/framework/tests/Feature/Services/HydeSmartDocsTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Hyde\Testing\Framework\Feature\Services;
+namespace Hyde\Framework\Testing\Feature\Services;
 
 use Hyde\Framework\Actions\MarkdownConverter;
 use Hyde\Framework\Hyde;

--- a/packages/framework/tests/Feature/Services/Markdown/CodeblockFilepathProcessorTest.php
+++ b/packages/framework/tests/Feature/Services/Markdown/CodeblockFilepathProcessorTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Hyde\Testing\Framework\Feature\Services\Markdown;
+namespace Hyde\Framework\Testing\Feature\Services\Markdown;
 
 use Hyde\Framework\Services\Markdown\CodeblockFilepathProcessor;
 use Hyde\Testing\TestCase;

--- a/packages/framework/tests/Feature/Services/Markdown/ShortcodeProcessorTest.php
+++ b/packages/framework/tests/Feature/Services/Markdown/ShortcodeProcessorTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Hyde\Testing\Framework\Feature\Services\Markdown;
+namespace Hyde\Framework\Testing\Feature\Services\Markdown;
 
 use Hyde\Framework\Contracts\MarkdownShortcodeContract;
 use Hyde\Framework\Services\Markdown\ShortcodeProcessor;

--- a/packages/framework/tests/Feature/Services/RssFeedServiceTest.php
+++ b/packages/framework/tests/Feature/Services/RssFeedServiceTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Hyde\Testing\Framework\Feature\Services;
+namespace Hyde\Framework\Testing\Feature\Services;
 
 use Hyde\Framework\Hyde;
 use Hyde\Framework\Services\RssFeedService;

--- a/packages/framework/tests/Feature/Services/SitemapServiceTest.php
+++ b/packages/framework/tests/Feature/Services/SitemapServiceTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Hyde\Testing\Framework\Feature\Services;
+namespace Hyde\Framework\Testing\Feature\Services;
 
 use Hyde\Framework\Hyde;
 use Hyde\Framework\Services\SitemapService;

--- a/packages/framework/tests/Feature/Services/StarterFileServiceTest.php
+++ b/packages/framework/tests/Feature/Services/StarterFileServiceTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Hyde\Testing\Framework\Feature\Services;
+namespace Hyde\Framework\Testing\Feature\Services;
 
 use Hyde\Framework\Hyde;
 use Hyde\Framework\Services\StarterFileService;

--- a/packages/framework/tests/Feature/Services/ValidationServiceTest.php
+++ b/packages/framework/tests/Feature/Services/ValidationServiceTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Hyde\Testing\Framework\Feature\Services;
+namespace Hyde\Framework\Testing\Feature\Services;
 
 use Hyde\Framework\Hyde;
 use Hyde\Framework\Models\ValidationResult;
@@ -13,7 +13,7 @@ use Hyde\Testing\TestCase;
  * @covers \Hyde\Framework\Services\ValidationService
  * @covers \Hyde\Framework\Models\ValidationResult
  *
- * @see \Hyde\Testing\Framework\Feature\Commands\HydeValidateCommandTest
+ * @see \Hyde\Framework\Testing\Feature\Commands\HydeValidateCommandTest
  */
 class ValidationServiceTest extends TestCase
 {

--- a/packages/framework/tests/Feature/SourceDirectoriesCanBeChangedTest.php
+++ b/packages/framework/tests/Feature/SourceDirectoriesCanBeChangedTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Hyde\Testing\Framework\Feature;
+namespace Hyde\Framework\Testing\Feature;
 
 use Hyde\Framework\Hyde;
 use Hyde\Framework\Models\BladePage;

--- a/packages/framework/tests/Feature/StaticPageBuilderTest.php
+++ b/packages/framework/tests/Feature/StaticPageBuilderTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Hyde\Testing\Framework\Feature;
+namespace Hyde\Framework\Testing\Feature;
 
 use Hyde\Framework\Actions\CreatesDefaultDirectories;
 use Hyde\Framework\Hyde;

--- a/packages/framework/tests/Unit/AuthorGetNameTest.php
+++ b/packages/framework/tests/Unit/AuthorGetNameTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Hyde\Testing\Framework\Unit;
+namespace Hyde\Framework\Testing\Unit;
 
 use Hyde\Framework\Models\Author;
 use Hyde\Testing\TestCase;

--- a/packages/framework/tests/Unit/BlogPostFrontMatterIsOptionalTest.php
+++ b/packages/framework/tests/Unit/BlogPostFrontMatterIsOptionalTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Hyde\Testing\Framework\Unit;
+namespace Hyde\Framework\Testing\Unit;
 
 use Hyde\Framework\Hyde;
 use Hyde\Testing\TestCase;

--- a/packages/framework/tests/Unit/CreatesDefaultDirectoriesTest.php
+++ b/packages/framework/tests/Unit/CreatesDefaultDirectoriesTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Hyde\Testing\Framework\Unit;
+namespace Hyde\Framework\Testing\Unit;
 
 use Hyde\Framework\Actions\CreatesDefaultDirectories;
 use Hyde\Framework\Hyde;

--- a/packages/framework/tests/Unit/DateStringTest.php
+++ b/packages/framework/tests/Unit/DateStringTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Hyde\Testing\Framework\Unit;
+namespace Hyde\Framework\Testing\Unit;
 
 use DateTime;
 use Hyde\Framework\Exceptions\CouldNotParseDateStringException;

--- a/packages/framework/tests/Unit/DiscoveryServiceCanFindModelFromCustomSourceFilePathTest.php
+++ b/packages/framework/tests/Unit/DiscoveryServiceCanFindModelFromCustomSourceFilePathTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Hyde\Testing\Framework\Unit;
+namespace Hyde\Framework\Testing\Unit;
 
 use Hyde\Framework\Models\BladePage;
 use Hyde\Framework\Models\DocumentationPage;

--- a/packages/framework/tests/Unit/DocumentationPageParserTest.php
+++ b/packages/framework/tests/Unit/DocumentationPageParserTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Hyde\Testing\Framework\Unit;
+namespace Hyde\Framework\Testing\Unit;
 
 use Hyde\Framework\Hyde;
 use Hyde\Framework\Models\DocumentationPage;

--- a/packages/framework/tests/Unit/DocumentationPageTest.php
+++ b/packages/framework/tests/Unit/DocumentationPageTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Hyde\Testing\Framework\Unit;
+namespace Hyde\Framework\Testing\Unit;
 
 use Hyde\Framework\Models\DocumentationPage;
 use Hyde\Testing\TestCase;

--- a/packages/framework/tests/Unit/EnsureCommandsFollowNamingConventionTest.php
+++ b/packages/framework/tests/Unit/EnsureCommandsFollowNamingConventionTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Hyde\Testing\Framework\Unit;
+namespace Hyde\Framework\Testing\Unit;
 
 use Hyde\Testing\TestCase;
 

--- a/packages/framework/tests/Unit/FileCacheServiceUnixsumMethodTest.php
+++ b/packages/framework/tests/Unit/FileCacheServiceUnixsumMethodTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Hyde\Testing\Framework\Unit;
+namespace Hyde\Framework\Testing\Unit;
 
 use Hyde\Framework\Services\FileCacheService as Service;
 use Hyde\Testing\TestCase;

--- a/packages/framework/tests/Unit/FileHelperPageLinkPrettyUrlTest.php
+++ b/packages/framework/tests/Unit/FileHelperPageLinkPrettyUrlTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Hyde\Testing\Framework\Unit;
+namespace Hyde\Framework\Testing\Unit;
 
 use Hyde\Framework\Hyde;
 use Hyde\Testing\TestCase;

--- a/packages/framework/tests/Unit/FileHelperRelativeLinkTest.php
+++ b/packages/framework/tests/Unit/FileHelperRelativeLinkTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Hyde\Testing\Framework\Unit;
+namespace Hyde\Framework\Testing\Unit;
 
 use Hyde\Framework\Hyde;
 use Hyde\Testing\TestCase;

--- a/packages/framework/tests/Unit/FluentPathHelpersTest.php
+++ b/packages/framework/tests/Unit/FluentPathHelpersTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Hyde\Testing\Framework\Unit;
+namespace Hyde\Framework\Testing\Unit;
 
 use Hyde\Framework\Hyde;
 use Hyde\Framework\Models\BladePage;

--- a/packages/framework/tests/Unit/GetLatestMarkdownPostsTest.php
+++ b/packages/framework/tests/Unit/GetLatestMarkdownPostsTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Hyde\Testing\Framework\Unit;
+namespace Hyde\Framework\Testing\Unit;
 
 use Hyde\Framework\Hyde;
 use Hyde\Framework\Models\MarkdownPost;

--- a/packages/framework/tests/Unit/HasAuthorTest.php
+++ b/packages/framework/tests/Unit/HasAuthorTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Hyde\Testing\Framework\Unit;
+namespace Hyde\Framework\Testing\Unit;
 
 use Hyde\Framework\Concerns\HasAuthor;
 use Hyde\Framework\Models\Author;

--- a/packages/framework/tests/Unit/HasDynamicTitleTest.php
+++ b/packages/framework/tests/Unit/HasDynamicTitleTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Hyde\Testing\Framework\Unit;
+namespace Hyde\Framework\Testing\Unit;
 
 use Hyde\Framework\Models\MarkdownDocument;
 use Hyde\Testing\TestCase;

--- a/packages/framework/tests/Unit/HasFeaturedImageTest.php
+++ b/packages/framework/tests/Unit/HasFeaturedImageTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Hyde\Testing\Framework\Unit;
+namespace Hyde\Framework\Testing\Unit;
 
 use Hyde\Framework\Concerns\HasFeaturedImage;
 use Hyde\Framework\Models\Image;

--- a/packages/framework/tests/Unit/HasMarkdownFeaturesTest.php
+++ b/packages/framework/tests/Unit/HasMarkdownFeaturesTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Hyde\Testing\Framework\Unit;
+namespace Hyde\Framework\Testing\Unit;
 
 use Hyde\Framework\Concerns\Markdown\HasMarkdownFeatures;
 use Hyde\Testing\TestCase;

--- a/packages/framework/tests/Unit/HasPageMetadataRssFeedLinkTest.php
+++ b/packages/framework/tests/Unit/HasPageMetadataRssFeedLinkTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Hyde\Testing\Framework\Unit;
+namespace Hyde\Framework\Testing\Unit;
 
 use Hyde\Framework\Models\BladePage;
 use Hyde\Framework\Models\DocumentationPage;

--- a/packages/framework/tests/Unit/HasTableOfContentsTest.php
+++ b/packages/framework/tests/Unit/HasTableOfContentsTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Hyde\Testing\Framework\Unit;
+namespace Hyde\Framework\Testing\Unit;
 
 use Hyde\Framework\Concerns\HasTableOfContents;
 use Hyde\Testing\TestCase;
@@ -10,7 +10,7 @@ use Hyde\Testing\TestCase;
  *
  * @covers \Hyde\Framework\Concerns\HasTableOfContents
  *
- * @see \Hyde\Testing\Framework\Feature\Actions\GeneratesTableOfContentsTest
+ * @see \Hyde\Framework\Testing\Feature\Actions\GeneratesTableOfContentsTest
  */
 class HasTableOfContentsTest extends TestCase
 {

--- a/packages/framework/tests/Unit/HydeBasePathCanBeChangedTest.php
+++ b/packages/framework/tests/Unit/HydeBasePathCanBeChangedTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Hyde\Testing\Framework\Unit;
+namespace Hyde\Framework\Testing\Unit;
 
 use Hyde\Framework\Hyde;
 use Hyde\Testing\TestCase;

--- a/packages/framework/tests/Unit/HydeGetBasePathHasFallbackTest.php
+++ b/packages/framework/tests/Unit/HydeGetBasePathHasFallbackTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Hyde\Testing\Framework\Unit;
+namespace Hyde\Framework\Testing\Unit;
 
 use Hyde\Framework\Hyde;
 use Hyde\Testing\TestCase;

--- a/packages/framework/tests/Unit/HydePathHelperTest.php
+++ b/packages/framework/tests/Unit/HydePathHelperTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Hyde\Testing\Framework\Unit;
+namespace Hyde\Framework\Testing\Unit;
 
 use Hyde\Framework\Hyde;
 use Hyde\Testing\TestCase;

--- a/packages/framework/tests/Unit/HydeSafeCopyHelperTest.php
+++ b/packages/framework/tests/Unit/HydeSafeCopyHelperTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Hyde\Testing\Framework\Unit;
+namespace Hyde\Framework\Testing\Unit;
 
 use Hyde\Framework\Hyde;
 use Hyde\Testing\TestCase;

--- a/packages/framework/tests/Unit/HydeServiceProviderTest.php
+++ b/packages/framework/tests/Unit/HydeServiceProviderTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Hyde\Testing\Framework\Unit;
+namespace Hyde\Framework\Testing\Unit;
 
 use Hyde\Framework\HydeServiceProvider;
 use Hyde\Testing\TestCase;

--- a/packages/framework/tests/Unit/HydeVendorPathHelperTest.php
+++ b/packages/framework/tests/Unit/HydeVendorPathHelperTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Hyde\Testing\Framework\Unit;
+namespace Hyde\Framework\Testing\Unit;
 
 use Hyde\Framework\Hyde;
 use Hyde\Testing\TestCase;

--- a/packages/framework/tests/Unit/InteractsWithDirectoriesConcernTest.php
+++ b/packages/framework/tests/Unit/InteractsWithDirectoriesConcernTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Hyde\Testing\Framework\Unit;
+namespace Hyde\Framework\Testing\Unit;
 
 use Hyde\Framework\Concerns\InteractsWithDirectories;
 use Hyde\Framework\Hyde;

--- a/packages/framework/tests/Unit/MarkdownConverterTest.php
+++ b/packages/framework/tests/Unit/MarkdownConverterTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Hyde\Testing\Framework\Unit;
+namespace Hyde\Framework\Testing\Unit;
 
 use Hyde\Framework\Actions\MarkdownConverter;
 use Hyde\Testing\TestCase;

--- a/packages/framework/tests/Unit/MarkdownPageModelConstructorArgumentsAreOptionalTest.php
+++ b/packages/framework/tests/Unit/MarkdownPageModelConstructorArgumentsAreOptionalTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Hyde\Testing\Framework\Unit;
+namespace Hyde\Framework\Testing\Unit;
 
 use Hyde\Framework\Models\DocumentationPage;
 use Hyde\Framework\Models\MarkdownPage;

--- a/packages/framework/tests/Unit/MarkdownPostHelpersTest.php
+++ b/packages/framework/tests/Unit/MarkdownPostHelpersTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Hyde\Testing\Framework\Unit;
+namespace Hyde\Framework\Testing\Unit;
 
 use Hyde\Framework\Models\MarkdownPost;
 use Hyde\Testing\TestCase;

--- a/packages/framework/tests/Unit/MarkdownPostParserTest.php
+++ b/packages/framework/tests/Unit/MarkdownPostParserTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Hyde\Testing\Framework\Unit;
+namespace Hyde\Framework\Testing\Unit;
 
 use Hyde\Framework\Hyde;
 use Hyde\Framework\Models\MarkdownPost;
@@ -8,7 +8,7 @@ use Hyde\Framework\Models\Parsers\MarkdownPostParser;
 use Hyde\Testing\TestCase;
 
 /**
- * @see \Hyde\Testing\Framework\Feature\Commands\StaticSiteBuilderPostModuleTest for the compiler test.
+ * @see \Hyde\Framework\Testing\Feature\Commands\StaticSiteBuilderPostModuleTest for the compiler test.
  */
 class MarkdownPostParserTest extends TestCase
 {

--- a/packages/framework/tests/Unit/PageModelGetAllFilesHelperTest.php
+++ b/packages/framework/tests/Unit/PageModelGetAllFilesHelperTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Hyde\Testing\Framework\Unit;
+namespace Hyde\Framework\Testing\Unit;
 
 use Hyde\Framework\Hyde;
 use Hyde\Framework\Models\BladePage;

--- a/packages/framework/tests/Unit/PageModelGetHelperTest.php
+++ b/packages/framework/tests/Unit/PageModelGetHelperTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Hyde\Testing\Framework\Unit;
+namespace Hyde\Framework\Testing\Unit;
 
 use Hyde\Framework\Hyde;
 use Hyde\Framework\Models\BladePage;

--- a/packages/framework/tests/Unit/PageModelParseHelperTest.php
+++ b/packages/framework/tests/Unit/PageModelParseHelperTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Hyde\Testing\Framework\Unit;
+namespace Hyde\Framework\Testing\Unit;
 
 use Hyde\Framework\Hyde;
 use Hyde\Framework\Models\BladePage;

--- a/packages/framework/tests/Unit/SourceFilesInCustomDirectoriesCanBeCompiledTest.php
+++ b/packages/framework/tests/Unit/SourceFilesInCustomDirectoriesCanBeCompiledTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Hyde\Testing\Framework\Unit;
+namespace Hyde\Framework\Testing\Unit;
 
 use Hyde\Framework\Hyde;
 use Hyde\Framework\Models\BladePage;

--- a/packages/framework/tests/Unit/TestBuildStaticSiteCommandFlagToEnablePrettyUrlsTest.php
+++ b/packages/framework/tests/Unit/TestBuildStaticSiteCommandFlagToEnablePrettyUrlsTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Hyde\Testing\Framework\Unit;
+namespace Hyde\Framework\Testing\Unit;
 
 use Hyde\Testing\TestCase;
 

--- a/packages/framework/tests/Unit/ValidatesExistenceTest.php
+++ b/packages/framework/tests/Unit/ValidatesExistenceTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Hyde\Testing\Framework\Unit;
+namespace Hyde\Framework\Testing\Unit;
 
 use Hyde\Framework\Concerns\ValidatesExistence;
 use Hyde\Framework\Exceptions\FileNotFoundException;

--- a/packages/framework/tests/Unit/Views/ArticleExcerptViewTest.php
+++ b/packages/framework/tests/Unit/Views/ArticleExcerptViewTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Hyde\Testing\Framework\Unit\Views;
+namespace Hyde\Framework\Testing\Unit\Views;
 
 use Hyde\Framework\Hyde;
 use Hyde\Framework\Models\MarkdownPost;


### PR DESCRIPTION
Changed namespace for Hyde/Framework tests from `Hyde\Testing\Framework` to `Hyde\Framework\Testing` to be more consistent and logical. 