### PR TITLE
Remove unused `$withoutNavigation` variable from the app layout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,7 +31,7 @@ This serves two purposes:
 - for soon-to-be removed features.
 
 ### Removed
-- for now removed features.
+- Remove unused `$withoutNavigation` variable from the app layout.
 
 ### Fixed
 - for any bug fixes.

--- a/packages/framework/resources/views/layouts/app.blade.php
+++ b/packages/framework/resources/views/layouts/app.blade.php
@@ -5,13 +5,13 @@
 </head>
 <body id="app" class="flex flex-col min-h-screen overflow-x-hidden dark:bg-gray-900 dark:text-white">
     <a href="#content" id="skip-to-content">Skip to content</a>
-    @includeUnless($withoutNavigation ?? false, 'hyde::layouts.navigation') 
+    @include('hyde::layouts.navigation') 
 
     <section>
         @yield('content') 
     </section>
 
-    @includeUnless(config('hyde.footer.enabled', true) && ($withoutNavigation ?? false), 'hyde::layouts.footer') 
+    @includeUnless(config('hyde.footer.enabled', true), 'hyde::layouts.footer') 
 
     @include('hyde::layouts.scripts') 
 </body>


### PR DESCRIPTION
I think this was a layover when using the app layout as the base for the documentation site. Now that the docs are in a separate layout we aren't using it. Resolves https://github.com/hydephp/develop/issues/118