### PR TITLE
Add new URL path helpers

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -10,14 +10,14 @@ This serves two purposes:
 2. At release time, you can move the Unreleased section changes into a new release version section.
 
 ### Added
-- Added `Hyde::qualifiedUrl()` and `Hyde::hasSiteUrl()` helpers, replacing now deprecated `Hyde::uriPath()` helper
+- Added `Hyde::url()` and `Hyde::hasSiteUrl()` helpers, replacing now deprecated `Hyde::uriPath()` helper
 
 ### Changed
 - internal: DiscoveryService.php is no longer deprecated
 - internal: CollectionService.php was merged into DiscoveryService
 
 ### Deprecated
-- Deprecated `Hyde::uriPath()`, use `Hyde::qualifiedUrl()` or `Hyde::hasSiteUrl()` instead
+- Deprecated `Hyde::uriPath()`, use `Hyde::url()` or `Hyde::hasSiteUrl()` instead
 
 ### Removed
 - internal: CollectionService.php has been removed, all its functionality has been moved to DiscoveryService

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -17,7 +17,7 @@ This serves two purposes:
 - internal: CollectionService.php was merged into DiscoveryService
 
 ### Deprecated
-- for soon-to-be removed features.
+- Deprecated `Hyde::uriPath()`, use `Hyde::qualifiedUrl()` or `Hyde::hasSiteUrl()` instead
 
 ### Removed
 - internal: CollectionService.php has been removed, all its functionality has been moved to DiscoveryService

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -10,7 +10,7 @@ This serves two purposes:
 2. At release time, you can move the Unreleased section changes into a new release version section.
 
 ### Added
-- for new features.
+- Added `Hyde::qualifiedUrl()` and `Hyde::hasSiteUrl()` helpers, replacing now deprecated `Hyde::uriPath()` helper
 
 ### Changed
 - internal: DiscoveryService.php is no longer deprecated

--- a/packages/framework/resources/views/components/article-excerpt.blade.php
+++ b/packages/framework/resources/views/components/article-excerpt.blade.php
@@ -4,7 +4,7 @@
 
 <article class="mt-4 mb-8" itemscope itemtype="http://schema.org/Article">
     <meta itemprop="identifier" content="{{ $post->slug }}">
-    @if(Hyde::uriPath())
+    @if(Hyde::hasSiteUrl())
         <meta itemprop="url" content="{{ Hyde::uriPath('posts/' . $post->slug) }}">
     @endif
 

--- a/packages/framework/resources/views/components/article-excerpt.blade.php
+++ b/packages/framework/resources/views/components/article-excerpt.blade.php
@@ -5,7 +5,7 @@
 <article class="mt-4 mb-8" itemscope itemtype="http://schema.org/Article">
     <meta itemprop="identifier" content="{{ $post->slug }}">
     @if(Hyde::hasSiteUrl())
-        <meta itemprop="url" content="{{ Hyde::uriPath('posts/' . $post->slug) }}">
+        <meta itemprop="url" content="{{ Hyde::qualifiedUrl('posts/' . $post->slug) }}">
     @endif
 
     <header>

--- a/packages/framework/resources/views/components/article-excerpt.blade.php
+++ b/packages/framework/resources/views/components/article-excerpt.blade.php
@@ -5,7 +5,7 @@
 <article class="mt-4 mb-8" itemscope itemtype="http://schema.org/Article">
     <meta itemprop="identifier" content="{{ $post->slug }}">
     @if(Hyde::hasSiteUrl())
-        <meta itemprop="url" content="{{ Hyde::qualifiedUrl('posts/' . $post->slug) }}">
+        <meta itemprop="url" content="{{ Hyde::url('posts/' . $post->slug) }}">
     @endif
 
     <header>

--- a/packages/framework/resources/views/components/post/article.blade.php
+++ b/packages/framework/resources/views/components/post/article.blade.php
@@ -1,8 +1,8 @@
-<article aria-label="Article" id="{{ Hyde::qualifiedUrl("posts/$page->slug", '') }}" itemscope itemtype="http://schema.org/Article"
+<article aria-label="Article" id="{{ Hyde::url("posts/$page->slug", '') }}" itemscope itemtype="http://schema.org/Article"
     @class(['post-article mx-auto prose dark:prose-invert', 'torchlight-enabled' => Hyde\Framework\Helpers\Features::hasTorchlight()])>
     <meta itemprop="identifier" content="{{ $page->slug }}">
     @if(Hyde::hasSiteUrl())
