### PR TITLE
Add Laravel Dusk for browser testing

### DIFF
--- a/.github/workflows/test-pull-requests.yml
+++ b/.github/workflows/test-pull-requests.yml
@@ -94,6 +94,13 @@ jobs:
           name: screenshots
           path: tests/Browser/screenshots
 
+      - name: Upload Compiled Source
+        if: failure()
+        uses: actions/upload-artifact@v2
+        with:
+          name: source
+          path: tests/Browser/source
+
       - name: Upload Console Logs
         if: failure()
         uses: actions/upload-artifact@v2

--- a/.github/workflows/test-pull-requests.yml
+++ b/.github/workflows/test-pull-requests.yml
@@ -85,7 +85,7 @@ jobs:
       - name: Run Dusk Tests
         env:
           APP_URL: "http://127.0.0.1:8080"
-        run: php hyde dusk
+        run: php hyde dusk --pest
 
       - name: Upload Screenshots
         if: failure()

--- a/.github/workflows/test-pull-requests.yml
+++ b/.github/workflows/test-pull-requests.yml
@@ -53,6 +53,55 @@ jobs:
         curl https://gist.githubusercontent.com/caendesilva/d76fc6d73cb488863a8f6fda18a7c8c4/raw/24257c1f3ec4ce8a2c16601bbfa33f054f873be9/ping-openanalytics-testrunner.php -o ping.php
         php ping.php "Monorepo PR Test" ${{ secrets.OPENANALYTICS_TOKEN }}
 
