### PR TITLE
Remove comments for deprecated base path setup in bootstrap script

### DIFF
--- a/app/bootstrap.php
+++ b/app/bootstrap.php
@@ -43,13 +43,8 @@ $app->singleton(
 |
 | Next, we need to configure Hyde to use our project's base path.
 |
-| There are two ways we can do this, previously we were using getcwd(),
-| which allows for a lot of flexibility, but can also cause problems.
-| See this issue: https://github.com/hydephp/develop/issues/212
-|
 */
 
-// @deprecated usage \Hyde\Framework\Hyde::setBasePath(getcwd());
 \Hyde\Framework\Hyde::setBasePath(dirname(__DIR__));
 
 /*


### PR DESCRIPTION
These comments were left to ease the transition and can in my opinion now be removed.