### PR TITLE
Add configuration option to allow more file types in the  media directory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,7 @@ This serves two purposes:
 2. At release time, you can move the Unreleased section changes into a new release version section.
 
 ### Added
-- for new features.
+- Added configuration option `hyde.media_extensions` to allow you to specify additional comma separated media file types. https://github.com/hydephp/develop/issues/39;
 
 ### Changed
 - for changes in existing functionality.

--- a/docs/architecture-concepts.md
+++ b/docs/architecture-concepts.md
@@ -58,7 +58,7 @@ and the file extensions supported by each. Files starting with an `_underscore` 
 
 <small>
 <blockquote>
-Media file types supported: `.png`, `.svg`, `.jpg`, `.jpeg`, `.gif`, `.ico`, `.css`, `.js`
+Default media file types supported: `.png`, `.svg`, `.jpg`, `.jpeg`, `.gif`, `.ico`, `.css`, `.js`. Can be changed using the `hyde.media_extensions` config setting.
 </blockquote>
 </small>
 

--- a/packages/framework/src/Services/CollectionService.php
+++ b/packages/framework/src/Services/CollectionService.php
@@ -122,6 +122,9 @@ class CollectionService
      */
     public static function getMediaAssetFiles(): array
     {
-        return glob(Hyde::path('_media/*.{png,svg,jpg,jpeg,gif,ico,css,js}'), GLOB_BRACE);
+        return glob(Hyde::path('_media/*.{'.str_replace(' ', '',
+            config('hyde.media_extensions', 'png,svg,jpg,jpeg,gif,ico,css,js')
+            ).'}'), GLOB_BRACE
+        );
     }
 }

--- a/packages/framework/tests/Feature/Services/CollectionServiceTest.php
+++ b/packages/framework/tests/Feature/Services/CollectionServiceTest.php
@@ -48,7 +48,7 @@ class CollectionServiceTest extends TestCase
             'js',
         ];
         foreach ($testFiles as $fileType) {
-            $path = Hyde::path('_media/test.' . $fileType);
+            $path = Hyde::path('_media/test.'.$fileType);
             touch($path);
             $this->assertContains($path, CollectionService::getMediaAssetFiles());
             unlink($path);

--- a/packages/framework/tests/Feature/Services/CollectionServiceTest.php
+++ b/packages/framework/tests/Feature/Services/CollectionServiceTest.php
@@ -35,6 +35,36 @@ class CollectionServiceTest extends TestCase
         $this->assertTrue(is_array(CollectionService::getMediaAssetFiles()));
     }
 
+    public function test_get_media_asset_files_discovers_files()
+    {
+        $testFiles = [
+            'png',
+            'svg',
+            'jpg',
+            'jpeg',
+            'gif',
+            'ico',
+            'css',
+            'js',
+        ];
+        foreach ($testFiles as $fileType) {
+            $path = Hyde::path('_media/test.' . $fileType);
+            touch($path);
+            $this->assertContains($path, CollectionService::getMediaAssetFiles());
+            unlink($path);
+        }
+    }
+
+    public function test_get_media_asset_files_discovers_custom_file_types()
+    {
+        $path = Hyde::path('_media/test.custom');
+        touch($path);
+        $this->assertNotContains($path, CollectionService::getMediaAssetFiles());
+        config(['hyde.media_extensions' => 'custom']);
+        $this->assertContains($path, CollectionService::getMediaAssetFiles());
+        unlink($path);
+    }
+
     public function test_files_starting_with_underscore_are_ignored()
     {
         touch(Hyde::path('_posts/_foo.md'));
@@ -52,12 +82,5 @@ class CollectionServiceTest extends TestCase
         $this->assertContains($expected, CollectionService::getSourceFileListForModel($model));
 
         unlink(Hyde::path($path));
-    }
-
-    public function tearDown(): void
-    {
-        // restoreDirectory(Hyde::path('_docs'));
-
-        parent::tearDown();
     }
 }


### PR DESCRIPTION
Added configuration option `hyde.media_extensions` to allow you to specify additional comma separated media file types. Fixes https://github.com/hydephp/develop/issues/39;

```php
config('hyde.media_extensions', 'png,svg,jpg,jpeg,gif,ico,css,js'))
```