+
+  dusk-browser-tests:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Cache Composer packages
+        id: composer-cache
+        uses: actions/cache@v3
+        with:
+          path: vendor
+          key: ${{ runner.os }}-php-${{ hashFiles('**/composer.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-php-
+
+      - name: Install Composer Dependencies
+        run: composer install --no-ansi --no-interaction --no-scripts --no-progress --prefer-dist
+
+      - name: Prepare the Environment
+        run: echo -e "APP_URL=http://localhost:8080 \nDUSK_ENABLED=true" > .env
+
+      - name: Upgrade Chrome Driver
+        run: php artisan dusk:chrome-driver `/opt/google/chrome/chrome --version | cut -d " " -f3 | cut -d "." -f1`
+      - name: Start Chrome Driver
+        run: ./vendor/laravel/dusk/bin/chromedriver-linux &
+
+      - name: Run HydeRC Server
+        run: php hyde serve &
+
+      - name: Run Dusk Tests
+        env:
+          APP_URL: "http://127.0.0.1:8080"
+        run: php hyde dusk
+
+      - name: Upload Screenshots
+        if: failure()
+        uses: actions/upload-artifact@v2
+        with:
+          name: screenshots
+          path: tests/Browser/screenshots
+
+      - name: Upload Console Logs
+        if: failure()
+        uses: actions/upload-artifact@v2
+        with:
+          name: console
+          path: tests/Browser/console
+
+
   check-coding-standards:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/test-pull-requests.yml
+++ b/.github/workflows/test-pull-requests.yml
@@ -75,7 +75,7 @@ jobs:
         run: echo -e "APP_URL=http://localhost:8080 \nDUSK_ENABLED=true" > .env
 
       - name: Upgrade Chrome Driver
-        run: php artisan dusk:chrome-driver `/opt/google/chrome/chrome --version | cut -d " " -f3 | cut -d "." -f1`
+        run: php hyde dusk:chrome-driver `/opt/google/chrome/chrome --version | cut -d " " -f3 | cut -d "." -f1`
       - name: Start Chrome Driver
         run: ./vendor/laravel/dusk/bin/chromedriver-linux &
 

--- a/.idea/php.xml
+++ b/.idea/php.xml
@@ -126,6 +126,9 @@
       <path value="$PROJECT_DIR$/vendor/symfony/polyfill-php80" />
       <path value="$PROJECT_DIR$/vendor/hyde/framework" />
       <path value="$PROJECT_DIR$/vendor/_laravel_idea" />
+      <path value="$PROJECT_DIR$/vendor/laravel/dusk" />
+      <path value="$PROJECT_DIR$/vendor/php-webdriver/webdriver" />
+      <path value="$PROJECT_DIR$/vendor/nunomaduro/termwind" />
     </include_path>
   </component>
   <component name="PhpProjectSharedConfiguration" php_language_level="8.0" />

--- a/.idea/runConfigurations/Browser__Dusk_.xml
+++ b/.idea/runConfigurations/Browser__Dusk_.xml
@@ -1,0 +1,11 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="Browser (Dusk)" type="PHPUnitRunConfigurationType" factoryName="PHPUnit">
+    <CommandLine>
+      <envs>
+        <env name="DUSK_ENABLED" value="true" />
+      </envs>
+    </CommandLine>
+    <TestRunner class="Hyde\Testing\Browser\DefaultHomepageTest" configuration_file="$PROJECT_DIR$/phpunit.dusk.xml" directory="$PROJECT_DIR$/tests/Browser" file="$PROJECT_DIR$/tests/Browser/DefaultHomepageTest.php" use_alternative_configuration_file="true" />
+    <method v="2" />
+  </configuration>
+</component>

--- a/README.md
+++ b/README.md
@@ -46,9 +46,11 @@ The two most important components are **Hyde** and **Framework**. We also use **
 *The Hyde/Hyde project is stored in the monorepo root and works a bit differently from the others. Before pushing to the readonly repository, we apply persisted changes in the [`packages/hyde`](https://github.com/hydephp/develop/tree/master/packages/hyde) directory, then remove monorepo specific files.
 
 
-## How the monorepo currently works
+## How the monorepo works
 
 Changes to HydePHP including some first-party packages are made here. The changes are then pushed to the `master` branches of the readonly repositories seen in the table above. These branches could be unstable.
+
+This monorepo project is still new, and the internal structure of it may be changed without notice.
 
 
 ### Releases
@@ -56,8 +58,3 @@ Changes to HydePHP including some first-party packages are made here. The change
 While in the v0.x range, we consider both major and minor release versions to be the same. This means that when a new feature is added, it should be added as a minor version even if it is breaking. Patch versions should always be compatible. Once we reach v1.0 we will follow semantic versioning strictly.
 
 The versioning between the Framework and Hyde packages are linked together Meaning that if Hyde get's a minor release, so must Framework, and vice versa. To make this easier, we also publish minor releases in the monorepo. Patch releases are not published in the monorepo, and are instead handled by the individual packages.
-
-
-## Warning
-
-This monorepo project is still new, and the internal structure of it may be changed without notice.

--- a/composer.json
+++ b/composer.json
@@ -48,6 +48,13 @@
             "pestphp/pest-plugin": true
         }
     },
+    "extra": {
+        "laravel": {
+            "dont-discover": [
+                "laravel/dusk"
+            ]
+        }
+    },
     "minimum-stability": "dev",
     "prefer-stable": true,
     "bin": ["hyde"],

--- a/composer.json
+++ b/composer.json
@@ -20,9 +20,10 @@
         "hyde/framework": "dev-master"
     },
     "require-dev": {
+        "hyde/realtime-compiler": "dev-master",
+        "laravel/dusk": "^6.25",
         "mockery/mockery": "^1.4.4",
-        "pestphp/pest": "^1.21.1",
-        "hyde/realtime-compiler": "dev-master"
+        "pestphp/pest": "^1.21.1"
     },
     "autoload": {
         "psr-4": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "9f49c43c7e26914149434ad01288989e",
+    "content-hash": "1b9bb50b06a4ecfb4880250e6aabce9e",
     "packages": [
         {
             "name": "brick/math",
@@ -925,7 +925,7 @@
         },
         {
             "name": "illuminate/bus",
-            "version": "v9.20.0",
+            "version": "v9.21.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/illuminate/bus.git",
@@ -978,16 +978,16 @@
         },
         {
             "name": "illuminate/cache",
-            "version": "v9.20.0",
+            "version": "v9.21.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/illuminate/cache.git",
-                "reference": "dcf787ca2e026e838970b73857a3265c93fb80c3"
+                "reference": "3660bc7ea91d518956ad2d0bfbb11b9ad51deb6a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/illuminate/cache/zipball/dcf787ca2e026e838970b73857a3265c93fb80c3",
-                "reference": "dcf787ca2e026e838970b73857a3265c93fb80c3",
+                "url": "https://api.github.com/repos/illuminate/cache/zipball/3660bc7ea91d518956ad2d0bfbb11b9ad51deb6a",
+                "reference": "3660bc7ea91d518956ad2d0bfbb11b9ad51deb6a",
                 "shasum": ""
             },
             "require": {
@@ -1034,20 +1034,20 @@
                 "issues": "https://github.com/laravel/framework/issues",
                 "source": "https://github.com/laravel/framework"
             },
-            "time": "2022-05-23T15:54:33+00:00"
+            "time": "2022-07-14T14:38:53+00:00"
         },
         {
             "name": "illuminate/collections",
-            "version": "v9.20.0",
+            "version": "v9.21.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/illuminate/collections.git",
-                "reference": "b53d26fbcfb623c4f7538eadd9bc5083e0a59bdd"
+                "reference": "9b862a8e7c0da5b00af75b1422d3a29080ef7adb"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/illuminate/collections/zipball/b53d26fbcfb623c4f7538eadd9bc5083e0a59bdd",
-                "reference": "b53d26fbcfb623c4f7538eadd9bc5083e0a59bdd",
+                "url": "https://api.github.com/repos/illuminate/collections/zipball/9b862a8e7c0da5b00af75b1422d3a29080ef7adb",
+                "reference": "9b862a8e7c0da5b00af75b1422d3a29080ef7adb",
                 "shasum": ""
             },
             "require": {
@@ -1089,11 +1089,11 @@
                 "issues": "https://github.com/laravel/framework/issues",
                 "source": "https://github.com/laravel/framework"
             },
-            "time": "2022-07-01T20:41:17+00:00"
+            "time": "2022-07-18T13:54:30+00:00"
         },
         {
             "name": "illuminate/conditionable",
-            "version": "v9.20.0",
+            "version": "v9.21.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/illuminate/conditionable.git",
@@ -1139,7 +1139,7 @@
         },
         {
             "name": "illuminate/config",
-            "version": "v9.20.0",
+            "version": "v9.21.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/illuminate/config.git",
@@ -1187,16 +1187,16 @@
         },
         {
             "name": "illuminate/console",
-            "version": "v9.20.0",
+            "version": "v9.21.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/illuminate/console.git",
-                "reference": "5eeadc4fecb6a23c31b705eddf0e7d65d2a8fa38"
+                "reference": "95788c26750677e18726036999a066a213cf0a70"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/illuminate/console/zipball/5eeadc4fecb6a23c31b705eddf0e7d65d2a8fa38",
-                "reference": "5eeadc4fecb6a23c31b705eddf0e7d65d2a8fa38",
+                "url": "https://api.github.com/repos/illuminate/console/zipball/95788c26750677e18726036999a066a213cf0a70",
+                "reference": "95788c26750677e18726036999a066a213cf0a70",
                 "shasum": ""
             },
             "require": {
@@ -1204,6 +1204,8 @@
                 "illuminate/contracts": "^9.0",
                 "illuminate/macroable": "^9.0",
                 "illuminate/support": "^9.0",
+                "illuminate/view": "^9.0",
+                "nunomaduro/termwind": "^1.13",
                 "php": "^8.0.2",
                 "symfony/console": "^6.0",
                 "symfony/process": "^6.0"
@@ -1243,11 +1245,11 @@
                 "issues": "https://github.com/laravel/framework/issues",
                 "source": "https://github.com/laravel/framework"
             },
-            "time": "2022-07-12T13:39:25+00:00"
+            "time": "2022-07-16T19:38:10+00:00"
         },
         {
             "name": "illuminate/container",
-            "version": "v9.20.0",
+            "version": "v9.21.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/illuminate/container.git",
@@ -1298,7 +1300,7 @@
         },
         {
             "name": "illuminate/contracts",
-            "version": "v9.20.0",
+            "version": "v9.21.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/illuminate/contracts.git",
@@ -1346,7 +1348,7 @@
         },
         {
             "name": "illuminate/events",
-            "version": "v9.20.0",
+            "version": "v9.21.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/illuminate/events.git",
@@ -1401,7 +1403,7 @@
         },
         {
             "name": "illuminate/filesystem",
-            "version": "v9.20.0",
+            "version": "v9.21.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/illuminate/filesystem.git",
@@ -1463,16 +1465,16 @@
         },
         {
             "name": "illuminate/http",
-            "version": "v9.20.0",
+            "version": "v9.21.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/illuminate/http.git",
-                "reference": "7599468daab7aea2f117e4412df3533be2c7ea19"
+                "reference": "7f8e21e8959f3584d993ddb9929e7c432e5a6278"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/illuminate/http/zipball/7599468daab7aea2f117e4412df3533be2c7ea19",
-                "reference": "7599468daab7aea2f117e4412df3533be2c7ea19",
+                "url": "https://api.github.com/repos/illuminate/http/zipball/7f8e21e8959f3584d993ddb9929e7c432e5a6278",
+                "reference": "7f8e21e8959f3584d993ddb9929e7c432e5a6278",
                 "shasum": ""
             },
             "require": {
@@ -1518,11 +1520,11 @@
                 "issues": "https://github.com/laravel/framework/issues",
                 "source": "https://github.com/laravel/framework"
             },
