### PR TITLE
Simplify page parsers

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -2,24 +2,20 @@
 
 ### About
 
-Keep an Unreleased section at the top to track upcoming changes.
-
-This serves two purposes:
-
-1. People can see what changes they might expect in upcoming releases
-2. At release time, you can move the Unreleased section changes into a new release version section.
+This update refactors the internal page source model parsing. This will likely not affect you directly, however, if you have written custom code that interacts with any class relating to the PageParser contract, you'll want to take a closer look at the changes.
 
 ### Added
 - for new features.
 
 ### Changed
-- for changes in existing functionality.
+- All source model parsing is now handled by the new SourceFileParser action
+- Blog post front matter no longer includes merged slug
 
 ### Deprecated
 - for soon-to-be removed features.
 
 ### Removed
-- for now removed features.
+- The PageParserContract interface, and all of its implementations have been removed
 
 ### Fixed
 - for any bug fixes.

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -5,7 +5,7 @@
 This update refactors the internal page source model parsing. This will likely not affect you directly, however, if you have written custom code that interacts with any class relating to the PageParser contract, you'll want to take a closer look at the changes.
 
 ### Added
-- for new features.
+- Added a new static shorthand to quickly parse Markdown files into MarkdownDocuments (`MarkdownFileParser::parse()`)
 
 ### Changed
 - All source model parsing is now handled by the new SourceFileParser action

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -12,7 +12,7 @@ This update refactors the internal page source model parsing. This will likely n
 - Blog post front matter no longer includes merged slug
 
 ### Deprecated
-- for soon-to-be removed features.
+- Deprecated `MarkdownDocument::parseFile()`, will be renamed to `MarkdownDocument::parse()`
 
 ### Removed
 - The PageParserContract interface, and all of its implementations have been removed