-    <meta itemprop="url" content="{{ Hyde::qualifiedUrl('posts/' . $page->slug) }}">
+    <meta itemprop="url" content="{{ Hyde::url('posts/' . $page->slug) }}">
     @endif
     
     <header aria-label="Header section" role="doc-pageheader">

--- a/packages/framework/resources/views/components/post/article.blade.php
+++ b/packages/framework/resources/views/components/post/article.blade.php
@@ -1,7 +1,7 @@
 <article aria-label="Article" id="{{ Hyde::uriPath() ?? '' }}posts/{{ $page->slug }}" itemscope itemtype="http://schema.org/Article"
     @class(['post-article mx-auto prose dark:prose-invert', 'torchlight-enabled' => Hyde\Framework\Helpers\Features::hasTorchlight()])>
     <meta itemprop="identifier" content="{{ $page->slug }}">
-    @if(Hyde::uriPath())
+    @if(Hyde::hasSiteUrl())
     <meta itemprop="url" content="{{ Hyde::uriPath('posts/' . $page->slug) }}">
     @endif
     

--- a/packages/framework/resources/views/components/post/article.blade.php
+++ b/packages/framework/resources/views/components/post/article.blade.php
@@ -1,8 +1,8 @@
-<article aria-label="Article" id="{{ Hyde::uriPath() ?? '' }}posts/{{ $page->slug }}" itemscope itemtype="http://schema.org/Article"
+<article aria-label="Article" id="{{ Hyde::qualifiedUrl("posts/$page->slug", '') }}" itemscope itemtype="http://schema.org/Article"
     @class(['post-article mx-auto prose dark:prose-invert', 'torchlight-enabled' => Hyde\Framework\Helpers\Features::hasTorchlight()])>
     <meta itemprop="identifier" content="{{ $page->slug }}">
     @if(Hyde::hasSiteUrl())
-    <meta itemprop="url" content="{{ Hyde::uriPath('posts/' . $page->slug) }}">
+    <meta itemprop="url" content="{{ Hyde::qualifiedUrl('posts/' . $page->slug) }}">
     @endif
     
     <header aria-label="Header section" role="doc-pageheader">

