### PR TITLE
Add public add route method to route service

### DIFF
--- a/packages/framework/src/Contracts/RoutingServiceContract.php
+++ b/packages/framework/src/Contracts/RoutingServiceContract.php
@@ -39,7 +39,7 @@ interface RoutingServiceContract
      * This internal method adds the specified route to the route index.
      * It's intended to be used for package developers to hook into the routing system.
      *
-     * @param \Hyde\Framework\Contracts\RouteContract $route
+     * @param  \Hyde\Framework\Contracts\RouteContract  $route
      * @return $this
      */
     public function addRoute(RouteContract $route): self;

--- a/packages/framework/src/Contracts/RoutingServiceContract.php
+++ b/packages/framework/src/Contracts/RoutingServiceContract.php
@@ -32,4 +32,15 @@ interface RoutingServiceContract
      * @return \Illuminate\Support\Collection<\Hyde\Framework\Contracts\RouteContract>
      */
     public function getRoutesForModel(string $pageClass): Collection;
+
+    /**
+     * Add a route to the router index.
+     *
+     * This internal method adds the specified route to the route index.
+     * It's intended to be used for package developers to hook into the routing system.
+     *
+     * @param \Hyde\Framework\Contracts\RouteContract $route
+     * @return $this
+     */
+    public function addRoute(RouteContract $route): self;
 }

--- a/packages/framework/src/Services/RoutingService.php
+++ b/packages/framework/src/Services/RoutingService.php
@@ -80,11 +80,21 @@ class RoutingService implements RoutingServiceContract
         });
     }
 
+    /**
+     * This internal method adds the specified route to the route index.
+     * It's intended to be used for package developers to hook into the routing system.
+     */
+    public function addRoute(RouteContract $route): self
+    {
+        $this->routes->put($route->getRouteKey(), $route);
+
+        return $this;
+    }
+
     protected function discover(PageContract $page): self
     {
         // Create a new route for the given page, and add it to the index.
-        $route = new Route($page);
-        $this->routes->put($route->getRouteKey(), $route);
+        $this->addRoute(new Route($page));
 
         return $this;
     }

--- a/packages/framework/tests/Feature/RoutingServiceTest.php
+++ b/packages/framework/tests/Feature/RoutingServiceTest.php
@@ -102,6 +102,28 @@ class RoutingServiceTest extends TestCase
         unlink('_docs/doc.md');
     }
 
+    public function test_add_route_adds_a_route_to_the_routes_collection()
+    {
+        $routes = (new RoutingService())->getRoutes();
+
+        $this->assertEquals(collect([
+            '404' => new Route(BladePage::parse('404')),
+            'index' => new Route(BladePage::parse('index')),
+        ]), $routes);
+
+        Hyde::touch('_pages/foo.md');
+        (new RoutingService())->addRoute(new Route(MarkdownPage::parse('foo')));
+        $routes = (new RoutingService())->getRoutes();
+
+        $this->assertEquals(collect([
+            '404' => new Route(BladePage::parse('404')),
+            'index' => new Route(BladePage::parse('index')),
+            'foo' => new Route(MarkdownPage::parse('foo')),
+        ]), $routes);
+
+        Hyde::unlink('_pages/foo.md');
+    }
+
     public function test_routes_with_custom_source_directories_are_discovered_properly()
     {
         $this->markTestSkipped('TODO');


### PR DESCRIPTION
This hook can then be used by package developers to add custom routes.

For example:

```php
class MyServiceProvider extends ServiceProvider {
    public function boot() {
        RoutingService::getInstance()->addRoute(
            (new CustomPage('source-file'))->getRoute()
        );
    }
}
```