### PR TITLE
Remove deprecated `DocumentationPage::getDocumentationOutputPath()`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ This serves two purposes:
 ### Removed
 - Remove deprecated `Hyde::getDocumentationOutputDirectory()`, replaced with `DocumentationPage::getOutputDirectory()`
 - Remove deprecated `Hyde::docsIndexPath()`, replaced with `DocumentationPage::indexPath()`
+- Remove deprecated `DocumentationPage::getDocumentationOutputPath()`, use `DocumentationPage::getOutputPath()` instead
 
 
 ### Fixed

--- a/packages/framework/src/HydeServiceProvider.php
+++ b/packages/framework/src/HydeServiceProvider.php
@@ -38,7 +38,7 @@ class HydeServiceProvider extends ServiceProvider
             BladePage::class => '',
             MarkdownPage::class => '',
             MarkdownPost::class => 'posts',
-            DocumentationPage::class => config('docs.output_directory', 'docs'),
+            DocumentationPage::class => unslash(config('docs.output_directory', 'docs')),
         ]);
 
         $this->storeCompiledSiteIn(Hyde::path(

--- a/packages/framework/src/Models/Pages/DocumentationPage.php
+++ b/packages/framework/src/Models/Pages/DocumentationPage.php
@@ -32,15 +32,7 @@ class DocumentationPage extends AbstractMarkdownPage
 
         return trim(config('docs.source_file_location_base'), '/').'/'.$this->slug.'.md';
     }
-
-    /**
-     * @deprecated v0.44.x Use DocumentationPage::getOutputDirectory() instead
-     */
-    public static function getDocumentationOutputPath(): string
-    {
-        return unslash(config('docs.output_directory', 'docs'));
-    }
-
+    
     /**
      * Get the path to the frontpage for the documentation.
      *

--- a/packages/framework/src/Models/Pages/DocumentationPage.php
+++ b/packages/framework/src/Models/Pages/DocumentationPage.php
@@ -32,7 +32,7 @@ class DocumentationPage extends AbstractMarkdownPage
 
         return trim(config('docs.source_file_location_base'), '/').'/'.$this->slug.'.md';
     }
-    
+
     /**
      * Get the path to the frontpage for the documentation.
      *

--- a/packages/framework/tests/Unit/DocumentationPageTest.php
+++ b/packages/framework/tests/Unit/DocumentationPageTest.php
@@ -53,14 +53,14 @@ class DocumentationPageTest extends TestCase
 
     public function test_can_get_documentation_output_path()
     {
-        $this->assertEquals('docs', DocumentationPage::getDocumentationOutputPath());
+        $this->assertEquals('docs', DocumentationPage::getOutputDirectory());
     }
 
     public function test_can_get_documentation_output_path_with_custom_output_directory()
     {
         config(['docs.output_directory' => 'foo']);
         (new HydeServiceProvider($this->app))->register();
-        $this->assertEquals('foo', DocumentationPage::getDocumentationOutputPath());
+        $this->assertEquals('foo', DocumentationPage::getOutputDirectory());
     }
 
     public function test_can_get_documentation_output_path_with_trailing_slashes()
@@ -76,7 +76,7 @@ class DocumentationPageTest extends TestCase
         foreach ($tests as $test) {
             config(['docs.output_directory' => $test]);
             (new HydeServiceProvider($this->app))->register();
-            $this->assertEquals('foo', DocumentationPage::getDocumentationOutputPath());
+            $this->assertEquals('foo', DocumentationPage::getOutputDirectory());
         }
     }
 }


### PR DESCRIPTION
This method has been replaced with `DocumentationPage::getOutputPath()`