### PR TITLE
Remove DocumentationPage localPath property

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -13,13 +13,13 @@ This serves two purposes:
 - for new features.
 
 ### Changed
-- for changes in existing functionality.
+- internal: The DocumentationPage slug now behaves like other pages, and the basename is produced at runtime, see below
 
 ### Deprecated
 - for soon-to-be removed features.
 
 ### Removed
-- for now removed features.
+- Removed `$localPath` property from DocumentationPage class, see above
 
 ### Fixed
 - for any bug fixes.

--- a/packages/framework/src/Actions/SourceFileParser.php
+++ b/packages/framework/src/Actions/SourceFileParser.php
@@ -100,7 +100,6 @@ class SourceFileParser
             title: FindsTitleForDocument::get($this->slug, $matter, $body),
             slug: basename($this->slug),
             category: $this->getDocumentationPageCategory($matter),
-            localPath: $this->slug
         );
     }
 

--- a/packages/framework/src/Models/Pages/DocumentationPage.php
+++ b/packages/framework/src/Models/Pages/DocumentationPage.php
@@ -20,19 +20,10 @@ class DocumentationPage extends AbstractMarkdownPage
      */
     public ?string $category;
 
-    /**
-     * The path to the page relative to the configured `_docs` directory.
-     * Generally only needed if the page is in a subdirectory.
-     *
-     * @deprecated It's better to modify the slug to get the basename when needed
-     */
-    public ?string $localPath;
-
     public function __construct(array $matter = [], string $body = '', string $title = '', string $slug = '', ?string $category = null, ?string $localPath = null)
     {
         parent::__construct($matter, $body, $title, $slug);
         $this->category = $category;
-        $this->localPath = $localPath;
     }
 
     /** @internal */

--- a/packages/framework/src/Models/Pages/DocumentationPage.php
+++ b/packages/framework/src/Models/Pages/DocumentationPage.php
@@ -35,12 +35,6 @@ class DocumentationPage extends AbstractMarkdownPage
         $this->localPath = $localPath;
     }
 
-    /** @inheritDoc */
-    public function getSourcePath(): string
-    {
-        return is_null($this->localPath) ? parent::getSourcePath() : static::qualifyBasename($this->localPath);
-    }
-
     /** @internal */
     public function getOnlineSourcePath(): string|false
     {

--- a/packages/framework/src/Models/Pages/DocumentationPage.php
+++ b/packages/framework/src/Models/Pages/DocumentationPage.php
@@ -23,6 +23,8 @@ class DocumentationPage extends AbstractMarkdownPage
     /**
      * The path to the page relative to the configured `_docs` directory.
      * Generally only needed if the page is in a subdirectory.
+     *
+     * @deprecated It's better to modify the slug to get the basename when needed
      */
     public ?string $localPath;
 

--- a/packages/framework/src/Models/Pages/DocumentationPage.php
+++ b/packages/framework/src/Models/Pages/DocumentationPage.php
@@ -26,6 +26,12 @@ class DocumentationPage extends AbstractMarkdownPage
         $this->category = $category;
     }
 
+    /** @inheritDoc */
+    public function getCurrentPagePath(): string
+    {
+        return trim(static::getOutputDirectory().'/'.basename($this->slug), '/');
+    }
+
     /** @internal */
     public function getOnlineSourcePath(): string|false
     {

--- a/packages/framework/src/Models/Pages/DocumentationPage.php
+++ b/packages/framework/src/Models/Pages/DocumentationPage.php
@@ -20,7 +20,7 @@ class DocumentationPage extends AbstractMarkdownPage
      */
     public ?string $category;
 
-    public function __construct(array $matter = [], string $body = '', string $title = '', string $slug = '', ?string $category = null, ?string $localPath = null)
+    public function __construct(array $matter = [], string $body = '', string $title = '', string $slug = '', ?string $category = null)
     {
         parent::__construct($matter, $body, $title, $slug);
         $this->category = $category;

--- a/packages/framework/tests/Unit/DocumentationPageTest.php
+++ b/packages/framework/tests/Unit/DocumentationPageTest.php
@@ -122,4 +122,10 @@ class DocumentationPageTest extends TestCase
         Config::set('docs.table_of_contents.enabled', false);
         $this->assertFalse(DocumentationPage::hasTableOfContents());
     }
+
+    public function test_compiled_pages_originating_in_subdirectories_get_output_to_root_docs_path()
+    {
+        $page = (new DocumentationPage([], '', '', 'foo/bar'));
+        $this->assertEquals('docs/bar.html', $page->getOutputPath());
+    }
 }


### PR DESCRIPTION
This property was added to allow automatic categorization based on subdirectory structures, but while keeping the file output in the root output directory (by keeping the slug as a basename). I think it's better to keep a consistent format between models, and thus include the subdirectory in the slug, and instead extract the basename when getting the currentpage property and output path.