### PR TITLE
Refactor the HydeServiceProvider structure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,7 +25,7 @@ This serves two purposes:
 - for new features.
 
 ### Changed
-- for changes in existing functionality.
+- internal: Move service provider helper methods to the RegistersFileLocations trait
 
 ### Deprecated
 - for soon-to-be removed features.

--- a/packages/framework/src/Concerns/RegistersFileLocations.php
+++ b/packages/framework/src/Concerns/RegistersFileLocations.php
@@ -5,6 +5,15 @@ namespace Hyde\Framework\Concerns;
 use Hyde\Framework\Contracts\AbstractPage;
 use Hyde\Framework\StaticPageBuilder;
 
+/**
+ * This trait registers the file paths for important Hyde locations.
+ *
+ * If you want to customize these directories, the recommended way is to
+ * create a service provider that uses this trait, and change your
+ * paths in the register method, like in the HydeServiceProvider.
+ *
+ * Remember that your overriding provider should be loaded after the HSP.
+ */
 trait RegistersFileLocations
 {
     /**
@@ -58,7 +67,7 @@ trait RegistersFileLocations
 
     /**
      * The absolute path to the directory when the compiled site is stored.
-     * 
+     *
      * Warning! This directory is emptied when compiling the site.
      */
     protected function storeCompiledSiteIn(string $directory): void

--- a/packages/framework/src/Concerns/RegistersFileLocations.php
+++ b/packages/framework/src/Concerns/RegistersFileLocations.php
@@ -58,6 +58,8 @@ trait RegistersFileLocations
 
     /**
      * The absolute path to the directory when the compiled site is stored.
+     * 
+     * Warning! This directory is emptied when compiling the site.
      */
     protected function storeCompiledSiteIn(string $directory): void
     {

--- a/packages/framework/src/Concerns/RegistersFileLocations.php
+++ b/packages/framework/src/Concerns/RegistersFileLocations.php
@@ -3,6 +3,7 @@
 namespace Hyde\Framework\Concerns;
 
 use Hyde\Framework\Contracts\AbstractPage;
+use Hyde\Framework\StaticPageBuilder;
 
 trait RegistersFileLocations
 {
@@ -53,5 +54,13 @@ trait RegistersFileLocations
             config('view.paths', []),
             [base_path($directory)]
         )]);
+    }
+
+    /**
+     * The absolute path to the directory when the compiled site is stored.
+     */
+    protected function storeCompiledSiteIn(string $directory): void
+    {
+        StaticPageBuilder::$outputPath = $directory;
     }
 }

--- a/packages/framework/src/Concerns/RegistersFileLocations.php
+++ b/packages/framework/src/Concerns/RegistersFileLocations.php
@@ -41,4 +41,17 @@ trait RegistersFileLocations
             $class::$outputDirectory = unslash($location);
         }
     }
+
+    /**
+     * If you are loading Blade views from a different directory,
+     * you need to add the path to the view.php config. This is
+     * here done automatically when registering the provider.
+     */
+    protected function discoverBladeViewsIn(string $directory): void
+    {
+        config(['view.paths' => array_merge(
+            config('view.paths', []),
+            [base_path($directory)]
+        )]);
+    }
 }

