### PR TITLE
Deprecate `DiscoveryService.php`

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -21,6 +21,7 @@ You will also need to update navigation related Blade templates, if you have pre
 
 ### Deprecated
 - Deprecated `DiscoveryService::findModelFromFilePath()` - Use the Router instead.
+- Deprecated `DiscoveryService.php` - Use the Router instead. (Some helpers may be moved to FluentPathHelpers.php)
 
 ### Removed
 - The "no pages found, skipping" message has been removed as the build loop no longer recieves empty collections.

--- a/packages/framework/src/Services/DiscoveryService.php
+++ b/packages/framework/src/Services/DiscoveryService.php
@@ -12,6 +12,8 @@ use Hyde\Framework\Models\Pages\MarkdownPost;
  * The Discovery Service (previously called BuildService) provides
  * helper methods for source file autodiscovery used in the building
  * process to determine where files are located and how to parse them.
+ *
+ * @deprecated v0.48.0 as autodiscovery is now powered by the Router. The helpers here can be moved to FluentPathHelpers.php
  */
 class DiscoveryService
 {


### PR DESCRIPTION
> The Discovery Service (previously called BuildService) provides helper methods for source file autodiscovery used in the building process to determine where files are located and how to parse them.

Autodiscovery is now powered by the Router. The helpers here can be moved to FluentPathHelpers.php