### PR TITLE
Improve Hyde title generation helper

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,8 @@ This serves two purposes:
 1. People can see what changes they might expect in upcoming releases
 2. At release time, you can move the Unreleased section changes into a new release version section.
 
+The Hyde::titleFromSlug() helper is internally moved and is referenced through the new Hyde::makeTitle() helper which is an improved version, with a more general name.
+
 ### Added
 - for new features.
 
@@ -28,7 +30,7 @@ This serves two purposes:
 - for changes in existing functionality.
 
 ### Deprecated
-- for soon-to-be removed features.
+- Deprecated Hyde::titleFromSlug(), use Hyde::makeTitle() instead.
 
 ### Removed
 - Remove unused `$withoutNavigation` variable from the app layout.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,7 +36,7 @@ The Hyde::titleFromSlug() helper is internally moved and is referenced through t
 - Remove unused `$withoutNavigation` variable from the app layout.
 
 ### Fixed
-- for any bug fixes.
+- Fix style bug https://github.com/hydephp/develop/issues/117, Hyde title helper should not capitalize non-principal words
 
 ### Security
 - in case of vulnerabilities.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,19 +21,17 @@ This serves two purposes:
 1. People can see what changes they might expect in upcoming releases
 2. At release time, you can move the Unreleased section changes into a new release version section.
 
-The Hyde::titleFromSlug() helper is internally moved and is referenced through the new Hyde::makeTitle() helper which is an improved version, with a more general name.
-
 ### Added
-- Added Hyde::makeTitle() helper, an improved version of Hyde::titleFromSlug().
+- Added Hyde::makeTitle() helper, an improved version of Hyde::titleFromSlug()
 
 ### Changed
-- Updates the codebase to use the new Hyde::makeTitle() helper.
+- Updates the codebase to use the new Hyde::makeTitle() helper
 
 ### Deprecated
-- Deprecated Hyde::titleFromSlug(), use Hyde::makeTitle() instead.
+- Deprecated Hyde::titleFromSlug(), use Hyde::makeTitle() instead
 
 ### Removed
-- Remove unused `$withoutNavigation` variable from the app layout.
+- Remove unused `$withoutNavigation` variable from the app layout
 
 ### Fixed
 - Fix style bug https://github.com/hydephp/develop/issues/117, Hyde title helper should not capitalize non-principal words

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,7 @@ This serves two purposes:
 The Hyde::titleFromSlug() helper is internally moved and is referenced through the new Hyde::makeTitle() helper which is an improved version, with a more general name.
 
 ### Added
-- for new features.
+- Added Hyde::makeTitle() helper, an improved version of Hyde::titleFromSlug().
 
 ### Changed
 - for changes in existing functionality.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,7 +27,7 @@ The Hyde::titleFromSlug() helper is internally moved and is referenced through t
 - Added Hyde::makeTitle() helper, an improved version of Hyde::titleFromSlug().
 
 ### Changed
-- for changes in existing functionality.
+- Updates the codebase to use the new Hyde::makeTitle() helper.
 
 ### Deprecated
 - Deprecated Hyde::titleFromSlug(), use Hyde::makeTitle() instead.

--- a/packages/framework/resources/views/components/docs/labeled-sidebar-navigation-menu.blade.php
+++ b/packages/framework/resources/views/components/docs/labeled-sidebar-navigation-menu.blade.php
@@ -1,7 +1,7 @@
 <ul id="sidebar-navigation-menu" role="list">
 	@foreach ($sidebar->getCategories() as $category)
 	<li class="sidebar-category" role="listitem">
-		<h4 class="sidebar-category-heading">{{ Hyde::titleFromSlug($category) }}</h4>
+		<h4 class="sidebar-category-heading">{{ Hyde::makeTitle($category) }}</h4>
 		<ul class="sidebar-category-list" role="list">
 			@foreach ($sidebar->getItemsInCategory($category) as $item)
 			<li @class([ 'sidebar-navigation-item' , 'active'=> $item->destination === basename($currentPage)]) role="listitem">

