### PR TITLE
HydeRC: Fix bug causing out of memory failures in exception handler

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,7 +35,7 @@ This serves two purposes:
 - Removed the `--pretty` build command option which was deprecated in v0.25.x
 
 ### Fixed
-- for any bug fixes.
+- HydeRC: Fixes a bug in the auxiliary exception handler leading to unintentional recursion causing out of memory errors in both the browser and the PHP server.
 
 ### Security
 - in case of vulnerabilities.

--- a/packages/realtime-compiler/bin/server.php
+++ b/packages/realtime-compiler/bin/server.php
@@ -11,7 +11,7 @@ try {
         $app->handle() // Process the request and create the response
             ->send(); // Send the response to the client
     } catch (Throwable $exception) {
-        \Hyde\RealtimeCompiler\Http\ExceptionHandler::handle($exception);
+        \Hyde\RealtimeCompiler\Http\ExceptionHandler::handle($exception)->send();
         exit($exception->getCode());
     }
 } catch (\Throwable $th) {

--- a/packages/realtime-compiler/src/Http/ExceptionHandler.php
+++ b/packages/realtime-compiler/src/Http/ExceptionHandler.php
@@ -24,6 +24,6 @@ class ExceptionHandler
             'Content-Type'   => 'text/html',
             'Content-Length' => strlen($html),
             'body'           => $html,
-        ])->send();
+        ]);
     }
 }


### PR DESCRIPTION
Fixes a bug in the auxiliary exception handler leading to unintentional recursion causing out of memory errors in both the browser and the PHP server.