### PR TITLE
Push split monorepo directly to master branches

### DIFF
--- a/.github/workflows/split-monorepo.yml
+++ b/.github/workflows/split-monorepo.yml
@@ -24,7 +24,7 @@ jobs:
     runs-on: ubuntu-latest
     environment:
       name: hydephp/framework
-      url: https://github.com/hydephp/framework/tree/develop
+      url: https://github.com/hydephp/framework/tree/master
 
     steps:
     - name: Checkout hydephp/develop
@@ -38,7 +38,7 @@ jobs:
       with:
         repository: hydephp/framework
         path: framework
-        ref: develop
+        ref: master
         fetch-depth: 0
         persist-credentials: false 
         
@@ -66,7 +66,7 @@ jobs:
     runs-on: ubuntu-latest
     environment:
       name: hydephp/realtime-compiler
-      url: https://github.com/realtime-compiler/hyde/tree/develop
+      url: https://github.com/realtime-compiler/hyde/tree/master
       
     steps:
     - name: Checkout hydephp/develop
@@ -80,7 +80,7 @@ jobs:
       with:
         repository: hydephp/realtime-compiler
         path: realtime-compiler
-        ref: develop
+        ref: master
         fetch-depth: 0
         persist-credentials: false 
     
@@ -108,7 +108,7 @@ jobs:
     runs-on: ubuntu-latest
     environment:
       name: hydephp/hydefront
-      url: https://github.com/hydephp/hydefront/tree/develop
+      url: https://github.com/hydephp/hydefront/tree/master
 
     steps:
     - name: Checkout hydephp/develop
@@ -122,7 +122,7 @@ jobs:
       with:
         repository: hydephp/hydefront
         path: hydefront
-        ref: develop
+        ref: master
         fetch-depth: 0
         persist-credentials: false 
     
@@ -196,7 +196,7 @@ jobs:
     runs-on: ubuntu-latest
     environment:
       name: hydephp/hyde
-      url: https://github.com/hydephp/hyde/tree/develop
+      url: https://github.com/hydephp/hyde/tree/master
       
     steps:
     - name: Checkout hydephp/develop
@@ -210,7 +210,7 @@ jobs:
       with:
         repository: hydephp/hyde
         path: hyde
-        ref: develop
+        ref: master
         fetch-depth: 0
         persist-credentials: false 
 


### PR DESCRIPTION
Want to test pushing the monorepo packages directly to the master branches. Since we are in v0.x I think it's okay if they are not entirely stable. This will reduce developer complexity a lot, and make it faster to deploy releases, allowing for more frequent and more scoped releases with less headache as merge pull requests don't need to be synced.

Once Hyde enters 1.x and becomes stable develop branches would make more sense. 