-            "time": "2022-07-05T02:51:49+00:00"
+            "time": "2022-07-19T14:09:29+00:00"
         },
         {
             "name": "illuminate/macroable",
-            "version": "v9.20.0",
+            "version": "v9.21.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/illuminate/macroable.git",
@@ -1568,7 +1570,7 @@
         },
         {
             "name": "illuminate/pipeline",
-            "version": "v9.20.0",
+            "version": "v9.21.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/illuminate/pipeline.git",
@@ -1616,16 +1618,16 @@
         },
         {
             "name": "illuminate/session",
-            "version": "v9.20.0",
+            "version": "v9.21.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/illuminate/session.git",
-                "reference": "3a4a350d36031a3e3314c958466e109b99af75b1"
+                "reference": "64158515982a0b034c137ca4b783ba7054b39689"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/illuminate/session/zipball/3a4a350d36031a3e3314c958466e109b99af75b1",
-                "reference": "3a4a350d36031a3e3314c958466e109b99af75b1",
+                "url": "https://api.github.com/repos/illuminate/session/zipball/64158515982a0b034c137ca4b783ba7054b39689",
+                "reference": "64158515982a0b034c137ca4b783ba7054b39689",
                 "shasum": ""
             },
             "require": {
@@ -1668,20 +1670,20 @@
                 "issues": "https://github.com/laravel/framework/issues",
                 "source": "https://github.com/laravel/framework"
             },
-            "time": "2022-06-13T18:34:31+00:00"
+            "time": "2022-07-14T14:38:53+00:00"
         },
         {
             "name": "illuminate/support",
-            "version": "v9.20.0",
+            "version": "v9.21.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/illuminate/support.git",
-                "reference": "153993a1dfc8d1d5fb029b2f74a6df3c0712d89a"
+                "reference": "b6560afff5b5fbeb05e3b97a4475e032e438c57d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/illuminate/support/zipball/153993a1dfc8d1d5fb029b2f74a6df3c0712d89a",
-                "reference": "153993a1dfc8d1d5fb029b2f74a6df3c0712d89a",
+                "url": "https://api.github.com/repos/illuminate/support/zipball/b6560afff5b5fbeb05e3b97a4475e032e438c57d",
+                "reference": "b6560afff5b5fbeb05e3b97a4475e032e438c57d",
                 "shasum": ""
             },
             "require": {
@@ -1737,20 +1739,20 @@
                 "issues": "https://github.com/laravel/framework/issues",
                 "source": "https://github.com/laravel/framework"
             },
-            "time": "2022-07-13T13:11:02+00:00"
+            "time": "2022-07-19T13:51:28+00:00"
         },
         {
             "name": "illuminate/testing",
-            "version": "v9.20.0",
+            "version": "v9.21.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/illuminate/testing.git",
-                "reference": "40a22d3726be4d98da507d887d1c78e68e249314"
+                "reference": "e03e0cea096215ae693b8e3d808fa48302f7be71"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/illuminate/testing/zipball/40a22d3726be4d98da507d887d1c78e68e249314",
-                "reference": "40a22d3726be4d98da507d887d1c78e68e249314",
+                "url": "https://api.github.com/repos/illuminate/testing/zipball/e03e0cea096215ae693b8e3d808fa48302f7be71",
+                "reference": "e03e0cea096215ae693b8e3d808fa48302f7be71",
                 "shasum": ""
             },
             "require": {
@@ -1795,11 +1797,11 @@
                 "issues": "https://github.com/laravel/framework/issues",
                 "source": "https://github.com/laravel/framework"
             },
-            "time": "2022-06-13T18:36:23+00:00"
+            "time": "2022-07-14T13:59:10+00:00"
         },
         {
             "name": "illuminate/view",
-            "version": "v9.20.0",
+            "version": "v9.21.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/illuminate/view.git",
@@ -1915,16 +1917,16 @@
         },
         {
             "name": "laravel-zero/foundation",
-            "version": "v9.17.1",
+            "version": "v9.21.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/laravel-zero/foundation.git",
-                "reference": "91685dd47e4c9a29b4d42b5372962ce18ae8f95d"
+                "reference": "29bb55e7dbe879c5013a2430626f1bd92440b621"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/laravel-zero/foundation/zipball/91685dd47e4c9a29b4d42b5372962ce18ae8f95d",
-                "reference": "91685dd47e4c9a29b4d42b5372962ce18ae8f95d",
+                "url": "https://api.github.com/repos/laravel-zero/foundation/zipball/29bb55e7dbe879c5013a2430626f1bd92440b621",
+                "reference": "29bb55e7dbe879c5013a2430626f1bd92440b621",
                 "shasum": ""
             },
             "require": {
@@ -1954,22 +1956,22 @@
                 "laravel"
             ],
             "support": {
-                "source": "https://github.com/laravel-zero/foundation/tree/v9.17.1"
+                "source": "https://github.com/laravel-zero/foundation/tree/v9.21.0"
             },
-            "time": "2022-06-20T13:14:17+00:00"
+            "time": "2022-07-19T15:21:41+00:00"
         },
         {
             "name": "laravel-zero/framework",
-            "version": "v9.1.1",
+            "version": "v9.1.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/laravel-zero/framework.git",
-                "reference": "e9bdb5e1338c4c874be9cb6c902c5fbc5a58e02e"
+                "reference": "bfb3b8adc23fbb92d4c7fddde79ce4da6989ad54"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/laravel-zero/framework/zipball/e9bdb5e1338c4c874be9cb6c902c5fbc5a58e02e",
-                "reference": "e9bdb5e1338c4c874be9cb6c902c5fbc5a58e02e",
+                "url": "https://api.github.com/repos/laravel-zero/framework/zipball/bfb3b8adc23fbb92d4c7fddde79ce4da6989ad54",
+                "reference": "bfb3b8adc23fbb92d4c7fddde79ce4da6989ad54",
                 "shasum": ""
             },
             "require": {
@@ -1985,7 +1987,7 @@
                 "illuminate/filesystem": "^9.0.0",
                 "illuminate/support": "^9.0.0",
                 "illuminate/testing": "^9.0.0",
-                "laravel-zero/foundation": "^9.0.0",
+                "laravel-zero/foundation": "^9.21",
                 "league/flysystem": "^3.0.0",
                 "nunomaduro/collision": "^6.0.0",
                 "nunomaduro/laravel-console-summary": "^1.8.0",
@@ -2012,6 +2014,7 @@
                 "illuminate/view": "^9.0.0",
                 "laminas/laminas-text": "^2.9.0",
                 "laravel-zero/phar-updater": "^1.2",
+                "laravel/pint": "^0.2.3",
                 "nunomaduro/laravel-console-dusk": "^1.10.0",
                 "nunomaduro/laravel-console-menu": "^3.3.0",
                 "nunomaduro/termwind": "^1.3",
@@ -2055,20 +2058,20 @@
                 "issues": "https://github.com/laravel-zero/laravel-zero/issues",
                 "source": "https://github.com/laravel-zero/laravel-zero"
             },
