### PR TITLE
Add `Route::home()` helper

### DIFF
--- a/packages/framework/src/Contracts/RouteFacadeContract.php
+++ b/packages/framework/src/Contracts/RouteFacadeContract.php
@@ -64,4 +64,9 @@ interface RouteFacadeContract
      * Get the current route for the page being rendered.
      */
     public static function current(): RouteContract;
+
+    /**
+     * Get the home route, usually the index page route.
+     */
+    public static function home(): RouteContract;
 }

--- a/packages/framework/src/Models/Route.php
+++ b/packages/framework/src/Models/Route.php
@@ -120,4 +120,10 @@ class Route implements RouteContract, RouteFacadeContract
     {
         return Hyde::currentRoute() ?? throw new RouteNotFoundException('current');
     }
+
+    /** @inheritDoc */
+    public static function home(): RouteContract
+    {
+        return static::getFromKey('index');
+    }
 }

--- a/packages/framework/src/Models/Route.php
+++ b/packages/framework/src/Models/Route.php
@@ -104,7 +104,7 @@ class Route implements RouteContract, RouteFacadeContract
     }
 
     /** @inheritDoc */
-    public static function getFromModel(PageContract $page): static
+    public static function getFromModel(PageContract $page): RouteContract
     {
         return $page->getRoute();
     }
@@ -116,7 +116,7 @@ class Route implements RouteContract, RouteFacadeContract
     }
 
     /** @inheritDoc */
-    public static function current(): static
+    public static function current(): RouteContract
     {
         return Hyde::currentRoute() ?? throw new RouteNotFoundException('current');
     }

--- a/packages/framework/tests/Feature/RouteTest.php
+++ b/packages/framework/tests/Feature/RouteTest.php
@@ -183,4 +183,9 @@ class RouteTest extends TestCase
         $this->expectException(RouteNotFoundException::class);
         Route::current();
     }
+
+    public function test_home_helper_returns_index_route()
+    {
+        $this->assertEquals(Route::get('index'), Route::home());
+    }
 }


### PR DESCRIPTION
Adds a helper to get the home route, usually the index page route.