### PR TITLE
Fix bug causing files starting with underscores to add empty values to the file collection array

### DIFF
--- a/packages/framework/src/Services/CollectionService.php
+++ b/packages/framework/src/Services/CollectionService.php
@@ -30,11 +30,13 @@ class CollectionService
             return false;
         }
 
-        return array_map(function ($filepath) use ($model) {
+        $files = [];
+        foreach (glob(Hyde::path($model::qualifyBasename('*'))) as $filepath) {
             if (! str_starts_with(basename($filepath), '_')) {
-                return basename($filepath, $model::getFileExtension());
+                $files[] = basename($filepath, $model::getFileExtension());
             }
-        }, glob(Hyde::path($model::qualifyBasename('*'))));
+        }
+        return $files;
     }
 
     /**

--- a/packages/framework/tests/Feature/GeneratesNavigationMenuTest.php
+++ b/packages/framework/tests/Feature/GeneratesNavigationMenuTest.php
@@ -60,4 +60,17 @@ class GeneratesNavigationMenuTest extends TestCase
             'priority' => 999,
         ], $result[1]);
     }
+
+    public function test_files_starting_with_underscores_are_ignored()
+    {
+        touch(Hyde::path('_pages/_foo.md'));
+        touch(Hyde::path('_pages/_foo.blade.php'));
+
+        $array = GeneratesNavigationMenu::getNavigationLinks();
+        $this->assertIsArray($array);
+        $this->assertCount(1, $array);
+
+        unlink(Hyde::path('_pages/_foo.md'));
+        unlink(Hyde::path('_pages/_foo.blade.php'));
+    }
 }

--- a/packages/framework/tests/Feature/GeneratesNavigationMenuTest.php
+++ b/packages/framework/tests/Feature/GeneratesNavigationMenuTest.php
@@ -24,6 +24,8 @@ class GeneratesNavigationMenuTest extends TestCase
         $this->assertIsArray($generator->links);
 
         $this->assertContains('docs/index.html', Arr::flatten($generator->links));
+
+        unlink(Hyde::path('_docs/index.md'));
     }
 
     public function test_get_links_from_config_method()

--- a/packages/framework/tests/Feature/Services/CollectionServiceTest.php
+++ b/packages/framework/tests/Feature/Services/CollectionServiceTest.php
@@ -129,12 +129,35 @@ class CollectionServiceTest extends TestCase
         unlink($path);
     }
 
-    public function test_files_starting_with_underscore_are_ignored()
+    public function test_blade_page_files_starting_with_underscore_are_ignored()
+    {
+        touch(Hyde::path('_pages/_foo.blade.php'));
+        $this->assertEquals([
+            '404',
+            'index',
+        ], CollectionService::getBladePageList());
+        unlink(Hyde::path('_pages/_foo.blade.php'));
+    }
+
+    public function test_markdown_page_files_starting_with_underscore_are_ignored()
+    {
+        touch(Hyde::path('_pages/_foo.md'));
+        $this->assertEquals([], CollectionService::getMarkdownPageList());
+        unlink(Hyde::path('_pages/_foo.md'));
+    }
+
+    public function test_post_files_starting_with_underscore_are_ignored()
     {
         touch(Hyde::path('_posts/_foo.md'));
-        $this->assertNotContains('_foo', CollectionService::getMarkdownPostList());
-        $this->assertNotContains('foo', CollectionService::getMarkdownPostList());
+        $this->assertEquals([], CollectionService::getMarkdownPostList());
         unlink(Hyde::path('_posts/_foo.md'));
+    }
+
+    public function test_documentation_page_files_starting_with_underscore_are_ignored()
+    {
+        touch(Hyde::path('_docs/_foo.md'));
+        $this->assertEquals([], CollectionService::getDocumentationPageList());
+        unlink(Hyde::path('_docs/_foo.md'));
     }
 
     protected function unitTestMarkdownBasedPageList(string $model, string $path, ?string $expected = null)


### PR DESCRIPTION
This is the underlying problem for this the navigation menu bug, which this will fix https://github.com/hydephp/develop/issues/139. See that thread for the error and the fix details.