### PR TITLE
Removed deprecated 'hyde.site_output_path' config option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,7 +52,7 @@ However, if you are a package developer, or if you have published Blade views or
 
 ### Removed
 - Remove unused `$withoutNavigation` variable from the app layout
-- Removed deprecated 'hyde.site_output_path' config option
+- Removed deprecated 'hyde.site_output_path' config option (use `hyde.output_directory` instead)
 
 ### Fixed
 - Fix style bug https://github.com/hydephp/develop/issues/117, Hyde title helper should not capitalize non-principal words

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,7 @@ However, if you are a package developer, or if you have published Blade views or
 
 ### Removed
 - Remove unused `$withoutNavigation` variable from the app layout
+- Removed deprecated 'hyde.site_output_path' config option
 
 ### Fixed
 - Fix style bug https://github.com/hydephp/develop/issues/117, Hyde title helper should not capitalize non-principal words

--- a/config/hyde.php
+++ b/config/hyde.php
@@ -224,11 +224,6 @@ return [
 
     'output_directory' => '_site',
 
-    /**
-     * @deprecated use the 'output_directory' setting instead
-     */
-    'site_output_path' => Hyde\Framework\Hyde::path('_site'),
-
     /*
     |--------------------------------------------------------------------------
     | Warn about outdated config?

--- a/packages/framework/config/hyde.php
+++ b/packages/framework/config/hyde.php
@@ -224,11 +224,6 @@ return [
 
     'output_directory' => '_site',
 
-    /**
-     * @deprecated use the 'output_directory' setting instead
-     */
-    'site_output_path' => Hyde\Framework\Hyde::path('_site'),
-
     /*
     |--------------------------------------------------------------------------
     | Warn about outdated config?

--- a/packages/framework/src/HydeServiceProvider.php
+++ b/packages/framework/src/HydeServiceProvider.php
@@ -64,19 +64,10 @@ class HydeServiceProvider extends ServiceProvider
 
         $this->discoverBladeViewsIn('_pages');
 
-        /** @deprecated v0.43.0-beta and is used here as a fallback for compatibility */
-        if (config('hyde.output_directory') === null) {
-            $this->storeCompiledSiteIn(config(
-                'hyde.site_output_path',
-                Hyde::path('_site')
-            ));
-        } else {
-            // Newer version which is safer.
-            $this->storeCompiledSiteIn(Hyde::path(config(
-                trim('hyde.output_directory', '_site'),
-                '/\\'
-            )));
-        }
+        $this->storeCompiledSiteIn(Hyde::path(config(
+            trim('hyde.output_directory', '_site'),
+            '/\\'
+        )));
 
         $this->commands([
             Commands\HydePublishHomepageCommand::class,


### PR DESCRIPTION
Removes support for the config option which was deprecated in the last release. It has since been replaced with the output_directory setting.