### PR TITLE
Improve internal page model structure

### DIFF
--- a/docs/advanced-customization.md
+++ b/docs/advanced-customization.md
@@ -39,7 +39,7 @@ use Hyde\Framework\Concerns\RegistersDefaultDirectories;
 
 public function register(): void
 {
-    $this->registerDefaultDirectories([
+    $this->registerSourceDirectories([
         BladePage::class => '_pages',
         MarkdownPage::class => '_pages',
         MarkdownPost::class => '_posts',

--- a/packages/framework/src/Actions/CreatesNewPageSourceFile.php
+++ b/packages/framework/src/Actions/CreatesNewPageSourceFile.php
@@ -42,18 +42,18 @@ class CreatesNewPageSourceFile
     public function createPage(string $type): int|false
     {
         if ($type === MarkdownPage::class) {
-            $this->needsDirectory(MarkdownPage::$sourceDirectory);
+            $this->needsDirectory(MarkdownPage::getSourceDirectory());
 
             return $this->createMarkdownFile();
         }
         if ($type === BladePage::class) {
-            $this->needsDirectory(BladePage::$sourceDirectory);
+            $this->needsDirectory(BladePage::getSourceDirectory());
 
             return $this->createBladeFile();
         }
 
         if ($type === DocumentationPage::class) {
-            $this->needsDirectory(DocumentationPage::$sourceDirectory);
+            $this->needsDirectory(DocumentationPage::getSourceDirectory());
 
             return $this->createDocumentationFile();
         }

--- a/packages/framework/src/Concerns/Internal/FileHelpers.php
+++ b/packages/framework/src/Concerns/Internal/FileHelpers.php
@@ -29,8 +29,9 @@ trait FileHelpers
 
     /**
      * Get the path to the frontpage for the documentation.
-     * 
+     *
      * @deprecated v0.44.x should be moved to the documentation page model.
+     *
      * @return string|false returns false if no frontpage is found
      */
     public static function docsIndexPath(): string|false

--- a/packages/framework/src/Concerns/Internal/FileHelpers.php
+++ b/packages/framework/src/Concerns/Internal/FileHelpers.php
@@ -24,7 +24,7 @@ trait FileHelpers
      */
     public static function getDocumentationOutputDirectory(): string
     {
-        return trim(config('docs.output_directory', 'docs'), '/\\');
+        return DocumentationPage::getOutputDirectory();
     }
 
     /**

--- a/packages/framework/src/Concerns/Internal/FileHelpers.php
+++ b/packages/framework/src/Concerns/Internal/FileHelpers.php
@@ -33,11 +33,11 @@ trait FileHelpers
      */
     public static function docsIndexPath(): string|false
     {
-        if (file_exists(static::path(DocumentationPage::$sourceDirectory.'/index.md'))) {
+        if (file_exists(static::path(DocumentationPage::getSourceDirectory().'/index.md'))) {
             return trim(static::pageLink(static::getDocumentationOutputDirectory().'/index.html'), '/');
         }
 
-        if (file_exists(static::path(DocumentationPage::$sourceDirectory.'/readme.md'))) {
+        if (file_exists(static::path(DocumentationPage::getSourceDirectory().'/readme.md'))) {
             return trim(static::pageLink(static::getDocumentationOutputDirectory().'/readme.html'), '/');
         }
 

--- a/packages/framework/src/Concerns/Internal/FileHelpers.php
+++ b/packages/framework/src/Concerns/Internal/FileHelpers.php
@@ -29,7 +29,8 @@ trait FileHelpers
 
     /**
      * Get the path to the frontpage for the documentation.
-     *
+     * 
+     * @deprecated v0.44.x should be moved to the documentation page model.
      * @return string|false returns false if no frontpage is found
      */
     public static function docsIndexPath(): string|false

--- a/packages/framework/src/Concerns/Internal/FileHelpers.php
+++ b/packages/framework/src/Concerns/Internal/FileHelpers.php
@@ -18,6 +18,7 @@ trait FileHelpers
      * Get the subdirectory compiled documentation files are stored in.
      *
      * @since v0.39.x (replaces `Hyde::docsDirectory()`)
+     * @deprecated v0.44.x (handled in the page model property `outputDirectory`)
      *
      * @return string
      */

--- a/packages/framework/src/Concerns/RegistersDefaultDirectories.php
+++ b/packages/framework/src/Concerns/RegistersDefaultDirectories.php
@@ -22,7 +22,7 @@ trait RegistersDefaultDirectories
     {
         foreach ($directoryMapping as $class => $location) {
             /** @var AbstractPage $class */
-            $class::$sourceDirectory = $location;
+            $class::$sourceDirectory = trim($location, '/\\');
         }
     }
 
@@ -41,7 +41,7 @@ trait RegistersDefaultDirectories
     {
         foreach ($directoryMapping as $class => $location) {
             /** @var AbstractPage $class */
-            $class::$outputDirectory = $location;
+            $class::$outputDirectory = trim($location, '/\\');
         }
     }
 }

--- a/packages/framework/src/Concerns/RegistersDefaultDirectories.php
+++ b/packages/framework/src/Concerns/RegistersDefaultDirectories.php
@@ -12,7 +12,7 @@ trait RegistersDefaultDirectories
      * @param  array  $directoryMapping
      * @return void
      */
-    protected function registerDefaultDirectories(array $directoryMapping): void
+    protected function registerSourceDirectories(array $directoryMapping): void
     {
         foreach ($directoryMapping as $class => $location) {
             /** @var AbstractPage $class */

--- a/packages/framework/src/Concerns/RegistersDefaultDirectories.php
+++ b/packages/framework/src/Concerns/RegistersDefaultDirectories.php
@@ -4,6 +4,9 @@ namespace Hyde\Framework\Concerns;
 
 use Hyde\Framework\Contracts\AbstractPage;
 
+/**
+ * @deprecated will be renamed to RegistersFileLocations or similar
+ */
 trait RegistersDefaultDirectories
 {
     /**

--- a/packages/framework/src/Concerns/RegistersDefaultDirectories.php
+++ b/packages/framework/src/Concerns/RegistersDefaultDirectories.php
@@ -10,9 +10,12 @@ use Hyde\Framework\Contracts\AbstractPage;
 trait RegistersDefaultDirectories
 {
     /**
-     * Register the default directories.
+     * Register the default source directories for the given page classes.
+     * Location string should be relative to the root of the application.
+     * 
+     * @example registerSourceDirectories([AbstractPage::class => '_pages'])
      *
-     * @param  array  $directoryMapping
+     * @param  array  $directoryMapping{class: string<AbstractPage>, location: string}
      * @return void
      */
     protected function registerSourceDirectories(array $directoryMapping): void

--- a/packages/framework/src/Concerns/RegistersDefaultDirectories.php
+++ b/packages/framework/src/Concerns/RegistersDefaultDirectories.php
@@ -15,7 +15,7 @@ trait RegistersDefaultDirectories
      *
      * @example registerSourceDirectories([AbstractPage::class => '_pages'])
      *
-     * @param  array  $directoryMapping{class: string<AbstractPage>, location: string}
+     * @param  array  $directoryMapping{class:  string<AbstractPage>, location: string}
      * @return void
      */
     protected function registerSourceDirectories(array $directoryMapping): void

--- a/packages/framework/src/Concerns/RegistersDefaultDirectories.php
+++ b/packages/framework/src/Concerns/RegistersDefaultDirectories.php
@@ -12,7 +12,7 @@ trait RegistersDefaultDirectories
     /**
      * Register the default source directories for the given page classes.
      * Location string should be relative to the root of the application.
-     * 
+     *
      * @example registerSourceDirectories([AbstractPage::class => '_pages'])
      *
      * @param  array  $directoryMapping{class: string<AbstractPage>, location: string}
@@ -23,6 +23,25 @@ trait RegistersDefaultDirectories
         foreach ($directoryMapping as $class => $location) {
             /** @var AbstractPage $class */
             $class::$sourceDirectory = $location;
+        }
+    }
+
+    /*
+     * Register the optional output directories.
+     * Some HTML pages, like Blade and Markdown pages are stored right in the _site/ directory.
+     * However, some pages, like docs and posts are in subdirectories of the _site/ directory.
+     * Location string should be relative to the root of the application.
+     *
+     * @example registerOutputDirectories([AbstractPage::class => 'docs'])
+     *
+     * @param  array  $directoryMapping{class: string<AbstractPage>, location: string}
+     * @return void
+     */
+    protected function registerOutputDirectories(array $directoryMapping): void
+    {
+        foreach ($directoryMapping as $class => $location) {
+            /** @var AbstractPage $class */
+            $class::$outputDirectory = $location;
         }
     }
 }

--- a/packages/framework/src/Concerns/ValidatesExistence.php
+++ b/packages/framework/src/Concerns/ValidatesExistence.php
@@ -21,7 +21,7 @@ trait ValidatesExistence
     {
         /** @var \Hyde\Framework\Contracts\AbstractPage $model */
         $filepath = $model::getSourceDirectory().'/'.
-            $slug.$model::$fileExtension;
+            $slug.$model::getFileExtension();
 
         if (! file_exists(Hyde::path($filepath))) {
             throw new FileNotFoundException($filepath);

--- a/packages/framework/src/Concerns/ValidatesExistence.php
+++ b/packages/framework/src/Concerns/ValidatesExistence.php
@@ -20,7 +20,7 @@ trait ValidatesExistence
     public function validateExistence(string $model, string $slug): void
     {
         /** @var \Hyde\Framework\Contracts\AbstractPage $model */
-        $filepath = $model::$sourceDirectory.'/'.
+        $filepath = $model::getSourceDirectory().'/'.
             $slug.$model::$fileExtension;
 
         if (! file_exists(Hyde::path($filepath))) {

--- a/packages/framework/src/Contracts/AbstractPage.php
+++ b/packages/framework/src/Contracts/AbstractPage.php
@@ -48,9 +48,7 @@ abstract class AbstractPage implements PageContract
         return static::$parserClass;
     }
 
-    /**
-     * @inheritDoc
-     */
+    /** @inheritDoc */
     public static function getParser(string $slug): PageParserContract
     {
         return new static::$parserClass($slug);

--- a/packages/framework/src/Contracts/AbstractPage.php
+++ b/packages/framework/src/Contracts/AbstractPage.php
@@ -38,7 +38,7 @@ abstract class AbstractPage implements PageContract
     /** @inheritDoc */
     final public static function getFileExtension(): string
     {
-        return static::$fileExtension;
+        return '.'. trim(static::$fileExtension, '.');
     }
 
     /** @inheritDoc */

--- a/packages/framework/src/Contracts/AbstractPage.php
+++ b/packages/framework/src/Contracts/AbstractPage.php
@@ -16,18 +16,31 @@ abstract class AbstractPage implements PageContract
 {
     use HasPageMetadata;
 
+    /**
+     * The directory in where source files are stored.
+     * Relative to the root of the project.
+     */
     public static string $sourceDirectory;
+
+    /**
+     * The output subdirectory to store compiled HTML.
+     * Relative to the site output directory.
+     */
     public static string $outputDirectory;
+
+    /**
+     * The file extension of the source file (e.g. ".md").
+     */
     public static string $fileExtension;
+
+    /**
+     * The class that parses source files into page models.
+     * @var string<\Hyde\Framework\Contracts\PageParserContract>
+     */
     public static string $parserClass;
 
-    public string $slug;
 
-    public function getCurrentPagePath(): string
-    {
-        return $this->slug;
-    }
-
+    /** @inheritDoc */
     public static function all(): Collection
     {
         $collection = new Collection();
@@ -39,13 +52,23 @@ abstract class AbstractPage implements PageContract
         return $collection;
     }
 
+    /** @inheritDoc */
     public static function files(): array
     {
         return CollectionService::getSourceFileListForModel(static::class);
     }
 
+    /** @inheritDoc */
     public static function parse(string $slug): AbstractPage
     {
         return (new static::$parserClass($slug))->get();
+    }
+
+
+    public string $slug;
+
+    public function getCurrentPagePath(): string
+    {
+        return $this->slug;
     }
 }

--- a/packages/framework/src/Contracts/AbstractPage.php
+++ b/packages/framework/src/Contracts/AbstractPage.php
@@ -92,7 +92,7 @@ abstract class AbstractPage implements PageContract
     {
         // Using the trim function we ensure we don't have a leading slash when the output directory is the root directory.
         return trim(
-            static::getOutputDirectory() . '/' . trim($basename, '\\/') . static::getFileExtension(), '/'
+            static::getOutputDirectory() . '/' . trim($basename, '\\/'), '/'
         ) . '.html';
     }
 

--- a/packages/framework/src/Contracts/AbstractPage.php
+++ b/packages/framework/src/Contracts/AbstractPage.php
@@ -7,53 +7,41 @@ use Hyde\Framework\Services\CollectionService;
 use Illuminate\Support\Collection;
 
 /**
- * To ensure compatability with the Hyde Framework,
- * all Page Models must extend this class.
+ * To ensure compatibility with the Hyde Framework, all Page Models should extend this class.
  *
- * Markdown-based Pages should extend MarkdownDocument.
+ * Markdown-based Pages can extend the MarkdownDocument class to get relevant helpers.
+ * 
+ * To learn about what the methods do, see the PHPDocs in the PageContract.
+ * @see \Hyde\Framework\Contracts\PageContract
  */
 abstract class AbstractPage implements PageContract
 {
     use HasPageMetadata;
 
-    /**
-     * The directory in where source files are stored.
-     * Relative to the root of the project.
-     */
     public static string $sourceDirectory;
-
-    /**
-     * The output subdirectory to store compiled HTML.
-     * Relative to the site output directory.
-     */
     public static string $outputDirectory;
-
-    /**
-     * The file extension of the source file (e.g. ".md").
-     */
     public static string $fileExtension;
-
-    /**
-     * The class that parses source files into page models.
-     * @var string<\Hyde\Framework\Contracts\PageParserContract>
-     */
     public static string $parserClass;
 
+    /** @inheritDoc */
     final public static function getSourceDirectory(): string
     {
         return static::$sourceDirectory;
     }
 
+    /** @inheritDoc */
     final public static function getOutputDirectory(): string
     {
         return static::$outputDirectory;
     }
 
+    /** @inheritDoc */
     final public static function getFileExtension(): string
     {
         return static::$fileExtension;
     }
 
+    /** @inheritDoc */
     final public static function getParserClass(): string
     {
         return static::$parserClass;

--- a/packages/framework/src/Contracts/AbstractPage.php
+++ b/packages/framework/src/Contracts/AbstractPage.php
@@ -39,22 +39,22 @@ abstract class AbstractPage implements PageContract
      */
     public static string $parserClass;
 
-    public static function getSourceDirectory(): string
+    final public static function getSourceDirectory(): string
     {
         return static::$sourceDirectory;
     }
 
-    public static function getOutputDirectory(): string
+    final public static function getOutputDirectory(): string
     {
         return static::$outputDirectory;
     }
 
-    public static function getFileExtension(): string
+    final public static function getFileExtension(): string
     {
         return static::$fileExtension;
     }
 
-    public static function getParserClass(): string
+    final public static function getParserClass(): string
     {
         return static::$parserClass;
     }

--- a/packages/framework/src/Contracts/AbstractPage.php
+++ b/packages/framework/src/Contracts/AbstractPage.php
@@ -17,6 +17,7 @@ abstract class AbstractPage implements PageContract
     use HasPageMetadata;
 
     public static string $sourceDirectory;
+    public static string $outputDirectory;
     public static string $fileExtension;
     public static string $parserClass;
 

--- a/packages/framework/src/Contracts/AbstractPage.php
+++ b/packages/framework/src/Contracts/AbstractPage.php
@@ -102,4 +102,10 @@ abstract class AbstractPage implements PageContract
     {
         return trim(static::getOutputDirectory() . '/' .  $this->slug, '/');
     }
+
+    /** @inheritDoc */
+    public function getOutputPath(): string
+    {
+        return static::getCurrentPagePath() . '.html';
+    }
 }

--- a/packages/framework/src/Contracts/AbstractPage.php
+++ b/packages/framework/src/Contracts/AbstractPage.php
@@ -10,8 +10,9 @@ use Illuminate\Support\Collection;
  * To ensure compatibility with the Hyde Framework, all Page Models should extend this class.
  *
  * Markdown-based Pages can extend the MarkdownDocument class to get relevant helpers.
- * 
+ *
  * To learn about what the methods do, see the PHPDocs in the PageContract.
+ *
  * @see \Hyde\Framework\Contracts\PageContract
  */
 abstract class AbstractPage implements PageContract
@@ -38,7 +39,7 @@ abstract class AbstractPage implements PageContract
     /** @inheritDoc */
     final public static function getFileExtension(): string
     {
-        return '.'. trim(static::$fileExtension, '.');
+        return '.'.trim(static::$fileExtension, '.');
     }
 
     /** @inheritDoc */
@@ -52,7 +53,7 @@ abstract class AbstractPage implements PageContract
      */
     public static function getParser(string $slug): PageParserContract
     {
-        return (new static::$parserClass($slug));
+        return new static::$parserClass($slug);
     }
 
     /** @inheritDoc */
@@ -82,7 +83,7 @@ abstract class AbstractPage implements PageContract
     /** @inheritDoc */
     public static function qualifyBasename(string $basename): string
     {
-        return static::getSourceDirectory() . '/' . trim($basename, '\\/') . static::getFileExtension();
+        return static::getSourceDirectory().'/'.trim($basename, '\\/').static::getFileExtension();
     }
 
     /** @inheritDoc */
@@ -90,22 +91,21 @@ abstract class AbstractPage implements PageContract
     {
         // Using the trim function we ensure we don't have a leading slash when the output directory is the root directory.
         return trim(
-            static::getOutputDirectory() . '/' . trim($basename, '\\/'), '/'
-        ) . '.html';
+            static::getOutputDirectory().'/'.trim($basename, '\\/'), '/'
+        ).'.html';
     }
-
 
     public string $slug;
 
     /** @inheritDoc */
     public function getCurrentPagePath(): string
     {
-        return trim(static::getOutputDirectory() . '/' .  $this->slug, '/');
+        return trim(static::getOutputDirectory().'/'.$this->slug, '/');
     }
 
     /** @inheritDoc */
     public function getOutputPath(): string
     {
-        return static::getCurrentPagePath() . '.html';
+        return static::getCurrentPagePath().'.html';
     }
 }

--- a/packages/framework/src/Contracts/AbstractPage.php
+++ b/packages/framework/src/Contracts/AbstractPage.php
@@ -72,8 +72,8 @@ abstract class AbstractPage implements PageContract
     {
         $collection = new Collection();
 
-        foreach (CollectionService::getSourceFileListForModel(static::class) as $basename) {
-            $collection->push((static::getParser($basename))->get());
+        foreach (static::files() as $basename) {
+            $collection->push(static::parse($basename));
         }
 
         return $collection;

--- a/packages/framework/src/Contracts/AbstractPage.php
+++ b/packages/framework/src/Contracts/AbstractPage.php
@@ -85,9 +85,7 @@ abstract class AbstractPage implements PageContract
         return static::getSourceDirectory() . '/' . trim($basename, '\\/') . static::getFileExtension();
     }
 
-    /**
-     * @inheritDoc
-     */
+    /** @inheritDoc */
     public static function getOutputLocation(string $basename): string
     {
         // Using the trim function we ensure we don't have a leading slash when the output directory is the root directory.
@@ -99,6 +97,7 @@ abstract class AbstractPage implements PageContract
 
     public string $slug;
 
+    /** @inheritDoc */
     public function getCurrentPagePath(): string
     {
         return trim(static::getOutputDirectory() . '/' .  $this->slug, '/');

--- a/packages/framework/src/Contracts/AbstractPage.php
+++ b/packages/framework/src/Contracts/AbstractPage.php
@@ -101,6 +101,6 @@ abstract class AbstractPage implements PageContract
 
     public function getCurrentPagePath(): string
     {
-        return $this->slug;
+        return trim(static::getOutputDirectory() . '/' .  $this->slug, '/');
     }
 }

--- a/packages/framework/src/Contracts/AbstractPage.php
+++ b/packages/framework/src/Contracts/AbstractPage.php
@@ -14,6 +14,7 @@ use Illuminate\Support\Collection;
  * To learn about what the methods do, see the PHPDocs in the PageContract.
  *
  * @see \Hyde\Framework\Contracts\PageContract
+ * @test \Hyde\Framework\Testing\Feature\AbstractPageTest
  */
 abstract class AbstractPage implements PageContract
 {

--- a/packages/framework/src/Contracts/AbstractPage.php
+++ b/packages/framework/src/Contracts/AbstractPage.php
@@ -56,15 +56,9 @@ abstract class AbstractPage implements PageContract
     }
 
     /** @inheritDoc */
-    public static function all(): Collection
+    public static function parse(string $slug): static
     {
-        $collection = new Collection();
-
-        foreach (CollectionService::getSourceFileListForModel(static::class) as $basename) {
-            $collection->push((static::getParser($basename))->get());
-        }
-
-        return $collection;
+        return (new static::$parserClass($slug))->get();
     }
 
     /** @inheritDoc */
@@ -74,9 +68,15 @@ abstract class AbstractPage implements PageContract
     }
 
     /** @inheritDoc */
-    public static function parse(string $slug): static
+    public static function all(): Collection
     {
-        return (new static::$parserClass($slug))->get();
+        $collection = new Collection();
+
+        foreach (CollectionService::getSourceFileListForModel(static::class) as $basename) {
+            $collection->push((static::getParser($basename))->get());
+        }
+
+        return $collection;
     }
 
 

--- a/packages/framework/src/Contracts/AbstractPage.php
+++ b/packages/framework/src/Contracts/AbstractPage.php
@@ -39,7 +39,7 @@ abstract class AbstractPage implements PageContract
     /** @inheritDoc */
     final public static function getFileExtension(): string
     {
-        return '.'.trim(static::$fileExtension, '.');
+        return '.'.ltrim(static::$fileExtension, '.');
     }
 
     /** @inheritDoc */

--- a/packages/framework/src/Contracts/AbstractPage.php
+++ b/packages/framework/src/Contracts/AbstractPage.php
@@ -39,6 +39,26 @@ abstract class AbstractPage implements PageContract
      */
     public static string $parserClass;
 
+    public static function getSourceDirectory(): string
+    {
+        return static::$sourceDirectory;
+    }
+
+    public static function getOutputDirectory(): string
+    {
+        return static::$outputDirectory;
+    }
+
+    public static function getFileExtension(): string
+    {
+        return static::$fileExtension;
+    }
+
+    public static function getParserClass(): string
+    {
+        return static::$parserClass;
+    }
+
 
     /** @inheritDoc */
     public static function all(): Collection

--- a/packages/framework/src/Contracts/AbstractPage.php
+++ b/packages/framework/src/Contracts/AbstractPage.php
@@ -38,7 +38,7 @@ abstract class AbstractPage implements PageContract
     /** @inheritDoc */
     final public static function getFileExtension(): string
     {
-        return '.'. trim(static::getFileExtension(), '.');
+        return '.'. trim(static::$fileExtension, '.');
     }
 
     /** @inheritDoc */

--- a/packages/framework/src/Contracts/AbstractPage.php
+++ b/packages/framework/src/Contracts/AbstractPage.php
@@ -26,13 +26,13 @@ abstract class AbstractPage implements PageContract
     /** @inheritDoc */
     final public static function getSourceDirectory(): string
     {
-        return static::$sourceDirectory;
+        return trim(static::$sourceDirectory, '\\/');
     }
 
     /** @inheritDoc */
     final public static function getOutputDirectory(): string
     {
-        return static::$outputDirectory;
+        return trim(static::$outputDirectory, '\\/');
     }
 
     /** @inheritDoc */

--- a/packages/framework/src/Contracts/AbstractPage.php
+++ b/packages/framework/src/Contracts/AbstractPage.php
@@ -85,6 +85,17 @@ abstract class AbstractPage implements PageContract
         return static::getSourceDirectory() . '/' . trim($basename, '\\/') . static::getFileExtension();
     }
 
+    /**
+     * @inheritDoc
+     */
+    public static function getOutputLocation(string $basename): string
+    {
+        // Using the trim function we ensure we don't have a leading slash when the output directory is the root directory.
+        return trim(
+            static::getOutputDirectory() . '/' . trim($basename, '\\/') . static::getFileExtension(), '/'
+        ) . '.html';
+    }
+
 
     public string $slug;
 

--- a/packages/framework/src/Contracts/AbstractPage.php
+++ b/packages/framework/src/Contracts/AbstractPage.php
@@ -67,7 +67,7 @@ abstract class AbstractPage implements PageContract
     }
 
     /** @inheritDoc */
-    public static function parse(string $slug): AbstractPage
+    public static function parse(string $slug): static
     {
         return (new static::$parserClass($slug))->get();
     }

--- a/packages/framework/src/Contracts/AbstractPage.php
+++ b/packages/framework/src/Contracts/AbstractPage.php
@@ -61,7 +61,7 @@ abstract class AbstractPage implements PageContract
         $collection = new Collection();
 
         foreach (CollectionService::getSourceFileListForModel(static::class) as $filepath) {
-            $collection->push((new static::$parserClass(basename($filepath, static::getFileExtension())))->get());
+            $collection->push((new static::$parserClass($filepath))->get());
         }
 
         return $collection;

--- a/packages/framework/src/Contracts/AbstractPage.php
+++ b/packages/framework/src/Contracts/AbstractPage.php
@@ -60,8 +60,8 @@ abstract class AbstractPage implements PageContract
     {
         $collection = new Collection();
 
-        foreach (CollectionService::getSourceFileListForModel(static::class) as $filepath) {
-            $collection->push((new static::$parserClass($filepath))->get());
+        foreach (CollectionService::getSourceFileListForModel(static::class) as $basename) {
+            $collection->push((static::getParser($basename))->get());
         }
 
         return $collection;

--- a/packages/framework/src/Contracts/AbstractPage.php
+++ b/packages/framework/src/Contracts/AbstractPage.php
@@ -47,6 +47,13 @@ abstract class AbstractPage implements PageContract
         return static::$parserClass;
     }
 
+    /**
+     * @inheritDoc
+     */
+    public static function getParser(string $slug): PageParserContract
+    {
+        return (new static::$parserClass($slug));
+    }
 
     /** @inheritDoc */
     public static function all(): Collection

--- a/packages/framework/src/Contracts/AbstractPage.php
+++ b/packages/framework/src/Contracts/AbstractPage.php
@@ -38,7 +38,7 @@ abstract class AbstractPage implements PageContract
     /** @inheritDoc */
     final public static function getFileExtension(): string
     {
-        return '.'. trim(static::$fileExtension, '.');
+        return '.'. trim(static::getFileExtension(), '.');
     }
 
     /** @inheritDoc */
@@ -54,7 +54,7 @@ abstract class AbstractPage implements PageContract
         $collection = new Collection();
 
         foreach (CollectionService::getSourceFileListForModel(static::class) as $filepath) {
-            $collection->push((new static::$parserClass(basename($filepath, static::$fileExtension)))->get());
+            $collection->push((new static::$parserClass(basename($filepath, static::getFileExtension())))->get());
         }
 
         return $collection;

--- a/packages/framework/src/Contracts/AbstractPage.php
+++ b/packages/framework/src/Contracts/AbstractPage.php
@@ -79,6 +79,12 @@ abstract class AbstractPage implements PageContract
         return $collection;
     }
 
+    /** @inheritDoc */
+    public static function qualifyBasename(string $basename): string
+    {
+        return static::getSourceDirectory() . '/' . trim($basename, '\\/') . static::getFileExtension();
+    }
+
 
     public string $slug;
 

--- a/packages/framework/src/Contracts/PageContract.php
+++ b/packages/framework/src/Contracts/PageContract.php
@@ -31,6 +31,12 @@ interface PageContract
     public static function getParserClass(): string;
 
     /**
+     * Create and return a new PageParser instance for this model,
+     * with the given slug passed to the constructor.
+     */
+    public static function getParser(string $slug): PageParserContract;
+
+    /**
      * Get a collection of all pages, parsed into page models.
      *
      * @return \Illuminate\Support\Collection<static>

--- a/packages/framework/src/Contracts/PageContract.php
+++ b/packages/framework/src/Contracts/PageContract.php
@@ -64,4 +64,11 @@ interface PageContract
      * @see \Hyde\Framework\Testing\Unit\PageModelGetHelperTest
      */
     public static function all(): Collection;
+
+    /**
+     * Qualify a page basename into a referenceable file path.
+     * @param string $basename for the page model source file.
+     * @return string  path to the file relative to project root
+     */
+    public static function qualifyBasename(string $basename): string;
 }

--- a/packages/framework/src/Contracts/PageContract.php
+++ b/packages/framework/src/Contracts/PageContract.php
@@ -6,6 +6,11 @@ use Illuminate\Support\Collection;
 
 interface PageContract
 {
+    public static function getSourceDirectory(): string;
+    public static function getOutputDirectory(): string;
+    public static function getFileExtension(): string;
+    public static function getParserClass(): string;
+
     /**
      * Get a collection of all pages, parsed into page models.
      *

--- a/packages/framework/src/Contracts/PageContract.php
+++ b/packages/framework/src/Contracts/PageContract.php
@@ -8,24 +8,28 @@ interface PageContract
 {
     /**
      * Get the directory in where source files are stored.
+     *
      * @return string Path relative to the root of the project
      */
     public static function getSourceDirectory(): string;
 
     /**
      * Get the output subdirectory to store compiled HTML.
+     *
      * @return string Relative to the site output directory.
      */
     public static function getOutputDirectory(): string;
 
     /**
      * Get the file extension of the source files.
+     *
      * @return string (e.g. ".md")
      */
     public static function getFileExtension(): string;
 
     /**
      * Get the class that parses source files into page models.
+     *
      * @return string<\Hyde\Framework\Contracts\PageParserContract>
      */
     public static function getParserClass(): string;
@@ -67,30 +71,35 @@ interface PageContract
 
     /**
      * Qualify a page basename into a referenceable file path.
-     * @param string $basename for the page model source file.
-     * @return string  path to the file relative to project root
+     *
+     * @param  string  $basename  for the page model source file.
+     * @return string path to the file relative to project root
      */
     public static function qualifyBasename(string $basename): string;
 
     /**
      * Get the proper site output path for a page model.
-     * @param string $basename for the page model source file.
+     *
+     * @param  string  $basename  for the page model source file.
      * @return string of the output file relative to the site output directory.
+     *
      * @example DocumentationPage::getOutputPath('index') => 'docs/index.html'
      */
     public static function getOutputLocation(string $basename): string;
 
-
     /**
      * Get the URI path relative to the site root.
+     *
      * @example if the compiled page will be saved to _site/docs/index.html,
      *          then this method will return 'docs/index'
+     *
      * @return string URI path relative to the site root.
      */
     public function getCurrentPagePath(): string;
 
     /**
      * Get the path where the compiled page will be saved.
+     *
      * @return string Relative to the site output directory.
      */
     public function getOutputPath(): string;

--- a/packages/framework/src/Contracts/PageContract.php
+++ b/packages/framework/src/Contracts/PageContract.php
@@ -79,4 +79,12 @@ interface PageContract
      * @example DocumentationPage::getOutputPath('index') => 'docs/index.html'
      */
     public static function getOutputLocation(string $basename): string;
+
+
+    /**
+     * Get the uri path relative to the site root.
+     * @example if the compiled page will be saved to _site/docs/index.html,
+     *          then this method will return 'docs/index'
+     */
+    public function getCurrentPagePath(): string;
 }

--- a/packages/framework/src/Contracts/PageContract.php
+++ b/packages/framework/src/Contracts/PageContract.php
@@ -33,7 +33,7 @@ interface PageContract
     /**
      * Get a collection of all pages, parsed into page models.
      *
-     * @return \Illuminate\Support\Collection<\Hyde\Framework\Contracts\PageContract>
+     * @return \Illuminate\Support\Collection<static>
      *
      * @see \Hyde\Framework\Testing\Unit\PageModelGetHelperTest
      */

--- a/packages/framework/src/Contracts/PageContract.php
+++ b/packages/framework/src/Contracts/PageContract.php
@@ -37,13 +37,14 @@ interface PageContract
     public static function getParser(string $slug): PageParserContract;
 
     /**
-     * Get a collection of all pages, parsed into page models.
+     * Parse a source file slug into a page model.
      *
-     * @return \Illuminate\Support\Collection<static>
+     * @param  string  $slug
+     * @return static New page model instance for the parsed source file.
      *
-     * @see \Hyde\Framework\Testing\Unit\PageModelGetHelperTest
+     * @see \Hyde\Framework\Testing\Unit\PageModelParseHelperTest
      */
-    public static function all(): Collection;
+    public static function parse(string $slug): static;
 
     /**
      * Get an array of all the source file slugs for the model.
@@ -56,12 +57,11 @@ interface PageContract
     public static function files(): array;
 
     /**
-     * Parse a source file slug into a page model.
+     * Get a collection of all pages, parsed into page models.
      *
-     * @param  string  $slug
-     * @return static New page model instance for the parsed source file.
+     * @return \Illuminate\Support\Collection<static>
      *
-     * @see \Hyde\Framework\Testing\Unit\PageModelParseHelperTest
+     * @see \Hyde\Framework\Testing\Unit\PageModelGetHelperTest
      */
-    public static function parse(string $slug): static;
+    public static function all(): Collection;
 }

--- a/packages/framework/src/Contracts/PageContract.php
+++ b/packages/framework/src/Contracts/PageContract.php
@@ -88,4 +88,10 @@ interface PageContract
      * @return string URI path relative to the site root.
      */
     public function getCurrentPagePath(): string;
+
+    /**
+     * Get the path where the compiled page will be saved.
+     * @return string Relative to the site output directory.
+     */
+    public function getOutputPath(): string;
 }

--- a/packages/framework/src/Contracts/PageContract.php
+++ b/packages/framework/src/Contracts/PageContract.php
@@ -6,9 +6,28 @@ use Illuminate\Support\Collection;
 
 interface PageContract
 {
+    /**
+     * Get the directory in where source files are stored.
+     * @return string Path relative to the root of the project
+     */
     public static function getSourceDirectory(): string;
+
+    /**
+     * Get the output subdirectory to store compiled HTML.
+     * @return string Relative to the site output directory.
+     */
     public static function getOutputDirectory(): string;
+
+    /**
+     * Get the file extension of the source files.
+     * @return string (e.g. ".md")
+     */
     public static function getFileExtension(): string;
+
+    /**
+     * Get the class that parses source files into page models.
+     * @return string<\Hyde\Framework\Contracts\PageParserContract>
+     */
     public static function getParserClass(): string;
 
     /**

--- a/packages/framework/src/Contracts/PageContract.php
+++ b/packages/framework/src/Contracts/PageContract.php
@@ -53,9 +53,9 @@ interface PageContract
      * Parse a source file slug into a page model.
      *
      * @param  string  $slug
-     * @return \Hyde\Framework\Contracts\AbstractPage
+     * @return static New page model instance for the parsed source file.
      *
      * @see \Hyde\Framework\Testing\Unit\PageModelParseHelperTest
      */
-    public static function parse(string $slug): AbstractPage;
+    public static function parse(string $slug): static;
 }

--- a/packages/framework/src/Contracts/PageContract.php
+++ b/packages/framework/src/Contracts/PageContract.php
@@ -71,4 +71,12 @@ interface PageContract
      * @return string  path to the file relative to project root
      */
     public static function qualifyBasename(string $basename): string;
+
+    /**
+     * Get the proper site output path for a page model.
+     * @param string $basename for the page model source file.
+     * @return string of the output file relative to the site output directory.
+     * @example DocumentationPage::getOutputPath('index') => 'docs/index.html'
+     */
+    public static function getOutputLocation(string $basename): string;
 }

--- a/packages/framework/src/Contracts/PageContract.php
+++ b/packages/framework/src/Contracts/PageContract.php
@@ -82,9 +82,10 @@ interface PageContract
 
 
     /**
-     * Get the uri path relative to the site root.
+     * Get the URI path relative to the site root.
      * @example if the compiled page will be saved to _site/docs/index.html,
      *          then this method will return 'docs/index'
+     * @return string URI path relative to the site root.
      */
     public function getCurrentPagePath(): string;
 }

--- a/packages/framework/src/HydeServiceProvider.php
+++ b/packages/framework/src/HydeServiceProvider.php
@@ -59,7 +59,7 @@ class HydeServiceProvider extends ServiceProvider
             BladePage::class => '',
             MarkdownPage::class => '',
             MarkdownPost::class => 'posts',
-            DocumentationPage::class => 'docs',
+            DocumentationPage::class => config('docs.output_directory', 'docs'),
         ]);
 
         $this->discoverBladeViewsIn('_pages');

--- a/packages/framework/src/HydeServiceProvider.php
+++ b/packages/framework/src/HydeServiceProvider.php
@@ -55,6 +55,13 @@ class HydeServiceProvider extends ServiceProvider
             DocumentationPage::class => '_docs',
         ]);
 
+        $this->registerOutputDirectories([
+            BladePage::class => '',
+            MarkdownPage::class => '',
+            MarkdownPost::class => 'posts',
+            DocumentationPage::class => 'docs',
+        ]);
+
         $this->discoverBladeViewsIn('_pages');
 
         /** @deprecated v0.43.0-beta and is used here as a fallback for compatibility */

--- a/packages/framework/src/HydeServiceProvider.php
+++ b/packages/framework/src/HydeServiceProvider.php
@@ -48,7 +48,7 @@ class HydeServiceProvider extends ServiceProvider
 
         $this->app->singleton(AssetServiceContract::class, AssetService::class);
 
-        $this->registerDefaultDirectories([
+        $this->registerSourceDirectories([
             BladePage::class => '_pages',
             MarkdownPage::class => '_pages',
             MarkdownPost::class => '_posts',

--- a/packages/framework/src/Models/BladePage.php
+++ b/packages/framework/src/Models/BladePage.php
@@ -3,11 +3,12 @@
 namespace Hyde\Framework\Models;
 
 use Hyde\Framework\Contracts\AbstractPage;
+use Hyde\Framework\Contracts\PageParserContract;
 
 /**
  * A basic wrapper for the custom Blade View compiler.
  */
-class BladePage extends AbstractPage
+class BladePage extends AbstractPage implements PageParserContract
 {
     /**
      * The name of the Blade View to compile.
@@ -40,6 +41,13 @@ class BladePage extends AbstractPage
     public static string $fileExtension = '.blade.php';
     public static string $parserClass = self::class;
 
+
+    public function getCurrentPagePath(): string
+    {
+        return $this->view;
+    }
+
+
     /**
      * Since this model also acts as a Blade View compiler,
      * we implement the get method for compatability.
@@ -49,8 +57,11 @@ class BladePage extends AbstractPage
         return $this;
     }
 
-    public function getCurrentPagePath(): string
-    {
-        return $this->view;
+    /**
+     * Since this model also acts as a Blade View compiler,
+     * we implement the execute method for compatability.
+     */
+    public function execute(): void {
+        // There's nothing to do here.
     }
 }

--- a/packages/framework/src/Models/BladePage.php
+++ b/packages/framework/src/Models/BladePage.php
@@ -38,6 +38,8 @@ class BladePage extends AbstractPage implements PageParserContract
     }
 
     public static string $sourceDirectory = '_pages';
+    public static string $outputDirectory = '';
+    
     public static string $fileExtension = '.blade.php';
     public static string $parserClass = self::class;
 

--- a/packages/framework/src/Models/BladePage.php
+++ b/packages/framework/src/Models/BladePage.php
@@ -39,11 +39,10 @@ class BladePage extends AbstractPage implements PageParserContract
 
     public static string $sourceDirectory = '_pages';
     public static string $outputDirectory = '';
-    
+
     public static string $fileExtension = '.blade.php';
     public static string $parserClass = self::class;
 
-    
     /**
      * Since this model also acts as a Blade View compiler,
      * we implement the get method for compatability.
@@ -57,7 +56,8 @@ class BladePage extends AbstractPage implements PageParserContract
      * Since this model also acts as a Blade View compiler,
      * we implement the execute method for compatability.
      */
-    public function execute(): void {
+    public function execute(): void
+    {
         // There's nothing to do here.
     }
 }

--- a/packages/framework/src/Models/BladePage.php
+++ b/packages/framework/src/Models/BladePage.php
@@ -43,13 +43,7 @@ class BladePage extends AbstractPage implements PageParserContract
     public static string $fileExtension = '.blade.php';
     public static string $parserClass = self::class;
 
-
-    public function getCurrentPagePath(): string
-    {
-        return $this->view;
-    }
-
-
+    
     /**
      * Since this model also acts as a Blade View compiler,
      * we implement the get method for compatability.

--- a/packages/framework/src/Models/DocumentationPage.php
+++ b/packages/framework/src/Models/DocumentationPage.php
@@ -11,6 +11,8 @@ class DocumentationPage extends MarkdownDocument
     use HasTableOfContents;
 
     public static string $sourceDirectory = '_docs';
+    public static string $outputDirectory = 'docs';
+    
     public static string $parserClass = DocumentationPageParser::class;
 
     public function __construct(array $matter = [], string $body = '', string $title = '', string $slug = '')

--- a/packages/framework/src/Models/DocumentationPage.php
+++ b/packages/framework/src/Models/DocumentationPage.php
@@ -22,10 +22,6 @@ class DocumentationPage extends MarkdownDocument
         $this->constructTableOfContents();
     }
 
-    public function getCurrentPagePath(): string
-    {
-        return trim(Hyde::getDocumentationOutputDirectory().'/'.$this->slug, '/');
-    }
 
     /** @internal */
     public function getOnlineSourcePath(): string|false

--- a/packages/framework/src/Models/DocumentationPage.php
+++ b/packages/framework/src/Models/DocumentationPage.php
@@ -39,6 +39,7 @@ class DocumentationPage extends MarkdownDocument
 
     /**
      * @since v0.39.x (replaces `Hyde::docsDirectory()`)
+     * @deprecated v0.44.x (handled in the page model property `outputDirectory`)
      */
     public static function getDocumentationOutputPath(): string
     {

--- a/packages/framework/src/Models/DocumentationPage.php
+++ b/packages/framework/src/Models/DocumentationPage.php
@@ -12,7 +12,7 @@ class DocumentationPage extends MarkdownDocument
 
     public static string $sourceDirectory = '_docs';
     public static string $outputDirectory = 'docs';
-    
+
     public static string $parserClass = DocumentationPageParser::class;
 
     public function __construct(array $matter = [], string $body = '', string $title = '', string $slug = '')
@@ -45,4 +45,17 @@ class DocumentationPage extends MarkdownDocument
     {
         return trim(config('docs.output_directory', 'docs'), '/\\');
     }
+
+    /**
+     * @internal for compatibility until the service provider bootstraps the page path
+     * @deprecated
+     */
+    public static function getOutputLocation(string $basename): string
+    {
+        return trim(
+                static::getDocumentationOutputPath() . '/' . trim($basename, '\\/'), '/'
+            ) . '.html';
+    }
+
+
 }

--- a/packages/framework/src/Models/DocumentationPage.php
+++ b/packages/framework/src/Models/DocumentationPage.php
@@ -45,17 +45,4 @@ class DocumentationPage extends MarkdownDocument
     {
         return trim(config('docs.output_directory', 'docs'), '/\\');
     }
-
-    /**
-     * @internal for compatibility until the service provider bootstraps the page path
-     * @deprecated
-     */
-    public static function getOutputLocation(string $basename): string
-    {
-        return trim(
-                static::getDocumentationOutputPath() . '/' . trim($basename, '\\/'), '/'
-            ) . '.html';
-    }
-
-
 }

--- a/packages/framework/src/Models/DocumentationPage.php
+++ b/packages/framework/src/Models/DocumentationPage.php
@@ -22,7 +22,6 @@ class DocumentationPage extends MarkdownDocument
         $this->constructTableOfContents();
     }
 
-
     /** @internal */
     public function getOnlineSourcePath(): string|false
     {

--- a/packages/framework/src/Models/MarkdownPage.php
+++ b/packages/framework/src/Models/MarkdownPage.php
@@ -7,5 +7,7 @@ use Hyde\Framework\Models\Parsers\MarkdownPageParser;
 class MarkdownPage extends MarkdownDocument
 {
     public static string $sourceDirectory = '_pages';
+    public static string $outputDirectory = '';
+
     public static string $parserClass = MarkdownPageParser::class;
 }

--- a/packages/framework/src/Models/MarkdownPost.php
+++ b/packages/framework/src/Models/MarkdownPost.php
@@ -39,11 +39,6 @@ class MarkdownPost extends MarkdownDocument
         $this->category = $this->matter['category'] ?? null;
     }
 
-    public function getCurrentPagePath(): string
-    {
-        return 'posts/'.$this->slug;
-    }
-
     public function getCanonicalLink(): string
     {
         return Hyde::uriPath(Hyde::pageLink($this->getCurrentPagePath().'.html'));

--- a/packages/framework/src/Models/MarkdownPost.php
+++ b/packages/framework/src/Models/MarkdownPost.php
@@ -20,6 +20,8 @@ class MarkdownPost extends MarkdownDocument
     public ?string $category;
 
     public static string $sourceDirectory = '_posts';
+    public static string $outputDirectory = 'posts';
+
     public static string $parserClass = MarkdownPostParser::class;
 
     /**

--- a/packages/framework/src/Services/CollectionService.php
+++ b/packages/framework/src/Services/CollectionService.php
@@ -53,7 +53,7 @@ class CollectionService
     {
         $array = [];
 
-        foreach (glob(Hyde::path(BladePage::$sourceDirectory.'/*.blade.php')) as $filepath) {
+        foreach (glob(Hyde::path(BladePage::getSourceDirectory().'/*.blade.php')) as $filepath) {
             if (! str_starts_with(basename($filepath), '_')) {
                 $array[] = basename($filepath, '.blade.php');
             }
@@ -71,7 +71,7 @@ class CollectionService
     {
         $array = [];
 
-        foreach (glob(Hyde::path(MarkdownPage::$sourceDirectory.'/*.md')) as $filepath) {
+        foreach (glob(Hyde::path(MarkdownPage::getSourceDirectory().'/*.md')) as $filepath) {
             if (! str_starts_with(basename($filepath), '_')) {
                 $array[] = basename($filepath, '.md');
             }
@@ -89,7 +89,7 @@ class CollectionService
     {
         $array = [];
 
-        foreach (glob(Hyde::path(MarkdownPost::$sourceDirectory.'/*.md')) as $filepath) {
+        foreach (glob(Hyde::path(MarkdownPost::getSourceDirectory().'/*.md')) as $filepath) {
             if (! str_starts_with(basename($filepath), '_')) {
                 $array[] = basename($filepath, '.md');
             }
@@ -107,7 +107,7 @@ class CollectionService
     {
         $array = [];
 
-        foreach (glob(Hyde::path(DocumentationPage::$sourceDirectory.'/*.md')) as $filepath) {
+        foreach (glob(Hyde::path(DocumentationPage::getSourceDirectory().'/*.md')) as $filepath) {
             if (! str_starts_with(basename($filepath), '_')) {
                 $array[] = basename($filepath, '.md');
             }

--- a/packages/framework/src/Services/CollectionService.php
+++ b/packages/framework/src/Services/CollectionService.php
@@ -53,7 +53,7 @@ class CollectionService
     {
         $array = [];
 
-        foreach (glob(Hyde::path(BladePage::getSourceDirectory().'/*.blade.php')) as $filepath) {
+        foreach (glob(Hyde::path(BladePage::qualifyBasename('*'))) as $filepath) {
             if (! str_starts_with(basename($filepath), '_')) {
                 $array[] = basename($filepath, '.blade.php');
             }
@@ -71,7 +71,7 @@ class CollectionService
     {
         $array = [];
 
-        foreach (glob(Hyde::path(MarkdownPage::getSourceDirectory().'/*.md')) as $filepath) {
+        foreach (glob(Hyde::path(MarkdownPage::qualifyBasename('*'))) as $filepath) {
             if (! str_starts_with(basename($filepath), '_')) {
                 $array[] = basename($filepath, '.md');
             }
@@ -89,7 +89,7 @@ class CollectionService
     {
         $array = [];
 
-        foreach (glob(Hyde::path(MarkdownPost::getSourceDirectory().'/*.md')) as $filepath) {
+        foreach (glob(Hyde::path(MarkdownPost::qualifyBasename('*'))) as $filepath) {
             if (! str_starts_with(basename($filepath), '_')) {
                 $array[] = basename($filepath, '.md');
             }
@@ -107,7 +107,7 @@ class CollectionService
     {
         $array = [];
 
-        foreach (glob(Hyde::path(DocumentationPage::getSourceDirectory().'/*.md')) as $filepath) {
+        foreach (glob(Hyde::path(DocumentationPage::qualifyBasename('*'))) as $filepath) {
             if (! str_starts_with(basename($filepath), '_')) {
                 $array[] = basename($filepath, '.md');
             }

--- a/packages/framework/src/Services/DiscoveryService.php
+++ b/packages/framework/src/Services/DiscoveryService.php
@@ -18,7 +18,7 @@ class DiscoveryService
     public static function getParserClassForModel(string $model): string
     {
         /** @var AbstractPage $model */
-        return $model::$parserClass;
+        return $model::getParserClass();
     }
 
     /**

--- a/packages/framework/src/Services/DiscoveryService.php
+++ b/packages/framework/src/Services/DiscoveryService.php
@@ -52,7 +52,7 @@ class DiscoveryService
     public static function getFilePathForModelClassFiles(string $model): string
     {
         /** @var AbstractPage $model */
-        return $model::$sourceDirectory;
+        return $model::getSourceDirectory();
     }
 
     /**
@@ -65,20 +65,20 @@ class DiscoveryService
      */
     public static function findModelFromFilePath(string $filepath): string|false
     {
-        if (str_starts_with($filepath, MarkdownPost::$sourceDirectory)) {
+        if (str_starts_with($filepath, MarkdownPost::getSourceDirectory())) {
             return MarkdownPost::class;
         }
 
-        if (str_starts_with($filepath, DocumentationPage::$sourceDirectory)) {
+        if (str_starts_with($filepath, DocumentationPage::getSourceDirectory())) {
             return DocumentationPage::class;
         }
 
-        if (str_starts_with($filepath, MarkdownPage::$sourceDirectory)
+        if (str_starts_with($filepath, MarkdownPage::getSourceDirectory())
             && str_ends_with($filepath, '.md')) {
             return MarkdownPage::class;
         }
 
-        if (str_starts_with($filepath, BladePage::$sourceDirectory)
+        if (str_starts_with($filepath, BladePage::getSourceDirectory())
             && str_ends_with($filepath, '.blade.php')) {
             return BladePage::class;
         }

--- a/packages/framework/src/Services/DiscoveryService.php
+++ b/packages/framework/src/Services/DiscoveryService.php
@@ -43,7 +43,7 @@ class DiscoveryService
     public static function getFileExtensionForModelFiles(string $model): string
     {
         /** @var AbstractPage $model */
-        return $model::$fileExtension;
+        return $model::getFileExtension();
     }
 
     /**

--- a/packages/framework/src/Services/SitemapService.php
+++ b/packages/framework/src/Services/SitemapService.php
@@ -84,7 +84,7 @@ class SitemapService
     {
         return date('c', filemtime(
             /** @var \Hyde\Framework\Contracts\AbstractPage $pageClass */
-            Hyde::path($pageClass::getSourceDirectory().DIRECTORY_SEPARATOR.$slug.$pageClass::$fileExtension)
+            Hyde::path($pageClass::getSourceDirectory().DIRECTORY_SEPARATOR.$slug.$pageClass::getFileExtension())
         ));
     }
 

--- a/packages/framework/src/Services/SitemapService.php
+++ b/packages/framework/src/Services/SitemapService.php
@@ -84,7 +84,7 @@ class SitemapService
     {
         return date('c', filemtime(
             /** @var \Hyde\Framework\Contracts\AbstractPage $pageClass */
-            Hyde::path($pageClass::$sourceDirectory.DIRECTORY_SEPARATOR.$slug.$pageClass::$fileExtension)
+            Hyde::path($pageClass::getSourceDirectory().DIRECTORY_SEPARATOR.$slug.$pageClass::$fileExtension)
         ));
     }
 

--- a/packages/framework/src/StaticPageBuilder.php
+++ b/packages/framework/src/StaticPageBuilder.php
@@ -52,30 +52,29 @@ class StaticPageBuilder
         $this->needsDirectory(Hyde::getSiteOutputPath(Hyde::getDocumentationOutputDirectory()));
 
         if ($this->page instanceof BladePage) {
-            return $this->save($this->page->view, $this->compileView());
+            return $this->save($this->compileView());
         }
 
         if ($this->page instanceof MarkdownPost) {
-            return $this->save('posts/'.$this->page->slug, $this->compilePost());
+            return $this->save($this->compilePost());
         }
 
         if ($this->page instanceof MarkdownPage) {
-            return $this->save($this->page->slug, $this->compilePage());
+            return $this->save($this->compilePage());
         }
 
         if ($this->page instanceof DocumentationPage) {
-            return $this->save(Hyde::getDocumentationOutputDirectory().'/'.$this->page->slug, $this->compileDocs());
+            return $this->save($this->compileDocs());
         }
     }
 
     /**
      * Save the compiled HTML to file.
      *
-     * @param  string  $location  of the output file relative to the site output directory
      * @param  string  $contents  to save to the file
      * @return string the path to the saved file (since v0.32.x)
      */
-    private function save(string $location, string $contents): string
+    private function save(string $contents): string
     {
         $path = Hyde::getSiteOutputPath($this->page::getOutputLocation($this->page->slug));
 

--- a/packages/framework/src/StaticPageBuilder.php
+++ b/packages/framework/src/StaticPageBuilder.php
@@ -75,7 +75,7 @@ class StaticPageBuilder
      */
     private function save(string $location, string $contents): string
     {
-        $path = Hyde::getSiteOutputPath("$location.html");
+        $path = Hyde::getSiteOutputPath($this->page::getOutputLocation($this->page->slug));
 
         file_put_contents($path, $contents);
 

--- a/packages/framework/src/StaticPageBuilder.php
+++ b/packages/framework/src/StaticPageBuilder.php
@@ -46,7 +46,9 @@ class StaticPageBuilder
         view()->share('currentPage', $this->page->getCurrentPagePath());
 
         $this->needsDirectory(static::$outputPath);
-        $this->needsDirectory(Hyde::getSiteOutputPath('posts'));
+        $this->needsDirectory(Hyde::getSiteOutputPath($this->page::getOutputDirectory()));
+
+        /** @deprecated */
         $this->needsDirectory(Hyde::getSiteOutputPath(Hyde::getDocumentationOutputDirectory()));
 
         if ($this->page instanceof BladePage) {

--- a/packages/framework/src/StaticPageBuilder.php
+++ b/packages/framework/src/StaticPageBuilder.php
@@ -48,9 +48,6 @@ class StaticPageBuilder
         $this->needsDirectory(static::$outputPath);
         $this->needsDirectory(Hyde::getSiteOutputPath($this->page::getOutputDirectory()));
 
-        /** @deprecated */
-        $this->needsDirectory(Hyde::getSiteOutputPath(Hyde::getDocumentationOutputDirectory()));
-
         if ($this->page instanceof BladePage) {
             return $this->save($this->compileView());
         }

--- a/packages/framework/src/StaticPageBuilder.php
+++ b/packages/framework/src/StaticPageBuilder.php
@@ -73,7 +73,7 @@ class StaticPageBuilder
      */
     private function save(string $contents): string
     {
-        $path = Hyde::getSiteOutputPath($this->page::getOutputLocation($this->page->slug));
+        $path = Hyde::getSiteOutputPath($this->page->getOutputPath());
 
         file_put_contents($path, $contents);
 

--- a/packages/framework/tests/Feature/AbstractPageTest.php
+++ b/packages/framework/tests/Feature/AbstractPageTest.php
@@ -3,10 +3,10 @@
 namespace Hyde\Framework\Testing\Feature;
 
 use Hyde\Framework\Hyde;
+use Hyde\Framework\Models\MarkdownPage;
 use Hyde\Framework\Models\Parsers\MarkdownPageParser;
 use Hyde\Framework\Models\Parsers\MarkdownPostParser;
 use Hyde\Testing\TestCase;
-use Hyde\Framework\Models\MarkdownPage;
 
 /**
  * Test the AbstractPage class.
@@ -21,42 +21,50 @@ use Hyde\Framework\Models\MarkdownPage;
  */
 class AbstractPageTest extends TestCase
 {
-    public function test_get_source_directory_returns_static_property() {
+    public function test_get_source_directory_returns_static_property()
+    {
         MarkdownPage::$sourceDirectory = 'foo';
         $this->assertEquals('foo', MarkdownPage::getSourceDirectory());
     }
 
-    public function test_get_source_directory_trims_trailing_slashes() {
+    public function test_get_source_directory_trims_trailing_slashes()
+    {
         MarkdownPage::$sourceDirectory = '/foo/\\';
         $this->assertEquals('foo', MarkdownPage::getSourceDirectory());
     }
 
-    public function test_get_output_directory_returns_static_property() {
+    public function test_get_output_directory_returns_static_property()
+    {
         MarkdownPage::$outputDirectory = 'foo';
         $this->assertEquals('foo', MarkdownPage::getOutputDirectory());
     }
 
-    public function test_get_output_directory_trims_trailing_slashes() {
+    public function test_get_output_directory_trims_trailing_slashes()
+    {
         MarkdownPage::$outputDirectory = '/foo/\\';
         $this->assertEquals('foo', MarkdownPage::getOutputDirectory());
     }
 
-    public function test_get_file_extension_returns_static_property() {
+    public function test_get_file_extension_returns_static_property()
+    {
         MarkdownPage::$fileExtension = '.foo';
         $this->assertEquals('.foo', MarkdownPage::getFileExtension());
     }
 
-    public function test_get_file_extension_forces_leading_period() {
+    public function test_get_file_extension_forces_leading_period()
+    {
         MarkdownPage::$fileExtension = 'foo';
         $this->assertEquals('.foo', MarkdownPage::getFileExtension());
     }
 
-    public function test_get_parser_class_returns_static_property() {
+    public function test_get_parser_class_returns_static_property()
+    {
         MarkdownPage::$parserClass = 'foo';
         $this->assertEquals('foo', MarkdownPage::getParserClass());
     }
 
-    public function test_get_parser_returns_the_configured_parser_class() {
+    public function test_get_parser_returns_the_configured_parser_class()
+    {
         touch(Hyde::path('_posts/foo.md'));
 
         MarkdownPage::$parserClass = MarkdownPostParser::class;
@@ -65,7 +73,8 @@ class AbstractPageTest extends TestCase
         unlink(Hyde::path('_posts/foo.md'));
     }
 
-    public function test_get_parser_returns_instantiated_parser_for_the_supplied_slug() {
+    public function test_get_parser_returns_instantiated_parser_for_the_supplied_slug()
+    {
         touch(Hyde::path('_pages/foo.md'));
 
         $this->assertInstanceOf(MarkdownPageParser::class, $parser = MarkdownPage::getParser('foo'));
@@ -74,7 +83,8 @@ class AbstractPageTest extends TestCase
         unlink(Hyde::path('_pages/foo.md'));
     }
 
-    public function test_parse_parses_supplied_slug_into_a_page_model() {
+    public function test_parse_parses_supplied_slug_into_a_page_model()
+    {
         touch(Hyde::path('_pages/foo.md'));
 
         $this->assertInstanceOf(MarkdownPage::class, $page = MarkdownPage::parse('foo'));
@@ -83,13 +93,15 @@ class AbstractPageTest extends TestCase
         unlink(Hyde::path('_pages/foo.md'));
     }
 
-    public function test_files_returns_array_of_source_files() {
+    public function test_files_returns_array_of_source_files()
+    {
         touch(Hyde::path('_pages/foo.md'));
         $this->assertEquals(['foo'], MarkdownPage::files());
         unlink(Hyde::path('_pages/foo.md'));
     }
 
-    public function test_all_returns_collection_of_all_source_files_parsed_into_the_model() {
+    public function test_all_returns_collection_of_all_source_files_parsed_into_the_model()
+    {
         touch(Hyde::path('_pages/foo.md'));
         $this->assertEquals(
             collect([new MarkdownPage([], '', '', 'foo')]),
@@ -98,56 +110,67 @@ class AbstractPageTest extends TestCase
         unlink(Hyde::path('_pages/foo.md'));
     }
 
-    public function test_qualify_basename_properly_expands_basename_for_the_model() {
+    public function test_qualify_basename_properly_expands_basename_for_the_model()
+    {
         $this->assertEquals('_pages/foo.md', MarkdownPage::qualifyBasename('foo'));
     }
 
-    public function test_qualify_basename_trims_slashes_from_input() {
+    public function test_qualify_basename_trims_slashes_from_input()
+    {
         $this->assertEquals('_pages/foo.md', MarkdownPage::qualifyBasename('/foo/\\'));
     }
 
-    public function test_qualify_basename_uses_the_static_properties() {
+    public function test_qualify_basename_uses_the_static_properties()
+    {
         MarkdownPage::$sourceDirectory = 'foo';
         MarkdownPage::$fileExtension = 'txt';
         $this->assertEquals('foo/bar.txt', MarkdownPage::qualifyBasename('bar'));
     }
 
-    public function test_get_output_location_returns_the_file_output_path_for_the_supplied_basename() {
+    public function test_get_output_location_returns_the_file_output_path_for_the_supplied_basename()
+    {
         $this->assertEquals('foo.html', MarkdownPage::getOutputLocation('foo'));
     }
 
-    public function test_get_output_location_returns_the_configured_location() {
+    public function test_get_output_location_returns_the_configured_location()
+    {
         MarkdownPage::$outputDirectory = 'foo';
         $this->assertEquals('foo/bar.html', MarkdownPage::getOutputLocation('bar'));
     }
 
-    public function test_get_output_location_trims_trailing_slashes_from_directory_setting() {
+    public function test_get_output_location_trims_trailing_slashes_from_directory_setting()
+    {
         MarkdownPage::$outputDirectory = '/foo/\\';
         $this->assertEquals('foo/bar.html', MarkdownPage::getOutputLocation('bar'));
     }
 
-    public function test_get_output_location_trims_trailing_slashes_from_basename() {
+    public function test_get_output_location_trims_trailing_slashes_from_basename()
+    {
         $this->assertEquals('foo.html', MarkdownPage::getOutputLocation('/foo/\\'));
     }
 
-    public function test_get_current_page_path_returns_output_directory_and_basename() {
+    public function test_get_current_page_path_returns_output_directory_and_basename()
+    {
         $page = new MarkdownPage([], '', '', 'foo');
         $this->assertEquals('foo', $page->getCurrentPagePath());
     }
 
-    public function test_get_current_page_path_returns_output_directory_and_basename_for_configured_directory() {
+    public function test_get_current_page_path_returns_output_directory_and_basename_for_configured_directory()
+    {
         MarkdownPage::$outputDirectory = 'foo';
         $page = new MarkdownPage([], '', '', 'bar');
         $this->assertEquals('foo/bar', $page->getCurrentPagePath());
     }
 
-    public function test_get_current_page_path_trims_trailing_slashes_from_directory_setting() {
+    public function test_get_current_page_path_trims_trailing_slashes_from_directory_setting()
+    {
         MarkdownPage::$outputDirectory = '/foo/\\';
         $page = new MarkdownPage([], '', '', 'bar');
         $this->assertEquals('foo/bar', $page->getCurrentPagePath());
     }
 
-    public function test_get_output_path_returns_current_page_path_with_html_extension_appended() {
+    public function test_get_output_path_returns_current_page_path_with_html_extension_appended()
+    {
         $page = new MarkdownPage([], '', '', 'foo');
         $this->assertEquals('foo.html', $page->getOutputPath());
     }

--- a/packages/framework/tests/Feature/AbstractPageTest.php
+++ b/packages/framework/tests/Feature/AbstractPageTest.php
@@ -2,6 +2,9 @@
 
 namespace Hyde\Framework\Testing\Feature;
 
+use Hyde\Framework\Hyde;
+use Hyde\Framework\Models\Parsers\MarkdownPageParser;
+use Hyde\Framework\Models\Parsers\MarkdownPostParser;
 use Hyde\Testing\TestCase;
 use Hyde\Framework\Models\MarkdownPage;
 
@@ -13,54 +16,139 @@ use Hyde\Framework\Models\MarkdownPage;
  * since it's the simplest implementation.
  *
  * @covers \Hyde\Framework\Contracts\AbstractPage
+ *
+ * @backupStaticAttributes enabled
  */
 class AbstractPageTest extends TestCase
 {
-    public function test_get_source_directory() {
-        $this->markTestSkipped('TODO');
+    public function test_get_source_directory_returns_static_property() {
+        MarkdownPage::$sourceDirectory = 'foo';
+        $this->assertEquals('foo', MarkdownPage::getSourceDirectory());
     }
 
-    public function test_get_output_directory() {
-        $this->markTestSkipped('TODO');
+    public function test_get_source_directory_trims_trailing_slashes() {
+        MarkdownPage::$sourceDirectory = '/foo/\\';
+        $this->assertEquals('foo', MarkdownPage::getSourceDirectory());
     }
 
-    public function test_get_file_extension() {
-        $this->markTestSkipped('TODO');
+    public function test_get_output_directory_returns_static_property() {
+        MarkdownPage::$outputDirectory = 'foo';
+        $this->assertEquals('foo', MarkdownPage::getOutputDirectory());
     }
 
-    public function test_get_parser_class() {
-        $this->markTestSkipped('TODO');
+    public function test_get_output_directory_trims_trailing_slashes() {
+        MarkdownPage::$outputDirectory = '/foo/\\';
+        $this->assertEquals('foo', MarkdownPage::getOutputDirectory());
     }
 
-    public function test_get_parser() {
-        $this->markTestSkipped('TODO');
+    public function test_get_file_extension_returns_static_property() {
+        MarkdownPage::$fileExtension = '.foo';
+        $this->assertEquals('.foo', MarkdownPage::getFileExtension());
     }
 
-    public function test_parse() {
-        $this->markTestSkipped('TODO');
+    public function test_get_file_extension_forces_leading_period() {
+        MarkdownPage::$fileExtension = 'foo';
+        $this->assertEquals('.foo', MarkdownPage::getFileExtension());
     }
 
-    public function test_files() {
-        $this->markTestSkipped('TODO');
+    public function test_get_parser_class_returns_static_property() {
+        MarkdownPage::$parserClass = 'foo';
+        $this->assertEquals('foo', MarkdownPage::getParserClass());
     }
 
-    public function test_all() {
-        $this->markTestSkipped('TODO');
+    public function test_get_parser_returns_the_configured_parser_class() {
+        touch(Hyde::path('_posts/foo.md'));
+
+        MarkdownPage::$parserClass = MarkdownPostParser::class;
+        $this->assertInstanceOf(MarkdownPostParser::class, MarkdownPage::getParser('foo'));
+
+        unlink(Hyde::path('_posts/foo.md'));
     }
 
-    public function test_qualify_basename() {
-        $this->markTestSkipped('TODO');
+    public function test_get_parser_returns_instantiated_parser_for_the_supplied_slug() {
+        touch(Hyde::path('_pages/foo.md'));
+
+        $this->assertInstanceOf(MarkdownPageParser::class, $parser = MarkdownPage::getParser('foo'));
+        $this->assertEquals('foo', $parser->get()->slug);
+
+        unlink(Hyde::path('_pages/foo.md'));
     }
 
-    public function test_get_output_location() {
-        $this->markTestSkipped('TODO');
+    public function test_parse_parses_supplied_slug_into_a_page_model() {
+        touch(Hyde::path('_pages/foo.md'));
+
+        $this->assertInstanceOf(MarkdownPage::class, $page = MarkdownPage::parse('foo'));
+        $this->assertEquals('foo', $page->slug);
+
+        unlink(Hyde::path('_pages/foo.md'));
     }
 
-    public function test_get_current_page_path() {
-        $this->markTestSkipped('TODO');
+    public function test_files_returns_array_of_source_files() {
+        touch(Hyde::path('_pages/foo.md'));
+        $this->assertEquals(['foo'], MarkdownPage::files());
+        unlink(Hyde::path('_pages/foo.md'));
     }
 
-    public function test_get_output_path() {
-        $this->markTestSkipped('TODO');
+    public function test_all_returns_collection_of_all_source_files_parsed_into_the_model() {
+        touch(Hyde::path('_pages/foo.md'));
+        $this->assertEquals(
+            collect([new MarkdownPage([], '', '', 'foo')]),
+            MarkdownPage::all()
+        );
+        unlink(Hyde::path('_pages/foo.md'));
+    }
+
+    public function test_qualify_basename_properly_expands_basename_for_the_model() {
+        $this->assertEquals('_pages/foo.md', MarkdownPage::qualifyBasename('foo'));
+    }
+
+    public function test_qualify_basename_trims_slashes_from_input() {
+        $this->assertEquals('_pages/foo.md', MarkdownPage::qualifyBasename('/foo/\\'));
+    }
+
+    public function test_qualify_basename_uses_the_static_properties() {
+        MarkdownPage::$sourceDirectory = 'foo';
+        MarkdownPage::$fileExtension = 'txt';
+        $this->assertEquals('foo/bar.txt', MarkdownPage::qualifyBasename('bar'));
+    }
+
+    public function test_get_output_location_returns_the_file_output_path_for_the_supplied_basename() {
+        $this->assertEquals('foo.html', MarkdownPage::getOutputLocation('foo'));
+    }
+
+    public function test_get_output_location_returns_the_configured_location() {
+        MarkdownPage::$outputDirectory = 'foo';
+        $this->assertEquals('foo/bar.html', MarkdownPage::getOutputLocation('bar'));
+    }
+
+    public function test_get_output_location_trims_trailing_slashes_from_directory_setting() {
+        MarkdownPage::$outputDirectory = '/foo/\\';
+        $this->assertEquals('foo/bar.html', MarkdownPage::getOutputLocation('bar'));
+    }
+
+    public function test_get_output_location_trims_trailing_slashes_from_basename() {
+        $this->assertEquals('foo.html', MarkdownPage::getOutputLocation('/foo/\\'));
+    }
+
+    public function test_get_current_page_path_returns_output_directory_and_basename() {
+        $page = new MarkdownPage([], '', '', 'foo');
+        $this->assertEquals('foo', $page->getCurrentPagePath());
+    }
+
+    public function test_get_current_page_path_returns_output_directory_and_basename_for_configured_directory() {
+        MarkdownPage::$outputDirectory = 'foo';
+        $page = new MarkdownPage([], '', '', 'bar');
+        $this->assertEquals('foo/bar', $page->getCurrentPagePath());
+    }
+
+    public function test_get_current_page_path_trims_trailing_slashes_from_directory_setting() {
+        MarkdownPage::$outputDirectory = '/foo/\\';
+        $page = new MarkdownPage([], '', '', 'bar');
+        $this->assertEquals('foo/bar', $page->getCurrentPagePath());
+    }
+
+    public function test_get_output_path_returns_current_page_path_with_html_extension_appended() {
+        $page = new MarkdownPage([], '', '', 'foo');
+        $this->assertEquals('foo.html', $page->getOutputPath());
     }
 }

--- a/packages/framework/tests/Feature/AbstractPageTest.php
+++ b/packages/framework/tests/Feature/AbstractPageTest.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Hyde\Framework\Testing\Feature;
+
+use Hyde\Testing\TestCase;
+use Hyde\Framework\Models\MarkdownPage;
+
+/**
+ * Test the AbstractPage class.
+ *
+ * Since the class is abstract, we can't test it directly,
+ * so we will use the MarkdownPage class as a proxy,
+ * since it's the simplest implementation.
+ *
+ * @covers \Hyde\Framework\Contracts\AbstractPage
+ */
+class AbstractPageTest extends TestCase
+{
+    //
+}

--- a/packages/framework/tests/Feature/AbstractPageTest.php
+++ b/packages/framework/tests/Feature/AbstractPageTest.php
@@ -16,5 +16,51 @@ use Hyde\Framework\Models\MarkdownPage;
  */
 class AbstractPageTest extends TestCase
 {
-    //
+    public function test_get_source_directory() {
+        $this->markTestSkipped('TODO');
+    }
+
+    public function test_get_output_directory() {
+        $this->markTestSkipped('TODO');
+    }
+
+    public function test_get_file_extension() {
+        $this->markTestSkipped('TODO');
+    }
+
+    public function test_get_parser_class() {
+        $this->markTestSkipped('TODO');
+    }
+
+    public function test_get_parser() {
+        $this->markTestSkipped('TODO');
+    }
+
+    public function test_parse() {
+        $this->markTestSkipped('TODO');
+    }
+
+    public function test_files() {
+        $this->markTestSkipped('TODO');
+    }
+
+    public function test_all() {
+        $this->markTestSkipped('TODO');
+    }
+
+    public function test_qualify_basename() {
+        $this->markTestSkipped('TODO');
+    }
+
+    public function test_get_output_location() {
+        $this->markTestSkipped('TODO');
+    }
+
+    public function test_get_current_page_path() {
+        $this->markTestSkipped('TODO');
+    }
+
+    public function test_get_output_path() {
+        $this->markTestSkipped('TODO');
+    }
 }

--- a/packages/framework/tests/Feature/Concerns/HasPageMetadataTest.php
+++ b/packages/framework/tests/Feature/Concerns/HasPageMetadataTest.php
@@ -31,6 +31,7 @@ class HasPageMetadataTest extends TestCase
             use HasPageMetadata;
 
             public string $slug = 'foo';
+            public static string $outputDirectory = '';
         };
         config(['hyde.site_url' => 'https://example.com']);
 
@@ -44,6 +45,7 @@ class HasPageMetadataTest extends TestCase
             use HasPageMetadata;
 
             public string $slug = 'foo';
+            public static string $outputDirectory = '';
         };
         config(['hyde.site_url' => 'https://example.com']);
         config(['hyde.pretty_urls' => true]);
@@ -58,6 +60,7 @@ class HasPageMetadataTest extends TestCase
             use HasPageMetadata;
 
             public string $slug = 'foo';
+            public static string $outputDirectory = '';
 
             public function getCurrentPagePath(): string
             {
@@ -76,6 +79,7 @@ class HasPageMetadataTest extends TestCase
             use HasPageMetadata;
 
             public string $slug = 'foo';
+            public static string $outputDirectory = '';
 
             public function getCurrentPagePath(): string
             {
@@ -94,6 +98,7 @@ class HasPageMetadataTest extends TestCase
             use HasPageMetadata;
 
             public string $slug = 'foo';
+            public static string $outputDirectory = '';
         };
         config(['hyde.site_url' => 'https://example.com']);
 
@@ -107,6 +112,7 @@ class HasPageMetadataTest extends TestCase
             use HasPageMetadata;
 
             public string $slug;
+            public static string $outputDirectory = '';
         };
 
         $this->assertFalse($page->canUseCanonicalUrl());
@@ -119,6 +125,7 @@ class HasPageMetadataTest extends TestCase
             use HasPageMetadata;
 
             public string $slug;
+            public static string $outputDirectory = '';
         };
         config(['hyde.site_url' => 'https://example.com']);
 
@@ -142,6 +149,7 @@ class HasPageMetadataTest extends TestCase
             use HasPageMetadata;
 
             public string $slug = 'foo';
+            public static string $outputDirectory = '';
         };
         config(['hyde.site_url' => 'https://example.com']);
 
@@ -163,6 +171,7 @@ class HasPageMetadataTest extends TestCase
             use HasPageMetadata;
 
             public string $slug = 'foo';
+            public static string $outputDirectory = '';
         };
 
         $this->assertEquals(
@@ -178,6 +187,7 @@ class HasPageMetadataTest extends TestCase
             use HasPageMetadata;
 
             public string $slug = 'foo';
+            public static string $outputDirectory = '';
         };
 
         $this->assertEquals(
@@ -193,6 +203,7 @@ class HasPageMetadataTest extends TestCase
             use HasPageMetadata;
 
             public string $slug = 'foo';
+            public static string $outputDirectory = '';
         };
         config(['hyde.site_url' => 'https://example.com']);
 

--- a/packages/framework/tests/Feature/Concerns/HasPageMetadataTest.php
+++ b/packages/framework/tests/Feature/Concerns/HasPageMetadataTest.php
@@ -24,15 +24,20 @@ class HasPageMetadataTest extends TestCase
         config(['hyde.generate_sitemap' => false]);
     }
 
-    public function test_get_canonical_url_returns_url_for_top_level_page()
+    protected function makePage(): AbstractPage
     {
-        $page = new class extends AbstractPage
+        return new class extends AbstractPage
         {
             use HasPageMetadata;
 
             public string $slug = 'foo';
             public static string $outputDirectory = '';
         };
+    }
+
+    public function test_get_canonical_url_returns_url_for_top_level_page()
+    {
+        $page = $this->makePage();
         config(['hyde.site_url' => 'https://example.com']);
 
         $this->assertEquals('https://example.com/foo.html', $page->getCanonicalUrl());
@@ -40,13 +45,7 @@ class HasPageMetadataTest extends TestCase
 
     public function test_get_canonical_url_returns_pretty_url_for_top_level_page()
     {
-        $page = new class extends AbstractPage
-        {
-            use HasPageMetadata;
-
-            public string $slug = 'foo';
-            public static string $outputDirectory = '';
-        };
+        $page = $this->makePage();
         config(['hyde.site_url' => 'https://example.com']);
         config(['hyde.pretty_urls' => true]);
 
@@ -93,13 +92,7 @@ class HasPageMetadataTest extends TestCase
 
     public function test_can_use_canonical_url_returns_true_when_both_uri_path_and_slug_is_set()
     {
-        $page = new class extends AbstractPage
-        {
-            use HasPageMetadata;
-
-            public string $slug = 'foo';
-            public static string $outputDirectory = '';
-        };
+        $page = $this->makePage();
         config(['hyde.site_url' => 'https://example.com']);
 
         $this->assertTrue($page->canUseCanonicalUrl());
@@ -144,13 +137,7 @@ class HasPageMetadataTest extends TestCase
 
     public function test_render_page_metadata_returns_string_with_merged_metadata()
     {
-        $page = new class extends AbstractPage
-        {
-            use HasPageMetadata;
-
-            public string $slug = 'foo';
-            public static string $outputDirectory = '';
-        };
+        $page = $this->makePage();
         config(['hyde.site_url' => 'https://example.com']);
 
         config(['hyde.meta' => [
@@ -166,13 +153,7 @@ class HasPageMetadataTest extends TestCase
 
     public function test_render_page_metadata_only_adds_canonical_if_conditions_are_met()
     {
-        $page = new class extends AbstractPage
-        {
-            use HasPageMetadata;
-
-            public string $slug = 'foo';
-            public static string $outputDirectory = '';
-        };
+        $page = $this->makePage();
 
         $this->assertEquals(
             '',
@@ -182,13 +163,7 @@ class HasPageMetadataTest extends TestCase
 
     public function test_get_dynamic_metadata_only_adds_canonical_if_conditions_are_met()
     {
-        $page = new class extends AbstractPage
-        {
-            use HasPageMetadata;
-
-            public string $slug = 'foo';
-            public static string $outputDirectory = '';
-        };
+        $page = $this->makePage();
 
         $this->assertEquals(
             [],
@@ -198,13 +173,7 @@ class HasPageMetadataTest extends TestCase
 
     public function test_get_dynamic_metadata_adds_canonical_url_when_conditions_are_met()
     {
-        $page = new class extends AbstractPage
-        {
-            use HasPageMetadata;
-
-            public string $slug = 'foo';
-            public static string $outputDirectory = '';
-        };
+        $page = $this->makePage();
         config(['hyde.site_url' => 'https://example.com']);
 
         config(['hyde.meta' => [

--- a/packages/framework/tests/Feature/StaticPageBuilderTest.php
+++ b/packages/framework/tests/Feature/StaticPageBuilderTest.php
@@ -3,6 +3,7 @@
 namespace Hyde\Framework\Testing\Feature;
 
 use Hyde\Framework\Hyde;
+use Hyde\Framework\HydeServiceProvider;
 use Hyde\Framework\Models\BladePage;
 use Hyde\Framework\Models\DocumentationPage;
 use Hyde\Framework\Models\MarkdownPage;
@@ -100,6 +101,7 @@ class StaticPageBuilderTest extends TestCase
         $page = new DocumentationPage([], '# Body', 'Title', 'foo');
 
         Config::set('docs.output_directory', 'docs/foo');
+        (new HydeServiceProvider($this->app))->register(); // Reregister the service provider to pick up the new config.
 
         new StaticPageBuilder($page, true);
 

--- a/packages/framework/tests/Unit/DocumentationPageTest.php
+++ b/packages/framework/tests/Unit/DocumentationPageTest.php
@@ -2,6 +2,7 @@
 
 namespace Hyde\Framework\Testing\Unit;
 
+use Hyde\Framework\HydeServiceProvider;
 use Hyde\Framework\Models\DocumentationPage;
 use Hyde\Testing\TestCase;
 
@@ -22,6 +23,7 @@ class DocumentationPageTest extends TestCase
         $this->assertEquals('docs/foo', $page->getCurrentPagePath());
 
         config(['docs.output_directory' => 'documentation/latest/']);
+        (new HydeServiceProvider($this->app))->register();
         $this->assertEquals('documentation/latest/foo', $page->getCurrentPagePath());
     }
 
@@ -57,6 +59,7 @@ class DocumentationPageTest extends TestCase
     public function test_can_get_documentation_output_path_with_custom_output_directory()
     {
         config(['docs.output_directory' => 'foo']);
+        (new HydeServiceProvider($this->app))->register();
         $this->assertEquals('foo', DocumentationPage::getDocumentationOutputPath());
     }
 
@@ -72,6 +75,7 @@ class DocumentationPageTest extends TestCase
 
         foreach ($tests as $test) {
             config(['docs.output_directory' => $test]);
+            (new HydeServiceProvider($this->app))->register();
             $this->assertEquals('foo', DocumentationPage::getDocumentationOutputPath());
         }
     }


### PR DESCRIPTION
This update refactors the internal page models to ensure a more predictable and consistent state. This is in large part done by further defining the page model contract, and abstracting the implementations to the base class, leading to less boilerplate for the actual implementations, while gaining a more defined source of truth. It also adds the scaffolding to customize more output directories, and unifies this with the legacy documentation output paths. Besides that, this PR does not add much in the terms of features, it does make several changes that may be considered breaking to the package developers.