--- a/packages/framework/src/Actions/SourceFileParser.php
+++ b/packages/framework/src/Actions/SourceFileParser.php
@@ -50,9 +50,9 @@ class SourceFileParser
 
     protected function parseMarkdownPage(): MarkdownPage
     {
-        $document = (new MarkdownFileParser(
+        $document = MarkdownFileParser::parse(
             MarkdownPage::qualifyBasename($this->slug)
-        ))->get();
+        );
 
         $matter = $document->matter;
         $body = $document->body;
@@ -67,9 +67,9 @@ class SourceFileParser
 
     protected function parseMarkdownPost(): MarkdownPost
     {
-        $document = (new MarkdownFileParser(
+        $document = MarkdownFileParser::parse(
             MarkdownPost::qualifyBasename($this->slug)
-        ))->get();
+        );
 
         $matter = $document->matter;
         $body = $document->body;
@@ -84,9 +84,9 @@ class SourceFileParser
 
     protected function parseDocumentationPage(): DocumentationPage
     {
-        $document = (new MarkdownFileParser(
+        $document = MarkdownFileParser::parse(
             DocumentationPage::qualifyBasename($this->slug)
-        ))->get();
+        );
 
         $matter = array_merge($document->matter, [
             'slug' => $this->slug,

--- a/packages/framework/src/Actions/SourceFileParser.php
+++ b/packages/framework/src/Actions/SourceFileParser.php
@@ -4,7 +4,6 @@ namespace Hyde\Framework\Actions;
 
 use Hyde\Framework\Concerns\ValidatesExistence;
 use Hyde\Framework\Contracts\PageContract;
-use Hyde\Framework\Hyde;
 use Hyde\Framework\Models\Pages\BladePage;
 use Hyde\Framework\Models\Pages\DocumentationPage;
 use Hyde\Framework\Models\Pages\MarkdownPage;

--- a/packages/framework/src/Actions/SourceFileParser.php
+++ b/packages/framework/src/Actions/SourceFileParser.php
@@ -87,10 +87,7 @@ class SourceFileParser
             DocumentationPage::qualifyBasename($this->slug)
         );
 
-        $matter = array_merge($document->matter, [
-            'slug' => $this->slug,
-        ]);
-
+        $matter = $document->matter;
         $body = $document->body;
 
         return new DocumentationPage(

--- a/packages/framework/src/Actions/SourceFileParser.php
+++ b/packages/framework/src/Actions/SourceFileParser.php
@@ -6,9 +6,6 @@ use Hyde\Framework\Concerns\ValidatesExistence;
 use Hyde\Framework\Contracts\AbstractMarkdownPage;
 use Hyde\Framework\Contracts\PageContract;
 use Hyde\Framework\Models\Pages\BladePage;
-use Hyde\Framework\Models\Pages\DocumentationPage;
-use Hyde\Framework\Models\Pages\MarkdownPage;
-use Hyde\Framework\Models\Pages\MarkdownPost;
 use Hyde\Framework\Modules\Markdown\MarkdownFileParser;
 
 /**

--- a/packages/framework/src/Actions/SourceFileParser.php
+++ b/packages/framework/src/Actions/SourceFileParser.php
@@ -51,7 +51,7 @@ class SourceFileParser
     protected function parseMarkdownPage(): MarkdownPage
     {
         $document = (new MarkdownFileParser(
-            Hyde::getMarkdownPagePath($this->slug.MarkdownPage::$fileExtension)
+            MarkdownPage::qualifyBasename($this->slug)
         ))->get();
 
         $matter = $document->matter;
@@ -68,7 +68,7 @@ class SourceFileParser
     protected function parseMarkdownPost(): MarkdownPost
     {
         $document = (new MarkdownFileParser(
-            Hyde::getMarkdownPostPath($this->slug.MarkdownPost::$fileExtension)
+            MarkdownPost::qualifyBasename($this->slug)
         ))->get();
 
         $matter = $document->matter;
@@ -85,7 +85,7 @@ class SourceFileParser
     protected function parseDocumentationPage(): DocumentationPage
     {
         $document = (new MarkdownFileParser(
-            Hyde::getDocumentationPagePath($this->slug.DocumentationPage::$fileExtension)
+            DocumentationPage::qualifyBasename($this->slug)
         ))->get();
 
         $matter = array_merge($document->matter, [

--- a/packages/framework/src/Actions/SourceFileParser.php
+++ b/packages/framework/src/Actions/SourceFileParser.php
@@ -9,7 +9,6 @@ use Hyde\Framework\Models\Pages\DocumentationPage;
 use Hyde\Framework\Models\Pages\MarkdownPage;
 use Hyde\Framework\Models\Pages\MarkdownPost;
 use Hyde\Framework\Modules\Markdown\MarkdownFileParser;
-use Illuminate\Support\Str;
 
 /**
  * Parses a source file and returns a new page model instance for it.
@@ -94,18 +93,8 @@ class SourceFileParser
             matter: $matter,
             body: $body,
             title: FindsTitleForDocument::get($this->slug, $matter, $body),
-            slug: basename($this->slug),
-            category: $this->getDocumentationPageCategory($matter),
+            slug: $this->slug,
         );
-    }
-
-    protected function getDocumentationPageCategory(array $matter): ?string
-    {
-        if (str_contains($this->slug, '/')) {
-            return Str::before($this->slug, '/');
-        }
-
-        return $matter['category'] ?? null;
     }
 
     public function get(): PageContract

--- a/packages/framework/src/Actions/SourceFileParser.php
+++ b/packages/framework/src/Actions/SourceFileParser.php
@@ -34,11 +34,9 @@ class SourceFileParser
 
         $this->slug = $slug;
 
-        if ($pageClass === BladePage::class) {
-            $this->page = $this->parseBladePage();
-        } else {
-            $this->page = $this->parseMarkdownPage($pageClass);
-        }
+        $this->page = $pageClass === BladePage::class
+            ? $this->parseBladePage()
+            : $this->parseMarkdownPage($pageClass);
     }
 
     protected function parseBladePage(): BladePage

--- a/packages/framework/src/Models/MarkdownDocument.php
+++ b/packages/framework/src/Models/MarkdownDocument.php
@@ -51,6 +51,9 @@ class MarkdownDocument implements MarkdownDocumentContract
         return Markdown::parse($this->body);
     }
 
+    /**
+     * @deprecated v0.56.0 - Will be renamed to parse()
+     */
     public static function parseFile(string $localFilepath): static
     {
         return (new MarkdownFileParser(Hyde::path($localFilepath)))->get();

--- a/packages/framework/src/Models/Pages/DocumentationPage.php
+++ b/packages/framework/src/Models/Pages/DocumentationPage.php
@@ -6,6 +6,7 @@ use Hyde\Framework\Concerns\HasTableOfContents;
 use Hyde\Framework\Contracts\AbstractMarkdownPage;
 use Hyde\Framework\Contracts\RouteContract;
 use Hyde\Framework\Models\Route;
+use Illuminate\Support\Str;
 
 class DocumentationPage extends AbstractMarkdownPage
 {
@@ -20,10 +21,19 @@ class DocumentationPage extends AbstractMarkdownPage
      */
     public ?string $category;
 
-    public function __construct(array $matter = [], string $body = '', string $title = '', string $slug = '', ?string $category = null)
+    public function __construct(array $matter = [], string $body = '', string $title = '', string $slug = '')
     {
         parent::__construct($matter, $body, $title, $slug);
-        $this->category = $category;
+        $this->category = $this->getDocumentationPageCategory();
+    }
+
+    protected function getDocumentationPageCategory(): ?string
+    {
+        if (str_contains($this->slug, '/')) {
+            return Str::before($this->slug, '/');
+        }
+
+        return $this->matter['category'] ?? null;
     }
 
     /** @inheritDoc */

--- a/packages/framework/src/Modules/Markdown/MarkdownFileParser.php
+++ b/packages/framework/src/Modules/Markdown/MarkdownFileParser.php
@@ -8,7 +8,7 @@ use Spatie\YamlFrontMatter\YamlFrontMatter;
 /**
  * Prepares a Markdown file for further usage by extracting the Front Matter and creating MarkdownDocument object.
  *
- * @see \Hyde\Framework\Testing\Feature\MarkdownFileServiceTest
+ * @see \Hyde\Framework\Testing\Feature\MarkdownFileParserTest
  */
 class MarkdownFileParser
 {

--- a/packages/framework/src/Modules/Markdown/MarkdownFileParser.php
+++ b/packages/framework/src/Modules/Markdown/MarkdownFileParser.php
@@ -56,4 +56,9 @@ class MarkdownFileParser
     {
         return new MarkdownDocument($this->matter, $this->body);
     }
+
+    public static function parse(string $filepath): MarkdownDocument
+    {
+        return (new self($filepath))->get();
+    }
 }

--- a/packages/framework/tests/Feature/MarkdownFileParserTest.php
+++ b/packages/framework/tests/Feature/MarkdownFileParserTest.php
@@ -77,4 +77,19 @@ This is a post stub used in the automated tests
         $this->assertArrayNotHasKey('slug', $post->matter);
         $this->assertEquals([], $post->matter);
     }
+
+    public function test_static_parse_shorthand()
+    {
+        $this->makeTestPost();
+
+        $post = MarkdownFileParser::parse(Hyde::path('_posts/test-post.md'));
+        $this->assertEquals('My New Post', $post->matter['title']);
+        $this->assertEquals('Mr. Hyde', $post->matter['author']);
+        $this->assertEquals('blog', $post->matter['category']);
+
+        $this->assertEquals(
+            '# My New PostThis is a post stub used in the automated tests',
+            str_replace(["\n", "\r"], '', $post->body)
+        );
+    }
 }

--- a/packages/framework/tests/Feature/MarkdownFileParserTest.php
+++ b/packages/framework/tests/Feature/MarkdownFileParserTest.php
@@ -68,4 +68,13 @@ This is a post stub used in the automated tests
         $this->assertEquals('Mr. Hyde', $post->matter['author']);
         $this->assertEquals('blog', $post->matter['category']);
     }
+
+    public function test_parsed_front_matter_does_not_contain_slug_key()
+    {
+        file_put_contents(Hyde::path('_posts/test-post.md'), "---\nslug: foo\n---\n");
+
+        $post = (new MarkdownFileParser(Hyde::path('_posts/test-post.md')))->get();
+        $this->assertArrayNotHasKey('slug', $post->matter);
+        $this->assertEquals([], $post->matter);
+    }
 }

--- a/packages/framework/tests/Feature/MarkdownFileParserTest.php
+++ b/packages/framework/tests/Feature/MarkdownFileParserTest.php
@@ -9,10 +9,8 @@ use Hyde\Testing\TestCase;
 
 class MarkdownFileParserTest extends TestCase
 {
-    protected function setUp(): void
+    protected function makeTestPost(): void
     {
-        parent::setUp();
-
         file_put_contents(Hyde::path('_posts/test-post.md'), '---
 title: My New Post
 category: blog
@@ -44,6 +42,8 @@ This is a post stub used in the automated tests
 
     public function test_can_parse_markdown_file_with_front_matter()
     {
+        $this->makeTestPost();
+
         $document = (new MarkdownFileParser(Hyde::path('_posts/test-post.md')))->get();
         $this->assertInstanceOf(MarkdownDocument::class, $document);
 
@@ -61,6 +61,8 @@ This is a post stub used in the automated tests
 
     public function test_parsed_markdown_post_contains_valid_front_matter()
     {
+        $this->makeTestPost();
+
         $post = (new MarkdownFileParser(Hyde::path('_posts/test-post.md')))->get();
         $this->assertEquals('My New Post', $post->matter['title']);
         $this->assertEquals('Mr. Hyde', $post->matter['author']);

--- a/packages/framework/tests/Feature/MarkdownFileParserTest.php
+++ b/packages/framework/tests/Feature/MarkdownFileParserTest.php
@@ -34,6 +34,16 @@ This is a post stub used in the automated tests
 
     public function test_can_parse_markdown_file()
     {
+        file_put_contents(Hyde::path('_posts/test-post.md'), 'Foo bar');
+
+        $document = (new MarkdownFileParser(Hyde::path('_posts/test-post.md')))->get();
+        $this->assertInstanceOf(MarkdownDocument::class, $document);
+
+        $this->assertEquals('Foo bar', $document->body);
+    }
+
+    public function test_can_parse_markdown_file_with_front_matter()
+    {
         $document = (new MarkdownFileParser(Hyde::path('_posts/test-post.md')))->get();
         $this->assertInstanceOf(MarkdownDocument::class, $document);
 

--- a/packages/framework/tests/Feature/SourceFileParserTest.php
+++ b/packages/framework/tests/Feature/SourceFileParserTest.php
@@ -60,30 +60,4 @@ class SourceFileParserTest extends TestCase
         $this->assertEquals('# Foo Bar', $page->body);
         $this->assertEquals('Foo Bar Baz', $page->title);
     }
-
-    public function test_documentation_page_parser_can_get_category_from_front_matter()
-    {
-        $this->markdown('_docs/foo.md', '# Foo Bar', ['category' => 'foo']);
-
-        $parser = new SourceFileParser(DocumentationPage::class, 'foo');
-
-        /** @var DocumentationPage $page */
-        $page = $parser->get();
-        $this->assertEquals('foo', $page->category);
-    }
-
-    public function test_documentation_page_parser_can_get_category_automatically_from_nested_page()
-    {
-        mkdir(Hyde::path('_docs/foo'));
-        touch(Hyde::path('_docs/foo/bar.md'));
-
-        $parser = new SourceFileParser(DocumentationPage::class, 'foo/bar');
-
-        /** @var DocumentationPage $page */
-        $page = $parser->get();
-        $this->assertEquals('foo', $page->category);
-
-        unlink(Hyde::path('_docs/foo/bar.md'));
-        rmdir(Hyde::path('_docs/foo'));
-    }
 }

--- a/packages/framework/tests/Unit/DocumentationPageTest.php
+++ b/packages/framework/tests/Unit/DocumentationPageTest.php
@@ -2,6 +2,7 @@
 
 namespace Hyde\Framework\Testing\Unit;
 
+use Hyde\Framework\Actions\SourceFileParser;
 use Hyde\Framework\Hyde;
 use Hyde\Framework\HydeServiceProvider;
 use Hyde\Framework\Models\Pages\DocumentationPage;
@@ -127,5 +128,31 @@ class DocumentationPageTest extends TestCase
     {
         $page = (new DocumentationPage([], '', '', 'foo/bar'));
         $this->assertEquals('docs/bar.html', $page->getOutputPath());
+    }
+
+    public function test_documentation_page_parser_can_get_category_from_front_matter()
+    {
+        $this->markdown('_docs/foo.md', '# Foo Bar', ['category' => 'foo']);
+
+        $parser = new SourceFileParser(DocumentationPage::class, 'foo');
+
+        /** @var DocumentationPage $page */
+        $page = $parser->get();
+        $this->assertEquals('foo', $page->category);
+    }
+
+    public function test_documentation_page_parser_can_get_category_automatically_from_nested_page()
+    {
+        mkdir(Hyde::path('_docs/foo'));
+        touch(Hyde::path('_docs/foo/bar.md'));
+
+        $parser = new SourceFileParser(DocumentationPage::class, 'foo/bar');
+
+        /** @var DocumentationPage $page */
+        $page = $parser->get();
+        $this->assertEquals('foo', $page->category);
+
+        unlink(Hyde::path('_docs/foo/bar.md'));
+        rmdir(Hyde::path('_docs/foo'));
     }
 }


### PR DESCRIPTION
Aims to refactor how pages are parsed, reducing boilerplate, and taking the opportunity to refactor related services.

In addition, this will reduce a lot of complexity. The first step I'm making is merging all page parsers in a single class https://github.com/hydephp/develop/pull/322, then this PR will refactor to simplify them further and reduce boilerplate.