### PR TITLE
Add Alpine.js

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -5,6 +5,7 @@
 This update makes breaking changes to the configuration. You will need to update your configuration to continue using the new changes. Each one has been documented in this changelog entry, which at the end has an upgrade guide.
 
 ### Added
+- Added [Alpine.js](https://alpinejs.dev/) to the default HydePHP layout
 - Added a new configuration file, `config/site.php`, see below
 - Added RSS feed configuration stubs to `config/site.php`
 - Added an `Includes` facade that can quickly import partials

--- a/packages/framework/resources/views/layouts/scripts.blade.php
+++ b/packages/framework/resources/views/layouts/scripts.blade.php
@@ -10,5 +10,8 @@
 <script defer src="{{ Hyde::relativeLink('media/app.js') }}"></script>
 @endif
 
+{{-- Alpine.js --}}
+<script defer src="https://cdn.jsdelivr.net/npm/alpinejs@3.10.3/dist/cdn.min.js" integrity="sha256-gOkV4d9/FmMNEkjOzVlyM2eNAWSUXisT+1RbMTTIgXI=" crossorigin="anonymous"></script>
+
 {{-- Add any extra scripts to include before the closing <body> tag --}}
 @stack('scripts')


### PR DESCRIPTION
[Alpine](https://alpinejs.dev/) is a rugged, minimal tool for composing behavior directly in the markup.

Adding it to HydePHP will allow us to port HydeFront scripts directly to the Blade views, allowing for extensive customization, and improved compatibility between versions, as well as reduced complexity.