### PR TITLE
Refactor footer component to use includes facade

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -58,6 +58,7 @@ If you have published and Blade views or written custom code that uses the confi
 
 The footer configuration options have been merged. Prior to this update, the config option looked as follows:
 ```php
+// filepath: config/hyde.php
 'footer' => [
   'enabled' => true,
   'markdown' => 'Markdown text...'
@@ -66,6 +67,8 @@ The footer configuration options have been merged. Prior to this update, the con
 
 Now, the config option looks as follows:
 ```php
+// filepath: config/hyde.php
+
 // To use Markdown text
 'footer' => 'Markdown text...',
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -22,7 +22,7 @@ This update makes breaking changes to the configuration. You will need to update
 - The default `site.url` is now `http://localhost` instead of `null`
 
 ### Deprecated
-- for soon-to-be removed features.
+- Deprecate ConvertsFooterMarkdown.php
 
 ### Removed
 - Removed `\Hyde\Framework\Facades\Route`. You can swap out usages with `\Hyde\Framework\Models\Route` without side effects.

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -20,6 +20,7 @@ This update makes breaking changes to the configuration. You will need to update
 - Moved config option `hyde.output_directory` to `site.output_directory`
 
 - The default `site.url` is now `http://localhost` instead of `null`
+- Merged configuration options for the footer, see below
 
 ### Deprecated
 - Deprecate ConvertsFooterMarkdown.php
@@ -38,6 +39,8 @@ This update makes breaking changes to the configuration. You will need to update
 
 ### Upgrade Guide
 
+#### Using the new site config
+
 Site-specific config options have been moved from `config/hyde.php` to `config/site.php`. The Hyde config is now used to configure behaviour of the site, while the site config is used to customize the look and feel, the presentation, of the site.
 
 The following configuration options have been moved. The actual usages remain the same, so you can upgrade by using copying over these options to the new file.
@@ -50,3 +53,24 @@ The following configuration options have been moved. The actual usages remain th
 - `hyde.output_directory`
 
 If you have published and Blade views or written custom code that uses the config options, you may need to update them. You can do this by republishing the Blade views, and/or using search and replace across your code. VSCode has a useful feature to make this a breeze: `CMD/CTRL+Shift+F`.
+
+#### Using the new footer config
+
+The footer configuration options have been merged. Prior to this update, the config option looked as follows:
+```php
+'footer' => [
+  'enabled' => true,
+  'markdown' => 'Markdown text...'
+],
+```
+
+Now, the config option looks as follows:
+```php
+// To use Markdown text
+'footer' => 'Markdown text...',
+
+// To disable it completely
+'footer' => false,
+```
+
+As you can see, the new config option is a string or the boolean false instead of an array. We use the same option for both the Markdown text and the footer disabled state.

