### PR TITLE
Add easy to use post-build hooks #79

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,5 @@
 # If you have a domain, you should set the URL here so that permalinks can be generated.
-# SITE_URL=https://example.org
+SITE_URL=http://localhost
 
 # If you want to use Torchlight.dev, enter your API token here to automatically enable it
 # TORCHLIGHT_TOKEN=torch_

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,7 @@ This serves two purposes:
 2. At release time, you can move the Unreleased section changes into a new release version section.
 
 ### Added
-- [ ] Added back the AppServiceProvider
+- [x] Added back the AppServiceProvider
 
 ### Changed
 - for changes in existing functionality.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,7 +28,7 @@ This serves two purposes:
 - for changes in existing functionality.
 
 ### Deprecated
-- for soon-to-be removed features.
+- Deprecate the site_output_path option in the Hyde config file. Will be handled by the HydeServiceProvider.
 
 ### Removed
 - [ ] Removed the deprecated bootstrap directory

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,8 @@ This serves two purposes:
 
 ### Added
 - [x] Added back the AppServiceProvider
+- Added system for defining easy to use post-build hooks https://github.com/hydephp/develop/issues/79
+
 
 ### Changed
 - for changes in existing functionality.

--- a/config/hyde.php
+++ b/config/hyde.php
@@ -221,6 +221,9 @@ return [
     |
     */
 
+    /**
+     * @deprecated will be handled in the service provider
+     */
     'site_output_path' => Hyde\Framework\Hyde::path('_site'),
 
     /*

--- a/docs/advanced-customization.md
+++ b/docs/advanced-customization.md
@@ -1,0 +1,53 @@
+---
+label: "Advanced Customization"
+priority: 30
+category: "Digging Deeper"
+---
+
+# Advanced Customization
+
+## Introduction & Warning
+
+>danger Danger lies ahead! Read this before you proceed.
+
+This page covers advanced usage of potentially experimental and unstable features and is intended for developers
+who know what they are doing and can handle the risk of breaking things. The article will also cover things
+that you _can_ do, but that you maybe should not. With great power comes great responsibility. You have been warned.
+
+### Emoji legend
+Each section is marked with an emoji that indicates the level of risk. Note that pretty much all of these
+are experimental features, and are not at all supported. Use at your own risk.
+
+- 🧪 = Indicates experimental features bound to change at any time.
+- ⚠ = Exercise caution when using this feature.
+- 💔 = This could seriously break things
+
+## Customizing source directories 🧪
+
+>warning This may cause integrations such as the realtime compiler to break.
+
+The source directory paths are stored in the PageModel objects. 
+You can change them by modifying the static property, for example in a service provider.
+
+Internally, the paths are registered in the HydeServiceProvider using the following method:
+
+```php
+// filepath Hyde\Framework\HydeServiceProvider
+use Hyde\Framework\Concerns\RegistersDefaultDirectories;
+
+public function register(): void
+{
+    $this->registerDefaultDirectories([
+        BladePage::class => '_pages',
+        MarkdownPage::class => '_pages',
+        MarkdownPost::class => '_posts',
+        DocumentationPage::class => '_docs',
+    ]);
+}
+```
+
+## Customizing the output directory 💔
+
+>danger Hyde deletes all files in the output directory before compiling the site. Don't set this path to a directory that contains important files!
+
+_The internal workings of this process is being rewritten, and such the documentation is deferred until the implementation._

--- a/docs/advanced-customization.md
+++ b/docs/advanced-customization.md
@@ -14,6 +14,8 @@ This page covers advanced usage of potentially experimental and unstable feature
 who know what they are doing and can handle the risk of breaking things. The article will also cover things
 that you _can_ do, but that you maybe should not. With great power comes great responsibility. You have been warned.
 
+Documentation here will be mainly example driven, as it is assumed you have somewhat of an understanding of what you are doing already.
+
 ### Emoji legend
 Each section is marked with an emoji that indicates the level of risk. Note that pretty much all of these
 are experimental features, and are not at all supported. Use at your own risk.
@@ -51,3 +53,80 @@ public function register(): void
 >danger Hyde deletes all files in the output directory before compiling the site. Don't set this path to a directory that contains important files!
 
 _The internal workings of this process is being rewritten, and such the documentation is deferred until the implementation._
+
+
+## Adding custom post-build hooks 🧪
+>info This feature should not be in danger of breaking things. However, it was added very recently and the implementation may change at any moment. See <a href=" https://github.com/hydephp/develop/issues/79">this GitHub issue</a> for up to date information.
+
+Since v0.40.0 you can create custom post-build hooks. These hooks are code that is executed automatically after the site has been built using the `php hyde build` command.
+
+### Minimal example
+
+Here is a minimal example to get you started. For all these examples we assume you put the file in the `App/Actions` directory, but you can put them anywhere.
+
+```php
+class SimpleHook extends AbstractBuildTask
+{
+    public function run(): void
+    {
+        $this->info('Hello World!');
+    }
+}
+```
+
+This will then output the following, where you can see that some extra output, including execution time tracking is added for us. We can of course customize this if we want, as you can see in the next example.
+
+<pre>
+<small style="color: gray">$ php hyde build</small>
+  <span style="color: gold">Generic build task...</span> Hello World! <span style="color: gray">Done in 0.26ms</span>
+</pre>
+
+
+### Full example
+
+You can also set the description, and an optional `then()` method to run after the main hook has been executed.
+
+```php
+<?php
+
+namespace App\Actions;
+
+use Hyde\Framework\Contracts\AbstractBuildTask;
+
+class ExampleHook extends AbstractBuildTask
+{
+    public static string $description = 'Say hello';
+
+    public function run(): void
+    {
+        $this->info('Hello World!');
+    }
+
+    public function then(): void
+    {
+		$this->line('Goodbye World!');
+    }
+}
+```
+
+<pre>
+<small style="color: gray">$ php hyde build</small>
+  <span style="color: gold">Say hello...</span> <span style="color: green">Hello World!</span>
+  Goodbye World!
+</pre>
+
+
+### Registering the hooks
+
+An autoloading feature is planned, but for now, you will need to register the hooks somewhere. There is a convenient place to do this, which is in the main configuration file, `config/hyde.php`.
+
+```php
+// filepath config/hyde.php
+'post_build_tasks' => [
+    \App\Actions\SimpleHook::class,
+    \App\Actions\ExampleHook::class,
+],
+```
+
+If you are developing an extension, I recommend you do this in the `boot` method of a service provider so that it can be loaded automatically. Do this by adding the fully qualified class name to the `BuildHookService::$postBuildTasks` array.
+

--- a/packages/framework/src/Actions/PostBuildTasks/GenerateSitemap.php
+++ b/packages/framework/src/Actions/PostBuildTasks/GenerateSitemap.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Hyde\Framework\Actions\PostBuildTasks;
+
+use Hyde\Framework\Contracts\AbstractBuildTask;
+use Illuminate\Support\Facades\Artisan;
+
+class GenerateSitemap extends AbstractBuildTask
+{
+    public static string $description = 'Generating sitemap';
+
+    public function run(): void
+    {
+        Artisan::call('build:sitemap');
+    }
+
+    public function then(): void
+    {
+        $this->writeln("\n".' > Created <info>sitemap.xml</info> in '.$this->getExecutionTime());
+    }
+}

--- a/packages/framework/src/Contracts/AbstractBuildTask.php
+++ b/packages/framework/src/Contracts/AbstractBuildTask.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace Hyde\Framework\Contracts;
+
+use Illuminate\Console\Concerns\InteractsWithIO;
+use Illuminate\Console\OutputStyle;
+
+abstract class AbstractBuildTask implements BuildTaskContract
+{
+    use InteractsWithIO;
+
+    protected static string $description = 'Generic build task';
+
+    protected float $timeStart;
+
+    public function __construct(?OutputStyle $output = null)
+    {
+        $this->output = $output;
+        $this->timeStart = microtime(true);
+    }
+
+    public function handle(): void
+    {
+        $this->write('<comment>'.$this->getDescription().'...</comment> ');
+
+        $this->run();
+        $this->then();
+
+        $this->newLine();
+    }
+
+    abstract public function run(): void;
+
+    public function then(): void
+    {
+        $this->write('<info>Done.</info> '.$this->getExecutionTime());
+    }
+
+    public function getDescription(): string
+    {
+        return static::$description;
+    }
+
+    public function getExecutionTime(): string
+    {
+        return number_format((microtime(true) - $this->timeStart) * 1000, 2) . 'ms';
+    }
+
+    public function write(string $message): void
+    {
+        $this->output->write($message);
+    }
+
+    public function writeln(string $message): void
+    {
+        $this->output->writeln($message);
+    }
+}

--- a/packages/framework/src/Contracts/AbstractBuildTask.php
+++ b/packages/framework/src/Contracts/AbstractBuildTask.php
@@ -30,7 +30,7 @@ abstract class AbstractBuildTask implements BuildTaskContract
         $this->run();
         $this->then();
 
-        $this->newLine();
+        $this->write("\n");
     }
 
     abstract public function run(): void;
@@ -52,11 +52,11 @@ abstract class AbstractBuildTask implements BuildTaskContract
 
     public function write(string $message): void
     {
-        $this->output->write($message);
+        $this->output?->write($message);
     }
 
     public function writeln(string $message): void
     {
-        $this->output->writeln($message);
+        $this->output?->writeln($message);
     }
 }

--- a/packages/framework/src/Contracts/AbstractBuildTask.php
+++ b/packages/framework/src/Contracts/AbstractBuildTask.php
@@ -5,6 +5,10 @@ namespace Hyde\Framework\Contracts;
 use Illuminate\Console\Concerns\InteractsWithIO;
 use Illuminate\Console\OutputStyle;
 
+/**
+ * @experimental This feature was recently added and may be changed without notice.
+ * @since 0.40.0
+ */
 abstract class AbstractBuildTask implements BuildTaskContract
 {
     use InteractsWithIO;

--- a/packages/framework/src/Contracts/AbstractBuildTask.php
+++ b/packages/framework/src/Contracts/AbstractBuildTask.php
@@ -7,6 +7,7 @@ use Illuminate\Console\OutputStyle;
 
 /**
  * @experimental This feature was recently added and may be changed without notice.
+ *
  * @since 0.40.0
  */
 abstract class AbstractBuildTask implements BuildTaskContract
@@ -47,7 +48,7 @@ abstract class AbstractBuildTask implements BuildTaskContract
 
     public function getExecutionTime(): string
     {
-        return number_format((microtime(true) - $this->timeStart) * 1000, 2) . 'ms';
+        return number_format((microtime(true) - $this->timeStart) * 1000, 2).'ms';
     }
 
     public function write(string $message): void

--- a/packages/framework/src/Contracts/AbstractBuildTask.php
+++ b/packages/framework/src/Contracts/AbstractBuildTask.php
@@ -37,7 +37,7 @@ abstract class AbstractBuildTask implements BuildTaskContract
 
     public function then(): void
     {
-        $this->write('<info>Done.</info> '.$this->getExecutionTime());
+        $this->writeln('<fg=gray>Done in '.$this->getExecutionTime().'</>');
     }
 
     public function getDescription(): string

--- a/packages/framework/src/Contracts/BuildTaskContract.php
+++ b/packages/framework/src/Contracts/BuildTaskContract.php
@@ -4,6 +4,10 @@ namespace Hyde\Framework\Contracts;
 
 use Illuminate\Console\OutputStyle;
 
+/**
+ * @experimental This feature was recently added and may be changed without notice.
+ * @since 0.40.0
+ */
 interface BuildTaskContract
 {
     public function __construct(?OutputStyle $output = null);

--- a/packages/framework/src/Contracts/BuildTaskContract.php
+++ b/packages/framework/src/Contracts/BuildTaskContract.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Hyde\Framework\Contracts;
+
+use Illuminate\Console\OutputStyle;
+
+interface BuildTaskContract
+{
+    public function __construct(?OutputStyle $output = null);
+
+    public function run(): void;
+    public function then(): void;
+
+    public function handle(): void;
+    public function getDescription(): string;
+    public function getExecutionTime(): string;
+}

--- a/packages/framework/src/Contracts/BuildTaskContract.php
+++ b/packages/framework/src/Contracts/BuildTaskContract.php
@@ -6,6 +6,7 @@ use Illuminate\Console\OutputStyle;
 
 /**
  * @experimental This feature was recently added and may be changed without notice.
+ *
  * @since 0.40.0
  */
 interface BuildTaskContract
@@ -13,9 +14,12 @@ interface BuildTaskContract
     public function __construct(?OutputStyle $output = null);
 
     public function run(): void;
+
     public function then(): void;
 
     public function handle(): void;
+
     public function getDescription(): string;
+
     public function getExecutionTime(): string;
 }

--- a/packages/framework/src/Services/BuildHookService.php
+++ b/packages/framework/src/Services/BuildHookService.php
@@ -1,0 +1,65 @@
+<?php
+
+namespace Hyde\Framework\Services;
+
+use Hyde\Framework\Contracts\BuildTaskContract;
+use Illuminate\Console\OutputStyle;
+
+/**
+ * @see \Hyde\Framework\Testing\Feature\Services\BuildHookServiceTest
+ */
+class BuildHookService
+{
+    /**
+     * Offers a hook for packages to add custom build tasks.
+     */
+    public static array $postBuildTasks = [];
+
+    protected OutputStyle $output;
+
+    public function __construct(?OutputStyle $output = null)
+    {
+        $this->output = $output;
+    }
+
+    public function runPostBuildTasks(): void
+    {
+        foreach ($this->getPostBuildTasks() as $task) {
+            $this->run($task);
+        }
+    }
+
+    /**
+     * @todo Automatically discover files in the app directory?
+     */
+    public function getPostBuildTasks(): array
+    {
+        return array_merge(
+            config('hyde.post_build_tasks', []),
+            static::$postBuildTasks
+        );
+    }
+
+    public function run(string $task): self
+    {
+        $this->runTask(new $task($this->output));
+
+        return $this;
+    }
+
+    public function runIf(string $task, callable|bool $condition): self
+    {
+        if (is_bool($condition) ? $condition : $condition()) {
+            $this->run($task);
+        }
+
+        return $this;
+    }
+
+    protected function runTask(BuildTaskContract $task): self
+    {
+        $task->handle();
+
+        return $this;
+    }
+}

--- a/packages/framework/src/Services/BuildHookService.php
+++ b/packages/framework/src/Services/BuildHookService.php
@@ -34,9 +34,11 @@ class BuildHookService
      */
     public function getPostBuildTasks(): array
     {
-        return array_merge(
-            config('hyde.post_build_tasks', []),
-            static::$postBuildTasks
+        return array_unique(
+            array_merge(
+                config('hyde.post_build_tasks', []),
+                static::$postBuildTasks
+            )
         );
     }
 

--- a/packages/framework/src/Services/BuildHookService.php
+++ b/packages/framework/src/Services/BuildHookService.php
@@ -15,7 +15,7 @@ class BuildHookService
      */
     public static array $postBuildTasks = [];
 
-    protected OutputStyle $output;
+    protected ?OutputStyle $output;
 
     public function __construct(?OutputStyle $output = null)
     {

--- a/packages/framework/tests/Feature/Services/BuildHookServiceTest.php
+++ b/packages/framework/tests/Feature/Services/BuildHookServiceTest.php
@@ -7,6 +7,7 @@ use Hyde\Testing\TestCase;
 /**
  * @covers \Hyde\Framework\Services\BuildHookService
  * @covers \Hyde\Framework\Contracts\AbstractBuildTask
+ * @covers \Hyde\Framework\Actions\PostBuildTasks\GenerateSitemap
  */
 class BuildHookServiceTest extends TestCase
 {
@@ -15,6 +16,9 @@ class BuildHookServiceTest extends TestCase
      */
     public function test_build_command_can_run_post_build_tasks()
     {
-        $this->artisan('build')->assertExitCode(0);
+        $this->artisan('build')
+            ->expectsOutputToContain('Generating sitemap')
+            ->expectsOutputToContain('Created sitemap.xml')
+            ->assertExitCode(0);
     }
 }

--- a/packages/framework/tests/Feature/Services/BuildHookServiceTest.php
+++ b/packages/framework/tests/Feature/Services/BuildHookServiceTest.php
@@ -5,9 +5,6 @@ namespace Hyde\Framework\Testing\Feature\Services;
 use Hyde\Framework\Contracts\AbstractBuildTask;
 use Hyde\Framework\Services\BuildHookService;
 use Hyde\Testing\TestCase;
-use Illuminate\Console\OutputStyle;
-use Mockery;
-use Symfony\Component\Console\Input\ArrayInput;
 
 /**
  * @covers \Hyde\Framework\Services\BuildHookService

--- a/packages/framework/tests/Feature/Services/BuildHookServiceTest.php
+++ b/packages/framework/tests/Feature/Services/BuildHookServiceTest.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Hyde\Framework\Testing\Feature\Services;
+
+use Hyde\Testing\TestCase;
+
+/**
+ * @covers \Hyde\Framework\Services\BuildHookService
+ * @covers \Hyde\Framework\Contracts\AbstractBuildTask
+ */
+class BuildHookServiceTest extends TestCase
+{
+    /**
+     * @covers \Hyde\Framework\Commands\HydeBuildStaticSiteCommand::runPostBuildActions
+     */
+    public function test_build_command_can_run_post_build_tasks()
+    {
+        $this->artisan('build')->assertExitCode(0);
+    }
+}

--- a/packages/framework/tests/Feature/Services/BuildHookServiceTest.php
+++ b/packages/framework/tests/Feature/Services/BuildHookServiceTest.php
@@ -18,6 +18,8 @@ class BuildHookServiceTest extends TestCase
      */
     public function test_build_command_can_run_post_build_tasks()
     {
+        config(['hyde.site_url' => 'foo']);
+
         $this->artisan('build')
             ->expectsOutputToContain('Generating sitemap')
             ->expectsOutputToContain('Created sitemap.xml')

--- a/packages/framework/tests/Feature/Services/BuildHookServiceTest.php
+++ b/packages/framework/tests/Feature/Services/BuildHookServiceTest.php
@@ -2,7 +2,12 @@
 
 namespace Hyde\Framework\Testing\Feature\Services;
 
+use Hyde\Framework\Contracts\AbstractBuildTask;
+use Hyde\Framework\Services\BuildHookService;
 use Hyde\Testing\TestCase;
+use Illuminate\Console\OutputStyle;
+use Mockery;
+use Symfony\Component\Console\Input\ArrayInput;
 
 /**
  * @covers \Hyde\Framework\Services\BuildHookService
@@ -20,5 +25,152 @@ class BuildHookServiceTest extends TestCase
             ->expectsOutputToContain('Generating sitemap')
             ->expectsOutputToContain('Created sitemap.xml')
             ->assertExitCode(0);
+    }
+
+    /**
+     * @covers \Hyde\Framework\Services\BuildHookService::runPostBuildTasks
+     */
+    public function test_run_post_build_tasks_runs_configured_tasks_does_nothing_if_no_tasks_are_configured()
+    {
+        BuildHookService::$postBuildTasks = [];
+
+        $service = $this->makeService();
+        $service->runPostBuildTasks();
+
+        $this->expectOutputString('');
+    }
+
+    /**
+     * @covers \Hyde\Framework\Services\BuildHookService::getPostBuildTasks
+     */
+    public function test_get_post_build_tasks_returns_array_merged_with_config()
+    {
+        BuildHookService::$postBuildTasks = ['foo'];
+        config(['hyde.post_build_tasks' => ['bar']]);
+
+        $service = $this->makeService();
+        $this->assertEquals(['bar', 'foo'], $service->getPostBuildTasks());
+    }
+
+    /**
+     * @covers \Hyde\Framework\Services\BuildHookService::getPostBuildTasks
+     */
+    public function test_get_post_build_tasks_merges_duplicate_keys()
+    {
+        BuildHookService::$postBuildTasks = ['foo'];
+        config(['hyde.post_build_tasks' => ['foo']]);
+
+        $service = $this->makeService();
+        $this->assertEquals(['foo'], $service->getPostBuildTasks());
+    }
+
+    /**
+     * @covers \Hyde\Framework\Services\BuildHookService::runPostBuildTasks
+     */
+    public function test_run_post_build_tasks_runs_configured_tasks()
+    {
+        $task = $this->makeTask();
+
+        BuildHookService::$postBuildTasks = [get_class($task)];
+
+        $service = $this->makeService();
+        $service->runPostBuildTasks();
+
+        $this->expectOutputString('AbstractBuildTask');
+    }
+
+    /**
+     * @covers \Hyde\Framework\Services\BuildHookService::run
+     */
+    public function test_run_method_runs_task_by_class_name_input_and_returns_self()
+    {
+        $task = $this->makeTask();
+
+        $service = $this->makeService();
+        $return = $service->run(get_class($task));
+
+        $this->expectOutputString('AbstractBuildTask');
+
+        $this->assertSame($service, $return);
+    }
+
+    /**
+     * @covers \Hyde\Framework\Services\BuildHookService::runIf
+     */
+    public function test_run_if_runs_task_if_supplied_boolean_is_true()
+    {
+        $task = $this->makeTask();
+
+        $service = $this->makeService();
+        $return = $service->runIf(get_class($task), true);
+
+        $this->expectOutputString('AbstractBuildTask');
+
+        $this->assertSame($service, $return);
+    }
+
+    /**
+     * @covers \Hyde\Framework\Services\BuildHookService::runIf
+     */
+    public function test_run_if_does_not_run_task_if_supplied_boolean_is_false()
+    {
+        $task = $this->makeTask();
+
+        $service = $this->makeService();
+        $return = $service->runIf(get_class($task), false);
+
+        $this->expectOutputString('');
+
+        $this->assertSame($service, $return);
+    }
+
+    /**
+     * @covers \Hyde\Framework\Services\BuildHookService::runIf
+     */
+    public function test_run_if_runs_task_if_supplied_callable_returns_true()
+    {
+        $task = $this->makeTask();
+
+        $service = $this->makeService();
+        $return = $service->runIf(get_class($task), function () {
+            return true;
+        });
+
+        $this->expectOutputString('AbstractBuildTask');
+
+        $this->assertSame($service, $return);
+    }
+
+    /**
+     * @covers \Hyde\Framework\Services\BuildHookService::runIf
+     */
+    public function test_run_if_does_not_run_task_if_supplied_callable_returns_false()
+    {
+        $task = $this->makeTask();
+
+        $service = $this->makeService();
+        $return = $service->runIf(get_class($task), function () {
+            return false;
+        });
+
+        $this->expectOutputString('');
+
+        $this->assertSame($service, $return);
+    }
+
+    protected function makeService(): BuildHookService
+    {
+        return new BuildHookService();
+    }
+
+    protected function makeTask(): AbstractBuildTask
+    {
+        return new class extends AbstractBuildTask
+        {
+            public function run(): void
+            {
+                echo 'AbstractBuildTask';
+            }
+        };
     }
 }


### PR DESCRIPTION


## Adding custom post-build hooks 🧪
>info This feature should not be in danger of breaking things. However, it was added very recently and the implementation may change at any moment. See <a href=" https://github.com/hydephp/develop/issues/79">this GitHub issue</a> for up to date information.

Since v0.40.0 you can create custom post-build hooks. These hooks are code that is executed automatically after the site has been built using the `php hyde build` command.

### Minimal example

Here is a minimal example to get you started. For all these examples we assume you put the file in the `App/Actions` directory, but you can put them anywhere.

```php
class SimpleHook extends AbstractBuildTask
{
    public function run(): void
    {
        $this->info('Hello World!');
    }
}
```

This will then output the following, where you can see that some extra output, including execution time tracking is added for us. We can of course customize this if we want, as you can see in the next example.

<pre>
<small style="color: gray">$ php hyde build</small>
  <span style="color: gold">Generic build task...</span> Hello World! <span style="color: gray">Done in 0.26ms</span>
</pre>


### Full example

You can also set the description, and an optional `then()` method to run after the main hook has been executed.

```php
<?php

namespace App\Actions;

use Hyde\Framework\Contracts\AbstractBuildTask;

class ExampleHook extends AbstractBuildTask
{
    public static string $description = 'Say hello';

    public function run(): void
    {
        $this->info('Hello World!');
    }

    public function then(): void
    {
	$this->line('Goodbye World!');
    }
}
```

<pre>
<small style="color: gray">$ php hyde build</small>
  <span style="color: gold">Say hello...</span> <span style="color: green">Hello World!</span>
  Goodbye World!
</pre>


### Registering the hooks

An autoloading feature is planned, but for now, you will need to register the hooks somewhere. There is a convenient place to do this, which is in the main configuration file, `config/hyde.php`.

```php
// filepath config/hyde.php
'post_build_tasks' => [
    \App\Actions\SimpleHook::class,
    \App\Actions\ExampleHook::class,
],
```

If you are developing an extension, I recommend you do this in the `boot` method of a service provider so that it can be loaded automatically. Do this by adding the fully qualified class name to the `BuildHookService::$postBuildTasks` array.

