### PR TITLE
Refine markdown document classes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ This serves two purposes:
 
 ### Added
 - Added Hyde::makeTitle() helper, an improved version of Hyde::titleFromSlug()
+- Added new helper method render() to MarkdownDocuments to compile the Markdown to HTML, fixes https://github.com/hydephp/develop/issues/109
 
 ### Changed
 - Update default HydeFront version to v1.12.x

--- a/packages/framework/src/Contracts/AbstractMarkdownPage.php
+++ b/packages/framework/src/Contracts/AbstractMarkdownPage.php
@@ -19,7 +19,7 @@ use Hyde\Framework\Models\MarkdownDocument;
  *
  * @test \Hyde\Framework\Testing\Feature\AbstractPageTest
  */
-abstract class AbstractMarkdownPage extends AbstractPage
+abstract class AbstractMarkdownPage extends AbstractPage implements MarkdownPageContract
 {
     use HasDynamicTitle;
 

--- a/packages/framework/src/Contracts/MarkdownDocumentContract.php
+++ b/packages/framework/src/Contracts/MarkdownDocumentContract.php
@@ -8,7 +8,44 @@ interface MarkdownDocumentContract
      * Construct the class.
      *
      * @param  array  $matter  The parsed front matter.
-     * @param  string  $body  The parsed markdown body.
+     * @param  string  $body  The parsed Markdown body.
      */
     public function __construct(array $matter = [], string $body = '');
+
+    /**
+     * Get the front matter property for the specified key, or null if it does not exist.
+     *
+     * @param string $key
+     */
+    public function __get(string $key);
+
+    /**
+     * Get all the front matter as an array, or the property if a key is specified,
+     * falling back to the supplied default return value if the key is not found.
+     *
+     * @param string|null $key
+     * @param mixed|null $default
+     * @return mixed|null
+     */
+    public function matter(string $key = null, mixed $default = null): mixed;
+
+    /**
+     * Get the Markdown body.
+     *
+     * @return string
+     */
+    public function body(): string;
+
+    /**
+     * Render the Markdown body into HTML.
+     */
+    public function render(): string;
+
+    /**
+     * Parse a Markdown file and return a new MarkdownDocument instance.
+     *
+     * @param string $localFilepath
+     * @return static<MarkdownDocumentContract>
+     */
+    public static function parseFile(string $localFilepath): static;
 }

--- a/packages/framework/src/Contracts/MarkdownDocumentContract.php
+++ b/packages/framework/src/Contracts/MarkdownDocumentContract.php
@@ -15,12 +15,13 @@ interface MarkdownDocumentContract
     /**
      * Get the front matter property for the specified key, or null if it does not exist.
      *
-     * @param string $key
+     * @param  string  $key
      */
     public function __get(string $key);
 
     /**
      * Get the Markdown body.
+     *
      * @return string
      */
     public function __toString(): string;
@@ -29,8 +30,8 @@ interface MarkdownDocumentContract
      * Get all the front matter as an array, or the property if a key is specified,
      * falling back to the supplied default return value if the key is not found.
      *
-     * @param string|null $key
-     * @param mixed|null $default
+     * @param  string|null  $key
+     * @param  mixed|null  $default
      * @return mixed|null
      */
     public function matter(string $key = null, mixed $default = null): mixed;
@@ -50,7 +51,7 @@ interface MarkdownDocumentContract
     /**
      * Parse a Markdown file and return a new MarkdownDocument instance.
      *
-     * @param string $localFilepath
+     * @param  string  $localFilepath
      * @return static<MarkdownDocumentContract>
      */
     public static function parseFile(string $localFilepath): static;

--- a/packages/framework/src/Contracts/MarkdownDocumentContract.php
+++ b/packages/framework/src/Contracts/MarkdownDocumentContract.php
@@ -20,6 +20,12 @@ interface MarkdownDocumentContract
     public function __get(string $key);
 
     /**
+     * Get the Markdown body.
+     * @return string
+     */
+    public function __toString(): string;
+
+    /**
      * Get all the front matter as an array, or the property if a key is specified,
      * falling back to the supplied default return value if the key is not found.
      *

--- a/packages/framework/src/Contracts/MarkdownPageContract.php
+++ b/packages/framework/src/Contracts/MarkdownPageContract.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace Hyde\Framework\Contracts;
+
+interface MarkdownPageContract
+{
+	//
+}

--- a/packages/framework/src/Contracts/MarkdownPageContract.php
+++ b/packages/framework/src/Contracts/MarkdownPageContract.php
@@ -2,7 +2,14 @@
 
 namespace Hyde\Framework\Contracts;
 
+use Hyde\Framework\Models\MarkdownDocument;
+
 interface MarkdownPageContract
 {
-	//
+	/**
+	 * Get the page's Markdown Document object.
+	 *
+	 * @return \Hyde\Framework\Models\MarkdownDocument
+	 */
+	public function markdown(): MarkdownDocument;
 }

