### PR TITLE
Construct the HTML page title inside the AbstractPage class

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -13,6 +13,7 @@ This serves two purposes:
 - Added `Hyde::url()` and `Hyde::hasSiteUrl()` helpers, replacing now deprecated `Hyde::uriPath()` helper
 
 ### Changed
+- The HTML page titles are now generated in the page object, using the new `htmlTitle()` helper
 - internal: DiscoveryService.php is no longer deprecated
 - internal: CollectionService.php was merged into DiscoveryService
 

--- a/packages/framework/resources/views/layouts/head.blade.php
+++ b/packages/framework/resources/views/layouts/head.blade.php
@@ -1,6 +1,6 @@
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
-<title>{{ isset($title) ? config('site.name', 'HydePHP') . ' - ' . $title : config('site.name', 'HydePHP') }}</title>
+<title>{{ $page->htmlTitle($title ?? null) }}</title>
 
 @if (file_exists(Hyde::path('_media/favicon.ico'))) 
 <link rel="shortcut icon" href="{{ Hyde::relativeLink('media/favicon.ico') }}" type="image/x-icon">

--- a/packages/framework/src/Concerns/HasPageMetadata.php
+++ b/packages/framework/src/Concerns/HasPageMetadata.php
@@ -42,10 +42,10 @@ trait HasPageMetadata
 
         if (isset($this->title)) {
             if ($this->hasTwitterTitleInConfig()) {
-                $array[] = '<meta name="twitter:title" content="'.config('site.name', 'HydePHP').' - '.$this->title.'" />';
+                $array[] = '<meta name="twitter:title" content="'.$this->htmlTitle().'" />';
             }
             if ($this->hasOpenGraphTitleInConfig()) {
-                $array[] = '<meta property="og:title" content="'.config('site.name', 'HydePHP').' - '.$this->title.'" />';
+                $array[] = '<meta property="og:title" content="'.$this->htmlTitle().'" />';
             }
         }
 

--- a/packages/framework/src/Contracts/AbstractPage.php
+++ b/packages/framework/src/Contracts/AbstractPage.php
@@ -4,6 +4,7 @@ namespace Hyde\Framework\Contracts;
 
 use Hyde\Framework\Concerns\CanBeInNavigation;
 use Hyde\Framework\Concerns\HasPageMetadata;
+use Hyde\Framework\Hyde;
 use Hyde\Framework\Models\Route;
 use Hyde\Framework\Services\DiscoveryService;
 use Illuminate\Support\Collection;
@@ -123,5 +124,14 @@ abstract class AbstractPage implements PageContract
     public function getRoute(): Route
     {
         return new Route($this);
+    }
+
+    /** @inheritDoc */
+    public function htmlTitle(?string $title = null): string
+    {
+        $pageTitle = $title ?? $this->title ?? null;
+        return $pageTitle
+            ? config('site.name', 'HydePHP') . ' - ' . $pageTitle
+            : config('site.name', 'HydePHP');
     }
 }

--- a/packages/framework/src/Contracts/AbstractPage.php
+++ b/packages/framework/src/Contracts/AbstractPage.php
@@ -130,8 +130,9 @@ abstract class AbstractPage implements PageContract
     public function htmlTitle(?string $title = null): string
     {
         $pageTitle = $title ?? $this->title ?? null;
+
         return $pageTitle
-            ? config('site.name', 'HydePHP') . ' - ' . $pageTitle
+            ? config('site.name', 'HydePHP').' - '.$pageTitle
             : config('site.name', 'HydePHP');
     }
 }

--- a/packages/framework/src/Contracts/PageContract.php
+++ b/packages/framework/src/Contracts/PageContract.php
@@ -121,7 +121,7 @@ interface PageContract
     /**
      * Get the page title to display in the <head> section's <title> tag.
      *
-     * @param string|null $title An optional override title, so Blade templates can use the method until we implement static Blade parsing.
+     * @param  string|null  $title  An optional override title, so Blade templates can use the method until we implement static Blade parsing.
      * @return string Example: "Site Name - Page Title"
      */
     public function htmlTitle(?string $title = null): string;

--- a/packages/framework/src/Contracts/PageContract.php
+++ b/packages/framework/src/Contracts/PageContract.php
@@ -117,4 +117,12 @@ interface PageContract
      * @return \Hyde\Framework\Contracts\RouteContract
      */
     public function getRoute(): RouteContract;
+
+    /**
+     * Get the page title to display in the <head> section's <title> tag.
+     *
+     * @param string|null $title An optional override title, so Blade templates can use the method until we implement static Blade parsing.
+     * @return string Example: "Site Name - Page Title"
+     */
+    public function htmlTitle(?string $title = null): string;
 }

--- a/packages/framework/tests/Feature/AbstractPageTest.php
+++ b/packages/framework/tests/Feature/AbstractPageTest.php
@@ -360,4 +360,25 @@ class AbstractPageTest extends TestCase
         $page = new MarkdownPage();
         $this->assertEquals(new Route($page), $page->getRoute());
     }
+
+    public function test_html_title_returns_site_name_plus_page_title()
+    {
+        $this->assertEquals('HydePHP - Foo', (new MarkdownPage(['title' => 'Foo']))->htmlTitle());
+    }
+
+    public function test_html_title_can_be_overridden()
+    {
+        $this->assertEquals('HydePHP - Bar', (new MarkdownPage(['title' => 'Foo']))->htmlTitle('Bar'));
+    }
+
+    public function test_html_title_returns_site_name_if_no_page_title()
+    {
+        $this->assertEquals('HydePHP', (new MarkdownPage())->htmlTitle());
+    }
+
+    public function test_html_title_uses_configured_site_name()
+    {
+        config(['site.name' => 'Foo Bar']);
+        $this->assertEquals('Foo Bar', (new MarkdownPage())->htmlTitle());
+    }
 }


### PR DESCRIPTION
This provides a canonical place to assemble the displayed page title, while also making it easier to customize from the backend in the future.