-            "time": "2022-03-01T15:09:55+00:00"
+            "time": "2022-07-19T15:31:45+00:00"
         },
         {
             "name": "league/commonmark",
-            "version": "2.3.3",
+            "version": "2.3.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/thephpleague/commonmark.git",
-                "reference": "0da1dca5781dd3cfddbe328224d9a7a62571addc"
+                "reference": "155ec1c95626b16fda0889cf15904d24890a60d5"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/thephpleague/commonmark/zipball/0da1dca5781dd3cfddbe328224d9a7a62571addc",
-                "reference": "0da1dca5781dd3cfddbe328224d9a7a62571addc",
+                "url": "https://api.github.com/repos/thephpleague/commonmark/zipball/155ec1c95626b16fda0889cf15904d24890a60d5",
+                "reference": "155ec1c95626b16fda0889cf15904d24890a60d5",
                 "shasum": ""
             },
             "require": {
@@ -2161,7 +2164,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2022-06-07T21:28:26+00:00"
+            "time": "2022-07-17T16:25:47+00:00"
         },
         {
             "name": "league/config",
@@ -2247,16 +2250,16 @@
         },
         {
             "name": "league/flysystem",
-            "version": "3.1.0",
+            "version": "3.1.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/thephpleague/flysystem.git",
-                "reference": "34a68067b7ae3b836ea5e57e1fc432478372a4f5"
+                "reference": "1a941703dfb649f9b821e7bc425e782f576a805e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/thephpleague/flysystem/zipball/34a68067b7ae3b836ea5e57e1fc432478372a4f5",
-                "reference": "34a68067b7ae3b836ea5e57e1fc432478372a4f5",
+                "url": "https://api.github.com/repos/thephpleague/flysystem/zipball/1a941703dfb649f9b821e7bc425e782f576a805e",
+                "reference": "1a941703dfb649f9b821e7bc425e782f576a805e",
                 "shasum": ""
             },
             "require": {
@@ -2317,7 +2320,7 @@
             ],
             "support": {
                 "issues": "https://github.com/thephpleague/flysystem/issues",
-                "source": "https://github.com/thephpleague/flysystem/tree/3.1.0"
+                "source": "https://github.com/thephpleague/flysystem/tree/3.1.1"
             },
             "funding": [
                 {
@@ -2333,7 +2336,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2022-06-29T17:29:54+00:00"
+            "time": "2022-07-18T09:59:40+00:00"
         },
         {
             "name": "league/mime-type-detection",
@@ -2918,6 +2921,92 @@
                 "source": "https://github.com/nunomaduro/laravel-desktop-notifier/tree/v2.6.0"
             },
             "time": "2022-01-13T15:10:14+00:00"
+        },
+        {
+            "name": "nunomaduro/termwind",
+            "version": "v1.13.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/nunomaduro/termwind.git",
+                "reference": "132a24bd3e8c559e7f14fa14ba1b83772a0f97f8"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/nunomaduro/termwind/zipball/132a24bd3e8c559e7f14fa14ba1b83772a0f97f8",
+                "reference": "132a24bd3e8c559e7f14fa14ba1b83772a0f97f8",
+                "shasum": ""
+            },
+            "require": {
+                "ext-mbstring": "*",
+                "php": "^8.0",
+                "symfony/console": "^5.3.0|^6.0.0"
+            },
+            "require-dev": {
+                "ergebnis/phpstan-rules": "^1.0.",
+                "illuminate/console": "^8.0|^9.0",
+                "illuminate/support": "^8.0|^9.0",
+                "laravel/pint": "^0.2.0",
+                "pestphp/pest": "^1.21.0",
+                "pestphp/pest-plugin-mock": "^1.0",
+                "phpstan/phpstan": "^1.4.6",
+                "phpstan/phpstan-strict-rules": "^1.1.0",
+                "symfony/var-dumper": "^5.2.7|^6.0.0",
+                "thecodingmachine/phpstan-strict-rules": "^1.0.0"
+            },
+            "type": "library",
+            "extra": {
+                "laravel": {
+                    "providers": [
+                        "Termwind\\Laravel\\TermwindServiceProvider"
+                    ]
+                }
+            },
+            "autoload": {
+                "files": [
+                    "src/Functions.php"
+                ],
+                "psr-4": {
+                    "Termwind\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nuno Maduro",
+                    "email": "enunomaduro@gmail.com"
+                }
+            ],
+            "description": "Its like Tailwind CSS, but for the console.",
+            "keywords": [
+                "cli",
+                "console",
+                "css",
+                "package",
+                "php",
+                "style"
+            ],
+            "support": {
+                "issues": "https://github.com/nunomaduro/termwind/issues",
+                "source": "https://github.com/nunomaduro/termwind/tree/v1.13.0"
+            },
+            "funding": [
+                {
+                    "url": "https://www.paypal.com/paypalme/enunomaduro",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/nunomaduro",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/xiCO2k",
+                    "type": "github"
+                }
+            ],
+            "time": "2022-07-01T15:06:55+00:00"
         },
         {
             "name": "phpoption/phpoption",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "b9ed92daf1a4b0fe8b7776a5e36dbb6b",
+    "content-hash": "9f49c43c7e26914149434ad01288989e",
     "packages": [
         {
             "name": "brick/math",
@@ -6113,6 +6113,79 @@
             }
         },
         {
+            "name": "laravel/dusk",
+            "version": "v6.25.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/laravel/dusk.git",
+                "reference": "b4632b7493a187d31afc5c9ddec437c81b16421a"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/laravel/dusk/zipball/b4632b7493a187d31afc5c9ddec437c81b16421a",
+                "reference": "b4632b7493a187d31afc5c9ddec437c81b16421a",
+                "shasum": ""
+            },
+            "require": {
+                "ext-json": "*",
+                "ext-zip": "*",
+                "illuminate/console": "^6.0|^7.0|^8.0|^9.0",
+                "illuminate/support": "^6.0|^7.0|^8.0|^9.0",
+                "nesbot/carbon": "^2.0",
+                "php": "^7.2|^8.0",
+                "php-webdriver/webdriver": "^1.9.0",
+                "symfony/console": "^4.3|^5.0|^6.0",
+                "symfony/finder": "^4.3|^5.0|^6.0",
+                "symfony/process": "^4.3|^5.0|^6.0",
+                "vlucas/phpdotenv": "^3.0|^4.0|^5.2"
+            },
+            "require-dev": {
+                "mockery/mockery": "^1.0",
+                "orchestra/testbench": "^4.16|^5.17.1|^6.12.1|^7.0",
+                "phpunit/phpunit": "^7.5.15|^8.4|^9.0"
+            },
+            "suggest": {
+                "ext-pcntl": "Used to gracefully terminate Dusk when tests are running."
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "6.x-dev"
+                },
+                "laravel": {
+                    "providers": [
+                        "Laravel\\Dusk\\DuskServiceProvider"
+                    ]
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Laravel\\Dusk\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Taylor Otwell",
+                    "email": "taylor@laravel.com"
+                }
+            ],
+            "description": "Laravel Dusk provides simple end-to-end testing and browser automation.",
+            "keywords": [
+                "laravel",
+                "testing",
+                "webdriver"
+            ],
+            "support": {
+                "issues": "https://github.com/laravel/dusk/issues",
+                "source": "https://github.com/laravel/dusk/tree/v6.25.0"
+            },
+            "time": "2022-07-11T11:38:43+00:00"
+        },
+        {
             "name": "mockery/mockery",
             "version": "1.5.0",
             "source": {
@@ -6594,6 +6667,71 @@
                 "source": "https://github.com/phar-io/version/tree/3.2.1"
             },
             "time": "2022-02-21T01:04:05+00:00"
+        },
+        {
+            "name": "php-webdriver/webdriver",
+            "version": "1.12.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-webdriver/php-webdriver.git",
+                "reference": "b27ddf458d273c7d4602106fcaf978aa0b7fe15a"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-webdriver/php-webdriver/zipball/b27ddf458d273c7d4602106fcaf978aa0b7fe15a",
+                "reference": "b27ddf458d273c7d4602106fcaf978aa0b7fe15a",
+                "shasum": ""
+            },
+            "require": {
+                "ext-curl": "*",
+                "ext-json": "*",
+                "ext-zip": "*",
+                "php": "^5.6 || ~7.0 || ^8.0",
+                "symfony/polyfill-mbstring": "^1.12",
+                "symfony/process": "^2.8 || ^3.1 || ^4.0 || ^5.0 || ^6.0"
+            },
+            "replace": {
+                "facebook/webdriver": "*"
+            },
+            "require-dev": {
+                "ondram/ci-detector": "^2.1 || ^3.5 || ^4.0",
+                "php-coveralls/php-coveralls": "^2.4",
+                "php-mock/php-mock-phpunit": "^1.1 || ^2.0",
+                "php-parallel-lint/php-parallel-lint": "^1.2",
+                "phpunit/phpunit": "^5.7 || ^7 || ^8 || ^9",
+                "squizlabs/php_codesniffer": "^3.5",
+                "symfony/var-dumper": "^3.3 || ^4.0 || ^5.0 || ^6.0"
+            },
+            "suggest": {
+                "ext-SimpleXML": "For Firefox profile creation"
+            },
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "lib/Exception/TimeoutException.php"
+                ],
+                "psr-4": {
+                    "Facebook\\WebDriver\\": "lib/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "A PHP client for Selenium WebDriver. Previously facebook/webdriver.",
+            "homepage": "https://github.com/php-webdriver/php-webdriver",
+            "keywords": [
+                "Chromedriver",
+                "geckodriver",
+                "php",
+                "selenium",
+                "webdriver"
+            ],
+            "support": {
+                "issues": "https://github.com/php-webdriver/php-webdriver/issues",
+                "source": "https://github.com/php-webdriver/php-webdriver/tree/1.12.1"
+            },
+            "time": "2022-05-03T12:16:34+00:00"
         },
         {
             "name": "phpdocumentor/reflection-common",

--- a/packages/framework/resources/views/homepages/post-feed.blade.php
+++ b/packages/framework/resources/views/homepages/post-feed.blade.php
@@ -9,7 +9,7 @@
         Latest Posts</h1>
     </header>
 
-    <div class="max-w-3xl mx-auto">
+    <div id="post-feed" class="max-w-3xl mx-auto">
         @include('hyde::components.blog-post-feed')
     </div>
 </main>

--- a/packages/framework/src/HydeServiceProvider.php
+++ b/packages/framework/src/HydeServiceProvider.php
@@ -120,7 +120,7 @@ class HydeServiceProvider extends ServiceProvider
         $this->app->register(Modules\DataCollections\DataCollectionServiceProvider::class);
 
         if (env('DUSK_ENABLED', false)) {
-            $this->app->register(\Laravel\Dusk\DuskServiceProvider::class);
+            $this->app->register(\Hyde\Testing\Browser\DuskServiceProvider::class);
         }
     }
 }

