### PR TITLE
Create static file collections

### DIFF
--- a/packages/framework/src/HydeServiceProvider.php
+++ b/packages/framework/src/HydeServiceProvider.php
@@ -88,6 +88,8 @@ class HydeServiceProvider extends ServiceProvider
 
             Commands\HydePackageDiscoverCommand::class,
         ]);
+
+        $this->registerModuleServiceProviders();
     }
 
     /**
@@ -135,5 +137,13 @@ class HydeServiceProvider extends ServiceProvider
     protected function storeCompiledSiteIn(string $directory): void
     {
         StaticPageBuilder::$outputPath = $directory;
+    }
+
+    /**
+     * Register module service providers.
+     */
+    protected function registerModuleServiceProviders(): void
+    {
+        $this->app->register(Modules\DataCollections\DataCollectionServiceProvider::class);
     }
 }

--- a/packages/framework/src/HydeServiceProvider.php
+++ b/packages/framework/src/HydeServiceProvider.php
@@ -141,6 +141,8 @@ class HydeServiceProvider extends ServiceProvider
 
     /**
      * Register module service providers.
+     *
+     * @todo Make modules configurable.
      */
     protected function registerModuleServiceProviders(): void
     {

--- a/packages/framework/src/Modules/DataCollections/DataCollection.php
+++ b/packages/framework/src/Modules/DataCollections/DataCollection.php
@@ -12,6 +12,8 @@ use Illuminate\Support\Collection as BaseCollection;
  */
 class DataCollection
 {
+    public static string $dataPath = '_data';
+
     /**
      * Get a collection of Markdown documents in the _data/<$key> directory.
      * Each Markdown file will be parsed into a MarkdownDocument with front matter.
@@ -22,7 +24,7 @@ class DataCollection
         $collection = new BaseCollection();
         $collection->key = $key;
         $collection->name = Hyde::titleFromSlug($key);
-        foreach (glob(Hyde::path('_data/' . $key . '/*.md')) as $file) {
+        foreach (glob(Hyde::path(static::$dataPath . '/' . $key . '/*.md')) as $file) {
             $collection->push(
                 (new MarkdownFileService($file))->get()
             );

--- a/packages/framework/src/Modules/DataCollections/DataCollection.php
+++ b/packages/framework/src/Modules/DataCollections/DataCollection.php
@@ -54,9 +54,11 @@ class DataCollection extends Collection
     {
         $collection = new DataCollection($key);
         foreach ($collection->getMarkdownFiles() as $file) {
-            $collection->push(
-                (new MarkdownFileService($file))->get()
-            );
+            if (! str_starts_with(basename($file), '_')) {
+                $collection->push(
+                    (new MarkdownFileService($file))->get()
+                );
+            }
         }
 
         return $collection->getCollection();

--- a/packages/framework/src/Modules/DataCollections/DataCollection.php
+++ b/packages/framework/src/Modules/DataCollections/DataCollection.php
@@ -2,11 +2,29 @@
 
 namespace Hyde\Framework\Modules\DataCollections;
 
+use Hyde\Framework\Hyde;
+use Hyde\Framework\Services\MarkdownFileService;
+use Illuminate\Support\Collection as BaseCollection;
+
 /**
  * Provides a facade for generating on-the-fly Laravel Collections
  * from static data files such as Markdown components and YAML files.
  */
 class DataCollection
 {
-    //
+    /**
+     * Get a collection of Markdown documents in the _data/<$key> directory.
+     * Each Markdown file will be parsed into a MarkdownDocument with front matter.
+     */
+    public static function markdown(string $key): BaseCollection
+    {
+        $files = glob(Hyde::path('_data/' . $key . '/*.md'));
+        $collection = new BaseCollection();
+        foreach ($files as $file) {
+            $collection->push(
+                (new MarkdownFileService($file))->get()
+            );
+        }
+        return $collection;
+    }
 }

--- a/packages/framework/src/Modules/DataCollections/DataCollection.php
+++ b/packages/framework/src/Modules/DataCollections/DataCollection.php
@@ -19,11 +19,10 @@ class DataCollection
     public static function markdown(string $key): BaseCollection
     {
         $time_start = microtime(true);
-        $files = glob(Hyde::path('_data/' . $key . '/*.md'));
         $collection = new BaseCollection();
         $collection->key = $key;
         $collection->name = Hyde::titleFromSlug($key);
-        foreach ($files as $file) {
+        foreach (glob(Hyde::path('_data/' . $key . '/*.md')) as $file) {
             $collection->push(
                 (new MarkdownFileService($file))->get()
             );

--- a/packages/framework/src/Modules/DataCollections/DataCollection.php
+++ b/packages/framework/src/Modules/DataCollections/DataCollection.php
@@ -2,7 +2,32 @@
 
 namespace Hyde\Framework\Modules\DataCollections;
 
-class DataCollection
+use Hyde\Framework\Hyde;
+use Illuminate\Support\Collection;
+
+class DataCollection extends Collection
 {
-    //
+    public string $key;
+    public string $name;
+
+    protected float $timeStart;
+    public float $parseTimeInMs;
+
+    public static string $dataPath = '_data';
+
+    public function __construct(string $key, ?string $name = null)
+    {
+        $this->timeStart = microtime(true);
+        $this->key = $key;
+        $this->name = $name ?? Hyde::titleFromSlug($key);
+
+        parent::__construct();
+    }
+
+    public function push(...$values)
+    {
+        $this->parseTimeInMs = round((microtime(true) - $this->timeStart) * 1000, 2);
+
+        return parent::push($values);
+    }
 }

--- a/packages/framework/src/Modules/DataCollections/DataCollection.php
+++ b/packages/framework/src/Modules/DataCollections/DataCollection.php
@@ -3,6 +3,7 @@
 namespace Hyde\Framework\Modules\DataCollections;
 
 use Hyde\Framework\Hyde;
+use Hyde\Framework\Models\MarkdownDocument;
 use Illuminate\Support\Collection;
 
 class DataCollection extends Collection
@@ -30,5 +31,12 @@ class DataCollection extends Collection
         unset($this->timeStart);
 
         return $this;
+    }
+
+    public function getMarkdownFiles(): array
+    {
+        return glob(Hyde::path(
+            static::$sourceDirectory . '/' . $this->key . '/*' . MarkdownDocument::$fileExtension
+        ));
     }
 }

--- a/packages/framework/src/Modules/DataCollections/DataCollection.php
+++ b/packages/framework/src/Modules/DataCollections/DataCollection.php
@@ -3,6 +3,7 @@
 namespace Hyde\Framework\Modules\DataCollections;
 
 use Hyde\Framework\Hyde;
+use Hyde\Framework\Models\MarkdownDocument;
 use Hyde\Framework\Services\MarkdownFileService;
 use Illuminate\Support\Collection as BaseCollection;
 
@@ -24,7 +25,7 @@ class DataCollection
         $collection = new BaseCollection();
         $collection->key = $key;
         $collection->name = Hyde::titleFromSlug($key);
-        foreach (glob(Hyde::path(static::$dataPath . '/' . $key . '/*.md')) as $file) {
+        foreach (glob(Hyde::path(static::$dataPath . '/' . $key . '/*' . MarkdownDocument::$fileExtension)) as $file) {
             $collection->push(
                 (new MarkdownFileService($file))->get()
             );

--- a/packages/framework/src/Modules/DataCollections/DataCollection.php
+++ b/packages/framework/src/Modules/DataCollections/DataCollection.php
@@ -10,6 +10,8 @@ use Illuminate\Support\Collection;
 /**
  * Generates Laravel Collections from static data files,
  * such as Markdown components and YAML files.
+ *
+ * @see \Hyde\Framework\Testing\Modules\DataCollections\DataCollectionTest\DataCollectionTest
  */
 class DataCollection extends Collection
 {

--- a/packages/framework/src/Modules/DataCollections/DataCollection.php
+++ b/packages/framework/src/Modules/DataCollections/DataCollection.php
@@ -21,6 +21,8 @@ class DataCollection
         $time_start = microtime(true);
         $files = glob(Hyde::path('_data/' . $key . '/*.md'));
         $collection = new BaseCollection();
+        $collection->key = $key;
+        $collection->name = Hyde::titleFromSlug($key);
         foreach ($files as $file) {
             $collection->push(
                 (new MarkdownFileService($file))->get()

--- a/packages/framework/src/Modules/DataCollections/DataCollection.php
+++ b/packages/framework/src/Modules/DataCollections/DataCollection.php
@@ -14,18 +14,16 @@ use Illuminate\Support\Collection;
 class DataCollection extends Collection
 {
     public string $key;
-    public string $name;
 
     protected float $timeStart;
     public float $parseTimeInMs;
 
     public static string $sourceDirectory = '_data';
 
-    public function __construct(string $key, ?string $name = null)
+    public function __construct(string $key)
     {
         $this->timeStart = microtime(true);
         $this->key = $key;
-        $this->name = $name ?? Hyde::titleFromSlug($key);
 
         parent::__construct();
     }

--- a/packages/framework/src/Modules/DataCollections/DataCollection.php
+++ b/packages/framework/src/Modules/DataCollections/DataCollection.php
@@ -39,7 +39,7 @@ class DataCollection extends Collection
     public function getMarkdownFiles(): array
     {
         return glob(Hyde::path(
-            static::$sourceDirectory . '/' . $this->key . '/*' . MarkdownDocument::$fileExtension
+            static::$sourceDirectory.'/'.$this->key.'/*'.MarkdownDocument::$fileExtension
         ));
     }
 
@@ -47,7 +47,7 @@ class DataCollection extends Collection
      * Get a collection of Markdown documents in the _data/<$key> directory.
      * Each Markdown file will be parsed into a MarkdownDocument with front matter.
      *
-     * @param string $key for a subdirectory of the _data directory
+     * @param  string  $key  for a subdirectory of the _data directory
      * @return DataCollection<\Hyde\Framework\Models\MarkdownDocument>
      */
     public static function markdown(string $key): DataCollection
@@ -58,6 +58,7 @@ class DataCollection extends Collection
                 (new MarkdownFileService($file))->get()
             );
         }
+
         return $collection->getCollection();
     }
 }

--- a/packages/framework/src/Modules/DataCollections/DataCollection.php
+++ b/packages/framework/src/Modules/DataCollections/DataCollection.php
@@ -18,6 +18,7 @@ class DataCollection
      */
     public static function markdown(string $key): BaseCollection
     {
+        $time_start = microtime(true);
         $files = glob(Hyde::path('_data/' . $key . '/*.md'));
         $collection = new BaseCollection();
         foreach ($files as $file) {
@@ -25,6 +26,12 @@ class DataCollection
                 (new MarkdownFileService($file))->get()
             );
         }
+        $collection->parseTimeInMs = static::getExecutionTime($time_start);
         return $collection;
+    }
+
+    protected static function getExecutionTime(float $time_start): float
+    {
+        return round((microtime(true) - $time_start) * 1000, 2);
     }
 }

--- a/packages/framework/src/Modules/DataCollections/DataCollection.php
+++ b/packages/framework/src/Modules/DataCollections/DataCollection.php
@@ -2,40 +2,7 @@
 
 namespace Hyde\Framework\Modules\DataCollections;
 
-use Hyde\Framework\Hyde;
-use Hyde\Framework\Models\MarkdownDocument;
-use Hyde\Framework\Services\MarkdownFileService;
-use Illuminate\Support\Collection as BaseCollection;
-
-/**
- * Provides a facade for generating on-the-fly Laravel Collections
- * from static data files such as Markdown components and YAML files.
- */
 class DataCollection
 {
-    public static string $dataPath = '_data';
-
-    /**
-     * Get a collection of Markdown documents in the _data/<$key> directory.
-     * Each Markdown file will be parsed into a MarkdownDocument with front matter.
-     */
-    public static function markdown(string $key): BaseCollection
-    {
-        $time_start = microtime(true);
-        $collection = new BaseCollection();
-        $collection->key = $key;
-        $collection->name = Hyde::titleFromSlug($key);
-        foreach (glob(Hyde::path(static::$dataPath . '/' . $key . '/*' . MarkdownDocument::$fileExtension)) as $file) {
-            $collection->push(
-                (new MarkdownFileService($file))->get()
-            );
-        }
-        $collection->parseTimeInMs = static::getExecutionTime($time_start);
-        return $collection;
-    }
-
-    protected static function getExecutionTime(float $time_start): float
-    {
-        return round((microtime(true) - $time_start) * 1000, 2);
-    }
+    //
 }

--- a/packages/framework/src/Modules/DataCollections/DataCollection.php
+++ b/packages/framework/src/Modules/DataCollections/DataCollection.php
@@ -24,10 +24,11 @@ class DataCollection extends Collection
         parent::__construct();
     }
 
-    public function push(...$values)
+    public function getCollection(): DataCollection
     {
         $this->parseTimeInMs = round((microtime(true) - $this->timeStart) * 1000, 2);
+        unset($this->timeStart);
 
-        return parent::push($values);
+        return $this;
     }
 }

--- a/packages/framework/src/Modules/DataCollections/DataCollection.php
+++ b/packages/framework/src/Modules/DataCollections/DataCollection.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Hyde\Framework\Modules\DataCollections;
+
+/**
+ * Provides a facade for generating on-the-fly Laravel Collections
+ * from static data files such as Markdown components and YAML files.
+ */
+class DataCollection
+{
+    //
+}

--- a/packages/framework/src/Modules/DataCollections/DataCollection.php
+++ b/packages/framework/src/Modules/DataCollections/DataCollection.php
@@ -4,8 +4,13 @@ namespace Hyde\Framework\Modules\DataCollections;
 
 use Hyde\Framework\Hyde;
 use Hyde\Framework\Models\MarkdownDocument;
+use Hyde\Framework\Services\MarkdownFileService;
 use Illuminate\Support\Collection;
 
+/**
+ * Generates Laravel Collections from static data files,
+ * such as Markdown components and YAML files.
+ */
 class DataCollection extends Collection
 {
     public string $key;
@@ -38,5 +43,23 @@ class DataCollection extends Collection
         return glob(Hyde::path(
             static::$sourceDirectory . '/' . $this->key . '/*' . MarkdownDocument::$fileExtension
         ));
+    }
+
+    /**
+     * Get a collection of Markdown documents in the _data/<$key> directory.
+     * Each Markdown file will be parsed into a MarkdownDocument with front matter.
+     *
+     * @param string $key for a subdirectory of the _data directory
+     * @return DataCollection<\Hyde\Framework\Models\MarkdownDocument>
+     */
+    public static function markdown(string $key): DataCollection
+    {
+        $collection = new DataCollection($key);
+        foreach ($collection->getMarkdownFiles() as $file) {
+            $collection->push(
+                (new MarkdownFileService($file))->get()
+            );
+        }
+        return $collection->getCollection();
     }
 }

