### PR TITLE
Rename internal trait RegistersDefaultDirectories to RegistersFileLocations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ This serves two purposes:
 
 ### Changed
 - DataCollections are now disabled by default
+- Rename internal trait RegistersDefaultDirectories to RegistersFileLocations
 
 ### Deprecated
 - for soon-to-be removed features.

--- a/docs/advanced-customization.md
+++ b/docs/advanced-customization.md
@@ -39,7 +39,7 @@ Internally, the paths are registered in the HydeServiceProvider using the follow
 
 ```php
 // filepath Hyde\Framework\HydeServiceProvider
-use Hyde\Framework\Concerns\RegistersDefaultDirectories;
+use Hyde\Framework\Concerns\RegistersFileLocations;
 
 public function register(): void
 {

--- a/packages/framework/src/Concerns/RegistersFileLocations.php
+++ b/packages/framework/src/Concerns/RegistersFileLocations.php
@@ -4,9 +4,6 @@ namespace Hyde\Framework\Concerns;
 
 use Hyde\Framework\Contracts\AbstractPage;
 
-/**
- * @deprecated v0.44.x will be renamed to RegistersFileLocations or similar
- */
 trait RegistersFileLocations
 {
     /**

--- a/packages/framework/src/Concerns/RegistersFileLocations.php
+++ b/packages/framework/src/Concerns/RegistersFileLocations.php
@@ -7,7 +7,7 @@ use Hyde\Framework\Contracts\AbstractPage;
 /**
  * @deprecated v0.44.x will be renamed to RegistersFileLocations or similar
  */
-trait RegistersDefaultDirectories
+trait RegistersFileLocations
 {
     /**
      * Register the default source directories for the given page classes.

--- a/packages/framework/src/HydeServiceProvider.php
+++ b/packages/framework/src/HydeServiceProvider.php
@@ -2,7 +2,7 @@
 
 namespace Hyde\Framework;
 
-use Hyde\Framework\Concerns\RegistersDefaultDirectories;
+use Hyde\Framework\Concerns\RegistersFileLocations;
 use Hyde\Framework\Contracts\AssetServiceContract;
 use Hyde\Framework\Models\Pages\BladePage;
 use Hyde\Framework\Models\Pages\DocumentationPage;
@@ -16,7 +16,7 @@ use Illuminate\Support\ServiceProvider;
  */
 class HydeServiceProvider extends ServiceProvider
 {
-    use RegistersDefaultDirectories;
+    use RegistersFileLocations;
 
     /**
      * Register any application services.


### PR DESCRIPTION
The original name was deprecated in v0.44.0 where the rename was advised. 