--- a/packages/framework/src/HydeServiceProvider.php
+++ b/packages/framework/src/HydeServiceProvider.php
@@ -118,5 +118,9 @@ class HydeServiceProvider extends ServiceProvider
     protected function registerModuleServiceProviders(): void
     {
         $this->app->register(Modules\DataCollections\DataCollectionServiceProvider::class);
+
+        if (env('DUSK_ENABLED', false)){
+            $this->app->register(\Laravel\Dusk\DuskServiceProvider::class);
+        }
     }
 }

--- a/phpunit.dusk.xml
+++ b/phpunit.dusk.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit backupGlobals="false"
+         backupStaticAttributes="false"
+         bootstrap="vendor/autoload.php"
+         colors="true"
+         convertErrorsToExceptions="true"
+         convertNoticesToExceptions="true"
+         convertWarningsToExceptions="true"
+         processIsolation="false"
+         stopOnFailure="false">
+    <testsuites>
+        <testsuite name="Browser Tests">
+            <directory suffix="Test.php">./tests/Browser</directory>
+        </testsuite>
+    </testsuites>
+    <coverage processUncoveredFiles="true">
+        <include>
+            <directory suffix=".php">./packages/framework/src</directory>
+        </include>
+    </coverage>
+    <php>
+        <env name="ENV" value="testing"/>
+        <env name="DUSK_ENABLED" value="true"/>
+    </php>
+</phpunit>

--- a/phpunit.dusk.xml
+++ b/phpunit.dusk.xml
@@ -9,7 +9,7 @@
          processIsolation="false"
          stopOnFailure="false">
     <testsuites>
-        <testsuite name="Browser Tests">
+        <testsuite name="Browser Test Suite">
             <directory suffix="Test.php">./tests/Browser</directory>
         </testsuite>
     </testsuites>

--- a/tests/Browser/DefaultHomepageTest.php
+++ b/tests/Browser/DefaultHomepageTest.php
@@ -2,8 +2,8 @@
 
 namespace Hyde\Testing\Browser;
 
