### PR TITLE
Fix missing AppServiceProvider

### DIFF
--- a/app/Monorepo/Commands/MonorepoMakeReleaseCommand.php
+++ b/app/Monorepo/Commands/MonorepoMakeReleaseCommand.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace App\Commands;
+namespace App\Monorepo\Commands;
 
 use Illuminate\Support\Facades\Http;
 use LaravelZero\Framework\Commands\Command;

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace App\Providers;
+
+use Illuminate\Support\ServiceProvider;
+
+class AppServiceProvider extends ServiceProvider
+{
+    /**
+     * Register any application services.
+     *
+     * @return void
+     */
+    public function register()
+    {
+        //
+    }
+
+    /**
+     * Bootstrap any application services.
+     *
+     * @return void
+     */
+    public function boot()
+    {
+        //
+    }
+}


### PR DESCRIPTION
Somehow, somewhere, the AppServiceProvider that was supposed to be restored got lost during the way. While I look into how this happened, I'm yanking the affected Hyde/Hyde release and pushing a beta patch release.