--- a/packages/framework/src/Commands/HydeBuildSitemapCommand.php
+++ b/packages/framework/src/Commands/HydeBuildSitemapCommand.php
@@ -52,7 +52,7 @@ class HydeBuildSitemapCommand extends Command
         if (! SitemapService::canGenerateSitemap()) {
             $this->error('Cannot generate sitemap.xml, please check your configuration.');
 
-            if ((Hyde::uriPath() === false)) {
+            if (! Hyde::hasSiteUrl()) {
                 $this->warn('Hint: You don\'t have a site URL configured. Check config/hyde.php');
             }
             if (config('site.generate_sitemap', true) !== true) {

--- a/packages/framework/src/Concerns/GeneratesPageMetadata.php
+++ b/packages/framework/src/Concerns/GeneratesPageMetadata.php
@@ -60,7 +60,7 @@ trait GeneratesPageMetadata
     protected function makeOpenGraphPropertiesForArticle(): void
     {
         $this->properties['og:type'] = 'article';
-        if (Hyde::uriPath()) {
+        if (Hyde::hasSiteUrl()) {
             $this->properties['og:url'] = Hyde::uriPath(Hyde::pageLink('posts/'.$this->slug.'.html'));
         }
 

--- a/packages/framework/src/Concerns/GeneratesPageMetadata.php
+++ b/packages/framework/src/Concerns/GeneratesPageMetadata.php
@@ -61,7 +61,7 @@ trait GeneratesPageMetadata
     {
         $this->properties['og:type'] = 'article';
         if (Hyde::hasSiteUrl()) {
-            $this->properties['og:url'] = Hyde::qualifiedUrl(Hyde::pageLink('posts/'.$this->slug.'.html'));
+            $this->properties['og:url'] = Hyde::url(Hyde::pageLink('posts/'.$this->slug.'.html'));
         }
 
         if (isset($this->matter['title'])) {

--- a/packages/framework/src/Concerns/GeneratesPageMetadata.php
+++ b/packages/framework/src/Concerns/GeneratesPageMetadata.php
@@ -61,7 +61,7 @@ trait GeneratesPageMetadata
     {
         $this->properties['og:type'] = 'article';
         if (Hyde::hasSiteUrl()) {
-            $this->properties['og:url'] = Hyde::uriPath(Hyde::pageLink('posts/'.$this->slug.'.html'));
+            $this->properties['og:url'] = Hyde::qualifiedUrl(Hyde::pageLink('posts/'.$this->slug.'.html'));
         }
 
         if (isset($this->matter['title'])) {

--- a/packages/framework/src/Concerns/HasPageMetadata.php
+++ b/packages/framework/src/Concerns/HasPageMetadata.php
@@ -17,7 +17,7 @@ trait HasPageMetadata
 {
     public function getCanonicalUrl(): string
     {
-        return Hyde::qualifiedUrl(Hyde::pageLink($this->getCurrentPagePath().'.html'));
+        return Hyde::url(Hyde::pageLink($this->getCurrentPagePath().'.html'));
     }
 
     public function getDynamicMetadata(): array
@@ -29,14 +29,14 @@ trait HasPageMetadata
         }
 
         if ($this->canUseSitemapLink()) {
-            $array[] = '<link rel="sitemap" type="application/xml" title="Sitemap" href="'.Hyde::qualifiedUrl('sitemap.xml').'" />';
+            $array[] = '<link rel="sitemap" type="application/xml" title="Sitemap" href="'.Hyde::url('sitemap.xml').'" />';
         }
 
         if ($this->canUseRssFeedlink()) {
             $array[] = '<link rel="alternate" type="application/rss+xml" title="'
             .RssFeedService::getTitle()
             .' RSS Feed" href="'
-            .Hyde::qualifiedUrl(RssFeedService::getDefaultOutputFilename())
+            .Hyde::url(RssFeedService::getDefaultOutputFilename())
             .'" />';
         }
 

--- a/packages/framework/src/Concerns/HasPageMetadata.php
+++ b/packages/framework/src/Concerns/HasPageMetadata.php
@@ -74,7 +74,7 @@ trait HasPageMetadata
 
     public function canUseCanonicalUrl(): bool
     {
-        return Hyde::uriPath() && isset($this->slug);
+        return Hyde::hasSiteUrl() && isset($this->slug);
     }
 
     public function canUseSitemapLink(): bool

--- a/packages/framework/src/Concerns/HasPageMetadata.php
+++ b/packages/framework/src/Concerns/HasPageMetadata.php
@@ -17,7 +17,7 @@ trait HasPageMetadata
 {
     public function getCanonicalUrl(): string
     {
-        return Hyde::uriPath(Hyde::pageLink($this->getCurrentPagePath().'.html'));
+        return Hyde::qualifiedUrl(Hyde::pageLink($this->getCurrentPagePath().'.html'));
     }
 
     public function getDynamicMetadata(): array
@@ -29,14 +29,14 @@ trait HasPageMetadata
         }
 
         if ($this->canUseSitemapLink()) {
-            $array[] = '<link rel="sitemap" type="application/xml" title="Sitemap" href="'.Hyde::uriPath('sitemap.xml').'" />';
+            $array[] = '<link rel="sitemap" type="application/xml" title="Sitemap" href="'.Hyde::qualifiedUrl('sitemap.xml').'" />';
         }
 
         if ($this->canUseRssFeedlink()) {
             $array[] = '<link rel="alternate" type="application/rss+xml" title="'
             .RssFeedService::getTitle()
             .' RSS Feed" href="'
-            .Hyde::uriPath(RssFeedService::getDefaultOutputFilename())
+            .Hyde::qualifiedUrl(RssFeedService::getDefaultOutputFilename())
             .'" />';
         }
 

--- a/packages/framework/src/Hyde.php
+++ b/packages/framework/src/Hyde.php
@@ -36,7 +36,7 @@ use Illuminate\Support\Facades\Facade;
  * @method static string currentPage()
  * @method static false|string uriPath(null|string $path = '')
  * @method static bool hasSiteUrl()
- * @method static string qualifiedUrl(string $path = '', ?string $default = null)
+ * @method static string url(string $path = '', ?string $default = null)
  * @method static void setBasePath($basePath)
  * @method static void mixin(object $mixin, bool $replace = true)
  * @method static string makeTitle(string $slug)

--- a/packages/framework/src/Hyde.php
+++ b/packages/framework/src/Hyde.php
@@ -36,7 +36,7 @@ use Illuminate\Support\Facades\Facade;
  * @method static string currentPage()
  * @method static false|string uriPath(null|string $path = '')
  * @method static bool hasSiteUrl()
- * @method static string qualifiedUrl(string $path = '')
+ * @method static string qualifiedUrl(string $path = '', ?string $default = null)
  * @method static void setBasePath($basePath)
  * @method static void mixin(object $mixin, bool $replace = true)
  * @method static string makeTitle(string $slug)

--- a/packages/framework/src/Hyde.php
+++ b/packages/framework/src/Hyde.php
@@ -35,6 +35,8 @@ use Illuminate\Support\Facades\Facade;
  * @method static RouteContract|null currentRoute()
  * @method static string currentPage()
  * @method static false|string uriPath(null|string $path = '')
+ * @method static bool hasSiteUrl()
+ * @method static string qualifiedUrl(string $path = '')
  * @method static void setBasePath($basePath)
  * @method static void mixin(object $mixin, bool $replace = true)
  * @method static string makeTitle(string $slug)

--- a/packages/framework/src/HydeKernel.php
+++ b/packages/framework/src/HydeKernel.php
@@ -223,8 +223,8 @@ class HydeKernel implements HydeKernelContract
     /**
      * Return a qualified URI path to the supplied path if a base URL is set.
      *
-     * @param string $path optional relative path suffix. Omit to return base url.
-     * @param string|null $default optional default value to return if no site url is set.
+     * @param  string  $path  optional relative path suffix. Omit to return base url.
+     * @param  string|null  $default  optional default value to return if no site url is set.
      * @return string
      *
      * @throws \Exception If no site URL is set and no default is provided
@@ -236,7 +236,7 @@ class HydeKernel implements HydeKernelContract
         }
 
         if ($default !== null) {
-            return $default . '/'.(trim($path, '/') ?? '');
+            return $default.'/'.(trim($path, '/') ?? '');
         }
 
         throw new \Exception('No site URL has been set in config (or .env).');

--- a/packages/framework/src/HydeKernel.php
+++ b/packages/framework/src/HydeKernel.php
@@ -198,7 +198,7 @@ class HydeKernel implements HydeKernelContract
     /**
      * Return a qualified URI path, if SITE_URL is set in .env, else return false.
      *
-     * @deprecated v0.53.0-beta - Use Hyde::qualifiedUrl() or Hyde::hasSiteUrl() instead.
+     * @deprecated v0.53.0-beta - Use Hyde::url() or Hyde::hasSiteUrl() instead.
      *
      * @param  string  $path  optional relative path suffix. Omit to return base url.
      * @return string|false
@@ -229,7 +229,7 @@ class HydeKernel implements HydeKernelContract
      *
      * @throws \Exception If no site URL is set and no default is provided
      */
-    public function qualifiedUrl(string $path = '', ?string $default = null): string
+    public function url(string $path = '', ?string $default = null): string
     {
         if ($this->hasSiteUrl()) {
             return rtrim(rtrim(config('site.url'), '/').'/'.(trim($path, '/') ?? ''), '/');

--- a/packages/framework/src/HydeKernel.php
+++ b/packages/framework/src/HydeKernel.php
@@ -213,6 +213,30 @@ class HydeKernel implements HydeKernelContract
     }
 
     /**
+     * Check if a site base URL has been set in config (or .env).
+     */
+    public function hasSiteUrl(): bool
+    {
+        return config('site.url') !== null;
+    }
+
+    /**
+     * Return a qualified URI path, if a SITE_URL is set, else an exception is thrown.
+     *
+     * @param  string  $path  optional relative path suffix. Omit to return base url.
+     * @return string
+     * @throws \Exception
+     */
+    public function qualifiedUrl(string $path = ''): string
+    {
+        if ($this->hasSiteUrl()) {
+            return rtrim(rtrim(config('site.url'), '/').'/'.(trim($path, '/') ?? ''), '/');
+        }
+
+        throw new \Exception('No site URL has been set in config (or .env).');
+    }
+
+    /**
      * Wrapper for the copy function, but allows choosing if files may be overwritten.
      *
      * @param  string  $from  The source file path.

--- a/packages/framework/src/HydeKernel.php
+++ b/packages/framework/src/HydeKernel.php
@@ -221,17 +221,22 @@ class HydeKernel implements HydeKernelContract
     }
 
     /**
-     * Return a qualified URI path, if a SITE_URL is set, else an exception is thrown.
+     * Return a qualified URI path to the supplied path if a base URL is set.
      *
-     * @param  string  $path  optional relative path suffix. Omit to return base url.
+     * @param string $path optional relative path suffix. Omit to return base url.
+     * @param string|null $default optional default value to return if no site url is set.
      * @return string
      *
-     * @throws \Exception
+     * @throws \Exception If no site URL is set and no default is provided
      */
-    public function qualifiedUrl(string $path = ''): string
+    public function qualifiedUrl(string $path = '', ?string $default = null): string
     {
         if ($this->hasSiteUrl()) {
             return rtrim(rtrim(config('site.url'), '/').'/'.(trim($path, '/') ?? ''), '/');
+        }
+
+        if ($default !== null) {
+            return $default . '/'.(trim($path, '/') ?? '');
         }
 
         throw new \Exception('No site URL has been set in config (or .env).');

--- a/packages/framework/src/HydeKernel.php
+++ b/packages/framework/src/HydeKernel.php
@@ -225,6 +225,7 @@ class HydeKernel implements HydeKernelContract
      *
      * @param  string  $path  optional relative path suffix. Omit to return base url.
      * @return string
+     *
      * @throws \Exception
      */
     public function qualifiedUrl(string $path = ''): string

--- a/packages/framework/src/HydeKernel.php
+++ b/packages/framework/src/HydeKernel.php
@@ -217,7 +217,7 @@ class HydeKernel implements HydeKernelContract
      */
     public function hasSiteUrl(): bool
     {
-        return config('site.url') !== null;
+        return ! blank(config('site.url'));
     }
 
     /**

--- a/packages/framework/src/HydeKernel.php
+++ b/packages/framework/src/HydeKernel.php
@@ -198,6 +198,8 @@ class HydeKernel implements HydeKernelContract
     /**
      * Return a qualified URI path, if SITE_URL is set in .env, else return false.
      *
+     * @deprecated v0.53.0-beta - Use Hyde::qualifiedUrl() or Hyde::hasSiteUrl() instead.
+     *
      * @param  string  $path  optional relative path suffix. Omit to return base url.
      * @return string|false
      */

--- a/packages/framework/src/Models/Pages/MarkdownPost.php
+++ b/packages/framework/src/Models/Pages/MarkdownPost.php
@@ -39,7 +39,7 @@ class MarkdownPost extends AbstractMarkdownPage
 
     public function getCanonicalLink(): string
     {
-        return Hyde::qualifiedUrl(Hyde::pageLink($this->getCurrentPagePath().'.html'));
+        return Hyde::url(Hyde::pageLink($this->getCurrentPagePath().'.html'));
     }
 
     public function getPostDescription(): string

--- a/packages/framework/src/Models/Pages/MarkdownPost.php
+++ b/packages/framework/src/Models/Pages/MarkdownPost.php
@@ -39,7 +39,7 @@ class MarkdownPost extends AbstractMarkdownPage
 
     public function getCanonicalLink(): string
     {
-        return Hyde::uriPath(Hyde::pageLink($this->getCurrentPagePath().'.html'));
+        return Hyde::qualifiedUrl(Hyde::pageLink($this->getCurrentPagePath().'.html'));
     }
 
     public function getPostDescription(): string

--- a/packages/framework/src/Models/Route.php
+++ b/packages/framework/src/Models/Route.php
@@ -75,7 +75,7 @@ class Route implements RouteContract, RouteFacadeContract
     /** @todo add to contract */
     public function getPermalink(): string
     {
-        return Hyde::uriPath(Hyde::pageLink($this->getOutputFilePath()));
+        return Hyde::qualifiedUrl(Hyde::pageLink($this->getOutputFilePath()));
     }
 
     /** @inheritDoc */

--- a/packages/framework/src/Models/Route.php
+++ b/packages/framework/src/Models/Route.php
@@ -75,7 +75,7 @@ class Route implements RouteContract, RouteFacadeContract
     /** @todo add to contract */
     public function getPermalink(): string
     {
-        return Hyde::qualifiedUrl(Hyde::pageLink($this->getOutputFilePath()));
+        return Hyde::url(Hyde::pageLink($this->getOutputFilePath()));
     }
 
     /** @inheritDoc */

--- a/packages/framework/src/Services/RssFeedService.php
+++ b/packages/framework/src/Services/RssFeedService.php
@@ -70,7 +70,7 @@ class RssFeedService
 
         if (isset($post->image)) {
             $image = $item->addChild('enclosure');
-            $image->addAttribute('url', isset($post->image->path) ? Hyde::uriPath('media/'.basename($post->image->path)) : $post->image->getSource());
+            $image->addAttribute('url', isset($post->image->path) ? Hyde::qualifiedUrl('media/'.basename($post->image->path)) : $post->image->getSource());
             $image->addAttribute('type', str_ends_with($post->image->getSource(), '.png') ? 'image/png' : 'image/jpeg');
             $image->addAttribute('length', $post->image->getContentLength());
         }

--- a/packages/framework/src/Services/RssFeedService.php
+++ b/packages/framework/src/Services/RssFeedService.php
@@ -70,7 +70,7 @@ class RssFeedService
 
         if (isset($post->image)) {
             $image = $item->addChild('enclosure');
-            $image->addAttribute('url', isset($post->image->path) ? Hyde::qualifiedUrl('media/'.basename($post->image->path)) : $post->image->getSource());
+            $image->addAttribute('url', isset($post->image->path) ? Hyde::url('media/'.basename($post->image->path)) : $post->image->getSource());
             $image->addAttribute('type', str_ends_with($post->image->getSource(), '.png') ? 'image/png' : 'image/jpeg');
             $image->addAttribute('length', $post->image->getContentLength());
         }

--- a/packages/framework/src/Services/RssFeedService.php
+++ b/packages/framework/src/Services/RssFeedService.php
@@ -141,7 +141,7 @@ class RssFeedService
 
     public static function canGenerateFeed(): bool
     {
-        return (Hyde::uriPath() !== false)
+        return Hyde::hasSiteUrl()
             && config('hyde.generate_rss_feed', true)
             && Features::hasBlogPosts()
             && extension_loaded('simplexml');

--- a/packages/framework/src/Services/SitemapService.php
+++ b/packages/framework/src/Services/SitemapService.php
@@ -95,7 +95,7 @@ class SitemapService
 
     public static function canGenerateSitemap(): bool
     {
-        return (Hyde::uriPath() !== false)
+        return Hyde::hasSiteUrl()
             && config('site.generate_sitemap', true)
             && extension_loaded('simplexml');
     }

--- a/packages/framework/src/Services/ValidationService.php
+++ b/packages/framework/src/Services/ValidationService.php
@@ -94,7 +94,7 @@ class ValidationService
 
     public function check_site_has_a_base_url_set(Result $result): Result
     {
-        if ((bool) Hyde::uriPath() === true) {
+        if (Hyde::hasSiteUrl()) {
             return $result->pass('Your site has a base URL set')
                 ->withTip('This will allow Hyde to generate canonical URLs, sitemaps, RSS feeds, and more.');
         }

--- a/packages/framework/tests/Unit/HydeUriPathHelperTest.php
+++ b/packages/framework/tests/Unit/HydeUriPathHelperTest.php
@@ -3,6 +3,9 @@
 use Hyde\Framework\Hyde;
 use Hyde\Testing\TestCase;
 
+/**
+ * @deprecated as method is deprecated
+ */
 class HydeUriPathHelperTest extends TestCase
 {
     public function test_helper_returns_false_when_no_site_url_is_set()

--- a/packages/framework/tests/Unit/HydeUrlPathHelpersTest.php
+++ b/packages/framework/tests/Unit/HydeUrlPathHelpersTest.php
@@ -76,6 +76,20 @@ class HydeUrlPathHelpersTest extends TestCase
         Hyde::qualifiedUrl();
     }
 
+    // test that qualifiedUrl uses default parameter when supplied and no site url is set
+    public function test_qualified_url_uses_default_parameter_when_no_site_url_is_set()
+    {
+        config(['site.url' => null]);
+        $this->assertEquals('bar/foo', Hyde::qualifiedUrl('foo', 'bar'));
+    }
+
+    // test that qualifiedUrl does not use default parameter when supplied and a site url is set
+    public function test_qualified_url_does_not_use_default_parameter_when_site_url_is_set()
+    {
+        config(['site.url' => 'https://example.com']);
+        $this->assertEquals('https://example.com/foo', Hyde::qualifiedUrl('foo', 'bar'));
+    }
+
     public function test_helper_returns_expected_string_when_site_url_is_set()
     {
         config(['site.url' => 'https://example.com']);

--- a/packages/framework/tests/Unit/HydeUrlPathHelpersTest.php
+++ b/packages/framework/tests/Unit/HydeUrlPathHelpersTest.php
@@ -7,7 +7,7 @@ use Hyde\Testing\TestCase;
 
 /**
  * @covers \Hyde\Framework\HydeKernel::hasSiteUrl
- * @covers \Hyde\Framework\HydeKernel::qualifiedUrl
+ * @covers \Hyde\Framework\HydeKernel::url
  */
 class HydeUrlPathHelpersTest extends TestCase
 {
@@ -23,76 +23,76 @@ class HydeUrlPathHelpersTest extends TestCase
         $this->assertTrue(Hyde::hasSiteUrl());
     }
 
-    // test that qualifiedUrl returns the site url when no path is given
+    // test that url returns the site url when no path is given
     public function test_qualified_url_returns_site_url_when_no_path_is_given()
     {
         config(['site.url' => 'https://example.com']);
-        $this->assertEquals('https://example.com', Hyde::qualifiedUrl());
+        $this->assertEquals('https://example.com', Hyde::url());
     }
 
-    // test that qualifiedUrl returns the site url plus the given path
+    // test that url returns the site url plus the given path
     public function test_qualified_url_returns_site_url_plus_given_path()
     {
         config(['site.url' => 'https://example.com']);
-        $this->assertEquals('https://example.com/path', Hyde::qualifiedUrl('path'));
+        $this->assertEquals('https://example.com/path', Hyde::url('path'));
     }
 
-    // test that qualifiedUrl returns the site url plus the given path with extension
+    // test that url returns the site url plus the given path with extension
     public function test_qualified_url_returns_site_url_plus_given_path_with_extension()
     {
         config(['site.url' => 'https://example.com']);
-        $this->assertEquals('https://example.com/path.html', Hyde::qualifiedUrl('path.html'));
+        $this->assertEquals('https://example.com/path.html', Hyde::url('path.html'));
     }
 
-    // test that qualifiedUrl returns the site url plus the given path with extension and query string
+    // test that url returns the site url plus the given path with extension and query string
     public function test_qualified_url_returns_site_url_plus_given_path_with_extension_and_query_string()
     {
         config(['site.url' => 'https://example.com']);
-        $this->assertEquals('https://example.com/path.html?query=string', Hyde::qualifiedUrl('path.html?query=string'));
+        $this->assertEquals('https://example.com/path.html?query=string', Hyde::url('path.html?query=string'));
     }
 
-    // test that qualifiedUrl trims trailing slashes
+    // test that url trims trailing slashes
     public function test_qualified_url_trims_trailing_slashes()
     {
         config(['site.url' => 'https://example.com/']);
-        $this->assertEquals('https://example.com', Hyde::qualifiedUrl());
-        $this->assertEquals('https://example.com', Hyde::qualifiedUrl('/'));
-        $this->assertEquals('https://example.com/foo', Hyde::qualifiedUrl('/foo/'));
+        $this->assertEquals('https://example.com', Hyde::url());
+        $this->assertEquals('https://example.com', Hyde::url('/'));
+        $this->assertEquals('https://example.com/foo', Hyde::url('/foo/'));
     }
 
-    // test that qualifiedUrl accepts multiple schemes
+    // test that url accepts multiple schemes
     public function test_qualified_url_accepts_multiple_schemes()
     {
         config(['site.url' => 'http://example.com']);
-        $this->assertEquals('http://example.com', Hyde::qualifiedUrl());
+        $this->assertEquals('http://example.com', Hyde::url());
     }
 
-    // test that qualifiedUrl throws an exception when no site url is set
+    // test that url throws an exception when no site url is set
     public function test_qualified_url_throws_exception_when_no_site_url_is_set()
     {
         config(['site.url' => null]);
         $this->expectException(\Exception::class);
         $this->expectExceptionMessage('No site URL has been set in config (or .env).');
-        Hyde::qualifiedUrl();
+        Hyde::url();
     }
 
-    // test that qualifiedUrl uses default parameter when supplied and no site url is set
+    // test that url uses default parameter when supplied and no site url is set
     public function test_qualified_url_uses_default_parameter_when_no_site_url_is_set()
     {
         config(['site.url' => null]);
-        $this->assertEquals('bar/foo', Hyde::qualifiedUrl('foo', 'bar'));
+        $this->assertEquals('bar/foo', Hyde::url('foo', 'bar'));
     }
 
-    // test that qualifiedUrl does not use default parameter when supplied and a site url is set
+    // test that url does not use default parameter when supplied and a site url is set
     public function test_qualified_url_does_not_use_default_parameter_when_site_url_is_set()
     {
         config(['site.url' => 'https://example.com']);
-        $this->assertEquals('https://example.com/foo', Hyde::qualifiedUrl('foo', 'bar'));
+        $this->assertEquals('https://example.com/foo', Hyde::url('foo', 'bar'));
     }
 
     public function test_helper_returns_expected_string_when_site_url_is_set()
     {
         config(['site.url' => 'https://example.com']);
-        $this->assertEquals('https://example.com/foo/bar.html', Hyde::qualifiedUrl('foo/bar.html'));
+        $this->assertEquals('https://example.com/foo/bar.html', Hyde::url('foo/bar.html'));
     }
 }

--- a/packages/framework/tests/Unit/HydeUrlPathHelpersTest.php
+++ b/packages/framework/tests/Unit/HydeUrlPathHelpersTest.php
@@ -93,6 +93,6 @@ class HydeUrlPathHelpersTest extends TestCase
     public function test_helper_returns_expected_string_when_site_url_is_set()
     {
         config(['site.url' => 'https://example.com']);
-        $this->assertEquals('https://example.com/foo/bar.html', Hyde::uriPath('foo/bar.html'));
+        $this->assertEquals('https://example.com/foo/bar.html', Hyde::qualifiedUrl('foo/bar.html'));
     }
 }

--- a/packages/framework/tests/Unit/HydeUrlPathHelpersTest.php
+++ b/packages/framework/tests/Unit/HydeUrlPathHelpersTest.php
@@ -1,0 +1,84 @@
+<?php
+
+namespace Hyde\Framework\Testing\Unit;
+
+use Hyde\Framework\Hyde;
+use Hyde\Testing\TestCase;
+
+/**
+ * @covers \Hyde\Framework\HydeKernel::hasSiteUrl
+ * @covers \Hyde\Framework\HydeKernel::qualifiedUrl
+ */
+class HydeUrlPathHelpersTest extends TestCase
+{
+    public function test_has_site_url_returns_false_when_no_site_url_is_set()
+    {
+        config(['site.url' => null]);
+        $this->assertFalse(Hyde::hasSiteUrl());
+    }
+
+    public function test_has_site_url_returns_true_when_site_url_is_set()
+    {
+        config(['site.url' => 'https://example.com']);
+        $this->assertTrue(Hyde::hasSiteUrl());
+    }
+
+    // test that qualifiedUrl returns the site url when no path is given
+    public function test_qualified_url_returns_site_url_when_no_path_is_given()
+    {
+        config(['site.url' => 'https://example.com']);
+        $this->assertEquals('https://example.com', Hyde::qualifiedUrl());
+    }
+
+    // test that qualifiedUrl returns the site url plus the given path
+    public function test_qualified_url_returns_site_url_plus_given_path()
+    {
+        config(['site.url' => 'https://example.com']);
+        $this->assertEquals('https://example.com/path', Hyde::qualifiedUrl('path'));
+    }
+
+    // test that qualifiedUrl returns the site url plus the given path with extension
+    public function test_qualified_url_returns_site_url_plus_given_path_with_extension()
+    {
+        config(['site.url' => 'https://example.com']);
+        $this->assertEquals('https://example.com/path.html', Hyde::qualifiedUrl('path.html'));
+    }
+
+    // test that qualifiedUrl returns the site url plus the given path with extension and query string
+    public function test_qualified_url_returns_site_url_plus_given_path_with_extension_and_query_string()
+    {
+        config(['site.url' => 'https://example.com']);
+        $this->assertEquals('https://example.com/path.html?query=string', Hyde::qualifiedUrl('path.html?query=string'));
+    }
+
+    // test that qualifiedUrl trims trailing slashes
+    public function test_qualified_url_trims_trailing_slashes()
+    {
+        config(['site.url' => 'https://example.com/']);
+        $this->assertEquals('https://example.com', Hyde::qualifiedUrl());
+        $this->assertEquals('https://example.com', Hyde::qualifiedUrl('/'));
+        $this->assertEquals('https://example.com/foo', Hyde::qualifiedUrl('/foo/'));
+    }
+
+    // test that qualifiedUrl accepts multiple schemes
+    public function test_qualified_url_accepts_multiple_schemes()
+    {
+        config(['site.url' => 'http://example.com']);
+        $this->assertEquals('http://example.com', Hyde::qualifiedUrl());
+    }
+
+    // test that qualifiedUrl throws an exception when no site url is set
+    public function test_qualified_url_throws_exception_when_no_site_url_is_set()
+    {
+        config(['site.url' => null]);
+        $this->expectException(\Exception::class);
+        $this->expectExceptionMessage('No site URL has been set in config (or .env).');
+        Hyde::qualifiedUrl();
+    }
+
+    public function test_helper_returns_expected_string_when_site_url_is_set()
+    {
+        config(['site.url' => 'https://example.com']);
+        $this->assertEquals('https://example.com/foo/bar.html', Hyde::uriPath('foo/bar.html'));
+    }
+}


### PR DESCRIPTION
Having a function that can return both a string and a psuedo-boolean (false) can lead to unpredictable states. This PR deprecates the `Hyde::uriPath()` helper and adds two new ones instead, `Hyde::qualifiedUrl()` and `Hyde::hasSiteUrl()`, effectively splitting the former into the latter.