--- a/packages/framework/src/Concerns/RegistersFileLocations.php
+++ b/packages/framework/src/Concerns/RegistersFileLocations.php
@@ -59,10 +59,10 @@ trait RegistersFileLocations
      */
     protected function discoverBladeViewsIn(string $directory): void
     {
-        config(['view.paths' => array_merge(
+        config(['view.paths' => array_unique(array_merge(
             config('view.paths', []),
             [base_path($directory)]
-        )]);
+        ))]);
     }
 
     /**

--- a/packages/framework/src/HydeServiceProvider.php
+++ b/packages/framework/src/HydeServiceProvider.php
@@ -41,14 +41,13 @@ class HydeServiceProvider extends ServiceProvider
             DocumentationPage::class => config('docs.output_directory', 'docs'),
         ]);
 
-        $this->discoverBladeViewsIn(BladePage::getSourceDirectory());
-
         $this->storeCompiledSiteIn(Hyde::path(
             unslash(config('hyde.output_directory', '_site'))
         ));
 
-        $this->registerHydeConsoleCommands();
+        $this->discoverBladeViewsIn(BladePage::getSourceDirectory());
 
+        $this->registerHydeConsoleCommands();
         $this->registerModuleServiceProviders();
     }
 

--- a/packages/framework/src/HydeServiceProvider.php
+++ b/packages/framework/src/HydeServiceProvider.php
@@ -100,19 +100,6 @@ class HydeServiceProvider extends ServiceProvider
     }
 
     /**
-     * If you are loading Blade views from a different directory,
-     * you need to add the path to the view.php config. This is
-     * here done automatically when registering this provider.
-     */
-    protected function discoverBladeViewsIn(string $directory): void
-    {
-        config(['view.paths' => array_merge(
-            config('view.paths', []),
-            [base_path($directory)]
-        )]);
-    }
-
-    /**
      * The absolute path to the directory when the compiled site is stored.
      */
     protected function storeCompiledSiteIn(string $directory): void

--- a/packages/framework/src/HydeServiceProvider.php
+++ b/packages/framework/src/HydeServiceProvider.php
@@ -100,14 +100,6 @@ class HydeServiceProvider extends ServiceProvider
     }
 
     /**
-     * The absolute path to the directory when the compiled site is stored.
-     */
-    protected function storeCompiledSiteIn(string $directory): void
-    {
-        StaticPageBuilder::$outputPath = $directory;
-    }
-
-    /**
      * Register module service providers.
      *
      * @todo Make modules configurable.

--- a/packages/framework/src/HydeServiceProvider.php
+++ b/packages/framework/src/HydeServiceProvider.php
@@ -41,7 +41,7 @@ class HydeServiceProvider extends ServiceProvider
             DocumentationPage::class => config('docs.output_directory', 'docs'),
         ]);
 
-        $this->discoverBladeViewsIn('_pages');
+        $this->discoverBladeViewsIn(BladePage::getSourceDirectory());
 
         $this->storeCompiledSiteIn(Hyde::path(
             unslash(config('hyde.output_directory', '_site'))

--- a/packages/framework/src/HydeServiceProvider.php
+++ b/packages/framework/src/HydeServiceProvider.php
@@ -47,24 +47,7 @@ class HydeServiceProvider extends ServiceProvider
             unslash(config('hyde.output_directory', '_site'))
         ));
 
-        $this->commands([
-            Commands\HydePublishHomepageCommand::class,
-            Commands\HydeUpdateConfigsCommand::class,
-            Commands\HydePublishViewsCommand::class,
-            Commands\HydeRebuildStaticSiteCommand::class,
-            Commands\HydeBuildStaticSiteCommand::class,
-            Commands\HydeBuildSitemapCommand::class,
-            Commands\HydeBuildRssFeedCommand::class,
-            Commands\HydeBuildSearchCommand::class,
-            Commands\HydeMakePostCommand::class,
-            Commands\HydeMakePageCommand::class,
-            Commands\HydeValidateCommand::class,
-            Commands\HydeInstallCommand::class,
-            Commands\HydeDebugCommand::class,
-            Commands\HydeServeCommand::class,
-
-            Commands\HydePackageDiscoverCommand::class,
-        ]);
+        $this->registerHydeConsoleCommands();
 
         $this->registerModuleServiceProviders();
     }
@@ -97,6 +80,31 @@ class HydeServiceProvider extends ServiceProvider
         $this->publishes([
             Hyde::vendorPath('resources/views/homepages/welcome.blade.php') => Hyde::path('_pages/index.blade.php'),
         ], 'hyde-welcome-page');
+    }
+
+    /**
+     * Register the HydeCLI console commands.
+     */
+    protected function registerHydeConsoleCommands(): void
+    {
+        $this->commands([
+            Commands\HydePublishHomepageCommand::class,
+            Commands\HydeUpdateConfigsCommand::class,
+            Commands\HydePublishViewsCommand::class,
+            Commands\HydeRebuildStaticSiteCommand::class,
+            Commands\HydeBuildStaticSiteCommand::class,
+            Commands\HydeBuildSitemapCommand::class,
+            Commands\HydeBuildRssFeedCommand::class,
+            Commands\HydeBuildSearchCommand::class,
+            Commands\HydeMakePostCommand::class,
+            Commands\HydeMakePageCommand::class,
+            Commands\HydeValidateCommand::class,
+            Commands\HydeInstallCommand::class,
+            Commands\HydeDebugCommand::class,
+            Commands\HydeServeCommand::class,
+
+            Commands\HydePackageDiscoverCommand::class,
+        ]);
     }
 
     /**

--- a/packages/framework/tests/Unit/HydeServiceProviderTest.php
+++ b/packages/framework/tests/Unit/HydeServiceProviderTest.php
@@ -5,6 +5,9 @@ namespace Hyde\Framework\Testing\Unit;
 use Hyde\Framework\HydeServiceProvider;
 use Hyde\Testing\TestCase;
 
+/**
+ * @todo Improve testing for this class.
+ */
 class HydeServiceProviderTest extends TestCase
 {
     protected HydeServiceProvider $provider;

--- a/packages/framework/tests/Unit/HydeServiceProviderTest.php
+++ b/packages/framework/tests/Unit/HydeServiceProviderTest.php
@@ -144,7 +144,7 @@ class HydeServiceProviderTest extends TestCase
         }, Artisan::all());
 
         foreach (glob(Hyde::vendorPath('src/Commands/*.php')) as $file) {
-            $class = 'Hyde\Framework\Commands\\'. basename($file, '.php');
+            $class = 'Hyde\Framework\Commands\\'.basename($file, '.php');
 
             $this->assertContains($class, $commands);
         }

