### PR TITLE
Add a safer output directory config option to replace deprecated setting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ This serves two purposes:
 
 ### Added
 - Added configuration option `hyde.media_extensions` to allow you to specify additional comma separated media file types. https://github.com/hydephp/develop/issues/39;
+- Adds a safer config option `hyde.output_directory` for customizing the output directory.
 
 ### Changed
 - for changes in existing functionality.

--- a/config/hyde.php
+++ b/config/hyde.php
@@ -214,8 +214,8 @@ return [
     |--------------------------------------------------------------------------
     |
     | This setting specifies the output path for your site, useful to for
-    | example, store the site in the docs/ directory for GitHub Pages. 
-    | The path is relative to the root of your project. 
+    | example, store the site in the docs/ directory for GitHub Pages.
+    | The path is relative to the root of your project.
     |
     | To use an absolute path, or just to learn more:
     | @see https://hydephp.com/docs/master/advanced-customization#customizing-the-output-directory-
@@ -223,7 +223,6 @@ return [
     */
 
     'output_directory' => '_site',
-
 
     /**
      * @deprecated use the 'output_directory' setting instead

--- a/config/hyde.php
+++ b/config/hyde.php
@@ -213,18 +213,20 @@ return [
     | Site Output Directory (Experimental 🧪)
     |--------------------------------------------------------------------------
     |
-    | This setting specifies the output path for your site, and is useful if you,
-    | for example, want to store the site in the docs/ directory for GitHub Pages. 
-    | You should use the Hyde::path() helper to ensure the path is relative to your project.
+    | This setting specifies the output path for your site, useful to for
+    | example, store the site in the docs/ directory for GitHub Pages. 
+    | The path is relative to the root of your project. 
     |
-    | ⚠ Warning: This directory will be emptied when rebuilding the site!
-    | You should read the documentation before changing this setting.
+    | To use an absolute path, or just to learn more:
     | @see https://hydephp.com/docs/master/advanced-customization#customizing-the-output-directory-
     | 
     */
 
+    'output_directory' => '_site',
+
+
     /**
-     * @deprecated will be handled in the service provider
+     * @deprecated use the 'output_directory' setting instead
      */
     'site_output_path' => Hyde\Framework\Hyde::path('_site'),
 

--- a/docs/advanced-customization.md
+++ b/docs/advanced-customization.md
@@ -48,24 +48,27 @@ public function register(): void
 }
 ```
 
-## Customizing the output directory 💔
+## Customizing the output directory ⚠
 
 >danger Hyde deletes all files in the output directory before compiling the site. Don't set this path to a directory that contains important files!
 
 If you want to store your compiled website in a different directory than
-the default `_pages`, you can change the path using the following configuration option in config/hyde.php:
+the default `_pages`, you can change the path using the following configuration option in config/hyde.php. The path is expected to be relative to your project root.
 
 ```php
 // filepath config/hyde.php
 return [
-    'site_output_path' => Hyde\Framework\Hyde::path('_site'),
+    'output_directory' => 'docs',
 ];
 ```
 
-The Hyde::path() helper ensures the path is relative to your Hyde project.
-While you can set the path to an absolute path outside the project,
-this is not officially supported and may be unstable and may cause unintentional files and directories to be deleted.
+### Setting an absolute path 💔
+If you want to store the output website outside your project with an absolute path you may do so at your own risk using a service provider. This is not supported or reccomended as it may cause unintentional file deletions.
 
+```php
+// filepath Boot method of a service provider
+StaticPageBuilder::$outputPath = '/var/www/my-project/';
+```
 
 ## Adding custom post-build hooks 🧪
 >info This feature should not be in danger of breaking things. However, it was added very recently and the implementation may change at any moment. See <a href=" https://github.com/hydephp/develop/issues/79">this GitHub issue</a> for up to date information.

--- a/packages/framework/config/hyde.php
+++ b/packages/framework/config/hyde.php
@@ -213,16 +213,20 @@ return [
     | Site Output Directory (Experimental 🧪)
     |--------------------------------------------------------------------------
     |
-    | If you want to store your compiled website in a different directory than
-    | the default `_pages`, you can change the path here. The Hyde::path()
-    | helper ensures the path is relative to your Hyde project. While
-    | you can set the path to an absolute path outside the project,
-    | this is not officially supported and may be unstable.
+    | This setting specifies the output path for your site, useful to for
+    | example, store the site in the docs/ directory for GitHub Pages. 
+    | The path is relative to the root of your project. 
+    |
+    | To use an absolute path, or just to learn more:
+    | @see https://hydephp.com/docs/master/advanced-customization#customizing-the-output-directory-
     |
     */
 
+    'output_directory' => '_site',
+
+
     /**
-     * @deprecated will be handled in the service provider
+     * @deprecated use the 'output_directory' setting instead
      */
     'site_output_path' => Hyde\Framework\Hyde::path('_site'),
 

--- a/packages/framework/config/hyde.php
+++ b/packages/framework/config/hyde.php
@@ -214,8 +214,8 @@ return [
     |--------------------------------------------------------------------------
     |
     | This setting specifies the output path for your site, useful to for
-    | example, store the site in the docs/ directory for GitHub Pages. 
-    | The path is relative to the root of your project. 
+    | example, store the site in the docs/ directory for GitHub Pages.
+    | The path is relative to the root of your project.
     |
     | To use an absolute path, or just to learn more:
     | @see https://hydephp.com/docs/master/advanced-customization#customizing-the-output-directory-
@@ -223,7 +223,6 @@ return [
     */
 
     'output_directory' => '_site',
-
 
     /**
      * @deprecated use the 'output_directory' setting instead

--- a/packages/framework/src/HydeServiceProvider.php
+++ b/packages/framework/src/HydeServiceProvider.php
@@ -57,11 +57,20 @@ class HydeServiceProvider extends ServiceProvider
 
         $this->discoverBladeViewsIn('_pages');
 
-        $this->storeCompiledSiteIn(config(
-            'hyde.site_output_path',
-            Hyde::path('_site')
-        ));
-
+        
+        /** @deprecated v0.43.0-beta and is used here as a fallback for compatibility */
+        if (config('hyde.output_directory') === null) {
+            $this->storeCompiledSiteIn(config(
+                'hyde.site_output_path',
+                Hyde::path('_site')
+            ));
+        } else {
+            // Newer version which is safer.
+            $this->storeCompiledSiteIn(Hyde::path(config(
+                trim('hyde.output_directory', '_site'), '/\\')
+            ));
+        }
+        
         $this->commands([
             Commands\HydePublishHomepageCommand::class,
             Commands\HydeUpdateConfigsCommand::class,

--- a/packages/framework/src/HydeServiceProvider.php
+++ b/packages/framework/src/HydeServiceProvider.php
@@ -57,7 +57,6 @@ class HydeServiceProvider extends ServiceProvider
 
         $this->discoverBladeViewsIn('_pages');
 
-        
         /** @deprecated v0.43.0-beta and is used here as a fallback for compatibility */
         if (config('hyde.output_directory') === null) {
             $this->storeCompiledSiteIn(config(
@@ -70,7 +69,7 @@ class HydeServiceProvider extends ServiceProvider
                 trim('hyde.output_directory', '_site'), '/\\')
             ));
         }
-        
+
         $this->commands([
             Commands\HydePublishHomepageCommand::class,
             Commands\HydeUpdateConfigsCommand::class,


### PR DESCRIPTION
## About
The `hyde.site_output_path` option was recently deprecated. This update adds an alternative which resolves the relative path within the service provider. This makes it safer to set the output directory to something within the project. If one wants to use an absolute path outside the project that must be done in a service provider, which has now been documented.


> **Warning**
> Hyde deletes all files in the output directory before compiling the site. Don't set this path to a directory that contains important files!

If you want to store your compiled website in a different directory than the default `_pages`, you can change the path using the following configuration option in config/hyde.php. The path is expected to be relative to your project root.

```php
// filepath config/hyde.php
return [
    'output_directory' => 'docs',
];
```

### Setting an absolute path 
If you want to store the output website outside your project with an absolute path you may do so at your own risk using a service provider. This is not supported or recommended as it may cause unintentional file deletions.

```php
// filepath Boot method of a service provider
StaticPageBuilder::$outputPath = '/var/www/my-project/';
```