### PR TITLE
Fix bug #94: Hyde::docsIndexPath() checks the hard-coded source directory 

### DIFF
--- a/packages/framework/src/Concerns/Internal/FileHelpers.php
+++ b/packages/framework/src/Concerns/Internal/FileHelpers.php
@@ -2,6 +2,8 @@
 
 namespace Hyde\Framework\Concerns\Internal;
 
+use Hyde\Framework\Models\DocumentationPage;
+
 /**
  * Offloads file helper methods for the Hyde Facade.
  *
@@ -31,11 +33,11 @@ trait FileHelpers
      */
     public static function docsIndexPath(): string|false
     {
-        if (file_exists(static::path('_docs/index.md'))) {
+        if (file_exists(static::path(DocumentationPage::$sourceDirectory.'/index.md'))) {
             return trim(static::pageLink(static::getDocumentationOutputDirectory().'/index.html'), '/');
         }
 
-        if (file_exists(static::path('_docs/readme.md'))) {
+        if (file_exists(static::path(DocumentationPage::$sourceDirectory.'/readme.md'))) {
             return trim(static::pageLink(static::getDocumentationOutputDirectory().'/readme.html'), '/');
         }
 

--- a/packages/framework/tests/Feature/HydeDocsIndexPathTest.php
+++ b/packages/framework/tests/Feature/HydeDocsIndexPathTest.php
@@ -3,6 +3,7 @@
 namespace Hyde\Framework\Testing\Feature;
 
 use Hyde\Framework\Hyde;
+use Hyde\Framework\Models\DocumentationPage;
 use Hyde\Testing\TestCase;
 
 class HydeDocsIndexPathTest extends TestCase
@@ -43,6 +44,18 @@ class HydeDocsIndexPathTest extends TestCase
     {
         $this->setIndex();
         $this->assertEquals('docs/index.html', Hyde::docsIndexPath());
+    }
+
+    public function test_helper_can_find_index_path_when_custom_docs_directory_is_used()
+    {
+        mkdir(Hyde::path('foo'));
+        file_put_contents(Hyde::path('foo/index.md'), '');
+
+        DocumentationPage::$sourceDirectory = 'foo';
+        $this->assertEquals('docs/index.html', Hyde::docsIndexPath());
+
+        unlink(Hyde::path('foo/index.md'));
+        rmdir(Hyde::path('foo'));
     }
 
     private function setReadme()


### PR DESCRIPTION
Uses the model class property, and adds a test to make sure it works.