### PR TITLE
Disable autoloader optimization in default composer config

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -42,7 +42,7 @@
     "config": {
         "preferred-install": "dist",
         "sort-packages": true,
-        "optimize-autoloader": true,
+        "optimize-autoloader": false,
         "allow-plugins": {
             "pestphp/pest-plugin": true
         }


### PR DESCRIPTION
This will speed up a lot of stuff. And one can always pass the optimize-autoloader flag when running Composer commands, however there does not seem to be an inverse. When we move to stable v1 it'd be good to enable it again.