### PR TITLE
Remove test files from Hyde package

### DIFF
--- a/.github/workflows/split-monorepo.yml
+++ b/.github/workflows/split-monorepo.yml
@@ -229,13 +229,6 @@ jobs:
     - name: Copy over persisted files
       run: cp -rf develop/packages/hyde/. hyde -v
 
-    - name: Copy test files
-      run: |
-        mkdir hyde/tests/Feature -p
-        cp -rf develop/tests/Hyde/Feature/. hyde/tests/Feature -v
-        cp -f develop/tests/Pest.php hyde/tests/Pest.php -v
-        cp -f develop/tests/TestCase.php hyde/tests/TestCase.php -v
-
     - name: Commit and push changes
       run: |
         cd hyde

--- a/.github/workflows/split-monorepo.yml
+++ b/.github/workflows/split-monorepo.yml
@@ -229,6 +229,10 @@ jobs:
     - name: Copy over persisted files
       run: cp -rf develop/packages/hyde/. hyde -v
 
+    - name: Remove test files
+      run: |
+        rm hyde/phpunit.dusk.xml
+
     - name: Commit and push changes
       run: |
         cd hyde

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -19,7 +19,7 @@ This serves two purposes:
 - for soon-to-be removed features.
 
 ### Removed
-- for now removed features.
+- Removed test files from the hyde/hyde sub repository
 
 ### Fixed
 - for any bug fixes.

--- a/packages/hyde/composer.json
+++ b/packages/hyde/composer.json
@@ -25,7 +25,6 @@
         "laravel-zero/framework": "^9.1"
     },
     "require-dev": {
-        "hyde/testing": "dev-master",
         "hyde/realtime-compiler": "^2.4"
     },
     "autoload": {

--- a/packages/testing/stubs/hyde-testing-workflow.stub
+++ b/packages/testing/stubs/hyde-testing-workflow.stub
@@ -1,0 +1,31 @@
+# A sample workflow to run Hyde/Hyde tests in a GitHub Actions CI
+
+name: Hyde Tests
+
+on:
+  push:
+    branches: [ "master" ]
+  pull_request:
+    branches: [ "master" ]
+
+jobs:
+  hyde-tests:
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+    runs-on: ${{ matrix.os }}
+
+    steps:
+    - uses: shivammathur/setup-php@15c43e89cdef867065b0213be354c2841860869e
+      with:
+        php-version: '8.0'
+        extensions: fileinfo
+
+    - uses: actions/checkout@v3
+
+    - name: Install Dependencies
+      run: composer install -q --no-ansi --no-interaction --no-scripts --no-progress --prefer-dist
+
+    - name: Execute tests (Unit and Feature tests) via PHPUnit
+      run: vendor/bin/phpunit


### PR DESCRIPTION
Building a website with HydePHP is often a bit different than developing a full stack application with Laravel, as with Hyde you mainly focus on content for the frontend. For the majority of use cases, users of the Hyde/Hyde package will not need to run tests (and if they do, they'll likely be with a front end tool like Cypress, instead of PHPUnit/Pest).

Removing these test files from the split package will reduce complexity (and resolve https://github.com/hydephp/hyde/issues/206). Users that need to run tests can with ease set up a suite by installing the framework of their choice. I also added a [sample workflow file](https://github.com/hydephp/develop/blob/6e41acf2518d1d89e196d3040e7faebf89af54f4/packages/testing/stubs/hyde-testing-workflow.stub) (the one currently in hyde/hyde what will be removed).

For now, I think the phpunit.dist.xml file can be kept, though I'm removing the Dusk one.