### PR TITLE
Improves how the site output directory is emptied, helping prevent accidental deletion of files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@ However, if you are a package developer, or if you have published Blade views or
 - Moved `Hyde\Framework\Models\MarkdownPage` to new namespace `Hyde\Framework\Models\Pages\MarkdownPage`
 - Moved `Hyde\Framework\Models\MarkdownPost` to new namespace `Hyde\Framework\Models\Pages\MarkdownPost`
 - Moved `Hyde\Framework\Models\DocumentationPage` to new namespace `Hyde\Framework\Models\Pages\DocumentationPage`
+- Improves how the site output directory is emptied, helping prevent accidental deletion of files.
 
 ### Deprecated
 - Deprecated Hyde::titleFromSlug(), use Hyde::makeTitle() instead

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,7 +38,7 @@ However, if you are a package developer, or if you have published Blade views or
 - Moved `Hyde\Framework\Models\MarkdownPage` to new namespace `Hyde\Framework\Models\Pages\MarkdownPage`
 - Moved `Hyde\Framework\Models\MarkdownPost` to new namespace `Hyde\Framework\Models\Pages\MarkdownPost`
 - Moved `Hyde\Framework\Models\DocumentationPage` to new namespace `Hyde\Framework\Models\Pages\DocumentationPage`
-- Improves how the site output directory is emptied, helping prevent accidental deletion of files.
+- Improves how the site output directory is emptied, helping prevent accidental deletion of files https://github.com/hydephp/develop/pull/135
 
 ### Deprecated
 - Deprecated Hyde::titleFromSlug(), use Hyde::makeTitle() instead

--- a/packages/framework/src/Commands/HydeBuildStaticSiteCommand.php
+++ b/packages/framework/src/Commands/HydeBuildStaticSiteCommand.php
@@ -176,8 +176,8 @@ class HydeBuildStaticSiteCommand extends Command
         $this->warn('Removing all files from build directory.');
         if (! in_array(basename(Hyde::getSiteOutputPath()), config('hyde.safe_output_directories', ['_site', 'docs', 'build']))) {
             if (! $this->confirm('The configured output directory ('.Hyde::getSiteOutputPath().') is potentially unsafe to empty. Are you sure you want to continue?')) {
-                $this->info('Aborting!');
-                exit(130);
+                $this->info('Output directory will not be emptied.');
+                return;
             }
         }
         File::cleanDirectory(Hyde::getSiteOutputPath());

--- a/packages/framework/src/Commands/HydeBuildStaticSiteCommand.php
+++ b/packages/framework/src/Commands/HydeBuildStaticSiteCommand.php
@@ -174,6 +174,12 @@ class HydeBuildStaticSiteCommand extends Command
     public function purge(): void
     {
         $this->warn('Removing all files from build directory.');
+        if (! in_array(basename(Hyde::getSiteOutputPath()), config('hyde.safe_output_directories', ['_site', 'docs', 'build']))) {
+            if (! $this->confirm('The configured output directory ('.Hyde::getSiteOutputPath().') is potentially unsafe to empty. Are you sure you want to continue?')) {
+                $this->info('Aborting!');
+                exit(130);
+            }
+        }
         File::cleanDirectory(Hyde::getSiteOutputPath());
     }
 

--- a/packages/framework/src/Commands/HydeBuildStaticSiteCommand.php
+++ b/packages/framework/src/Commands/HydeBuildStaticSiteCommand.php
@@ -180,7 +180,8 @@ class HydeBuildStaticSiteCommand extends Command
                 return;
             }
         }
-        File::cleanDirectory(Hyde::getSiteOutputPath());
+        array_map('unlink', glob(Hyde::getSiteOutputPath('*.{html,json}'), GLOB_BRACE));
+        File::cleanDirectory(Hyde::getSiteOutputPath('media'));
     }
 
     /** @internal */

--- a/packages/framework/tests/Feature/Commands/BuildStaticSiteCommandTest.php
+++ b/packages/framework/tests/Feature/Commands/BuildStaticSiteCommandTest.php
@@ -3,8 +3,10 @@
 namespace Hyde\Framework\Testing\Feature\Commands;
 
 use Hyde\Framework\Hyde;
+use Hyde\Framework\StaticPageBuilder;
 use Hyde\Testing\ResetsApplication;
 use Hyde\Testing\TestCase;
+use Illuminate\Support\Facades\File;
 
 /**
  * @covers \Hyde\Framework\Commands\HydeBuildStaticSiteCommand
@@ -151,5 +153,22 @@ class BuildStaticSiteCommandTest extends TestCase
             ->expectsOutput('Generating documentation site search index...')
             ->expectsOutput('Generating search page...')
             ->assertExitCode(0);
+    }
+
+    public function test_aborts_when_non_standard_directory_is_emptied()
+    {
+        StaticPageBuilder::$outputPath = 'foo';
+
+        mkdir(Hyde::path('foo'));
+        touch(Hyde::path('foo/keep.html'));
+
+        $this->artisan('build')
+            ->expectsOutput('Removing all files from build directory.')
+            ->expectsQuestion('The configured output directory (foo) is potentially unsafe to empty. Are you sure you want to continue?', false)
+            ->expectsOutput('Output directory will not be emptied.')
+            ->assertExitCode(0);
+
+        $this->assertFileExists(Hyde::path('foo/keep.html'));
+        File::deleteDirectory(Hyde::path('foo'));
     }
 }


### PR DESCRIPTION
First checks if the configured directory is on the whitelist of safe directories (can be configured using `hyde.safe_output_directories`, please submit PRs/comments with more ideas for default safe directories!), and asks if the user really wants the directory to be emptied. Defaults to false. Then when it's okay to proceed, the output is emptied using a less nuclear approach to prevent accidental file deletions. Yes, I accidentally deleted my .git directory. And I did so twice. (And the somehow the vendor directory in the CI).