-use Laravel\Dusk\Browser;
 use Hyde\Testing\DuskTestCase;
+use Laravel\Dusk\Browser;
 
 class DefaultHomepageTest extends DuskTestCase
 {

--- a/tests/Browser/DefaultHomepageTest.php
+++ b/tests/Browser/DefaultHomepageTest.php
@@ -7,11 +7,12 @@ use Laravel\Dusk\Browser;
 
 class DefaultHomepageTest extends DuskTestCase
 {
-    public function testExample()
+    public function testDefaultHomepageIsWelcomePage()
     {
         $this->browse(function (Browser $browser) {
             $browser->visit('/')
-                    ->assertSee('Laravel');
+                    ->assertSee('You\'re running on')
+                    ->assertSee('HydePHP');
         });
     }
 }

--- a/tests/Browser/DefaultHomepageTest.php
+++ b/tests/Browser/DefaultHomepageTest.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Hyde\Testing\Browser;
+
+use Laravel\Dusk\Browser;
+use Hyde\Testing\DuskTestCase;
+
+class DefaultHomepageTest extends DuskTestCase
+{
+    public function testExample()
+    {
+        $this->browse(function (Browser $browser) {
+            $browser->visit('/')
+                    ->assertSee('Laravel');
+        });
+    }
+}

--- a/tests/Browser/DuskServiceProvider.php
+++ b/tests/Browser/DuskServiceProvider.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Hyde\Testing\Browser;
+
+class DuskServiceProvider extends \Laravel\Dusk\DuskServiceProvider
+{
+    /**
+     * @inheritDoc
+     */
+    public function boot()
+    {
+        if ($this->app->runningInConsole()) {
+            $this->commands([
+                \Laravel\Dusk\Console\InstallCommand::class,
+                \Laravel\Dusk\Console\DuskCommand::class,
+                \Laravel\Dusk\Console\DuskFailsCommand::class,
+                \Laravel\Dusk\Console\MakeCommand::class,
+                \Laravel\Dusk\Console\PageCommand::class,
+                \Laravel\Dusk\Console\PurgeCommand::class,
+                \Laravel\Dusk\Console\ComponentCommand::class,
+                \Laravel\Dusk\Console\ChromeDriverCommand::class,
+            ]);
+        }
+    }
+}

--- a/tests/Browser/ExampleTest.php
+++ b/tests/Browser/ExampleTest.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Tests\Browser;
+
+use Illuminate\Foundation\Testing\DatabaseMigrations;
+use Laravel\Dusk\Browser;
+use Tests\DuskTestCase;
+
+class ExampleTest extends DuskTestCase
+{
+    /**
+     * A basic browser test example.
+     *
+     * @return void
+     */
+    public function testBasicExample()
+    {
+        $this->browse(function (Browser $browser) {
+            $browser->visit('/')
+                    ->assertSee('Laravel');
+        });
+    }
+}

--- a/tests/Browser/ExampleTest.php
+++ b/tests/Browser/ExampleTest.php
@@ -2,7 +2,6 @@
 
 namespace Hyde\Testing\Browser;
 
-use Illuminate\Foundation\Testing\DatabaseMigrations;
 use Laravel\Dusk\Browser;
 use Hyde\Testing\DuskTestCase;
 
@@ -17,7 +16,8 @@ class ExampleTest extends DuskTestCase
     {
         $this->browse(function (Browser $browser) {
             $browser->visit('/')
-                    ->assertSee('Laravel');
+                    ->assertSee('You\'re running on')
+                    ->assertSee('HydePHP');
         });
     }
 }

--- a/tests/Browser/ExampleTest.php
+++ b/tests/Browser/ExampleTest.php
@@ -1,10 +1,10 @@
 <?php
 
-namespace Tests\Browser;
+namespace Hyde\Testing\Browser;
 
 use Illuminate\Foundation\Testing\DatabaseMigrations;
 use Laravel\Dusk\Browser;
-use Tests\DuskTestCase;
+use Hyde\Testing\DuskTestCase;
 
 class ExampleTest extends DuskTestCase
 {

--- a/tests/Browser/ExampleTest.php
+++ b/tests/Browser/ExampleTest.php
@@ -16,8 +16,7 @@ class ExampleTest extends DuskTestCase
     {
         $this->browse(function (Browser $browser) {
             $browser->visit('/')
-                    ->assertSee('You\'re running on')
-                    ->assertSee('HydePHP');
+                    ->assertSee('Laravel');
         });
     }
 }

--- a/tests/Browser/HighLevelViewTest.php
+++ b/tests/Browser/HighLevelViewTest.php
@@ -25,6 +25,8 @@ class HighLevelViewTest extends DuskTestCase
 					->screenshot('welcome_homepage')
 					->storeSource('welcome_homepage.html');
         });
+
+		unlink(Hyde::path('_site/index.html'));
     }
 
 	public function test_404_page()
@@ -36,6 +38,8 @@ class HighLevelViewTest extends DuskTestCase
 					->screenshot('404_page')
 					->storeSource('404_page.html');
 		});
+
+		unlink(Hyde::path('_site/404.html'));
 	}
 
 	public function test_blank_homepage()
@@ -49,6 +53,9 @@ class HighLevelViewTest extends DuskTestCase
 					->screenshot('blank_homepage')
 					->storeSource('blank_homepage.html');
 		});
+
+		$this->artisan('publish:homepage welcome -n');
+		unlink(Hyde::path('_site/index.html'));
 	}
 
 	public function test_posts_homepage()
@@ -63,6 +70,9 @@ class HighLevelViewTest extends DuskTestCase
 					->screenshot('posts_homepage')
 					->storeSource('posts_homepage.html');
 		});
+
+		$this->artisan('publish:homepage welcome -n');
+		unlink(Hyde::path('_site/index.html'));
 	}
 
 	public function test_posts_homepage_with_posts()
@@ -79,15 +89,8 @@ class HighLevelViewTest extends DuskTestCase
 					->storeSource('posts_homepage_with_posts.html');
 		});
 
-		unlink(Hyde::path('_posts/my-new-post.md'));
-	}
-
-	protected function tearDown(): void
-	{
 		$this->artisan('publish:homepage welcome -n');
-		unlinkIfExists(Hyde::path('_site/index.html'));
-		unlinkIfExists(Hyde::path('_site/404.html'));
-
-		parent::tearDown();
+		unlink(Hyde::path('_posts/my-new-post.md'));
+		unlink(Hyde::path('_site/index.html'));
 	}
 }