--- a/packages/framework/src/Actions/GeneratesNavigationMenu.php
+++ b/packages/framework/src/Actions/GeneratesNavigationMenu.php
@@ -143,7 +143,7 @@ class GeneratesNavigationMenu
             return 'Home';
         }
 
-        return Hyde::titleFromSlug($slug);
+        return Hyde::makeTitle($slug);
     }
 
     /**

--- a/packages/framework/src/Concerns/HasDynamicTitle.php
+++ b/packages/framework/src/Concerns/HasDynamicTitle.php
@@ -20,7 +20,7 @@ trait HasDynamicTitle
         }
 
         return $this->findTitleTagInMarkdown($this->body)
-            ?: Hyde::titleFromSlug($this->slug);
+            ?: Hyde::makeTitle($this->slug);
     }
 
     /**

--- a/packages/framework/src/Helpers/HydeHelperFacade.php
+++ b/packages/framework/src/Helpers/HydeHelperFacade.php
@@ -26,6 +26,6 @@ trait HydeHelperFacade
      */
     public static function makeTitle(string $slug): string
     {
-        return Str::title(str_replace(['-', '_'], ' ', ($slug)));
+        return Str::headline($slug);
     }
 }

--- a/packages/framework/src/Helpers/HydeHelperFacade.php
+++ b/packages/framework/src/Helpers/HydeHelperFacade.php
@@ -26,6 +26,12 @@ trait HydeHelperFacade
      */
     public static function makeTitle(string $slug): string
     {
-        return Str::headline($slug);
+        $alwaysLowercase = ['a', 'an', 'the', 'in', 'on', 'by', 'with', 'of', 'and', 'or', 'but'];
+
+        return ucfirst(str_ireplace(
+            $alwaysLowercase,
+            $alwaysLowercase,
+            Str::headline($slug)
+        ));
     }
 }

--- a/packages/framework/src/Helpers/HydeHelperFacade.php
+++ b/packages/framework/src/Helpers/HydeHelperFacade.php
@@ -2,6 +2,8 @@
 
 namespace Hyde\Framework\Helpers;
 
+use Illuminate\Support\Str;
+
 /**
  * Provides convenient access to Hyde helpers, through the main Hyde facade.
  *
@@ -17,5 +19,13 @@ trait HydeHelperFacade
     public static function hasFeature(string $feature): bool
     {
         return Features::enabled($feature);
+    }
+
+    /**
+     * @since 0.44.0-beta (renamed from titleFromSlug)
+     */
+    public static function makeTitle(string $slug): string
+    {
+        return Str::title(str_replace('-', ' ', ($slug)));
     }
 }

--- a/packages/framework/src/Helpers/HydeHelperFacade.php
+++ b/packages/framework/src/Helpers/HydeHelperFacade.php
@@ -26,6 +26,6 @@ trait HydeHelperFacade
      */
     public static function makeTitle(string $slug): string
     {
-        return Str::title(str_replace('-', ' ', ($slug)));
+        return Str::title(str_replace(['-', '_'], ' ', ($slug)));
     }
 }

--- a/packages/framework/src/Hyde.php
+++ b/packages/framework/src/Hyde.php
@@ -44,6 +44,9 @@ class Hyde
         static::$basePath = $path;
     }
 