--- a/packages/framework/tests/Unit/HydeServiceProviderTest.php
+++ b/packages/framework/tests/Unit/HydeServiceProviderTest.php
@@ -47,7 +47,6 @@ class HydeServiceProviderTest extends TestCase
         $this->assertTrue(method_exists($this->provider, 'boot'));
     }
 
-    // test provider registers AssetServiceContract
     public function test_provider_registers_asset_service_contract()
     {
         $this->assertTrue($this->app->bound(AssetServiceContract::class));
@@ -55,7 +54,6 @@ class HydeServiceProviderTest extends TestCase
         $this->assertInstanceOf(AssetService::class, $this->app->make(AssetServiceContract::class));
     }
 
-    // test provider registers source directories
     public function test_provider_registers_source_directories()
     {
         BladePage::$sourceDirectory = '';
@@ -76,7 +74,6 @@ class HydeServiceProviderTest extends TestCase
         $this->assertEquals('_docs', DocumentationPage::getSourceDirectory());
     }
 
-    // test provider registers output directories
     public function test_provider_registers_output_directories()
     {
         BladePage::$outputDirectory = 'foo';
@@ -97,7 +94,6 @@ class HydeServiceProviderTest extends TestCase
         $this->assertEquals('docs', DocumentationPage::getOutputDirectory());
     }
 
-    // test provider registers configured documentation output directory
     public function test_provider_registers_configured_documentation_output_directory()
     {
         $this->assertEquals('docs', DocumentationPage::getOutputDirectory());
@@ -109,7 +105,6 @@ class HydeServiceProviderTest extends TestCase
         $this->assertEquals('foo', DocumentationPage::getOutputDirectory());
     }
 
-    // test provider registers site output directory
     public function test_provider_registers_site_output_directory()
     {
         $this->assertEquals(Hyde::path('_site'), StaticPageBuilder::$outputPath);
@@ -121,7 +116,6 @@ class HydeServiceProviderTest extends TestCase
         $this->assertEquals(Hyde::path('foo'), StaticPageBuilder::$outputPath);
     }
 
