### PR TITLE
Improve the make:page command

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -11,6 +11,7 @@ This serves two purposes:
 
 ### Added
 - Add Laravel Tinker as a development dependency for the Monorepo
+- Improved the `hyde make:page` command to add page type selection shorthands
 
 ### Changed
 - for changes in existing functionality.

--- a/docs/console-commands.md
+++ b/docs/console-commands.md
@@ -171,6 +171,8 @@ php hyde make:page "Photo Gallery" --type=blade
 php hyde make:page "Hyde CLI Guide" --type=docs
 ```
 
+> Tip: You can also use the shorthand `--blade` or `--docs` instead of `--type=blade` or `--type=docs`.
+
 ### Publish a default homepage
 ```bash
 php hyde publish:homepage [<name>]

--- a/packages/framework/src/Commands/HydeMakePageCommand.php
+++ b/packages/framework/src/Commands/HydeMakePageCommand.php
@@ -39,6 +39,11 @@ class HydeMakePageCommand extends Command
     public string $title;
 
     /**
+     * The selected page type.
+     */
+    public string $selectedType;
+
+    /**
      * The page type.
      */
     public string $type;
@@ -59,9 +64,9 @@ class HydeMakePageCommand extends Command
             ?? $this->ask('What is the title of the page?')
             ?? 'My New Page';
 
-        $this->line('<info>Creating page with title:</> '.$this->title."\n");
-
         $this->validateOptions();
+
+        $this->line('<info>Creating a new '.ucwords($this->selectedType).' page with title:</> '.$this->title."\n");
 
         $this->force = $this->option('force') ?? false;
 
@@ -81,7 +86,7 @@ class HydeMakePageCommand extends Command
      */
     protected function validateOptions(): void
     {
-        $type = strtolower($this->option('type') ?? 'markdown');
+        $type = $this->getSelectedType();
 
         // Set the type to the fully qualified class name
         if ($type === 'markdown') {
@@ -101,5 +106,15 @@ class HydeMakePageCommand extends Command
         }
 
         throw new UnsupportedPageTypeException("Invalid page type: $type");
+    }
+
+    /**
+     * Get the selected page type.
+     *
+     * @return string
+     */
+    protected function getSelectedType(): string
+    {
+        return $this->selectedType = strtolower($this->option('type') ?? 'markdown');
     }
 }

--- a/packages/framework/src/Commands/HydeMakePageCommand.php
+++ b/packages/framework/src/Commands/HydeMakePageCommand.php
@@ -24,6 +24,8 @@ class HydeMakePageCommand extends Command
     protected $signature = 'make:page 
 		{title? : The name of the page file to create. Will be used to generate the slug}
 		{--type=markdown : The type of page to create (markdown, blade, or docs)}
+        {--blade : Create a Blade page}
+        {--docs : Create a Documentation page}
 		{--force : Overwrite any existing files}';
 
     /**
@@ -115,6 +117,18 @@ class HydeMakePageCommand extends Command
      */
     protected function getSelectedType(): string
     {
-        return $this->selectedType = strtolower($this->option('type') ?? 'markdown');
+        $type = 'markdown';
+
+        if ($this->option('type') !== null) {
+            $type = strtolower($this->option('type'));
+        } 
+        
+        if ($this->option('blade')) {
+            $type = 'blade';
+        } elseif ($this->option('docs')) {
+            $type = 'documentation';
+        }
+
+        return $this->selectedType = $type;
     }
 }

--- a/packages/framework/src/Commands/HydeMakePageCommand.php
+++ b/packages/framework/src/Commands/HydeMakePageCommand.php
@@ -121,8 +121,8 @@ class HydeMakePageCommand extends Command
 
         if ($this->option('type') !== null) {
             $type = strtolower($this->option('type'));
-        } 
-        
+        }
+
         if ($this->option('blade')) {
             $type = 'blade';
         } elseif ($this->option('docs')) {

--- a/packages/framework/tests/Feature/Commands/HydeMakePageCommandTest.php
+++ b/packages/framework/tests/Feature/Commands/HydeMakePageCommandTest.php
@@ -126,7 +126,7 @@ class HydeMakePageCommandTest extends TestCase
     {
         $this->artisan('make:page')
             ->expectsQuestion('What is the title of the page?', 'Test Page')
-            ->expectsOutput("Creating page with title: Test Page\n")
+            ->expectsOutput("Creating a new Markdown page with title: Test Page\n")
             ->assertExitCode(0);
 
         unlink(Hyde::path('_pages/test-page.md'));
@@ -137,7 +137,7 @@ class HydeMakePageCommandTest extends TestCase
     {
         $this->artisan('make:page')
             ->expectsQuestion('What is the title of the page?', null)
-            ->expectsOutput("Creating page with title: My New Page\n")
+            ->expectsOutput("Creating a new Markdown page with title: My New Page\n")
             ->assertExitCode(0);
 
         unlink(Hyde::path('_pages/my-new-page.md'));

--- a/packages/framework/tests/Feature/Commands/HydeMakePageCommandTest.php
+++ b/packages/framework/tests/Feature/Commands/HydeMakePageCommandTest.php
@@ -142,4 +142,25 @@ class HydeMakePageCommandTest extends TestCase
 
         unlink(Hyde::path('_pages/my-new-page.md'));
     }
+
+    // assert page type shorthand can be used to create blade pages
+    public function test_page_type_shorthand_can_be_used_to_create_blade_pages()
+    {
+        $this->artisan('make:page "foo test page" --blade')
+            ->expectsOutput("Creating a new Blade page with title: foo test page\n")
+            ->assertExitCode(0);
+
+        $this->assertFileExists($this->bladePath);
+    }
+
+    // assert page type shorthand can be used to create documentation pages
+    public function test_page_type_shorthand_can_be_used_to_create_documentation_pages()
+    {
+        $this->artisan('make:page "foo test page" --docs')
+            ->expectsOutput("Creating a new Documentation page with title: foo test page\n")
+            ->assertExitCode(0);
+
+        $this->assertFileExists(Hyde::path('_docs/foo-test-page.md'));
+        unlink(Hyde::path('_docs/foo-test-page.md'));
+    }
 }


### PR DESCRIPTION
Adds new shorthands to the `hyde make:page` command: `--blade` or `--docs` instead of `--type=blade` or `--type=docs`.