--- a/config/hyde.php
+++ b/config/hyde.php
@@ -97,19 +97,18 @@ return [
     | Footer Text
     |--------------------------------------------------------------------------
     |
-    | Most websites have a footer with copyright details and contact information.
-    | You probably want to change the Markdown to include your information,
-    | though you are of course welcome to keep the attribution link!
+    | Here you can customize the footer Markdown text for your site.
     |
-    | You can also customize the blade view if you want a more complex footer.
-    | You can disable it completely by setting `enabled` to `false`.
+    | If you don't want to write Markdown here, you use a Markdown include.
+    | You can also customize the Blade view if you want a more complex footer.
+    | You can disable it completely by changing the setting to `false`.
+    |
+    | To read about the many configuration options here, visit:
+    | https://hydephp.com/docs/master/customization#footer
     |
     */
 
-    'footer' => [
-        'enabled' => true,
-        'markdown' => 'Site proudly built with [HydePHP](https://github.com/hydephp/hyde) 🎩',
-    ],
+    'footer' => 'Site proudly built with [HydePHP](https://github.com/hydephp/hyde) 🎩',
 
     /*
     |--------------------------------------------------------------------------

--- a/docs/customization.md
+++ b/docs/customization.md
@@ -113,14 +113,42 @@ author: mr_hyde
 ```
 
 ### Footer
-The footer can be customized using Markdown, and even disabled completely.
+
+Most websites have a footer with copyright details and contact information. You probably want to change the Markdown to include your information, though you are of course welcome to keep the default attribution link!
+
+The footer component is made up of a few levels of components, depending on how much you want to customize.
+
+#### Customizing the Markdown text
+
+There are two ways to customize the footer text. First, you can set it in the configuration file:
 
 ```php
-// torchlight! {"lineNumbers": false}
-'footer' => [
-  'enabled' => true,
-  'markdown' => 'Site built with [HydePHP](https://github.com/hydephp/hyde).'
-],
+// filepath: config/hyde.php
+'footer' => 'Site proudly built with [HydePHP](https://github.com/hydephp/hyde) 🎩',
+```
+
+If you don't want to write Markdown in the configuration file, you can create a Markdown file in your includes directory. When this file is found, it will be used instead of the configuration setting.
+
+```markdown
+// filepath: resources/_includes/footer.md
+Site proudly built with [HydePHP](https://github.com/hydephp/hyde) 🎩
+```
+
+In both cases the parsed Markdown will be rendered in the footer Blade component.
+
+#### Customizing the Blade component
+
+The actual footer component is rendered using the [`layouts/footer.blade.php`](https://github.com/hydephp/framework/blob/master/resources/views/layouts/footer.blade.php) Blade template.
+
+In this template we automatically render the configured footer Markdown text. If you want to change this behaviour, for example, HydePHP.com uses a more sophisticated footer, simply [publish the footer component](#blade-views). 
+
+#### Disabling the footer entirely
+
+If you don't want to have a footer on your site, you can set the `'footer'` configuration option to `false`.
+
+```php
+// filepath: config/hyde.php
+'footer' => 'false',
 ```
 
 ### Navigation Menu & Sidebar

--- a/packages/framework/config/hyde.php
+++ b/packages/framework/config/hyde.php
@@ -97,19 +97,18 @@ return [
     | Footer Text
     |--------------------------------------------------------------------------
     |
-    | Most websites have a footer with copyright details and contact information.
-    | You probably want to change the Markdown to include your information,
-    | though you are of course welcome to keep the attribution link!
+    | Here you can customize the footer Markdown text for your site.
     |
-    | You can also customize the blade view if you want a more complex footer.
-    | You can disable it completely by setting `enabled` to `false`.
+    | If you don't want to write Markdown here, you use a Markdown include.
+    | You can also customize the Blade view if you want a more complex footer.
+    | You can disable it completely by changing the setting to `false`.
+    |
+    | To read about the many configuration options here, visit:
+    | https://hydephp.com/docs/master/customization#footer
     |
     */
 
-    'footer' => [
-        'enabled' => true,
-        'markdown' => 'Site proudly built with [HydePHP](https://github.com/hydephp/hyde) 🎩',
-    ],
+    'footer' => 'Site proudly built with [HydePHP](https://github.com/hydephp/hyde) 🎩',
 
     /*
     |--------------------------------------------------------------------------

--- a/packages/framework/resources/views/layouts/app.blade.php
+++ b/packages/framework/resources/views/layouts/app.blade.php
@@ -11,7 +11,7 @@
         @yield('content') 
     </section>
 
-    @includeWhen(config('hyde.footer.enabled', true), 'hyde::layouts.footer') 
+    @include('hyde::layouts.footer') 
 
     @include('hyde::layouts.scripts') 
 </body>

--- a/packages/framework/resources/views/layouts/footer.blade.php
+++ b/packages/framework/resources/views/layouts/footer.blade.php
@@ -1,4 +1,4 @@
-@if(config('hyde.footer', true) !== false)
+@if(config('hyde.footer') !== false)
 <footer aria-label="Page footer" class="flex py-4 px-6 w-full text-center mt-auto bg-slate-100 dark:bg-gray-800">
 	<div class="prose dark:prose-invert text-center mx-auto">
 		{!! Hyde\Framework\Actions\ConvertsFooterMarkdown::execute() !!}

--- a/packages/framework/resources/views/layouts/footer.blade.php
+++ b/packages/framework/resources/views/layouts/footer.blade.php
@@ -1,4 +1,4 @@
-@if(config('hyde.footer.enabled', true))
+@if(config('hyde.footer', true) !== false)
 <footer aria-label="Page footer" class="flex py-4 px-6 w-full text-center mt-auto bg-slate-100 dark:bg-gray-800">
 	<div class="prose dark:prose-invert text-center mx-auto">
 		{!! Hyde\Framework\Actions\ConvertsFooterMarkdown::execute() !!}

--- a/packages/framework/resources/views/layouts/footer.blade.php
+++ b/packages/framework/resources/views/layouts/footer.blade.php
@@ -1,3 +1,4 @@
+@if(config('hyde.footer.enabled', true))
 <footer aria-label="Page footer" class="flex py-4 px-6 w-full text-center mt-auto bg-slate-100 dark:bg-gray-800">
 	<div class="prose dark:prose-invert text-center mx-auto">
 		{!! Hyde\Framework\Actions\ConvertsFooterMarkdown::execute() !!}
@@ -10,3 +11,4 @@
 		</button>
 	</a>
 </footer>
+@endif

--- a/packages/framework/resources/views/layouts/footer.blade.php
+++ b/packages/framework/resources/views/layouts/footer.blade.php
@@ -1,7 +1,8 @@
 @if(config('hyde.footer') !== false)
 <footer aria-label="Page footer" class="flex py-4 px-6 w-full text-center mt-auto bg-slate-100 dark:bg-gray-800">
 	<div class="prose dark:prose-invert text-center mx-auto">
-		{!! Hyde\Framework\Actions\ConvertsFooterMarkdown::execute() !!}
+		{!! \Hyde\Framework\Facades\Includes::markdown('footer',
+				config('hyde.footer', 'Site proudly built with [HydePHP](https://github.com/hydephp/hyde) 🎩')) !!}
 	</div>
 	<a href="#app" aria-label="Go to top of page" class="float-right">
 		<button title="Scroll to top">

--- a/packages/framework/src/Actions/ConvertsFooterMarkdown.php
+++ b/packages/framework/src/Actions/ConvertsFooterMarkdown.php
@@ -11,6 +11,7 @@ use Illuminate\Support\Str;
  * otherwise, it falls back to a default string.
  *
  * @see \Hyde\Framework\Testing\Unit\ConvertsFooterMarkdownTest
+ * @deprecated v0.50.x
  */
 class ConvertsFooterMarkdown
 {


### PR DESCRIPTION

### Footer

Most websites have a footer with copyright details and contact information. You probably want to change the Markdown to include your information, though you are of course welcome to keep the default attribution link!

The footer component is made up of a few levels of components, depending on how much you want to customize.

#### Customizing the Markdown text

There are two ways to customize the footer text. First, you can set it in the configuration file:

```php
// filepath: config/hyde.php
'footer' => 'Site proudly built with [HydePHP](https://github.com/hydephp/hyde) 🎩',
```

If you don't want to write Markdown in the configuration file, you can create a Markdown file in your includes directory. When this file is found, it will be used instead of the configuration setting.

```markdown
// filepath: resources/_includes/footer.md
Site proudly built with [HydePHP](https://github.com/hydephp/hyde) 🎩
```

In both cases the parsed Markdown will be rendered in the footer Blade component.

#### Customizing the Blade component

The actual footer component is rendered using the [`layouts/footer.blade.php`](https://github.com/hydephp/framework/blob/master/resources/views/layouts/footer.blade.php) Blade template.

In this template we automatically render the configured footer Markdown text. If you want to change this behaviour, for example, HydePHP.com uses a more sophisticated footer, simply [publish the footer component](#blade-views). 

#### Disabling the footer entirely

If you don't want to have a footer on your site, you can set the `'footer'` configuration option to `false`.

```php
// filepath: config/hyde.php
'footer' => 'false',
```