-    // test provider registers blade view discovery location for configured blade view path
     public function test_provider_registers_blade_view_discovery_location_for_configured_blade_view_path()
     {
         config(['view.paths' => []]);
@@ -132,7 +126,6 @@ class HydeServiceProviderTest extends TestCase
         $this->assertEquals([Hyde::path('_pages')], config('view.paths'));
     }
 
-    // test blade view locations are only registered once per key
     public function test_blade_view_locations_are_only_registered_once_per_key()
     {
         config(['view.paths' => []]);
@@ -144,7 +137,6 @@ class HydeServiceProviderTest extends TestCase
         $this->assertEquals([Hyde::path('_pages')], config('view.paths'));
     }
 
-    // test provider registers console commands
     public function test_provider_registers_console_commands()
     {
         $commands = array_map(function ($command) {
@@ -158,7 +150,6 @@ class HydeServiceProviderTest extends TestCase
         }
     }
 
-    // test provider registers additional module service providers
     public function test_provider_registers_additional_module_service_providers()
     {
         $this->provider->register();

--- a/packages/framework/tests/Unit/HydeServiceProviderTest.php
+++ b/packages/framework/tests/Unit/HydeServiceProviderTest.php
@@ -2,11 +2,24 @@
 
 namespace Hyde\Framework\Testing\Unit;
 
+use Hyde\Framework\Contracts\AssetServiceContract;
+use Hyde\Framework\Hyde;
 use Hyde\Framework\HydeServiceProvider;
+use Hyde\Framework\Models\Pages\BladePage;
+use Hyde\Framework\Models\Pages\DocumentationPage;
+use Hyde\Framework\Models\Pages\MarkdownPage;
+use Hyde\Framework\Models\Pages\MarkdownPost;
+use Hyde\Framework\Modules\DataCollections\DataCollectionServiceProvider;
+use Hyde\Framework\Services\AssetService;
+use Hyde\Framework\StaticPageBuilder;
 use Hyde\Testing\TestCase;
+use Illuminate\Support\Facades\Artisan;
 
 /**
- * @todo Improve testing for this class.
+ * @todo #162 Improve testing for this class.
+ *
+ * @covers \Hyde\Framework\HydeServiceProvider
+ * @covers \Hyde\Framework\Concerns\RegistersFileLocations
  */
 class HydeServiceProviderTest extends TestCase
 {
@@ -14,9 +27,9 @@ class HydeServiceProviderTest extends TestCase
 
     public function setUp(): void
     {
-        $this->provider = new HydeServiceProvider(app());
-
         parent::setUp();
+
+        $this->provider = new HydeServiceProvider(app());
     }
 
     public function test_provider_is_constructed()
@@ -32,5 +45,124 @@ class HydeServiceProviderTest extends TestCase
     public function test_provider_has_boot_method()
     {
         $this->assertTrue(method_exists($this->provider, 'boot'));
+    }
+
+    // test provider registers AssetServiceContract
+    public function test_provider_registers_asset_service_contract()
+    {
+        $this->assertTrue($this->app->bound(AssetServiceContract::class));
+        $this->assertInstanceOf(AssetServiceContract::class, $this->app->make(AssetServiceContract::class));
+        $this->assertInstanceOf(AssetService::class, $this->app->make(AssetServiceContract::class));
+    }
+
+    // test provider registers source directories
+    public function test_provider_registers_source_directories()
+    {
+        BladePage::$sourceDirectory = '';
+        MarkdownPage::$sourceDirectory = '';
+        MarkdownPost::$sourceDirectory = '';
+        DocumentationPage::$sourceDirectory = '';
+
+        $this->assertEquals('', BladePage::getSourceDirectory());
+        $this->assertEquals('', MarkdownPage::getSourceDirectory());
+        $this->assertEquals('', MarkdownPost::getSourceDirectory());
+        $this->assertEquals('', DocumentationPage::getSourceDirectory());
+
+        $this->provider->register();
+
+        $this->assertEquals('_pages', BladePage::getSourceDirectory());
+        $this->assertEquals('_pages', MarkdownPage::getSourceDirectory());
+        $this->assertEquals('_posts', MarkdownPost::getSourceDirectory());
+        $this->assertEquals('_docs', DocumentationPage::getSourceDirectory());
+    }
+
+    // test provider registers output directories
+    public function test_provider_registers_output_directories()
+    {
+        BladePage::$outputDirectory = 'foo';
+        MarkdownPage::$outputDirectory = 'foo';
+        MarkdownPost::$outputDirectory = 'foo';
+        DocumentationPage::$outputDirectory = 'foo';
+
+        $this->assertEquals('foo', BladePage::getOutputDirectory());
+        $this->assertEquals('foo', MarkdownPage::getOutputDirectory());
+        $this->assertEquals('foo', MarkdownPost::getOutputDirectory());
+        $this->assertEquals('foo', DocumentationPage::getOutputDirectory());
+
+        $this->provider->register();
+
+        $this->assertEquals('', BladePage::getOutputDirectory());
+        $this->assertEquals('', MarkdownPage::getOutputDirectory());
+        $this->assertEquals('posts', MarkdownPost::getOutputDirectory());
+        $this->assertEquals('docs', DocumentationPage::getOutputDirectory());
+    }
+
+    // test provider registers configured documentation output directory
+    public function test_provider_registers_configured_documentation_output_directory()
+    {
+        $this->assertEquals('docs', DocumentationPage::getOutputDirectory());
+
+        config(['docs.output_directory' => 'foo']);
+
+        $this->provider->register();
+
+        $this->assertEquals('foo', DocumentationPage::getOutputDirectory());
+    }
+
+    // test provider registers site output directory
+    public function test_provider_registers_site_output_directory()
+    {
+        $this->assertEquals(Hyde::path('_site'), StaticPageBuilder::$outputPath);
+
+        config(['hyde.output_directory' => 'foo']);
+
+        $this->provider->register();
+
+        $this->assertEquals(Hyde::path('foo'), StaticPageBuilder::$outputPath);
+    }
+
+    // test provider registers blade view discovery location for configured blade view path
+    public function test_provider_registers_blade_view_discovery_location_for_configured_blade_view_path()
+    {
+        config(['view.paths' => []]);
+        $this->assertEquals([], config('view.paths'));
+
+        $this->provider->register();
+
+        $this->assertEquals([Hyde::path('_pages')], config('view.paths'));
+    }
+
+    // test blade view locations are only registered once per key
+    public function test_blade_view_locations_are_only_registered_once_per_key()
+    {
+        config(['view.paths' => []]);
+        $this->assertEquals([], config('view.paths'));
+
+        $this->provider->register();
+        $this->provider->register();
+
+        $this->assertEquals([Hyde::path('_pages')], config('view.paths'));
+    }
+
+    // test provider registers console commands
+    public function test_provider_registers_console_commands()
+    {
+        $commands = array_map(function ($command) {
+            return get_class($command);
+        }, Artisan::all());
+
+        foreach (glob(Hyde::vendorPath('src/Commands/*.php')) as $file) {
+            $class = 'Hyde\Framework\Commands\\'. basename($file, '.php');
+
+            $this->assertContains($class, $commands);
+        }
+    }
+
+    // test provider registers additional module service providers
+    public function test_provider_registers_additional_module_service_providers()
+    {
+        $this->provider->register();
+
+        $this->assertArrayHasKey(DataCollectionServiceProvider::class, $this->app->getLoadedProviders());
     }
 }


### PR DESCRIPTION
Moves methods related to directory mappings from the HydeServiceProvider to the RegistersFileLocations trait, making it easier to override them.