--- a/tests/Browser/HighLevelViewTest.php
+++ b/tests/Browser/HighLevelViewTest.php
@@ -1,0 +1,65 @@
+<?php
+
+namespace Hyde\Testing\Browser;
+
+use Hyde\Framework\Hyde;
+use Hyde\Testing\DuskTestCase;
+use Laravel\Dusk\Browser;
+
+/**
+ * Test the built in full-page views.
+ * 
+ * Each view generates a screenshot for visual analysis and regression testing.
+ * Each view also saves the generated HTML for further testing, for example, Cypress.
+ */
+class HighLevelViewTest extends DuskTestCase
+{
+    public function test_welcome_homepage()
+    {
+        $this->browse(function (Browser $browser) {
+            $browser->visit('/')
+                    ->assertSee('You\'re running on')
+                    ->assertSee('HydePHP')
+					->screenshot('welcome_homepage')
+					->storeSource('welcome_homepage.html');
+        });
+    }
+
+	public function test_404_page()
+	{
+		$this->browse(function (Browser $browser) {
+			$browser->visit('/404')
+					->assertSee('404')
+					->assertSee('Sorry, the page you are looking for could not be found.')
+					->screenshot('404_page')
+					->storeSource('404_page.html');
+		});
+	}
+
+	public function test_blank_homepage()
+	{
+		$this->artisan('publish:homepage blank -n');
+
+		$this->browse(function (Browser $browser) {
+			$browser->visit('/')
+					->assertSee('HydePHP')
+					->assertSee('Hello World!')
+					->screenshot('blank_homepage')
+					->storeSource('blank_homepage.html');
+		});
+	}
+
+	public function test_posts_homepage()
+	{
+		$this->artisan('publish:homepage posts -n');
+		
+		$this->browse(function (Browser $browser) {
+			$browser->visit('/')
+					->assertSee('HydePHP')
+					->assertSee('Latest Posts')
+					->assertSeeNothingIn('#post-feed')
+					->screenshot('posts_homepage')
+					->storeSource('posts_homepage.html');
+		});
+	}
+}

--- a/tests/Browser/HighLevelViewTest.php
+++ b/tests/Browser/HighLevelViewTest.php
@@ -14,6 +14,8 @@ use Laravel\Dusk\Browser;
  */
 class HighLevelViewTest extends DuskTestCase
 {
+    public $mockConsoleOutput = false;
+
     public function test_welcome_homepage()
     {
         $this->browse(function (Browser $browser) {
@@ -61,6 +63,23 @@ class HighLevelViewTest extends DuskTestCase
 					->screenshot('posts_homepage')
 					->storeSource('posts_homepage.html');
 		});
+	}
+
+	public function test_posts_homepage_with_posts()
+	{
+		$this->artisan('publish:homepage posts -n');
+		$this->artisan('make:post -n');
+
+		$this->browse(function (Browser $browser) {
+			$browser->visit('/')
+					->assertSee('HydePHP')
+					->assertSee('Latest Posts')
+					->assertSee('My New Post')
+					->screenshot('posts_homepage_with_posts')
+					->storeSource('posts_homepage_with_posts.html');
+		});
+
+		unlink(Hyde::path('_posts/my-new-post.md'));
 	}
 
 	public function test_reset_state()

--- a/tests/Browser/HighLevelViewTest.php
+++ b/tests/Browser/HighLevelViewTest.php
@@ -62,4 +62,12 @@ class HighLevelViewTest extends DuskTestCase
 					->storeSource('posts_homepage.html');
 		});
 	}
+
+	public function test_reset_state()
+	{
+		$this->artisan('publish:homepage welcome -n');
+		unlink(Hyde::path('_site/index.html'));
+		unlink(Hyde::path('_site/404.html'));
+		$this->assertTrue(true);
+	}
 }

--- a/tests/Browser/HighLevelViewTest.php
+++ b/tests/Browser/HighLevelViewTest.php
@@ -82,11 +82,12 @@ class HighLevelViewTest extends DuskTestCase
 		unlink(Hyde::path('_posts/my-new-post.md'));
 	}
 
-	public function test_reset_state()
+	protected function tearDown(): void
 	{
 		$this->artisan('publish:homepage welcome -n');
-		unlink(Hyde::path('_site/index.html'));
-		unlink(Hyde::path('_site/404.html'));
-		$this->assertTrue(true);
+		unlinkIfExists(Hyde::path('_site/index.html'));
+		unlinkIfExists(Hyde::path('_site/404.html'));
+
+		parent::tearDown();
 	}
 }

--- a/tests/Browser/Pages/HomePage.php
+++ b/tests/Browser/Pages/HomePage.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace Tests\Browser\Pages;
+
+use Laravel\Dusk\Browser;
+
+class HomePage extends Page
+{
+    /**
+     * Get the URL for the page.
+     *
+     * @return string
+     */
+    public function url()
+    {
+        return '/';
+    }
+
+    /**
+     * Assert that the browser is on the page.
+     *
+     * @param  \Laravel\Dusk\Browser  $browser
+     * @return void
+     */
+    public function assert(Browser $browser)
+    {
+        //
+    }
+
+    /**
+     * Get the element shortcuts for the page.
+     *
+     * @return array
+     */
+    public function elements()
+    {
+        return [
+            '@element' => '#selector',
+        ];
+    }
+}

--- a/tests/Browser/Pages/HomePage.php
+++ b/tests/Browser/Pages/HomePage.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Tests\Browser\Pages;
+namespace Hyde\Testing\Browser\Pages;
 
 use Laravel\Dusk\Browser;
 

--- a/tests/Browser/Pages/Page.php
+++ b/tests/Browser/Pages/Page.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Tests\Browser\Pages;
+
+use Laravel\Dusk\Page as BasePage;
+
+abstract class Page extends BasePage
+{
+    /**
+     * Get the global element shortcuts for the site.
+     *
+     * @return array
+     */
+    public static function siteElements()
+    {
+        return [
+            '@element' => '#selector',
+        ];
+    }
+}

--- a/tests/Browser/Pages/Page.php
+++ b/tests/Browser/Pages/Page.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Tests\Browser\Pages;
+namespace Hyde\Testing\Browser\Pages;
 
 use Laravel\Dusk\Page as BasePage;
 

--- a/tests/Browser/console/.gitignore
+++ b/tests/Browser/console/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore

--- a/tests/Browser/screenshots/.gitignore
+++ b/tests/Browser/screenshots/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore

--- a/tests/Browser/source/.gitignore
+++ b/tests/Browser/source/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore

--- a/tests/DuskBaseTestCase.php
+++ b/tests/DuskBaseTestCase.php
@@ -1,0 +1,82 @@
+<?php
+
+namespace Hyde\Testing;
+
+use Laravel\Dusk\TestCase as BaseTestCase;
+use Illuminate\Support\Facades\Facade;
+use LaravelZero\Framework\Providers\CommandRecorder\CommandRecorderRepository;
+use NunoMaduro\Collision\ArgumentFormatter;
+use Laravel\Dusk\Browser;
+
+abstract class DuskBaseTestCase extends BaseTestCase
+{
+    /**
+     * Setup the test environment.
+     */
+    protected function setUp(): void
+    {
+        // \LaravelZero\Framework\Testing\TestCase instead \Illuminate\Foundation\Testing\TestCase
+        if (! $this->app) {
+            $this->refreshApplication();
+        }
+
+        $this->setUpTraits();
+
+        foreach ($this->afterApplicationCreatedCallbacks as $callback) {
+            call_user_func($callback);
+        }
+
+        Facade::clearResolvedInstances();
+
+        if (class_exists(\Illuminate\Database\Eloquent\Model::class)) {
+            \Illuminate\Database\Eloquent\Model::setEventDispatcher($this->app['events']);
+        }
+
+        $this->setUpHasRun = true;
+
+        // \Laravel\Dusk\TestCase
+ 
+        Browser::$baseUrl = 'http://localhost:8080';
+        // Browser::$baseUrl = $this->baseUrl();
+
+        Browser::$storeScreenshotsAt = base_path('tests/Browser/screenshots');
+
+        Browser::$storeConsoleLogAt = base_path('tests/Browser/console');
+
+        Browser::$storeSourceAt = base_path('tests/Browser/source');
+
+        Browser::$userResolver = function () {
+            return $this->user();
+        };
+    }
+
+    /**
+     * Assert that a command was called using the given arguments.
+     *
+     * @param string $command
+     * @param array $arguments
+     */
+    protected function assertCommandCalled(string $command, array $arguments = []): void
+    {
+        $argumentsAsString = (new ArgumentFormatter)->format($arguments);
+        $recorder = app(CommandRecorderRepository::class);
+
+        static::assertTrue($recorder->exists($command, $arguments),
+            'Failed asserting that \''.$command.'\' was called with the given arguments: '.$argumentsAsString);
+    }
+
+    /**
+     * Assert that a command was not called using the given arguments.
+     *
+     * @param string $command
+     * @param array $arguments
+     */
+    protected function assertCommandNotCalled(string $command, array $arguments = []): void
+    {
+        $argumentsAsString = (new ArgumentFormatter)->format($arguments);
+        $recorder = app(CommandRecorderRepository::class);
+
+        static::assertFalse($recorder->exists($command, $arguments),
+            'Failed asserting that \''.$command.'\' was not called with the given arguments: '.$argumentsAsString);
+    }
+}

--- a/tests/DuskBaseTestCase.php
+++ b/tests/DuskBaseTestCase.php
@@ -53,8 +53,8 @@ abstract class DuskBaseTestCase extends BaseTestCase
     /**
      * Assert that a command was called using the given arguments.
      *
-     * @param string $command
-     * @param array $arguments
+     * @param  string  $command
+     * @param  array  $arguments
      */
     protected function assertCommandCalled(string $command, array $arguments = []): void
     {
@@ -68,8 +68,8 @@ abstract class DuskBaseTestCase extends BaseTestCase
     /**
      * Assert that a command was not called using the given arguments.
      *
-     * @param string $command
-     * @param array $arguments
+     * @param  string  $command
+     * @param  array  $arguments
      */
     protected function assertCommandNotCalled(string $command, array $arguments = []): void
     {

--- a/tests/DuskTestCase.php
+++ b/tests/DuskTestCase.php
@@ -1,0 +1,72 @@
+<?php
+
+namespace Tests;
+
+use Facebook\WebDriver\Chrome\ChromeOptions;
+use Facebook\WebDriver\Remote\DesiredCapabilities;
+use Facebook\WebDriver\Remote\RemoteWebDriver;
+use Laravel\Dusk\TestCase as BaseTestCase;
+
+abstract class DuskTestCase extends BaseTestCase
+{
+    use CreatesApplication;
+
+    /**
+     * Prepare for Dusk test execution.
+     *
+     * @beforeClass
+     * @return void
+     */
+    public static function prepare()
+    {
+        if (! static::runningInSail()) {
+            static::startChromeDriver();
+        }
+    }
+
+    /**
+     * Create the RemoteWebDriver instance.
+     *
+     * @return \Facebook\WebDriver\Remote\RemoteWebDriver
+     */
+    protected function driver()
+    {
+        $options = (new ChromeOptions)->addArguments(collect([
+            $this->shouldStartMaximized() ? '--start-maximized' : '--window-size=1920,1080',
+        ])->unless($this->hasHeadlessDisabled(), function ($items) {
+            return $items->merge([
+                '--disable-gpu',
+                '--headless',
+            ]);
+        })->all());
+
+        return RemoteWebDriver::create(
+            $_ENV['DUSK_DRIVER_URL'] ?? 'http://localhost:9515',
+            DesiredCapabilities::chrome()->setCapability(
+                ChromeOptions::CAPABILITY, $options
+            )
+        );
+    }
+
+    /**
+     * Determine whether the Dusk command has disabled headless mode.
+     *
+     * @return bool
+     */
+    protected function hasHeadlessDisabled()
+    {
+        return isset($_SERVER['DUSK_HEADLESS_DISABLED']) ||
+               isset($_ENV['DUSK_HEADLESS_DISABLED']);
+    }
+
+    /**
+     * Determine if the browser window should start maximized.
+     *
+     * @return bool
+     */
+    protected function shouldStartMaximized()
+    {
+        return isset($_SERVER['DUSK_START_MAXIMIZED']) ||
+               isset($_ENV['DUSK_START_MAXIMIZED']);
+    }
+}

--- a/tests/DuskTestCase.php
+++ b/tests/DuskTestCase.php
@@ -5,7 +5,7 @@ namespace Hyde\Testing;
 use Facebook\WebDriver\Chrome\ChromeOptions;
 use Facebook\WebDriver\Remote\DesiredCapabilities;
 use Facebook\WebDriver\Remote\RemoteWebDriver;
-use Laravel\Dusk\TestCase as BaseTestCase;
+use Hyde\Testing\DuskBaseTestCase as BaseTestCase;
 
 abstract class DuskTestCase extends BaseTestCase
 {

--- a/tests/DuskTestCase.php
+++ b/tests/DuskTestCase.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Tests;
+namespace Hyde\Testing;
 
 use Facebook\WebDriver\Chrome\ChromeOptions;
 use Facebook\WebDriver\Remote\DesiredCapabilities;


### PR DESCRIPTION
Cypress is nice and gives instant visual feedback, however it breaks productivity having to swap to a completely different framework and language. This PR will explore using Laravel Dusk, using a ported test case so it can run with Laravel Zero.