--- a/packages/framework/src/Modules/DataCollections/DataCollection.php
+++ b/packages/framework/src/Modules/DataCollections/DataCollection.php
@@ -13,7 +13,7 @@ class DataCollection extends Collection
     protected float $timeStart;
     public float $parseTimeInMs;
 
-    public static string $dataPath = '_data';
+    public static string $sourceDirectory = '_data';
 
     public function __construct(string $key, ?string $name = null)
     {

--- a/packages/framework/src/Modules/DataCollections/DataCollectionServiceProvider.php
+++ b/packages/framework/src/Modules/DataCollections/DataCollectionServiceProvider.php
@@ -2,8 +2,9 @@
 
 namespace Hyde\Framework\Modules\DataCollections;
 
-use Illuminate\Foundation\AliasLoader;
 use Illuminate\Support\ServiceProvider;
+use Illuminate\Foundation\AliasLoader;
+use Hyde\Framework\Hyde;
 
 class DataCollectionServiceProvider extends ServiceProvider
 {

--- a/packages/framework/src/Modules/DataCollections/DataCollectionServiceProvider.php
+++ b/packages/framework/src/Modules/DataCollections/DataCollectionServiceProvider.php
@@ -12,7 +12,7 @@ class DataCollectionServiceProvider extends ServiceProvider
     {
         // Register the class alias
         AliasLoader::getInstance()->alias(
-            'Collection', DataCollection::class
+            'Collection', Facades\Collection::class
         );
     }
 

--- a/packages/framework/src/Modules/DataCollections/DataCollectionServiceProvider.php
+++ b/packages/framework/src/Modules/DataCollections/DataCollectionServiceProvider.php
@@ -6,6 +6,9 @@ use Hyde\Framework\Hyde;
 use Illuminate\Foundation\AliasLoader;
 use Illuminate\Support\ServiceProvider;
 
+/**
+ * @see \Hyde\Framework\Testing\Modules\DataCollections\DataCollectionTest\DataCollectionTest
+ */
 class DataCollectionServiceProvider extends ServiceProvider
 {
     public function register()

--- a/packages/framework/src/Modules/DataCollections/DataCollectionServiceProvider.php
+++ b/packages/framework/src/Modules/DataCollections/DataCollectionServiceProvider.php
@@ -12,7 +12,7 @@ class DataCollectionServiceProvider extends ServiceProvider
     {
         // Register the class alias
         AliasLoader::getInstance()->alias(
-            'Collection', Facades\Collection::class
+            'Collection', Facades\MarkdownCollection::class
         );
     }
 

--- a/packages/framework/src/Modules/DataCollections/DataCollectionServiceProvider.php
+++ b/packages/framework/src/Modules/DataCollections/DataCollectionServiceProvider.php
@@ -2,13 +2,17 @@
 
 namespace Hyde\Framework\Modules\DataCollections;
 
+use Illuminate\Foundation\AliasLoader;
 use Illuminate\Support\ServiceProvider;
 
 class DataCollectionServiceProvider extends ServiceProvider
 {
     public function register()
     {
-        //
+        // Register the class alias
+        AliasLoader::getInstance()->alias(
+            'Collection', DataCollection::class
+        );
     }
 
     public function boot()

--- a/packages/framework/src/Modules/DataCollections/DataCollectionServiceProvider.php
+++ b/packages/framework/src/Modules/DataCollections/DataCollectionServiceProvider.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Hyde\Framework\Modules\DataCollections;
+
+use Illuminate\Support\ServiceProvider;
+
+class DataCollectionServiceProvider extends ServiceProvider
+{
+    public function register()
+    {
+        //
+    }
+
+    public function boot()
+    {
+        //
+    }
+}

--- a/packages/framework/src/Modules/DataCollections/DataCollectionServiceProvider.php
+++ b/packages/framework/src/Modules/DataCollections/DataCollectionServiceProvider.php
@@ -12,7 +12,7 @@ class DataCollectionServiceProvider extends ServiceProvider
     {
         // Register the class alias
         AliasLoader::getInstance()->alias(
-            'Collection', Facades\MarkdownCollection::class
+            'MarkdownCollection', Facades\MarkdownCollection::class
         );
     }
 

--- a/packages/framework/src/Modules/DataCollections/DataCollectionServiceProvider.php
+++ b/packages/framework/src/Modules/DataCollections/DataCollectionServiceProvider.php
@@ -2,9 +2,9 @@
 
 namespace Hyde\Framework\Modules\DataCollections;
 
-use Illuminate\Support\ServiceProvider;
-use Illuminate\Foundation\AliasLoader;
 use Hyde\Framework\Hyde;
+use Illuminate\Foundation\AliasLoader;
+use Illuminate\Support\ServiceProvider;
 
 class DataCollectionServiceProvider extends ServiceProvider
 {
@@ -19,7 +19,7 @@ class DataCollectionServiceProvider extends ServiceProvider
     public function boot()
     {
         // Create the _data directory if it doesn't exist
-        if (!is_dir(Hyde::path('_data'))) {
+        if (! is_dir(Hyde::path('_data'))) {
             mkdir(Hyde::path('_data'));
         }
     }

--- a/packages/framework/src/Modules/DataCollections/DataCollectionServiceProvider.php
+++ b/packages/framework/src/Modules/DataCollections/DataCollectionServiceProvider.php
@@ -17,6 +17,9 @@ class DataCollectionServiceProvider extends ServiceProvider
 
     public function boot()
     {
-        //
+        // Create the _data directory if it doesn't exist
+        if (!is_dir(Hyde::path('_data'))) {
+            mkdir(Hyde::path('_data'));
+        }
     }
 }

--- a/packages/framework/src/Modules/DataCollections/Facades/Collection.php
+++ b/packages/framework/src/Modules/DataCollections/Facades/Collection.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace Hyde\Framework\Modules\DataCollections\Facades;
+
+use Hyde\Framework\Hyde;
+use Hyde\Framework\Models\MarkdownDocument;
+use Hyde\Framework\Services\MarkdownFileService;
+use Illuminate\Support\Collection as BaseCollection;
+
+/**
+ * Provides a facade for generating on-the-fly Laravel Collections
+ * from static data files such as Markdown components and YAML files.
+ */
+class Collection
+{
+    public static string $dataPath = '_data';
+
+    /**
+     * Get a collection of Markdown documents in the _data/<$key> directory.
+     * Each Markdown file will be parsed into a MarkdownDocument with front matter.
+     */
+    public static function markdown(string $key): BaseCollection
+    {
+        $time_start = microtime(true);
+        $collection = new BaseCollection();
+        $collection->key = $key;
+        $collection->name = Hyde::titleFromSlug($key);
+        foreach (glob(Hyde::path(static::$dataPath . '/' . $key . '/*' . MarkdownDocument::$fileExtension)) as $file) {
+            $collection->push(
+                (new MarkdownFileService($file))->get()
+            );
+        }
+        $collection->parseTimeInMs = static::getExecutionTime($time_start);
+        return $collection;
+    }
+
+    protected static function getExecutionTime(float $time_start): float
+    {
+        return round((microtime(true) - $time_start) * 1000, 2);
+    }
+}

--- a/packages/framework/src/Modules/DataCollections/Facades/Collection.php
+++ b/packages/framework/src/Modules/DataCollections/Facades/Collection.php
@@ -25,6 +25,6 @@ class Collection
                 (new MarkdownFileService($file))->get()
             );
         }
-        return $collection;
+        return $collection->getCollection();
     }
 }

--- a/packages/framework/src/Modules/DataCollections/Facades/Collection.php
+++ b/packages/framework/src/Modules/DataCollections/Facades/Collection.php
@@ -20,11 +20,18 @@ class Collection
     public static function markdown(string $key): DataCollection
     {
         $collection = new DataCollection($key);
-        foreach (glob(Hyde::path(DataCollection::$sourceDirectory . '/' . $key . '/*' . MarkdownDocument::$fileExtension)) as $file) {
+        foreach (static::getMarkdownFiles($key) as $file) {
             $collection->push(
                 (new MarkdownFileService($file))->get()
             );
         }
         return $collection->getCollection();
+    }
+
+    protected static function getMarkdownFiles(string $key): array
+    {
+        return glob(Hyde::path(
+            DataCollection::$sourceDirectory . '/' . $key . '/*' . MarkdownDocument::$fileExtension
+        ));
     }
 }

--- a/packages/framework/src/Modules/DataCollections/Facades/Collection.php
+++ b/packages/framework/src/Modules/DataCollections/Facades/Collection.php
@@ -20,7 +20,7 @@ class Collection
     public static function markdown(string $key): DataCollection
     {
         $collection = new DataCollection($key);
-        foreach (glob(Hyde::path(DataCollection::$dataPath . '/' . $key . '/*' . MarkdownDocument::$fileExtension)) as $file) {
+        foreach (glob(Hyde::path(DataCollection::$sourceDirectory . '/' . $key . '/*' . MarkdownDocument::$fileExtension)) as $file) {
             $collection->push(
                 (new MarkdownFileService($file))->get()
             );

--- a/packages/framework/src/Modules/DataCollections/Facades/Collection.php
+++ b/packages/framework/src/Modules/DataCollections/Facades/Collection.php
@@ -4,8 +4,8 @@ namespace Hyde\Framework\Modules\DataCollections\Facades;
 
 use Hyde\Framework\Hyde;
 use Hyde\Framework\Models\MarkdownDocument;
+use Hyde\Framework\Modules\DataCollections\DataCollection;
 use Hyde\Framework\Services\MarkdownFileService;
-use Illuminate\Support\Collection as BaseCollection;
 
 /**
  * Provides a facade for generating on-the-fly Laravel Collections
@@ -13,29 +13,18 @@ use Illuminate\Support\Collection as BaseCollection;
  */
 class Collection
 {
-    public static string $dataPath = '_data';
-
     /**
      * Get a collection of Markdown documents in the _data/<$key> directory.
      * Each Markdown file will be parsed into a MarkdownDocument with front matter.
      */
-    public static function markdown(string $key): BaseCollection
+    public static function markdown(string $key): DataCollection
     {
-        $time_start = microtime(true);
-        $collection = new BaseCollection();
-        $collection->key = $key;
-        $collection->name = Hyde::titleFromSlug($key);
-        foreach (glob(Hyde::path(static::$dataPath . '/' . $key . '/*' . MarkdownDocument::$fileExtension)) as $file) {
+        $collection = new DataCollection($key);
+        foreach (glob(Hyde::path(DataCollection::$dataPath . '/' . $key . '/*' . MarkdownDocument::$fileExtension)) as $file) {
             $collection->push(
                 (new MarkdownFileService($file))->get()
             );
         }
-        $collection->parseTimeInMs = static::getExecutionTime($time_start);
         return $collection;
-    }
-
-    protected static function getExecutionTime(float $time_start): float
-    {
-        return round((microtime(true) - $time_start) * 1000, 2);
     }
 }

--- a/packages/framework/src/Modules/DataCollections/Facades/Collection.php
+++ b/packages/framework/src/Modules/DataCollections/Facades/Collection.php
@@ -14,6 +14,9 @@ class Collection
     /**
      * Get a collection of Markdown documents in the _data/<$key> directory.
      * Each Markdown file will be parsed into a MarkdownDocument with front matter.
+     *
+     * @param string $key for a subdirectory of the _data directory
+     * @return DataCollection<\Hyde\Framework\Models\MarkdownDocument>
      */
     public static function markdown(string $key): DataCollection
     {

--- a/packages/framework/src/Modules/DataCollections/Facades/Collection.php
+++ b/packages/framework/src/Modules/DataCollections/Facades/Collection.php
@@ -20,18 +20,11 @@ class Collection
     public static function markdown(string $key): DataCollection
     {
         $collection = new DataCollection($key);
-        foreach (static::getMarkdownFiles($key) as $file) {
+        foreach ($collection->getMarkdownFiles() as $file) {
             $collection->push(
                 (new MarkdownFileService($file))->get()
             );
         }
         return $collection->getCollection();
-    }
-
-    protected static function getMarkdownFiles(string $key): array
-    {
-        return glob(Hyde::path(
-            DataCollection::$sourceDirectory . '/' . $key . '/*' . MarkdownDocument::$fileExtension
-        ));
     }
 }

--- a/packages/framework/src/Modules/DataCollections/Facades/Collection.php
+++ b/packages/framework/src/Modules/DataCollections/Facades/Collection.php
@@ -5,27 +5,8 @@ namespace Hyde\Framework\Modules\DataCollections\Facades;
 use Hyde\Framework\Modules\DataCollections\DataCollection;
 use Hyde\Framework\Services\MarkdownFileService;
 
-/**
- * Provides a facade for generating on-the-fly Laravel Collections
- * from static data files such as Markdown components and YAML files.
- */
+
 class Collection
 {
-    /**
-     * Get a collection of Markdown documents in the _data/<$key> directory.
-     * Each Markdown file will be parsed into a MarkdownDocument with front matter.
-     *
-     * @param string $key for a subdirectory of the _data directory
-     * @return DataCollection<\Hyde\Framework\Models\MarkdownDocument>
-     */
-    public static function markdown(string $key): DataCollection
-    {
-        $collection = new DataCollection($key);
-        foreach ($collection->getMarkdownFiles() as $file) {
-            $collection->push(
-                (new MarkdownFileService($file))->get()
-            );
-        }
-        return $collection->getCollection();
-    }
+  //
 }

--- a/packages/framework/src/Modules/DataCollections/Facades/Collection.php
+++ b/packages/framework/src/Modules/DataCollections/Facades/Collection.php
@@ -2,8 +2,6 @@
 
 namespace Hyde\Framework\Modules\DataCollections\Facades;
 
-use Hyde\Framework\Hyde;
-use Hyde\Framework\Models\MarkdownDocument;
 use Hyde\Framework\Modules\DataCollections\DataCollection;
 use Hyde\Framework\Services\MarkdownFileService;
 

--- a/packages/framework/src/Modules/DataCollections/Facades/MarkdownCollection.php
+++ b/packages/framework/src/Modules/DataCollections/Facades/MarkdownCollection.php
@@ -4,6 +4,9 @@ namespace Hyde\Framework\Modules\DataCollections\Facades;
 
 use Hyde\Framework\Modules\DataCollections\DataCollection;
 
+/**
+ * @see \Hyde\Framework\Testing\Modules\DataCollections\DataCollectionTest\DataCollectionTest
+ */
 class MarkdownCollection
 {
     public static function get(string $collectionKey): DataCollection

--- a/packages/framework/src/Modules/DataCollections/Facades/MarkdownCollection.php
+++ b/packages/framework/src/Modules/DataCollections/Facades/MarkdownCollection.php
@@ -6,5 +6,8 @@ use Hyde\Framework\Modules\DataCollections\DataCollection;
 
 class MarkdownCollection
 {
-    //
+    public static function get(string $collectionKey): DataCollection
+    {
+        return new DataCollection($collectionKey);
+    }
 }

--- a/packages/framework/src/Modules/DataCollections/Facades/MarkdownCollection.php
+++ b/packages/framework/src/Modules/DataCollections/Facades/MarkdownCollection.php
@@ -8,6 +8,6 @@ class MarkdownCollection
 {
     public static function get(string $collectionKey): DataCollection
     {
-        return new DataCollection($collectionKey);
+        return DataCollection::markdown($collectionKey);
     }
 }

--- a/packages/framework/src/Modules/DataCollections/Facades/MarkdownCollection.php
+++ b/packages/framework/src/Modules/DataCollections/Facades/MarkdownCollection.php
@@ -3,10 +3,8 @@
 namespace Hyde\Framework\Modules\DataCollections\Facades;
 
 use Hyde\Framework\Modules\DataCollections\DataCollection;
-use Hyde\Framework\Services\MarkdownFileService;
 
-
-class Collection
+class MarkdownCollection
 {
-  //
+    //
 }

--- a/packages/framework/src/Modules/README.md
+++ b/packages/framework/src/Modules/README.md
@@ -2,3 +2,9 @@
 
 This directory contains self-contained code modules,
 that may eventually be extracted into packages.
+
+They may also be merged into the Hyde core.
+
+As these modules may be experimental,
+the namespaces used may be changed without notice
+as per the current 0.x semantic versioning range.

--- a/tests/Hyde/Feature/Hyde/Framework/Testing/Modules/DataCollections/DataCollectionTest/DataCollectionTest.php
+++ b/tests/Hyde/Feature/Hyde/Framework/Testing/Modules/DataCollections/DataCollectionTest/DataCollectionTest.php
@@ -131,7 +131,7 @@ class DataCollectionTest extends TestCase
         $this->assertCount(1, DataCollection::markdown('foo'));
         File::deleteDirectory(Hyde::path('_data/foo'));
     }
-    
+
     public function test_markdown_facade_returns_same_result_as_static_markdown_helper()
     {
         $expected = DataCollection::markdown('foo');

--- a/tests/Hyde/Feature/Hyde/Framework/Testing/Modules/DataCollections/DataCollectionTest/DataCollectionTest.php
+++ b/tests/Hyde/Feature/Hyde/Framework/Testing/Modules/DataCollections/DataCollectionTest/DataCollectionTest.php
@@ -19,12 +19,6 @@ use Illuminate\Support\Facades\File;
  */
 class DataCollectionTest extends TestCase
 {
-    // test class has static source directory property
-    public function testClassHasStaticSourceDirectoryProperty()
-    {
-        $this->assertEquals('_data', DataCollection::$sourceDirectory);
-    }
-
     // constructor creates new data collection instance
     public function test_constructor_creates_new_data_collection_instance()
     {
@@ -176,5 +170,23 @@ class DataCollectionTest extends TestCase
         (new DataCollectionServiceProvider($this->app))->boot();
 
         $this->assertFileExists(Hyde::path('_data'));
+    }
+
+    // test class has static source directory property
+    public function testClassHasStaticSourceDirectoryProperty()
+    {
+        $this->assertEquals('_data', DataCollection::$sourceDirectory);
+    }
+
+    // test source directory can be changed
+    public function testSourceDirectoryCanBeChanged()
+    {
+        DataCollection::$sourceDirectory = 'foo';
+        mkdir(Hyde::path('foo/bar'), recursive: true);
+        touch(Hyde::path('foo/bar/foo.md'));
+        $this->assertEquals([
+            Hyde::path('foo/bar/foo.md'),
+        ], (new DataCollection('bar'))->getMarkdownFiles());
+        File::deleteDirectory(Hyde::path('foo'));
     }
 }

--- a/tests/Hyde/Feature/Hyde/Framework/Testing/Modules/DataCollections/DataCollectionTest/DataCollectionTest.php
+++ b/tests/Hyde/Feature/Hyde/Framework/Testing/Modules/DataCollections/DataCollectionTest/DataCollectionTest.php
@@ -27,28 +27,24 @@ class DataCollectionTest extends TestCase
         $this->assertInstanceOf(Collection::class, $class);
     }
 
-    // test constructor sets key
     public function test_constructor_sets_key()
     {
         $class = new DataCollection('foo');
         $this->assertEquals('foo', $class->key);
     }
 
-    // test key is required
     public function test_key_is_required()
     {
         $this->expectException(\ArgumentCountError::class);
         new DataCollection();
     }
 
-    // test Get Collection method returns the collection instance
     public function test_get_collection_method_returns_the_collection_instance()
     {
         $class = new DataCollection('foo');
         $this->assertSame($class, $class->getCollection());
     }
 
-    // test get collection method sets parse time in ms
     public function test_get_collection_method_sets_parse_time_in_ms()
     {
         $class = new DataCollection('foo');
@@ -56,7 +52,6 @@ class DataCollectionTest extends TestCase
         $this->assertIsFloat($class->parseTimeInMs);
     }
 
-    // test get markdown files method returns empty array if the specified directory does not exist
     public function test_get_markdown_files_method_returns_empty_array_if_the_specified_directory_does_not_exist()
     {
         $class = new DataCollection('foo');
@@ -64,7 +59,6 @@ class DataCollectionTest extends TestCase
         $this->assertEmpty($class->getMarkdownFiles());
     }
 
-    // test get markdown files method returns empty array if no files are found in specified directory
     public function test_get_markdown_files_method_returns_empty_array_if_no_files_are_found_in_specified_directory()
     {
         mkdir(Hyde::path('_data/foo'));
@@ -74,7 +68,6 @@ class DataCollectionTest extends TestCase
         rmdir(Hyde::path('_data/foo'));
     }
 
-    // test get markdown files method returns an array of markdown files in the specified directory
     public function test_get_markdown_files_method_returns_an_array_of_markdown_files_in_the_specified_directory()
     {
         mkdir(Hyde::path('_data/foo'));
@@ -89,7 +82,6 @@ class DataCollectionTest extends TestCase
         File::deleteDirectory(Hyde::path('_data/foo'));
     }
 
-    // test get markdown files method does not include files in subdirectories
     public function test_get_markdown_files_method_does_not_include_files_in_subdirectories()
     {
         mkdir(Hyde::path('_data/foo'));
@@ -102,7 +94,6 @@ class DataCollectionTest extends TestCase
         File::deleteDirectory(Hyde::path('_data/foo'));
     }
 
-    // test get markdown files method does not include files with extensions other than .md
     public function test_get_markdown_files_method_does_not_include_files_with_extensions_other_than_md()
     {
         mkdir(Hyde::path('_data/foo'));
@@ -114,13 +105,11 @@ class DataCollectionTest extends TestCase
         File::deleteDirectory(Hyde::path('_data/foo'));
     }
 
-    // test static markdown helper returns new data collection instance
     public function test_static_markdown_helper_returns_new_data_collection_instance()
     {
         $this->assertInstanceOf(DataCollection::class, DataCollection::markdown('foo'));
     }
 
-    // test static markdown helper discovers and parses markdown files in the specified directory
     public function test_static_markdown_helper_discovers_and_parses_markdown_files_in_the_specified_directory()
     {
         mkdir(Hyde::path('_data/foo'));
@@ -134,7 +123,6 @@ class DataCollectionTest extends TestCase
         File::deleteDirectory(Hyde::path('_data/foo'));
     }
 
-    // test static markdown helper ignores files starting with an underscore
     public function test_static_markdown_helper_ignores_files_starting_with_an_underscore()
     {
         mkdir(Hyde::path('_data/foo'));
@@ -144,7 +132,6 @@ class DataCollectionTest extends TestCase
         File::deleteDirectory(Hyde::path('_data/foo'));
     }
     
-    // test markdown facade returns same result as static markdown helper
     public function test_markdown_facade_returns_same_result_as_static_markdown_helper()
     {
         $expected = DataCollection::markdown('foo');
@@ -155,14 +142,13 @@ class DataCollectionTest extends TestCase
     }
 
     // Test DataCollectionServiceProvider registers the facade as an alias
-    public function test_DataCollectionServiceProvider_registers_the_facade_as_an_alias()
+    public function test_data_collection_service_provider_registers_the_facade_as_an_alias()
     {
         $this->assertArrayHasKey('MarkdownCollection', AliasLoader::getInstance()->getAliases());
         $this->assertContains(MarkdownCollection::class, AliasLoader::getInstance()->getAliases());
     }
 
-    // test DataCollectionServiceProvider creates the _data directory if it does not exist
-    public function test_DataCollectionServiceProvider_creates_the__data_directory_if_it_does_not_exist()
+    public function test_data_collection_service_provider_creates_the__data_directory_if_it_does_not_exist()
     {
         File::deleteDirectory(Hyde::path('_data'));
         $this->assertFileDoesNotExist(Hyde::path('_data'));
@@ -172,14 +158,12 @@ class DataCollectionTest extends TestCase
         $this->assertFileExists(Hyde::path('_data'));
     }
 
-    // test class has static source directory property
-    public function testClassHasStaticSourceDirectoryProperty()
+    public function test_class_has_static_source_directory_property()
     {
         $this->assertEquals('_data', DataCollection::$sourceDirectory);
     }
 
-    // test source directory can be changed
-    public function testSourceDirectoryCanBeChanged()
+    public function test_source_directory_can_be_changed()
     {
         DataCollection::$sourceDirectory = 'foo';
         mkdir(Hyde::path('foo/bar'), recursive: true);

--- a/tests/Hyde/Feature/Hyde/Framework/Testing/Modules/DataCollections/DataCollectionTest/DataCollectionTest.php
+++ b/tests/Hyde/Feature/Hyde/Framework/Testing/Modules/DataCollections/DataCollectionTest/DataCollectionTest.php
@@ -1,0 +1,149 @@
+<?php
+
+namespace Hyde\Framework\Testing\Modules\DataCollections\DataCollectionTest;
+
+use Hyde\Framework\Hyde;
+use Hyde\Framework\Models\MarkdownDocument;
+use Hyde\Framework\Modules\DataCollections\DataCollection;
+use Hyde\Testing\TestCase;
+use Illuminate\Support\Collection;
+use Illuminate\Support\Facades\File;
+
+/**
+ * @covers \Hyde\Framework\Modules\DataCollections\DataCollection
+ * @covers \Hyde\Framework\Modules\DataCollections\DataCollectionServiceProvider
+ * @covers \Hyde\Framework\Modules\DataCollections\Facades\MarkdownCollection
+ */
+class DataCollectionTest extends TestCase
+{
+    // test class has static source directory property
+    public function testClassHasStaticSourceDirectoryProperty()
+    {
+        $this->assertEquals('_data', DataCollection::$sourceDirectory);
+    }
+
+    // constructor creates new data collection instance
+    public function test_constructor_creates_new_data_collection_instance()
+    {
+        $class = new DataCollection('foo');
+        $this->assertInstanceOf(DataCollection::class, $class);
+        $this->assertInstanceOf(Collection::class, $class);
+    }
+
+    // test constructor sets key
+    public function test_constructor_sets_key()
+    {
+        $class = new DataCollection('foo');
+        $this->assertEquals('foo', $class->key);
+    }
+
+    // test key is required
+    public function test_key_is_required()
+    {
+        $this->expectException(\ArgumentCountError::class);
+        new DataCollection();
+    }
+
+    // test Get Collection method returns the collection instance
+    public function test_get_collection_method_returns_the_collection_instance()
+    {
+        $class = new DataCollection('foo');
+        $this->assertSame($class, $class->getCollection());
+    }
+
+    // test get collection method sets parse time in ms
+    public function test_get_collection_method_sets_parse_time_in_ms()
+    {
+        $class = new DataCollection('foo');
+        $class->getCollection();
+        $this->assertIsFloat($class->parseTimeInMs);
+    }
+
+    // test get markdown files method returns empty array if the specified directory does not exist
+    public function test_get_markdown_files_method_returns_empty_array_if_the_specified_directory_does_not_exist()
+    {
+        $class = new DataCollection('foo');
+        $this->assertIsArray($class->getMarkdownFiles());
+        $this->assertEmpty($class->getMarkdownFiles());
+    }
+
+    // test get markdown files method returns empty array if no files are found in specified directory
+    public function test_get_markdown_files_method_returns_empty_array_if_no_files_are_found_in_specified_directory()
+    {
+        mkdir(Hyde::path('_data/foo'));
+        $class = new DataCollection('foo');
+        $this->assertIsArray($class->getMarkdownFiles());
+        $this->assertEmpty($class->getMarkdownFiles());
+        rmdir(Hyde::path('_data/foo'));
+    }
+
+    // test get markdown files method returns an array of markdown files in the specified directory
+    public function test_get_markdown_files_method_returns_an_array_of_markdown_files_in_the_specified_directory()
+    {
+        mkdir(Hyde::path('_data/foo'));
+        touch(Hyde::path('_data/foo/foo.md'));
+        touch(Hyde::path('_data/foo/bar.md'));
+
+        $this->assertEquals([
+            Hyde::path('_data/foo/bar.md'),
+            Hyde::path('_data/foo/foo.md'),
+        ], (new DataCollection('foo'))->getMarkdownFiles());
+
+        File::deleteDirectory(Hyde::path('_data/foo'));
+    }
+
+    // test get markdown files method does not include files in subdirectories
+    public function test_get_markdown_files_method_does_not_include_files_in_subdirectories()
+    {
+        mkdir(Hyde::path('_data/foo'));
+        mkdir(Hyde::path('_data/foo/bar'));
+        touch(Hyde::path('_data/foo/foo.md'));
+        touch(Hyde::path('_data/foo/bar/bar.md'));
+        $this->assertEquals([
+            Hyde::path('_data/foo/foo.md'),
+        ], (new DataCollection('foo'))->getMarkdownFiles());
+        File::deleteDirectory(Hyde::path('_data/foo'));
+    }
+
+    // test get markdown files method does not include files with extensions other than .md
+    public function test_get_markdown_files_method_does_not_include_files_with_extensions_other_than_md()
+    {
+        mkdir(Hyde::path('_data/foo'));
+        touch(Hyde::path('_data/foo/foo.md'));
+        touch(Hyde::path('_data/foo/bar.txt'));
+        $this->assertEquals([
+            Hyde::path('_data/foo/foo.md'),
+        ], (new DataCollection('foo'))->getMarkdownFiles());
+        File::deleteDirectory(Hyde::path('_data/foo'));
+    }
+
+    // test static markdown helper returns new data collection instance
+    public function test_static_markdown_helper_returns_new_data_collection_instance()
+    {
+        $this->assertInstanceOf(DataCollection::class, DataCollection::markdown('foo'));
+    }
+
+    // test static markdown helper discovers and parses markdown files in the specified directory
+    public function test_static_markdown_helper_discovers_and_parses_markdown_files_in_the_specified_directory()
+    {
+        mkdir(Hyde::path('_data/foo'));
+        touch(Hyde::path('_data/foo/foo.md'));
+        touch(Hyde::path('_data/foo/bar.md'));
+
+        $collection = DataCollection::markdown('foo');
+
+        $this->assertContainsOnlyInstancesOf(MarkdownDocument::class, $collection);
+
+        File::deleteDirectory(Hyde::path('_data/foo'));
+    }
+
+    // test static markdown helper ignores files starting with an underscore
+    public function test_static_markdown_helper_ignores_files_starting_with_an_underscore()
+    {
+        mkdir(Hyde::path('_data/foo'));
+        touch(Hyde::path('_data/foo/foo.md'));
+        touch(Hyde::path('_data/foo/_bar.md'));
+        $this->assertCount(1, DataCollection::markdown('foo'));
+        File::deleteDirectory(Hyde::path('_data/foo'));
+    }
+}

--- a/tests/Hyde/Feature/Hyde/Framework/Testing/Modules/DataCollections/DataCollectionTest/DataCollectionTest.php
+++ b/tests/Hyde/Feature/Hyde/Framework/Testing/Modules/DataCollections/DataCollectionTest/DataCollectionTest.php
@@ -5,6 +5,7 @@ namespace Hyde\Framework\Testing\Modules\DataCollections\DataCollectionTest;
 use Hyde\Framework\Hyde;
 use Hyde\Framework\Models\MarkdownDocument;
 use Hyde\Framework\Modules\DataCollections\DataCollection;
+use Hyde\Framework\Modules\DataCollections\Facades\MarkdownCollection;
 use Hyde\Testing\TestCase;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\File;
@@ -145,5 +146,15 @@ class DataCollectionTest extends TestCase
         touch(Hyde::path('_data/foo/_bar.md'));
         $this->assertCount(1, DataCollection::markdown('foo'));
         File::deleteDirectory(Hyde::path('_data/foo'));
+    }
+    
+    // test markdown facade returns same result as static markdown helper
+    public function test_markdown_facade_returns_same_result_as_static_markdown_helper()
+    {
+        $expected = DataCollection::markdown('foo');
+        $actual = MarkdownCollection::get('foo');
+        unset($expected->parseTimeInMs);
+        unset($actual->parseTimeInMs);
+        $this->assertEquals($expected, $actual);
     }
 }

--- a/tests/Hyde/Feature/Hyde/Framework/Testing/Modules/DataCollections/DataCollectionTest/DataCollectionTest.php
+++ b/tests/Hyde/Feature/Hyde/Framework/Testing/Modules/DataCollections/DataCollectionTest/DataCollectionTest.php
@@ -5,8 +5,10 @@ namespace Hyde\Framework\Testing\Modules\DataCollections\DataCollectionTest;
 use Hyde\Framework\Hyde;
 use Hyde\Framework\Models\MarkdownDocument;
 use Hyde\Framework\Modules\DataCollections\DataCollection;
+use Hyde\Framework\Modules\DataCollections\DataCollectionServiceProvider;
 use Hyde\Framework\Modules\DataCollections\Facades\MarkdownCollection;
 use Hyde\Testing\TestCase;
+use Illuminate\Foundation\AliasLoader;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\File;
 
@@ -156,5 +158,23 @@ class DataCollectionTest extends TestCase
         unset($expected->parseTimeInMs);
         unset($actual->parseTimeInMs);
         $this->assertEquals($expected, $actual);
+    }
+
+    // Test DataCollectionServiceProvider registers the facade as an alias
+    public function test_DataCollectionServiceProvider_registers_the_facade_as_an_alias()
+    {
+        $this->assertArrayHasKey('MarkdownCollection', AliasLoader::getInstance()->getAliases());
+        $this->assertContains(MarkdownCollection::class, AliasLoader::getInstance()->getAliases());
+    }
+
+    // test DataCollectionServiceProvider creates the _data directory if it does not exist
+    public function test_DataCollectionServiceProvider_creates_the__data_directory_if_it_does_not_exist()
+    {
+        File::deleteDirectory(Hyde::path('_data'));
+        $this->assertFileDoesNotExist(Hyde::path('_data'));
+
+        (new DataCollectionServiceProvider($this->app))->boot();
+
+        $this->assertFileExists(Hyde::path('_data'));
     }
 }


### PR DESCRIPTION
## About

Not sure if this is the best name for it, but this update adds a DataCollection module (which may me merged into the core as it became much simpler than I expected), which reads flatfile content and parses them into usable Laravel collections.

Currently only a Markdown collection type is added. This is easel accessible with the MarkdownCollection facade that is made available to Blade views through the DataCollectionServiceProvider.

Supply the name for a subdirectory of the new `_data` directory to the facade to get a collection with the parsed files.

## Example usage

For example, imagine we have a directory called `_data/testimonials` where we collect testimonials in the form of Markdown files, with front matter to specify the author and link.

```md
// filepath: _data/testimonials/one.md
---
author: John Doe
---

Lorem ipsum dolor sit amet, consectetur adipiscing elit...
```

We can then use the MarkdownCollection facade
```php
MarkdownCollection::get('testimonials')
```

To get the testimonials in a Blade view
```blade
@foreach(MarkdownCollection::get('testimonials') as $testimonial)
<blockquote>
    <p>{!! $testimonial->body !!}</p>
    <small>{{ $testimonial->matter['author'] }}</small>
</blockquote>
@endforeach
```

![Rendered result](https://user-images.githubusercontent.com/95144705/175764999-e4996abc-4f1c-4a2f-a65d-a170e89f8e0f.png "Rendered result")

And if we take a look at the data dump, you'll see that the Markdown files are rendered into the MarkdownDocument object model, same as all Markdown based pages in Hyde. 
![Data dump](https://user-images.githubusercontent.com/95144705/175765136-7e8d1a6d-c02b-4def-9e89-dca24bcd0a56.png)