+    /**
+     * @deprecated v0.44.0-beta use Hyde::makeTitle() instead.
+     */
     public static function titleFromSlug(string $slug): string
     {
         return Str::title(str_replace('-', ' ', ($slug)));

--- a/packages/framework/src/Models/DocumentationSidebarItem.php
+++ b/packages/framework/src/Models/DocumentationSidebarItem.php
@@ -55,7 +55,7 @@ class DocumentationSidebarItem
         )->matter();
 
         return new static(
-            $matter['label'] ?? Hyde::titleFromSlug($documentationPageSlug),
+            $matter['label'] ?? Hyde::makeTitle($documentationPageSlug),
             $documentationPageSlug,
             $matter['priority'] ?? null,
             $matter['category'] ?? null,

--- a/packages/framework/tests/Unit/HydeHelperFacadeMakeTitleTest.php
+++ b/packages/framework/tests/Unit/HydeHelperFacadeMakeTitleTest.php
@@ -11,4 +11,9 @@ class HydeHelperFacadeMakeTitleTest extends TestCase
     {
         $this->assertEquals('Hello World', HydeHelperFacade::makeTitle('hello-world'));
     }
+
+    public function test_make_title_helper_parses_snake_case_into_title()
+    {
+        $this->assertEquals('Hello World', HydeHelperFacade::makeTitle('hello_world'));
+    }
 }

--- a/packages/framework/tests/Unit/HydeHelperFacadeMakeTitleTest.php
+++ b/packages/framework/tests/Unit/HydeHelperFacadeMakeTitleTest.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Hyde\Framework\Testing\Unit;
+
+use Hyde\Framework\Helpers\HydeHelperFacade;
+use Hyde\Testing\TestCase;
+
+class HydeHelperFacadeMakeTitleTest extends TestCase
+{
+    public function test_make_title_helper_parses_kebab_case_into_title()
+    {
+        $this->assertEquals('Hello World', HydeHelperFacade::makeTitle('hello-world'));
+    }
+}

--- a/packages/framework/tests/Unit/HydeHelperFacadeMakeTitleTest.php
+++ b/packages/framework/tests/Unit/HydeHelperFacadeMakeTitleTest.php
@@ -36,4 +36,10 @@ class HydeHelperFacadeMakeTitleTest extends TestCase
     {
         $this->assertEquals('Hello World', HydeHelperFacade::makeTitle('Hello World'));
     }
+
+    public function test_make_title_helper_does_not_capitalize_auxiliary_words()
+    {
+        $this->assertEquals('The a an the in on by with of and or but',
+            HydeHelperFacade::makeTitle('the_a_an_the_in_on_by_with_of_and_or_but'));
+    }
 }

--- a/packages/framework/tests/Unit/HydeHelperFacadeMakeTitleTest.php
+++ b/packages/framework/tests/Unit/HydeHelperFacadeMakeTitleTest.php
@@ -16,4 +16,24 @@ class HydeHelperFacadeMakeTitleTest extends TestCase
     {
         $this->assertEquals('Hello World', HydeHelperFacade::makeTitle('hello_world'));
     }
+
+    public function test_make_title_helper_parses_camel_case_into_title()
+    {
+        $this->assertEquals('Hello World', HydeHelperFacade::makeTitle('helloWorld'));
+    }
+
+    public function test_make_title_helper_parses_pascal_case_into_title()
+    {
+        $this->assertEquals('Hello World', HydeHelperFacade::makeTitle('HelloWorld'));
+    }
+
+    public function test_make_title_helper_parses_title_case_into_title()
+    {
+        $this->assertEquals('Hello World', HydeHelperFacade::makeTitle('Hello World'));
+    }
+
+    public function test_make_title_helper_parses_title_case_with_spaces_into_title()
+    {
+        $this->assertEquals('Hello World', HydeHelperFacade::makeTitle('Hello World'));
+    }
 }


### PR DESCRIPTION
The Hyde::titleFromSlug() helper is internally moved and is referenced through the new Hyde::makeTitle() helper which is an improved version, with a more general name. This is done by replacing the underlying implementation to use the Str::headline() helper instead of Str::title(), combined with a lookup table of auxiliary words that should be lowercase, while ensuring the first word is always capitalized.

The helper does not support fully uppercase input, which is okay since it is mainly intended to convert slugs to titles, as a fallback. I think it may be out of scope to parse uppercase input Hyde source filenames are recommended to be lowercase, but am open to change if requested.