### PR TITLE
Add macroable trait to the Hyde facade

### DIFF
--- a/packages/framework/src/Hyde.php
+++ b/packages/framework/src/Hyde.php
@@ -6,6 +6,7 @@ use Composer\InstalledVersions;
 use Hyde\Framework\Concerns\Internal\FileHelpers;
 use Hyde\Framework\Concerns\Internal\FluentPathHelpers;
 use Hyde\Framework\Helpers\HydeHelperFacade;
+use Illuminate\Support\Traits\Macroable;
 
 /**
  * General facade for Hyde services.
@@ -21,6 +22,7 @@ class Hyde
     use FileHelpers;
     use FluentPathHelpers;
     use HydeHelperFacade;
+    use Macroable;
 
     protected static string $basePath;
 

--- a/packages/framework/tests/Feature/AbstractPageTest.php
+++ b/packages/framework/tests/Feature/AbstractPageTest.php
@@ -74,7 +74,7 @@ class AbstractPageTest extends TestCase
 
     public function test_get_parser_returns_the_configured_parser_class()
     {
-        touch(Hyde::path('_posts/foo.md'));
+        Hyde::touch(('_posts/foo.md'));
 
         MarkdownPage::$parserClass = MarkdownPostParser::class;
         $this->assertInstanceOf(MarkdownPostParser::class, MarkdownPage::getParser('foo'));
@@ -84,7 +84,7 @@ class AbstractPageTest extends TestCase
 
     public function test_get_parser_returns_instantiated_parser_for_the_supplied_slug()
     {
-        touch(Hyde::path('_pages/foo.md'));
+        Hyde::touch(('_pages/foo.md'));
 
         $this->assertInstanceOf(MarkdownPageParser::class, $parser = MarkdownPage::getParser('foo'));
         $this->assertEquals('foo', $parser->get()->slug);
@@ -94,7 +94,7 @@ class AbstractPageTest extends TestCase
 
     public function test_parse_parses_supplied_slug_into_a_page_model()
     {
-        touch(Hyde::path('_pages/foo.md'));
+        Hyde::touch(('_pages/foo.md'));
 
         $this->assertInstanceOf(MarkdownPage::class, $page = MarkdownPage::parse('foo'));
         $this->assertEquals('foo', $page->slug);
@@ -104,14 +104,14 @@ class AbstractPageTest extends TestCase
 
     public function test_files_returns_array_of_source_files()
     {
-        touch(Hyde::path('_pages/foo.md'));
+        Hyde::touch(('_pages/foo.md'));
         $this->assertEquals(['foo'], MarkdownPage::files());
         unlink(Hyde::path('_pages/foo.md'));
     }
 
     public function test_all_returns_collection_of_all_source_files_parsed_into_the_model()
     {
-        touch(Hyde::path('_pages/foo.md'));
+        Hyde::touch(('_pages/foo.md'));
         $this->assertEquals(
             collect([new MarkdownPage([], '', '', 'foo')]),
             MarkdownPage::all()

--- a/packages/framework/tests/Feature/Actions/GeneratesDocumentationSearchIndexFileTest.php
+++ b/packages/framework/tests/Feature/Actions/GeneratesDocumentationSearchIndexFileTest.php
@@ -29,7 +29,7 @@ class GeneratesDocumentationSearchIndexFileTest extends TestCase
     {
         $this->resetDocs();
 
-        touch(Hyde::path('_docs/foo.md'));
+        Hyde::touch(('_docs/foo.md'));
 
         $expected = [
             [
@@ -51,9 +51,9 @@ class GeneratesDocumentationSearchIndexFileTest extends TestCase
 
     public function test_it_adds_all_files_to_search_index()
     {
-        touch(Hyde::path('_docs/foo.md'));
-        touch(Hyde::path('_docs/bar.md'));
-        touch(Hyde::path('_docs/baz.md'));
+        Hyde::touch(('_docs/foo.md'));
+        Hyde::touch(('_docs/bar.md'));
+        Hyde::touch(('_docs/baz.md'));
 
         $this->assertCount(3, (new Action())->generate()->searchIndex);
 
@@ -97,9 +97,9 @@ class GeneratesDocumentationSearchIndexFileTest extends TestCase
 
     public function test_get_source_file_slugs_returns_valid_array_for_source_files()
     {
-        touch(Hyde::path('_docs/a.md'));
-        touch(Hyde::path('_docs/b.md'));
-        touch(Hyde::path('_docs/c.md'));
+        Hyde::touch(('_docs/a.md'));
+        Hyde::touch(('_docs/b.md'));
+        Hyde::touch(('_docs/c.md'));
 
         $this->assertEquals(
             ['a', 'b', 'c'], (new Action())->getSourceFileSlugs()
@@ -152,7 +152,7 @@ class GeneratesDocumentationSearchIndexFileTest extends TestCase
 
     public function test_excluded_pages_are_not_present_in_the_search_index()
     {
-        touch(Hyde::path('_docs/excluded.md'));
+        Hyde::touch(('_docs/excluded.md'));
         config(['docs.exclude_from_search' => ['excluded']]);
 
         $this->assertNotContains('excluded', (new Action())->getSourceFileSlugs());

--- a/packages/framework/tests/Feature/Commands/HydeBuildSearchCommandTest.php
+++ b/packages/framework/tests/Feature/Commands/HydeBuildSearchCommandTest.php
@@ -67,7 +67,7 @@ class HydeBuildSearchCommandTest extends TestCase
     public function test_it_displays_the_estimation_message_when_it_is_greater_than_1_second()
     {
         HydeBuildSearchCommand::$guesstimationFactor = 1000;
-        touch(Hyde::path('_docs/foo.md'));
+        Hyde::touch(('_docs/foo.md'));
         $this->artisan('build:search')
             ->expectsOutput('Generating documentation site search index...')
             ->expectsOutputToContain('> This will take an estimated')

--- a/packages/framework/tests/Feature/Commands/HydeRebuildStaticSiteCommandTest.php
+++ b/packages/framework/tests/Feature/Commands/HydeRebuildStaticSiteCommandTest.php
@@ -31,7 +31,7 @@ class HydeRebuildStaticSiteCommandTest extends TestCase
         deleteDirectory(Hyde::path('_site/media'));
         mkdir(Hyde::path('_site/media'));
 
-        touch(Hyde::path('_media/test.jpg'));
+        Hyde::touch(('_media/test.jpg'));
 
         $this->artisan('rebuild _media')
             ->assertExitCode(0);
@@ -59,7 +59,7 @@ class HydeRebuildStaticSiteCommandTest extends TestCase
 
     public function test_rebuild_documentation_page()
     {
-        touch(Hyde::path('_docs/foo.md'));
+        Hyde::touch(('_docs/foo.md'));
 
         $this->artisan('rebuild _docs/foo.md')
             ->assertExitCode(0);
@@ -72,7 +72,7 @@ class HydeRebuildStaticSiteCommandTest extends TestCase
 
     public function test_rebuild_blog_post()
     {
-        touch(Hyde::path('_posts/foo.md'));
+        Hyde::touch(('_posts/foo.md'));
 
         $this->artisan('rebuild _posts/foo.md')
             ->assertExitCode(0);

--- a/packages/framework/tests/Feature/DataCollectionTest.php
+++ b/packages/framework/tests/Feature/DataCollectionTest.php
@@ -79,8 +79,8 @@ class DataCollectionTest extends TestCase
     public function test_get_markdown_files_method_returns_an_array_of_markdown_files_in_the_specified_directory()
     {
         mkdir(Hyde::path('_data/foo'));
-        touch(Hyde::path('_data/foo/foo.md'));
-        touch(Hyde::path('_data/foo/bar.md'));
+        Hyde::touch(('_data/foo/foo.md'));
+        Hyde::touch(('_data/foo/bar.md'));
 
         $this->assertEquals([
             Hyde::path('_data/foo/bar.md'),
@@ -94,8 +94,8 @@ class DataCollectionTest extends TestCase
     {
         mkdir(Hyde::path('_data/foo'));
         mkdir(Hyde::path('_data/foo/bar'));
-        touch(Hyde::path('_data/foo/foo.md'));
-        touch(Hyde::path('_data/foo/bar/bar.md'));
+        Hyde::touch(('_data/foo/foo.md'));
+        Hyde::touch(('_data/foo/bar/bar.md'));
         $this->assertEquals([
             Hyde::path('_data/foo/foo.md'),
         ], (new DataCollection('foo'))->getMarkdownFiles());
@@ -105,8 +105,8 @@ class DataCollectionTest extends TestCase
     public function test_get_markdown_files_method_does_not_include_files_with_extensions_other_than_md()
     {
         mkdir(Hyde::path('_data/foo'));
-        touch(Hyde::path('_data/foo/foo.md'));
-        touch(Hyde::path('_data/foo/bar.txt'));
+        Hyde::touch(('_data/foo/foo.md'));
+        Hyde::touch(('_data/foo/bar.txt'));
         $this->assertEquals([
             Hyde::path('_data/foo/foo.md'),
         ], (new DataCollection('foo'))->getMarkdownFiles());
@@ -121,8 +121,8 @@ class DataCollectionTest extends TestCase
     public function test_static_markdown_helper_discovers_and_parses_markdown_files_in_the_specified_directory()
     {
         mkdir(Hyde::path('_data/foo'));
-        touch(Hyde::path('_data/foo/foo.md'));
-        touch(Hyde::path('_data/foo/bar.md'));
+        Hyde::touch(('_data/foo/foo.md'));
+        Hyde::touch(('_data/foo/bar.md'));
 
         $collection = DataCollection::markdown('foo');
 
@@ -134,8 +134,8 @@ class DataCollectionTest extends TestCase
     public function test_static_markdown_helper_ignores_files_starting_with_an_underscore()
     {
         mkdir(Hyde::path('_data/foo'));
-        touch(Hyde::path('_data/foo/foo.md'));
-        touch(Hyde::path('_data/foo/_bar.md'));
+        Hyde::touch(('_data/foo/foo.md'));
+        Hyde::touch(('_data/foo/_bar.md'));
         $this->assertCount(1, DataCollection::markdown('foo'));
         File::deleteDirectory(Hyde::path('_data/foo'));
     }
@@ -188,7 +188,7 @@ class DataCollectionTest extends TestCase
     {
         DataCollection::$sourceDirectory = 'foo';
         mkdir(Hyde::path('foo/bar'), recursive: true);
-        touch(Hyde::path('foo/bar/foo.md'));
+        Hyde::touch(('foo/bar/foo.md'));
         $this->assertEquals([
             Hyde::path('foo/bar/foo.md'),
         ], (new DataCollection('bar'))->getMarkdownFiles());

--- a/packages/framework/tests/Feature/DiscoveryServiceTest.php
+++ b/packages/framework/tests/Feature/DiscoveryServiceTest.php
@@ -17,10 +17,10 @@ class DiscoveryServiceTest extends TestCase
 {
     public function createContentSourceTestFiles()
     {
-        touch(Hyde::path(DiscoveryService::getFilePathForModelClassFiles(MarkdownPost::class).'/test.md'));
-        touch(Hyde::path(DiscoveryService::getFilePathForModelClassFiles(MarkdownPage::class).'/test.md'));
-        touch(Hyde::path(DiscoveryService::getFilePathForModelClassFiles(DocumentationPage::class).'/test.md'));
-        touch(Hyde::path(DiscoveryService::getFilePathForModelClassFiles(BladePage::class).'/test.blade.php'));
+        Hyde::touch((DiscoveryService::getFilePathForModelClassFiles(MarkdownPost::class).'/test.md'));
+        Hyde::touch((DiscoveryService::getFilePathForModelClassFiles(MarkdownPage::class).'/test.md'));
+        Hyde::touch((DiscoveryService::getFilePathForModelClassFiles(DocumentationPage::class).'/test.md'));
+        Hyde::touch((DiscoveryService::getFilePathForModelClassFiles(BladePage::class).'/test.blade.php'));
     }
 
     public function deleteContentSourceTestFiles()

--- a/packages/framework/tests/Feature/GeneratesNavigationMenuTest.php
+++ b/packages/framework/tests/Feature/GeneratesNavigationMenuTest.php
@@ -18,7 +18,7 @@ class GeneratesNavigationMenuTest extends TestCase
 
     public function test_generated_links_include_documentation_pages()
     {
-        touch(Hyde::path('_docs/index.md'));
+        Hyde::touch(('_docs/index.md'));
 
         $generator = new GeneratesNavigationMenu('index');
         $this->assertIsArray($generator->links);
@@ -65,8 +65,8 @@ class GeneratesNavigationMenuTest extends TestCase
 
     public function test_files_starting_with_underscores_are_ignored()
     {
-        touch(Hyde::path('_pages/_foo.md'));
-        touch(Hyde::path('_pages/_foo.blade.php'));
+        Hyde::touch(('_pages/_foo.md'));
+        Hyde::touch(('_pages/_foo.blade.php'));
 
         $array = GeneratesNavigationMenu::getNavigationLinks();
         $this->assertIsArray($array);

--- a/packages/framework/tests/Feature/RebuildServiceTest.php
+++ b/packages/framework/tests/Feature/RebuildServiceTest.php
@@ -30,7 +30,7 @@ class RebuildServiceTest extends TestCase
     protected function runExecuteTest(string $prefix, string $suffix = '.md')
     {
         $path = $prefix.'/foo'.$suffix;
-        touch(Hyde::path($path));
+        Hyde::touch(($path));
         $service = new RebuildService($path);
         $result = $service->execute();
         $this->assertInstanceOf(StaticPageBuilder::class, $result);

--- a/packages/framework/tests/Feature/RouteTest.php
+++ b/packages/framework/tests/Feature/RouteTest.php
@@ -134,28 +134,28 @@ class RouteTest extends TestCase
 
     public function test_get_from_source_can_find_blade_pages()
     {
-        touch(Hyde::path('_pages/foo.blade.php'));
+        Hyde::touch(('_pages/foo.blade.php'));
         $this->assertEquals(new Route(BladePage::parse('foo')), Route::getFromSource('_pages/foo.blade.php'));
         unlink(Hyde::path('_pages/foo.blade.php'));
     }
 
     public function test_get_from_source_can_find_markdown_pages()
     {
-        touch(Hyde::path('_pages/foo.md'));
+        Hyde::touch(('_pages/foo.md'));
         $this->assertEquals(new Route(MarkdownPage::parse('foo')), Route::getFromSource('_pages/foo.md'));
         unlink(Hyde::path('_pages/foo.md'));
     }
 
     public function test_get_from_source_can_find_markdown_posts()
     {
-        touch(Hyde::path('_posts/foo.md'));
+        Hyde::touch(('_posts/foo.md'));
         $this->assertEquals(new Route(MarkdownPost::parse('foo')), Route::getFromSource('_posts/foo.md'));
         unlink(Hyde::path('_posts/foo.md'));
     }
 
     public function test_get_from_source_can_find_documentation_pages()
     {
-        touch(Hyde::path('_docs/foo.md'));
+        Hyde::touch(('_docs/foo.md'));
         $this->assertEquals(new Route(DocumentationPage::parse('foo')), Route::getFromSource('_docs/foo.md'));
         unlink(Hyde::path('_docs/foo.md'));
     }

--- a/packages/framework/tests/Feature/RouterTest.php
+++ b/packages/framework/tests/Feature/RouterTest.php
@@ -51,7 +51,7 @@ class RouterTest extends TestCase
      */
     public function test_get_routes_for_model_returns_only_routes_for_the_given_model()
     {
-        touch(Hyde::path('_pages/foo.md'));
+        Hyde::touch(('_pages/foo.md'));
 
         $routes = (new Router())->getRoutesForModel(MarkdownPage::class);
 
@@ -115,7 +115,7 @@ class RouterTest extends TestCase
     protected function testRouteModelDiscoveryForPageModel(string $class)
     {
         /** @var PageContract $class */
-        touch(Hyde::path($class::qualifyBasename('foo')));
+        Hyde::touch(($class::qualifyBasename('foo')));
 
         $expectedKey = 'foo';
         if ($class === MarkdownPost::class) {

--- a/packages/framework/tests/Feature/Services/CollectionServiceTest.php
+++ b/packages/framework/tests/Feature/Services/CollectionServiceTest.php
@@ -27,21 +27,21 @@ class CollectionServiceTest extends TestCase
 
     public function test_get_source_file_list_for_markdown_page()
     {
-        touch(Hyde::path('_pages/foo.md'));
+        Hyde::touch(('_pages/foo.md'));
         $this->assertEquals(['foo'], CollectionService::getMarkdownPageFiles());
         unlink(Hyde::path('_pages/foo.md'));
     }
 
     public function test_get_source_file_list_for_markdown_post()
     {
-        touch(Hyde::path('_posts/foo.md'));
+        Hyde::touch(('_posts/foo.md'));
         $this->assertEquals(['foo'], CollectionService::getMarkdownPostFiles());
         unlink(Hyde::path('_posts/foo.md'));
     }
 
     public function test_get_source_file_list_for_documentation_page()
     {
-        touch(Hyde::path('_docs/foo.md'));
+        Hyde::touch(('_docs/foo.md'));
         $this->assertEquals(['foo'], CollectionService::getDocumentationPageFiles());
         unlink(Hyde::path('_docs/foo.md'));
     }
@@ -131,7 +131,7 @@ class CollectionServiceTest extends TestCase
 
     public function test_blade_page_files_starting_with_underscore_are_ignored()
     {
-        touch(Hyde::path('_pages/_foo.blade.php'));
+        Hyde::touch(('_pages/_foo.blade.php'));
         $this->assertEquals([
             '404',
             'index',
@@ -141,28 +141,28 @@ class CollectionServiceTest extends TestCase
 
     public function test_markdown_page_files_starting_with_underscore_are_ignored()
     {
-        touch(Hyde::path('_pages/_foo.md'));
+        Hyde::touch(('_pages/_foo.md'));
         $this->assertEquals([], CollectionService::getMarkdownPageFiles());
         unlink(Hyde::path('_pages/_foo.md'));
     }
 
     public function test_post_files_starting_with_underscore_are_ignored()
     {
-        touch(Hyde::path('_posts/_foo.md'));
+        Hyde::touch(('_posts/_foo.md'));
         $this->assertEquals([], CollectionService::getMarkdownPostFiles());
         unlink(Hyde::path('_posts/_foo.md'));
     }
 
     public function test_documentation_page_files_starting_with_underscore_are_ignored()
     {
-        touch(Hyde::path('_docs/_foo.md'));
+        Hyde::touch(('_docs/_foo.md'));
         $this->assertEquals([], CollectionService::getDocumentationPageFiles());
         unlink(Hyde::path('_docs/_foo.md'));
     }
 
     protected function unitTestMarkdownBasedPageList(string $model, string $path, ?string $expected = null)
     {
-        touch(Hyde::path($path));
+        Hyde::touch(($path));
 
         $expected = $expected ?? basename($path, '.md');
 

--- a/packages/framework/tests/Feature/Services/DocumentationSidebarServiceTest.php
+++ b/packages/framework/tests/Feature/Services/DocumentationSidebarServiceTest.php
@@ -62,7 +62,7 @@ class DocumentationSidebarServiceTest extends TestCase
     public function test_index_page_is_removed_from_sidebar()
     {
         $this->createTestFiles();
-        touch(Hyde::path('_docs/index.md'));
+        Hyde::touch(('_docs/index.md'));
 
         $sidebar = DocumentationSidebarService::get();
         $this->assertCount(5, $sidebar);
@@ -80,9 +80,9 @@ class DocumentationSidebarServiceTest extends TestCase
     public function test_sidebar_is_ordered_alphabetically_when_no_order_is_set_in_config()
     {
         Config::set('docs.sidebar_order', []);
-        touch(Hyde::path('_docs/alpha.md'));
-        touch(Hyde::path('_docs/bravo.md'));
-        touch(Hyde::path('_docs/charlie.md'));
+        Hyde::touch(('_docs/alpha.md'));
+        Hyde::touch(('_docs/bravo.md'));
+        Hyde::touch(('_docs/charlie.md'));
 
         $sidebar = DocumentationSidebarService::get();
 
@@ -98,9 +98,9 @@ class DocumentationSidebarServiceTest extends TestCase
             'bravo',
             'alpha',
         ]);
-        touch(Hyde::path('_docs/alpha.md'));
-        touch(Hyde::path('_docs/bravo.md'));
-        touch(Hyde::path('_docs/charlie.md'));
+        Hyde::touch(('_docs/alpha.md'));
+        Hyde::touch(('_docs/bravo.md'));
+        Hyde::touch(('_docs/charlie.md'));
 
         $sidebar = DocumentationSidebarService::get();
         $this->assertEquals('charlie', $sidebar[0]->destination);
@@ -139,8 +139,8 @@ class DocumentationSidebarServiceTest extends TestCase
             'third',
             'second',
         ]);
-        touch(Hyde::path('_docs/first.md'));
-        touch(Hyde::path('_docs/second.md'));
+        Hyde::touch(('_docs/first.md'));
+        Hyde::touch(('_docs/second.md'));
         file_put_contents(Hyde::path('_docs/third.md'),
             (new ConvertsArrayToFrontMatter)->execute(['priority' => 300])
         );
@@ -264,7 +264,7 @@ class DocumentationSidebarServiceTest extends TestCase
     protected function createTestFiles(int $count = 5): void
     {
         for ($i = 0; $i < $count; $i++) {
-            touch(Hyde::path('_docs/test-'.$i.'.md'));
+            Hyde::touch(('_docs/test-'.$i.'.md'));
         }
     }
 }

--- a/packages/framework/tests/Feature/Services/SitemapServiceTest.php
+++ b/packages/framework/tests/Feature/Services/SitemapServiceTest.php
@@ -39,7 +39,7 @@ class SitemapServiceTest extends TestCase
 
     public function test_generate_adds_markdown_pages_to_xml()
     {
-        touch(Hyde::path('_pages/foo.md'));
+        Hyde::touch(('_pages/foo.md'));
 
         $service = new SitemapService();
         $service->generate();
@@ -51,7 +51,7 @@ class SitemapServiceTest extends TestCase
 
     public function test_generate_adds_markdown_posts_to_xml()
     {
-        touch(Hyde::path('_posts/foo.md'));
+        Hyde::touch(('_posts/foo.md'));
 
         $service = new SitemapService();
         $service->generate();
@@ -63,7 +63,7 @@ class SitemapServiceTest extends TestCase
 
     public function test_generate_adds_documentation_pages_to_xml()
     {
-        touch(Hyde::path('_docs/foo.md'));
+        Hyde::touch(('_docs/foo.md'));
 
         $service = new SitemapService();
         $service->generate();
@@ -114,7 +114,7 @@ class SitemapServiceTest extends TestCase
     {
         config(['hyde.pretty_urls' => false]);
         config(['hyde.site_url' => 'https://example.com']);
-        touch(Hyde::path('_pages/0-test.blade.php'));
+        Hyde::touch(('_pages/0-test.blade.php'));
 
         $service = new SitemapService();
         $date = date('c'); // Cache the expected date as around one in 1000 runs the second will switch over during execution
@@ -132,7 +132,7 @@ class SitemapServiceTest extends TestCase
     {
         config(['hyde.pretty_urls' => true]);
         config(['hyde.site_url' => 'https://example.com']);
-        touch(Hyde::path('_pages/0-test.blade.php'));
+        Hyde::touch(('_pages/0-test.blade.php'));
 
         $service = new SitemapService();
         $service->generate();

--- a/packages/framework/tests/Feature/Services/ValidationServiceTest.php
+++ b/packages/framework/tests/Feature/Services/ValidationServiceTest.php
@@ -153,7 +153,7 @@ class ValidationServiceTest extends TestCase
 
     public function test_check_for_conflicts_between_blade_and_markdown_pages_can_fail()
     {
-        touch(Hyde::path('_pages/index.md'));
+        Hyde::touch(('_pages/index.md'));
         $this->test('check_for_conflicts_between_blade_and_markdown_pages', 2);
         unlink(Hyde::path('_pages/index.md'));
     }

--- a/packages/framework/tests/Feature/SourceDirectoriesCanBeChangedTest.php
+++ b/packages/framework/tests/Feature/SourceDirectoriesCanBeChangedTest.php
@@ -51,7 +51,7 @@ class SourceDirectoriesCanBeChangedTest extends TestCase
     {
         // Using a subdirectory in a directory we know exists, to make cleanup easier.
         mkdir(Hyde::path('_posts/test'));
-        touch(Hyde::path('_posts/test/test.md'));
+        Hyde::touch(('_posts/test/test.md'));
 
         MarkdownPost::$sourceDirectory = '_posts/test';
 

--- a/packages/framework/tests/Feature/StaticSiteServiceTest.php
+++ b/packages/framework/tests/Feature/StaticSiteServiceTest.php
@@ -120,7 +120,7 @@ class StaticSiteServiceTest extends TestCase
         config(['hyde.site_url' => 'https://example.com']);
         config(['hyde.generate_rss_feed' => true]);
 
-        touch(Hyde::path('_posts/foo.md'));
+        Hyde::touch(('_posts/foo.md'));
 
         $this->artisan('build')
             ->expectsOutput('Generating RSS feed...')
@@ -140,7 +140,7 @@ class StaticSiteServiceTest extends TestCase
 
     public function test_generates_search_files_when_conditions_are_met()
     {
-        touch(Hyde::path('_docs/foo.md'));
+        Hyde::touch(('_docs/foo.md'));
 
         $this->artisan('build')
             ->expectsOutput('Generating documentation site search index...')
@@ -152,7 +152,7 @@ class StaticSiteServiceTest extends TestCase
 
     public function test_site_directory_is_emptied_before_build()
     {
-        touch(Hyde::path('_site/foo.html'));
+        Hyde::touch(('_site/foo.html'));
         $this->artisan('build')
             ->expectsOutput('Removing all files from build directory.')
             ->assertExitCode(0);
@@ -162,7 +162,7 @@ class StaticSiteServiceTest extends TestCase
     public function test_output_directory_is_not_emptied_if_disabled_in_config()
     {
         config(['hyde.empty_output_directory' => false]);
-        touch(Hyde::path('_site/keep.html'));
+        Hyde::touch(('_site/keep.html'));
 
         $this->artisan('build')
             ->doesntExpectOutput('Removing all files from build directory.')
@@ -177,7 +177,7 @@ class StaticSiteServiceTest extends TestCase
         StaticPageBuilder::$outputPath = 'foo';
 
         mkdir(Hyde::path('foo'));
-        touch(Hyde::path('foo/keep.html'));
+        Hyde::touch(('foo/keep.html'));
 
         $this->artisan('build')
             ->expectsOutput('Removing all files from build directory.')

--- a/packages/framework/tests/Unit/PageModelGetAllFilesHelperTest.php
+++ b/packages/framework/tests/Unit/PageModelGetAllFilesHelperTest.php
@@ -24,7 +24,7 @@ class PageModelGetAllFilesHelperTest extends TestCase
 
     public function test_markdown_page_get_helper_returns_markdown_page_array()
     {
-        touch(Hyde::path('_pages/test-page.md'));
+        Hyde::touch(('_pages/test-page.md'));
 
         $array = MarkdownPage::files();
         $this->assertCount(1, $array);
@@ -36,7 +36,7 @@ class PageModelGetAllFilesHelperTest extends TestCase
 
     public function test_markdown_post_get_helper_returns_markdown_post_array()
     {
-        touch(Hyde::path('_posts/test-post.md'));
+        Hyde::touch(('_posts/test-post.md'));
 
         $array = MarkdownPost::files();
         $this->assertCount(1, $array);
@@ -48,7 +48,7 @@ class PageModelGetAllFilesHelperTest extends TestCase
 
     public function test_documentation_page_get_helper_returns_documentation_page_array()
     {
-        touch(Hyde::path('_docs/test-page.md'));
+        Hyde::touch(('_docs/test-page.md'));
 
         $array = DocumentationPage::files();
         $this->assertCount(1, $array);

--- a/packages/framework/tests/Unit/PageModelGetHelperTest.php
+++ b/packages/framework/tests/Unit/PageModelGetHelperTest.php
@@ -25,7 +25,7 @@ class PageModelGetHelperTest extends TestCase
 
     public function test_markdown_page_get_helper_returns_markdown_page_collection()
     {
-        touch(Hyde::path('_pages/test-page.md'));
+        Hyde::touch(('_pages/test-page.md'));
 
         $collection = MarkdownPage::all();
         $this->assertCount(1, $collection);
@@ -37,7 +37,7 @@ class PageModelGetHelperTest extends TestCase
 
     public function test_markdown_post_get_helper_returns_markdown_post_collection()
     {
-        touch(Hyde::path('_posts/test-post.md'));
+        Hyde::touch(('_posts/test-post.md'));
 
         $collection = MarkdownPost::all();
         $this->assertCount(1, $collection);
@@ -49,7 +49,7 @@ class PageModelGetHelperTest extends TestCase
 
     public function test_documentation_page_get_helper_returns_documentation_page_collection()
     {
-        touch(Hyde::path('_docs/test-page.md'));
+        Hyde::touch(('_docs/test-page.md'));
 
         $collection = DocumentationPage::all();
         $this->assertCount(1, $collection);

--- a/packages/framework/tests/Unit/PageModelParseHelperTest.php
+++ b/packages/framework/tests/Unit/PageModelParseHelperTest.php
@@ -22,7 +22,7 @@ class PageModelParseHelperTest extends TestCase
 
     public function test_markdown_page_get_helper_returns_markdown_page_object()
     {
-        touch(Hyde::path('_pages/foo.md'));
+        Hyde::touch(('_pages/foo.md'));
 
         $object = MarkdownPage::parse('foo');
         $this->assertInstanceOf(MarkdownPage::class, $object);
@@ -32,7 +32,7 @@ class PageModelParseHelperTest extends TestCase
 
     public function test_markdown_post_get_helper_returns_markdown_post_object()
     {
-        touch(Hyde::path('_posts/foo.md'));
+        Hyde::touch(('_posts/foo.md'));
 
         $object = MarkdownPost::parse('foo');
         $this->assertInstanceOf(MarkdownPost::class, $object);
@@ -42,7 +42,7 @@ class PageModelParseHelperTest extends TestCase
 
     public function test_documentation_page_get_helper_returns_documentation_page_object()
     {
-        touch(Hyde::path('_docs/foo.md'));
+        Hyde::touch(('_docs/foo.md'));
 
         $object = DocumentationPage::parse('foo');
         $this->assertInstanceOf(DocumentationPage::class, $object);

--- a/packages/framework/tests/Unit/SourceFilesInCustomDirectoriesCanBeCompiledTest.php
+++ b/packages/framework/tests/Unit/SourceFilesInCustomDirectoriesCanBeCompiledTest.php
@@ -35,7 +35,7 @@ class SourceFilesInCustomDirectoriesCanBeCompiledTest extends TestCase
     public function test_markdown_posts_in_changed_directory_can_be_compiled()
     {
         mkdir(Hyde::path('testSourceDir/blog'));
-        touch(Hyde::path('testSourceDir/blog/test.md'));
+        Hyde::touch(('testSourceDir/blog/test.md'));
 
         MarkdownPost::$sourceDirectory = 'testSourceDir/blog';
 
@@ -55,7 +55,7 @@ class SourceFilesInCustomDirectoriesCanBeCompiledTest extends TestCase
     public function test_markdown_pages_in_changed_directory_can_be_compiled()
     {
         mkdir(Hyde::path('testSourceDir/pages'));
-        touch(Hyde::path('testSourceDir/pages/test.md'));
+        Hyde::touch(('testSourceDir/pages/test.md'));
 
         MarkdownPage::$sourceDirectory = 'testSourceDir/pages';
 
@@ -75,7 +75,7 @@ class SourceFilesInCustomDirectoriesCanBeCompiledTest extends TestCase
     public function test_documentation_pages_in_changed_directory_can_be_compiled()
     {
         mkdir(Hyde::path('testSourceDir/documentation'));
-        touch(Hyde::path('testSourceDir/documentation/test.md'));
+        Hyde::touch(('testSourceDir/documentation/test.md'));
 
         DocumentationPage::$sourceDirectory = 'testSourceDir/documentation';
 
@@ -95,7 +95,7 @@ class SourceFilesInCustomDirectoriesCanBeCompiledTest extends TestCase
     public function test_blade_pages_in_changed_directory_can_be_compiled()
     {
         mkdir(Hyde::path('testSourceDir/blade'));
-        touch(Hyde::path('testSourceDir/blade/test.blade.php'));
+        Hyde::touch(('testSourceDir/blade/test.blade.php'));
 
         BladePage::$sourceDirectory = 'testSourceDir/blade';
         Config::set('view.paths', ['testSourceDir/blade']);

--- a/packages/framework/tests/Unit/Views/ScriptsComponentViewTest.php
+++ b/packages/framework/tests/Unit/Views/ScriptsComponentViewTest.php
@@ -30,7 +30,7 @@ class ScriptsComponentViewTest extends TestCase
 
     public function test_component_has_link_to_app_js_file_when_it_exists()
     {
-        touch(Hyde::path('_media/app.js'));
+        Hyde::touch(('_media/app.js'));
         $this->assertStringContainsString('<script defer src="media/app.js"', $this->renderTestView());
         unlink(Hyde::path('_media/app.js'));
     }
@@ -42,7 +42,7 @@ class ScriptsComponentViewTest extends TestCase
 
     public function test_component_uses_relative_path_to_app_js_file_for_nested_pages()
     {
-        touch(Hyde::path('_media/app.js'));
+        Hyde::touch(('_media/app.js'));
         $this->mockCurrentPage = 'foo';
         $this->assertStringContainsString('<script defer src="media/app.js"', $this->renderTestView());
         $this->mockCurrentPage = 'foo/bar';
@@ -70,7 +70,7 @@ class ScriptsComponentViewTest extends TestCase
 
     public function test_component_renders_link_to_hyde_js_when_it_exists()
     {
-        touch(Hyde::path('_media/hyde.js'));
+        Hyde::touch(('_media/hyde.js'));
         $this->assertStringContainsString('<script defer src="media/hyde.js"', $this->renderTestView());
         unlink(Hyde::path('_media/hyde.js'));
     }
@@ -87,7 +87,7 @@ class ScriptsComponentViewTest extends TestCase
 
     public function test_component_does_not_render_cdn_link_when_a_local_file_exists()
     {
-        touch(Hyde::path('_media/hyde.js'));
+        Hyde::touch(('_media/hyde.js'));
         $this->assertStringNotContainsString('https://cdn.jsdelivr.net/npm/hydefront', $this->renderTestView());
         unlink(Hyde::path('_media/hyde.js'));
     }

--- a/packages/framework/tests/Unit/Views/StylesComponentViewTest.php
+++ b/packages/framework/tests/Unit/Views/StylesComponentViewTest.php
@@ -68,7 +68,7 @@ class StylesComponentViewTest extends TestCase
 
     public function test_component_renders_link_to_hyde_css_when_it_exists()
     {
-        touch(Hyde::path('_media/hyde.css'));
+        Hyde::touch(('_media/hyde.css'));
         $this->assertStringContainsString('<link rel="stylesheet" href="media/hyde.css"', $this->renderTestView());
         unlink(Hyde::path('_media/hyde.css'));
     }
@@ -85,7 +85,7 @@ class StylesComponentViewTest extends TestCase
 
     public function test_component_does_not_render_cdn_link_when_a_local_file_exists()
     {
-        touch(Hyde::path('_media/hyde.css'));
+        Hyde::touch(('_media/hyde.css'));
         $this->assertStringNotContainsString('https://cdn.jsdelivr.net/npm/hydefront', $this->renderTestView());
         unlink(Hyde::path('_media/hyde.css'));
     }

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -2,6 +2,7 @@
 
 namespace Hyde\Testing;
 
+use Hyde\Framework\Hyde;
 use LaravelZero\Framework\Testing\TestCase as BaseTestCase;
 
 abstract class TestCase extends BaseTestCase
@@ -22,6 +23,10 @@ abstract class TestCase extends BaseTestCase
 
         if (! static::$booted) {
             $this->resetApplication();
+
+            Hyde::macro('touch', function (string $path) {
+                return touch(Hyde::path($path));
+            });
 
             static::$booted = true;
         }


### PR DESCRIPTION
Implements the Laravel macroable trait and adds `Hyde::touch($path)` instead of `touch(Hyde::path($path))`,  which will speed up the writing of tests.