### PR TITLE
Replace search dialog element with custom implementation

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -56,6 +56,7 @@ Note that the goal with this release is to make the framework more stable and de
 ### Fixed
 - Fixed bug [#260](https://github.com/hydephp/develop/issues/260) where the command to publish a homepage did not display the selected value when it was supplied as a parameter
 - Fixed bug [#272](https://github.com/hydephp/develop/issues/272), only generate the table of contents when and where it is actually used
+- Fixed bug [#41](https://github.com/hydephp/develop/issues/41) where search window does not work reliably on Safari
 
 ### Security
 - in case of vulnerabilities.

--- a/packages/framework/resources/views/components/docs/search.blade.php
+++ b/packages/framework/resources/views/components/docs/search.blade.php
@@ -12,24 +12,28 @@
 	<svg xmlns="http://www.w3.org/2000/svg" height="24" viewBox="0 0 24 24" width="24" role="presentation"><path d="M0 0h24v24H0z" fill="none"/><path d="M15.5 14h-.79l-.28-.27C15.41 12.59 16 11.11 16 9.5 16 5.91 13.09 3 9.5 3S3 5.91 3 9.5 5.91 16 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19l-4.99-5zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14z"/></svg>
 </button>
 @push('scripts')
-	
-<dialog :open="searchWindowOpen" x-on:click.away="searchWindowOpen " id="searchMenu" class="prose dark:prose-invert bg-white dark:bg-gray-800 fixed z-50 p-4 rounded-lg overflow-y-hidden mt-[10vh] min-h-[300px] max-h-[75vh] w-[70ch] max-w-[90vw]">
-	<header class="flex justify-between pb-3 mb-3 border-b dark:border-gray-700 md:hidden">
-		<strong>Search the documentation site</strong>
-		<button @click="searchWindowOpen = false" title="Close search window" class="opacity-75 hover:opacity-100" aria-label="Close search window">
-			<svg class="w-6 h-6" fill="currentColor" viewBox="0 0 20 20">
-				<path fill-rule="evenodd" d="M4.293 4.293a1 1 0 011.414 0L10 8.586l4.293-4.293a1 1 0 111.414 1.414L11.414 10l4.293 4.293a1 1 0 01-1.414 1.414L10 11.414l-4.293 4.293a1 1 0 01-1.414-1.414L8.586 10 4.293 5.707a1 1 0 010-1.414z" clip-rule="evenodd"></path>
-			</svg>
-		</button>
-	</header>
-	<div>
-		<x-hyde::docs.search-input />
-	</div>
-	<footer class="mt-auto -mb-2 leading-4 text-center font-mono hidden sm:flex justify-center">
-		<small>
-			Press <code><kbd title="Forward slash">/</kbd></code> to open search window.
-			Use <code><kbd title="Escape key">esc</kbd></code> to close.
-		</small>
-	</footer>
-</dialog>
+<div id="search-window-container" x-show="searchWindowOpen" x-cloak role="dialog" class="z-30 fixed top-0 left-0 w-screen h-screen flex flex-col items-center">
+	<aside x-on:click.away="searchWindowOpen = false" id="searchMenu" class="prose dark:prose-invert bg-white dark:bg-gray-800  z-50 p-4 rounded-lg overflow-y-hidden mt-[10vh] min-h-[300px] max-h-[75vh] w-[70ch] max-w-[90vw] cursor-auto">
+		<header class="flex justify-between pb-3 mb-3 border-b dark:border-gray-700 md:hidden">
+			<strong>Search the documentation site</strong>
+			<button @click="searchWindowOpen = false" title="Close search window" class="opacity-75 hover:opacity-100" aria-label="Close search window">
+				<svg class="w-6 h-6" fill="currentColor" viewBox="0 0 20 20">
+					<path fill-rule="evenodd" d="M4.293 4.293a1 1 0 011.414 0L10 8.586l4.293-4.293a1 1 0 111.414 1.414L11.414 10l4.293 4.293a1 1 0 01-1.414 1.414L10 11.414l-4.293 4.293a1 1 0 01-1.414-1.414L8.586 10 4.293 5.707a1 1 0 010-1.414z" clip-rule="evenodd"></path>
+				</svg>
+			</button>
+		</header>
+		<div>
+			<x-hyde::docs.search-input />
+		</div>
+		<footer class="mt-auto -mb-2 leading-4 text-center font-mono hidden sm:flex justify-center">
+			<small>
+				Press <code><kbd title="Forward slash">/</kbd></code> to open search window.
+				Use <code><kbd title="Escape key">esc</kbd></code> to close.
+			</small>
+		</footer>
+	</aside>
+
+	<div id="search-window-backdrop" title="Click to close search window"
+		class="w-screen h-screen cursor-pointer z-40 bg-black/50 absolute"></div>
+</div>
 @endpush

--- a/packages/framework/resources/views/layouts/docs.blade.php
+++ b/packages/framework/resources/views/layouts/docs.blade.php
@@ -115,9 +115,6 @@
 		<div id="sidebar-backdrop" x-show="sidebarOpen" x-transition @click="sidebarOpen = false"
 			title="Click to close sidebar" class="w-screen h-screen fixed top-0 left-0 cursor-pointer z-10 bg-black/50">
 		</div>
-		<div id="search-window-backdrop" x-show="searchWindowOpen" @click="searchWindowOpen = false"
-			title="Click to close search window"
-			class="w-screen h-screen fixed top-0 left-0 cursor-pointer z-40 bg-black/50"></div>
 	</div>
 
 	@include('hyde::layouts.scripts')


### PR DESCRIPTION
Since the dialog element is not fully supported (looking at you Safari) this PR switches to a custom AlpineJS implementation until the dialog element becomes more stable.

Fixes https://github.com/hydephp/develop/issues/41