### PR TITLE
Add option to exclude documentation pages from search indexing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,10 +24,11 @@ This serves two purposes:
 ### Added
 - Added back the AppServiceProvider
 - Added system for defining easy to use post-build hooks https://github.com/hydephp/develop/issues/79
+- Added configuration option to exclude documentation pages from showing up in the JSON search index
 
 
 ### Changed
-- for changes in existing functionality.
+- Changelog files in the documentation source directory are now ignored by the JSON search index by default
 
 ### Deprecated
 - Deprecate the site_output_path option in the Hyde config file. Will be handled by the HydeServiceProvider.

--- a/config/docs.php
+++ b/config/docs.php
@@ -102,4 +102,24 @@ return [
         'min_heading_level' => 2,
         'max_heading_level' => 4,
     ],
+
+
+    /*
+    |--------------------------------------------------------------------------
+    | Search Customization
+    |--------------------------------------------------------------------------
+    |
+    | Hyde comes with an easy to use search feature for documentation pages.
+    | @see https://hydephp.com/docs/master/documentation-pages#search-feature
+    | 
+    */
+
+    // Should a docs/search.html page be generated?
+    'create_search_page' => true,
+
+    // Are there any pages you don't want to show in the search results?
+    'exclude_from_search' => [
+        'changelog',
+    ]
+
 ];

--- a/config/docs.php
+++ b/config/docs.php
@@ -103,7 +103,6 @@ return [
         'max_heading_level' => 4,
     ],
 
-
     /*
     |--------------------------------------------------------------------------
     | Search Customization
@@ -111,7 +110,7 @@ return [
     |
     | Hyde comes with an easy to use search feature for documentation pages.
     | @see https://hydephp.com/docs/master/documentation-pages#search-feature
-    | 
+    |
     */
 
     // Should a docs/search.html page be generated?
@@ -120,6 +119,6 @@ return [
     // Are there any pages you don't want to show in the search results?
     'exclude_from_search' => [
         'changelog',
-    ]
+    ],
 
 ];

--- a/docs/documentation-pages.md
+++ b/docs/documentation-pages.md
@@ -222,10 +222,14 @@ You can also disable the feature completely.
 
 ### Search feature
 
+#### Introduction
+
 The HydeSearch plugin was introduced in v0.29.0-beta and adds a search feature to documentation pages.
 
 The search feature is enabled by default.
 You can disable it by removing the `documentationSearch` from the Hyde `Features` config array.
+
+#### Using the search
 
 The search works by generating a JSON search index which the JavaScript plugin loads asynchronously.
 
@@ -235,6 +239,23 @@ Two types of search methods are added, one is a full page search screen that wil
 The second method is a button added to the documentation pages, similar to how Algolia DocSearch works.
 Opening it will open a dialog modal with an integrated search screen.
 You can also open the dialog using the keyboard shortcut `/`.
+
+#### Hiding pages from indexing
+
+> This feature was added in v0.40.0-beta.
+
+If you have a large page, like a changelog, on your documentation sites you may want to hide it from the search index. You can do this by adding the page slug to the `exclude_from_search` array in the `docs` config, similar to how navigation menu items are hidden.
+
+```php
+// filepath: config/docs.php
+
+'exclude_from_search' => [
+  'changelog',
+]
+```
+
+The page will still be accessible via the URL, but will be added to the search index JSON file. Don't include the file extension.
+
 
 ### Automatic "Edit Page" button
 

--- a/packages/framework/config/docs.php
+++ b/packages/framework/config/docs.php
@@ -102,4 +102,24 @@ return [
         'min_heading_level' => 2,
         'max_heading_level' => 4,
     ],
+
+
+    /*
+    |--------------------------------------------------------------------------
+    | Search Customization
+    |--------------------------------------------------------------------------
+    |
+    | Hyde comes with an easy to use search feature for documentation pages.
+    | @see https://hydephp.com/docs/master/documentation-pages#search-feature
+    | 
+    */
+
+    // Should a docs/search.html page be generated?
+    'create_search_page' => true,
+
+    // Are there any pages you don't want to show in the search results?
+    'exclude_from_search' => [
+        'changelog',
+    ]
+
 ];

--- a/packages/framework/config/docs.php
+++ b/packages/framework/config/docs.php
@@ -103,7 +103,6 @@ return [
         'max_heading_level' => 4,
     ],
 
-
     /*
     |--------------------------------------------------------------------------
     | Search Customization
@@ -111,7 +110,7 @@ return [
     |
     | Hyde comes with an easy to use search feature for documentation pages.
     | @see https://hydephp.com/docs/master/documentation-pages#search-feature
-    | 
+    |
     */
 
     // Should a docs/search.html page be generated?
@@ -120,6 +119,6 @@ return [
     // Are there any pages you don't want to show in the search results?
     'exclude_from_search' => [
         'changelog',
-    ]
+    ],
 
 ];

--- a/packages/framework/src/Actions/GeneratesDocumentationSearchIndexFile.php
+++ b/packages/framework/src/Actions/GeneratesDocumentationSearchIndexFile.php
@@ -70,7 +70,10 @@ class GeneratesDocumentationSearchIndexFile implements ActionContract
 
     public function getSourceFileSlugs(): array
     {
-        return CollectionService::getDocumentationPageList();
+        return array_diff(
+            CollectionService::getDocumentationPageList(),
+            config('docs.exclude_from_search', [])
+        );
     }
 
     public function getObject(): object

--- a/packages/framework/tests/Feature/Actions/GeneratesDocumentationSearchIndexFileTest.php
+++ b/packages/framework/tests/Feature/Actions/GeneratesDocumentationSearchIndexFileTest.php
@@ -150,4 +150,15 @@ class GeneratesDocumentationSearchIndexFileTest extends TestCase
             'foo', (new Action())->getDestinationForSlug('foo')
         );
     }
+
+    public function test_excluded_pages_are_not_present_in_the_search_index()
+    {
+        touch(Hyde::path('_docs/excluded.md'));
+        config(['docs.exclude_from_search' => ['excluded']]);
+
+        $this->assertNotContains('excluded', (new Action())->getSourceFileSlugs());
+        $this->assertStringNotContainsString('excluded', (new Action())->generate()->getJson());
+
+        unlink(Hyde::path('_docs/excluded.md'));
+    }
 }


### PR DESCRIPTION
### Fixes
Fixes https://github.com/hydephp/develop/issues/78

### Added
- Added configuration option to exclude documentation pages from showing up in the JSON search index

### Changed
- Changelog files in the documentation source directory are now ignored by the JSON search index by default


### Documentation


If you have a large page, like a changelog, on your documentation sites you may want to hide it from the search index. You can do this by adding the page slug to the `exclude_from_search` array in the `docs` config, similar to how navigation menu items are hidden.

```php
// filepath: config/docs.php
'exclude_from_search' => [
  'changelog',
]
```

The page will still be accessible via the URL, but will be added to the search index JSON file. Don't include the file extension.
