### PR TITLE
Add `array_map_unique()` helper

### DIFF
--- a/packages/framework/src/helpers.php
+++ b/packages/framework/src/helpers.php
@@ -26,3 +26,24 @@ if (! function_exists('unslash')) {
         return trim($string, '/\\');
     }
 }
+
+if (! function_exists('array_map_unique')) {
+    /**
+     * Map a callback over an array and remove duplicates.
+     *
+     * Important! The callback and the array parameter positions
+     * are reversed compared to the PHP function.
+     *
+     * @param  array|\Illuminate\Support\Collection  $array  $array
+     * @param  callable  $callback
+     * @return array
+     */
+    function array_map_unique(array|\Illuminate\Support\Collection $array, callable $callback): array
+    {
+        if ($array instanceof \Illuminate\Support\Collection) {
+            $array = $array->toArray();
+        }
+
+        return array_unique(array_map($callback, $array));
+    }
+}

--- a/packages/framework/src/helpers.php
+++ b/packages/framework/src/helpers.php
@@ -1,6 +1,7 @@
 <?php
 
 use Hyde\Framework\Hyde;
+use Illuminate\Support\Collection;
 
 if (! function_exists('hyde')) {
     /**
@@ -34,16 +35,18 @@ if (! function_exists('array_map_unique')) {
      * Important! The callback and the array parameter positions
      * are reversed compared to the PHP function.
      *
+     * Unlike array_unique, keys are reset.
+     *
      * @param  array|\Illuminate\Support\Collection  $array  $array
      * @param  callable  $callback
      * @return array
      */
-    function array_map_unique(array|\Illuminate\Support\Collection $array, callable $callback): array
+    function array_map_unique(array|Collection $array, callable $callback): array
     {
-        if ($array instanceof \Illuminate\Support\Collection) {
+        if ($array instanceof Collection) {
             $array = $array->toArray();
         }
 
-        return array_unique(array_map($callback, $array));
+        return array_values(array_unique(array_map($callback, $array)));
     }
 }

--- a/packages/framework/tests/Feature/HelpersTest.php
+++ b/packages/framework/tests/Feature/HelpersTest.php
@@ -31,7 +31,6 @@ class HelpersTest extends TestCase
         $this->assertTrue(function_exists('unslash'));
     }
 
-    // test unslash function trims trailing slashes
     /** @covers ::unslash */
     public function test_unslash_function_trims_trailing_slashes()
     {
@@ -52,5 +51,54 @@ class HelpersTest extends TestCase
         foreach ($tests as $test) {
             $this->assertSame('foo/bar', unslash($test));
         }
+    }
+
+    /** @covers ::array_map_unique */
+    public function test_array_map_unique_function_exists()
+    {
+        $this->assertTrue(function_exists('array_map_unique'));
+    }
+
+    /** @covers ::array_map_unique */
+    public function test_array_map_unique_function_accepts_array_or_collection()
+    {
+        $array = [1, 2, 3];
+        $collection = collect($array);
+
+        $this->assertSame($array, array_map_unique($array, function ($item) {
+            return $item;
+        }));
+        $this->assertSame($array, array_map_unique($collection, function ($item) {
+            return $item;
+        }));
+    }
+
+    /** @covers ::array_map_unique */
+    public function test_array_map_unique_function_returns_unique_array()
+    {
+        $array = [1, 1, 2];
+
+        $this->assertEquals([1, 2], array_map_unique($array, function ($item) {
+            return $item;
+        }));
+    }
+
+    /** @covers ::array_map_unique */
+    public function test_array_map_unique_function_returns_reset_keys()
+    {
+        $array = [1, 2, 2, 2, 3];
+
+        $this->assertEquals([1, 2, 3], array_map_unique($array, function ($item) {
+            return $item;
+        }));
+    }
+
+    public function test_array_map_unique_function_handles_string_arrays()
+    {
+        $array = ['foo', 'foo', 'bar'];
+
+        $this->assertEquals(['foo', 'bar'], array_map_unique($array, function ($item) {
+            return $item;
+        }));
     }
 }


### PR DESCRIPTION
Adds a helper which is a wrapper for the array_map function. However, the returned array is filtered for duplicates and its keys are reset. The callback function also comes after the original array as I think that presents a more logical developer flow.