### PR TITLE
Override facade method to return the HydeKernel instance directly from the service container 

### DIFF
--- a/packages/framework/src/Hyde.php
+++ b/packages/framework/src/Hyde.php
@@ -58,4 +58,10 @@ class Hyde extends Facade
     {
         return HydeKernel::version();
     }
+
+    /** @inheritDoc */
+    public static function getFacadeRoot()
+    {
+        return app(HydeKernelContract::class);
+    }
 }

--- a/packages/framework/tests/Feature/HydeKernelTest.php
+++ b/packages/framework/tests/Feature/HydeKernelTest.php
@@ -46,6 +46,18 @@ class HydeKernelTest extends TestCase
         $this->assertSame(app(HydeKernelContract::class), hyde());
     }
 
+    public function test_facade_returns_same_instance_as_kernel()
+    {
+        $this->assertSame(HydeKernel::getInstance(), Hyde::getFacadeRoot());
+    }
+
+    public function test_changes_are_persisted_over_all_instance_getting_methods()
+    {
+        app(HydeKernelContract::class)->setBasePath('foo');
+        $this->assertSame('foo', HydeKernel::getInstance()->getBasePath());
+        $this->assertSame('foo', Hyde::getBasePath());
+    }
+
     public function test_features_helper_returns_new_features_instance()
     {
         $this->assertInstanceOf(Features::class, Hyde::features());


### PR DESCRIPTION
Fixes https://github.com/hydephp/develop/issues/299