### PR TITLE
Update the Realtime Compiler plugin to use the new Router service

### DIFF
--- a/packages/realtime-compiler/src/Actions/Compiler.php
+++ b/packages/realtime-compiler/src/Actions/Compiler.php
@@ -8,6 +8,8 @@ use Hyde\Framework\StaticPageBuilder;
 /**
  * Hooks into the Hyde application to parse and compile
  * a page source file to static HTML for the request.
+ *
+ * @deprecated v2.4 - Not needed since Hyde/Framework version v0.48.0-beta
  */
 class Compiler extends StaticPageBuilder
 {

--- a/packages/realtime-compiler/src/Routing/LegacyPageRouter.php
+++ b/packages/realtime-compiler/src/Routing/LegacyPageRouter.php
@@ -1,0 +1,110 @@
+<?php
+
+namespace Hyde\RealtimeCompiler\Routing;
+
+use Desilva\Microserve\Request;
+use Desilva\Microserve\Response;
+use Hyde\Framework\Hyde;
+use Hyde\Framework\Models\Pages\BladePage;
+use Hyde\Framework\Models\Pages\DocumentationPage;
+use Hyde\Framework\Models\Pages\MarkdownPage;
+use Hyde\Framework\Models\Pages\MarkdownPost;
+use Hyde\RealtimeCompiler\Actions\Compiler;
+use Hyde\RealtimeCompiler\Concerns\InteractsWithLaravel;
+use Hyde\RealtimeCompiler\Concerns\SendsErrorResponses;
+
+/**
+ * Handle routing for a web page request.
+ *
+ * Does not send 404 responses upon missing source files,
+ * instead letting an exception be thrown, as it is
+ * better handled by the ExceptionHandler.
+ * 
+ * @deprecated v2.4 - Provides compatibility for Hyde/Framework versions lower than v0.48.0-beta
+ */
+class LegacyPageRouter
+{
+    use SendsErrorResponses;
+    use InteractsWithLaravel;
+
+    protected Request $request;
+
+    public function __construct(Request $request)
+    {
+        $this->request = $request;
+        $this->bootApplication();
+    }
+
+    protected function handlePageRequest(): Response
+    {
+        $requestPath = $this->normalizePath($this->request->path);
+        $sourceFilePath = $this->decodeSourceFilePath($requestPath);
+        $sourceFileModel = $this->decodeSourceFileModel($sourceFilePath);
+
+        $html = $this->getHtml($sourceFileModel, $sourceFilePath);
+
+        return (new Response(200, 'OK', [
+            'body' => $html,
+        ]))->withHeaders([
+            'Content-Type'   => 'text/html',
+            'Content-Length' => strlen($html),
+        ]);
+    }
+
+    protected function normalizePath(string $path): string
+    {
+        // If uri ends in .html, strip it
+        if (str_ends_with($path, '.html')) {
+            $path = substr($path, 0, -5);
+        }
+
+        // If the path is empty, serve the index file
+        if (empty($path) || $path == '/') {
+            $path = '/index';
+        }
+
+        return $path;
+    }
+
+    protected function decodeSourceFilePath(string $path): string
+    {
+        // Todo get paths from model class instead of hardcoded
+        if (str_starts_with($path, '/posts/')) {
+            return '_posts/'.basename($path);
+        }
+
+        if (str_starts_with($path, '/docs/')) {
+            return '_docs/'.basename($path);
+        }
+
+        return '_pages/'.basename($path);
+    }
+
+    protected function decodeSourceFileModel(string $path): string
+    {
+        if (str_starts_with($path, '_posts/')) {
+            return MarkdownPost::class;
+        }
+
+        if (str_starts_with($path, '_docs/')) {
+            return DocumentationPage::class;
+        }
+
+        if (file_exists(Hyde::path($path.'.md'))) {
+            return MarkdownPage::class;
+        }
+
+        return BladePage::class;
+    }
+
+    protected function getHtml(string $model, string $path): string
+    {
+        // todo add caching as we don't need to recompile pages that have not changed
+        return (new Compiler($model, $path))->render();
+    }
+
+    public static function handle(Request $request): Response
+    {
+        return (new self($request))->handlePageRequest();
+    }
+}

--- a/packages/realtime-compiler/src/Routing/LegacyPageRouter.php
+++ b/packages/realtime-compiler/src/Routing/LegacyPageRouter.php
@@ -19,7 +19,7 @@ use Hyde\RealtimeCompiler\Concerns\SendsErrorResponses;
  * Does not send 404 responses upon missing source files,
  * instead letting an exception be thrown, as it is
  * better handled by the ExceptionHandler.
- * 
+ *
  * @deprecated v2.4 - Provides compatibility for Hyde/Framework versions lower than v0.48.0-beta
  */
 class LegacyPageRouter

--- a/packages/realtime-compiler/src/Routing/PageRouter.php
+++ b/packages/realtime-compiler/src/Routing/PageRouter.php
@@ -4,16 +4,9 @@ namespace Hyde\RealtimeCompiler\Routing;
 
 use Desilva\Microserve\Request;
 use Desilva\Microserve\Response;
-use Hyde\Framework\Contracts\AbstractPage;
 use Hyde\Framework\Contracts\PageContract;
-use Hyde\Framework\Hyde;
-use Hyde\Framework\Models\Pages\BladePage;
-use Hyde\Framework\Models\Pages\DocumentationPage;
-use Hyde\Framework\Models\Pages\MarkdownPage;
-use Hyde\Framework\Models\Pages\MarkdownPost;
 use Hyde\Framework\Models\Route;
 use Hyde\Framework\StaticPageBuilder;
-use Hyde\RealtimeCompiler\Actions\Compiler;
 use Hyde\RealtimeCompiler\Concerns\InteractsWithLaravel;
 use Hyde\RealtimeCompiler\Concerns\SendsErrorResponses;
 

--- a/packages/realtime-compiler/src/Routing/Router.php
+++ b/packages/realtime-compiler/src/Routing/Router.php
@@ -46,6 +46,11 @@ class Router
             }
         }
 
+        // Temporary backwards compatibility for versions less than Hyde/Framework v0.48.0-beta
+        if (! class_exists('\Hyde\Framework\Router')) {
+            return LegacyPageRouter::handle($this->request);
+        }
+
         return PageRouter::handle($this->request);
     }
 


### PR DESCRIPTION
Separates the old compiling logic so it can stick around for a bit adding backwards compatibility. The old classes have been marked as deprecated.

The main services (automatically used when the foundation is available) now fetches routes from the Hyde route index, providing much greater compatibility as we don't have to attempt to reverse engineer paths at runtime.

Instead, the RC now works by formatting the URI string to a normalized route key, then using that to fetch the route from the route index. The route model is then passed directly to the static page builder for compiling.