--- a/packages/framework/src/Contracts/MarkdownPageContract.php
+++ b/packages/framework/src/Contracts/MarkdownPageContract.php
@@ -6,10 +6,10 @@ use Hyde\Framework\Models\MarkdownDocument;
 
 interface MarkdownPageContract
 {
-	/**
-	 * Get the page's Markdown Document object.
-	 *
-	 * @return \Hyde\Framework\Models\MarkdownDocument
-	 */
-	public function markdown(): MarkdownDocument;
+    /**
+     * Get the page's Markdown Document object.
+     *
+     * @return \Hyde\Framework\Models\MarkdownDocument
+     */
+    public function markdown(): MarkdownDocument;
 }

--- a/packages/framework/src/Models/MarkdownDocument.php
+++ b/packages/framework/src/Models/MarkdownDocument.php
@@ -21,6 +21,11 @@ class MarkdownDocument implements MarkdownDocumentContract
         $this->body = $body;
     }
 
+    public function __toString(): string
+    {
+        return $this->body;
+    }
+
     public function __get(string $key): mixed
     {
         return $this->matter($key);

--- a/packages/framework/src/Models/MarkdownDocument.php
+++ b/packages/framework/src/Models/MarkdownDocument.php
@@ -2,6 +2,7 @@
 
 namespace Hyde\Framework\Models;
 
+use Hyde\Framework\Actions\MarkdownConverter;
 use Hyde\Framework\Contracts\MarkdownDocumentContract;
 use Hyde\Framework\Hyde;
 use Hyde\Framework\Services\MarkdownFileService;
@@ -43,6 +44,11 @@ class MarkdownDocument implements MarkdownDocumentContract
     public function body(): string
     {
         return $this->body;
+    }
+
+    public function render(): string
+    {
+        return MarkdownConverter::parse($this->body);
     }
 
     public static function parseFile(string $localFilepath): static

--- a/packages/framework/src/Models/MarkdownDocument.php
+++ b/packages/framework/src/Models/MarkdownDocument.php
@@ -21,12 +21,12 @@ class MarkdownDocument implements MarkdownDocumentContract
         $this->body = $body;
     }
 
-    public function __get(string $key)
+    public function __get(string $key): mixed
     {
         return $this->matter($key);
     }
 
-    public function matter(string $key = null, $default = null)
+    public function matter(string $key = null, mixed $default = null): mixed
     {
         if ($key) {
             return Arr::get($this->matter, $key, $default);

--- a/packages/framework/tests/Unit/MarkdownDocumentTest.php
+++ b/packages/framework/tests/Unit/MarkdownDocumentTest.php
@@ -42,6 +42,12 @@ class MarkdownDocumentTest extends TestCase
         $this->assertNull($document->bar);
     }
 
+    public function test_magic_to_string_method_returns_body()
+    {
+        $document = new MarkdownDocument(['foo' => 'bar'], 'Hello, world!');
+        $this->assertEquals('Hello, world!', (string) $document);
+    }
+
     public function test_matter_method_returns_empty_array_if_document_has_no_matter()
     {
         $document = new MarkdownDocument();

--- a/packages/framework/tests/Unit/MarkdownDocumentTest.php
+++ b/packages/framework/tests/Unit/MarkdownDocumentTest.php
@@ -90,6 +90,12 @@ class MarkdownDocumentTest extends TestCase
         $this->assertEquals('Hello, world!', $document->body());
     }
 
+    public function test_render_method_returns_rendered_html()
+    {
+        $document = new MarkdownDocument([], 'Hello, world!');
+        $this->assertEquals("<p>Hello, world!</p>\n", $document->render());
+    }
+
     public function test_parse_file_method_parses_a_file_using_the_markdown_file_service()
     {
         file_put_contents('_pages/foo.md', 'Hello, world!');


### PR DESCRIPTION
Creates a MarkdownPage contract, adds a __toString magic method, and a method to render documents into HTML, which fixes https://github.com/hydephp/develop/issues/109.