### PR TITLE
Fix visual bug where navigation menu flashes on desktop until Alpine is loaded

### DIFF
--- a/packages/framework/resources/views/layouts/navigation.blade.php
+++ b/packages/framework/resources/views/layouts/navigation.blade.php
@@ -31,7 +31,7 @@
 	</div>
 
 	<div id="main-navigation-links"
-		 class="w-full  md:flex flex-grow md:flex-grow-0 md:items-center md:w-auto px-6 -mx-4 border-t mt-3 pt-3 md:border-none md:mt-0 md:py-0 border-gray-200 dark:border-gray-700"
+		 class="w-full x-uncloak-md md:flex flex-grow md:flex-grow-0 md:items-center md:w-auto px-6 -mx-4 border-t mt-3 pt-3 md:border-none md:mt-0 md:py-0 border-gray-200 dark:border-gray-700"
 		 :class="navigationOpen ? '' : 'hidden'" x-cloak>
 		<ul aria-label="Navigation links" class="md:flex-grow md:flex justify-end">
 			@foreach ($navigation->items as $item)


### PR DESCRIPTION
Adds the `x-uncloak-md` class to the navigation menu, preventing it from being cloaked by Alpine.