### PR TITLE
Breaking: Begin internal rename of slugs to identifiers

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -20,6 +20,8 @@ The identifier property is closely related to the page model's route key propert
 - for new features.
 
 ### Changed
+- Breaking: Rename AbstractMarkdownPage constructor parameter `slug` to `identifier`
+- Breaking: Rename AbstractMarkdownPage property `slug` to `identifier`
 - Begin changing references to slugs to identifiers, see motivation above
 
 ### Deprecated

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -2,12 +2,7 @@
 
 ### About
 
-Keep an Unreleased section at the top to track upcoming changes.
-
-This serves two purposes:
-
-1. People can see what changes they might expect in upcoming releases
-2. At release time, you can move the Unreleased section changes into a new release version section.
+This update contains **breaking changes** to the internal API regarding page models. This should only affect you directly if you've written any code that interacts with the internal page models, such as constructing them using non-built-in Hyde helpers.
 
 ### Added
 - for new features.

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -4,11 +4,23 @@
 
 This update contains **breaking changes** to the internal API regarding page models. This should only affect you directly if you've written any code that interacts with the internal page models, such as constructing them using non-built-in Hyde helpers.
 
+#### Rename slugs to identifiers
+
+Previously internally called `slug(s)`, are now called `identifier(s)`. In all honestly, this has 90% to do with the fact that I hate the word "slug".
+I considered using `basename` as an alternative, but that does not fit with nested pages. Here instead is the definition of an `identifier` in the context of HydePHP:
+
+> An identifier is a string that is in essence everything in the filepath between the source directory and the file extension.
+
+So, for example, a page source file stored as `_pages/foo/bar.md` would have the identifier `foo/bar`. Each page type can only have one identifier of the same name.
+But since you could have a file with the same identifier in the `_posts` directory, we internally always need to specify what source model we are using.
+
+The identifier property is closely related to the page model's route key property, which consists of the site output directory followed by the identifier. 
+
 ### Added
 - for new features.
 
 ### Changed
-- for changes in existing functionality.
+- Begin changing references to slugs to identifiers, see motivation above
 
 ### Deprecated
 - for soon-to-be removed features.
@@ -21,3 +33,4 @@ This update contains **breaking changes** to the internal API regarding page mod
 
 ### Security
 - in case of vulnerabilities.
+

--- a/packages/framework/resources/views/components/article-excerpt.blade.php
+++ b/packages/framework/resources/views/components/article-excerpt.blade.php
@@ -3,13 +3,13 @@
 @endphp
 
 <article class="mt-4 mb-8" itemscope itemtype="http://schema.org/Article">
-    <meta itemprop="identifier" content="{{ $post->slug }}">
+    <meta itemprop="identifier" content="{{ $post->identifier }}">
     @if(Hyde::hasSiteUrl())
-        <meta itemprop="url" content="{{ Hyde::url('posts/' . $post->slug) }}">
+        <meta itemprop="url" content="{{ Hyde::url('posts/' . $post->identifier) }}">
     @endif
 
     <header>
-        <a href="posts/{{ Hyde::formatHtmlPath($post->slug . '.html') }}" class="block w-fit">
+        <a href="posts/{{ Hyde::formatHtmlPath($post->identifier . '.html') }}" class="block w-fit">
             <h2 class="text-2xl font-bold text-gray-700 hover:text-gray-900 dark:text-gray-200 dark:hover:text-white transition-colors duration-75">
                 {{ $post->matter['title'] ?? $post->title }}
             </h2>
@@ -42,7 +42,8 @@
     @endisset
 
     <footer>
-        <a href="posts/{{ Hyde::formatHtmlPath($post->slug . '.html') }}" class="text-indigo-500 hover:underline font-medium">
+        <a href="posts/{{ Hyde::formatHtmlPath($post->identifier . '.html') }}"
+           class="text-indigo-500 hover:underline font-medium">
             Read post</a>
     </footer>
 </article>

--- a/packages/framework/resources/views/components/post/article.blade.php
+++ b/packages/framework/resources/views/components/post/article.blade.php
@@ -1,8 +1,8 @@
-<article aria-label="Article" id="{{ Hyde::url("posts/$page->slug", '') }}" itemscope itemtype="http://schema.org/Article"
+<article aria-label="Article" id="{{ Hyde::url("posts/$page->identifier", '') }}" itemscope itemtype="http://schema.org/Article"
     @class(['post-article mx-auto prose dark:prose-invert', 'torchlight-enabled' => Hyde\Framework\Helpers\Features::hasTorchlight()])>
-    <meta itemprop="identifier" content="{{ $page->slug }}">
+    <meta itemprop="identifier" content="{{ $page->identifier }}">
     @if(Hyde::hasSiteUrl())
-    <meta itemprop="url" content="{{ Hyde::url('posts/' . $page->slug) }}">
+    <meta itemprop="url" content="{{ Hyde::url('posts/' . $page->identifier) }}">
     @endif
     
     <header aria-label="Header section" role="doc-pageheader">

--- a/packages/framework/src/Actions/GeneratesDocumentationSearchIndexFile.php
+++ b/packages/framework/src/Actions/GeneratesDocumentationSearchIndexFile.php
@@ -49,7 +49,7 @@ class GeneratesDocumentationSearchIndexFile implements ActionContract
     {
         /** @var DocumentationPage $page */
         foreach (DocumentationPage::all() as $page) {
-            if (! in_array($page->slug, config('docs.exclude_from_search', []))) {
+            if (! in_array($page->identifier, config('docs.exclude_from_search', []))) {
                 $this->searchIndex->push(
                     $this->generatePageObject($page)
                 );
@@ -62,10 +62,10 @@ class GeneratesDocumentationSearchIndexFile implements ActionContract
     public function generatePageObject(DocumentationPage $page): object
     {
         return (object) [
-            'slug' => $page->slug,
+            'slug' => $page->identifier,
             'title' => $page->title,
             'content' => trim($this->getSearchContentForDocument($page)),
-            'destination' => $this->getDestinationForSlug($page->slug),
+            'destination' => $this->getDestinationForSlug($page->identifier),
         ];
     }
 

--- a/packages/framework/src/Actions/SourceFileParser.php
+++ b/packages/framework/src/Actions/SourceFileParser.php
@@ -62,7 +62,7 @@ class SourceFileParser
         return new $pageClass(
             matter: $matter,
             body: $body,
-            slug: $this->slug
+            identifier: $this->slug
         );
     }
 

--- a/packages/framework/src/Concerns/CanBeInNavigation.php
+++ b/packages/framework/src/Concerns/CanBeInNavigation.php
@@ -26,7 +26,7 @@ trait CanBeInNavigation
         }
 
         if ($this instanceof DocumentationPage) {
-            return $this->slug === 'index' && ! in_array('docs', config('hyde.navigation.exclude', []));
+            return $this->identifier === 'index' && ! in_array('docs', config('hyde.navigation.exclude', []));
         }
 
         if ($this instanceof AbstractMarkdownPage) {
@@ -35,7 +35,7 @@ trait CanBeInNavigation
             }
         }
 
-        if (in_array($this->slug, config('hyde.navigation.exclude', ['404']))) {
+        if (in_array($this->identifier, config('hyde.navigation.exclude', ['404']))) {
             return false;
         }
 
@@ -59,16 +59,16 @@ trait CanBeInNavigation
             return (int) config('hyde.navigation.order.docs', 100);
         }
 
-        if ($this->slug === 'index') {
+        if ($this->identifier === 'index') {
             return (int) config('hyde.navigation.order.index', 0);
         }
 
-        if ($this->slug === 'posts') {
+        if ($this->identifier === 'posts') {
             return (int) config('hyde.navigation.order.posts', 10);
         }
 
-        if (array_key_exists($this->slug, config('hyde.navigation.order', []))) {
-            return (int) config('hyde.navigation.order.'.$this->slug);
+        if (array_key_exists($this->identifier, config('hyde.navigation.order', []))) {
+            return (int) config('hyde.navigation.order.'.$this->identifier);
         }
 
         return 999;
@@ -91,7 +91,7 @@ trait CanBeInNavigation
             }
         }
 
-        if ($this->slug === 'index') {
+        if ($this->identifier === 'index') {
             if ($this instanceof DocumentationPage) {
                 return config('hyde.navigation.labels.docs', 'Docs');
             }
@@ -103,7 +103,7 @@ trait CanBeInNavigation
             return $this->title;
         }
 
-        return Hyde::makeTitle(basename($this->slug));
+        return Hyde::makeTitle(basename($this->identifier));
     }
 
     /**

--- a/packages/framework/src/Concerns/HasPageMetadata.php
+++ b/packages/framework/src/Concerns/HasPageMetadata.php
@@ -77,7 +77,7 @@ trait HasPageMetadata
 
     public function canUseCanonicalUrl(): bool
     {
-        return Hyde::hasSiteUrl() && isset($this->slug);
+        return Hyde::hasSiteUrl() && isset($this->identifier);
     }
 
     public function hasTwitterTitleInConfig(): bool

--- a/packages/framework/src/Contracts/AbstractMarkdownPage.php
+++ b/packages/framework/src/Contracts/AbstractMarkdownPage.php
@@ -26,7 +26,7 @@ abstract class AbstractMarkdownPage extends AbstractPage
     public array $matter;
     public string $body;
     public string $title;
-    public string $slug;
+    public string $identifier;
 
     public static string $fileExtension = '.md';
 
@@ -35,7 +35,7 @@ abstract class AbstractMarkdownPage extends AbstractPage
         $this->matter = $matter;
         $this->body = $body;
         $this->title = $title ?? $matter['title'] ?? '';
-        $this->slug = $identifier;
+        $this->identifier = $identifier;
 
         $this->markdown = $markdownDocument ?? new MarkdownDocument($matter, $body);
     }

--- a/packages/framework/src/Contracts/AbstractMarkdownPage.php
+++ b/packages/framework/src/Contracts/AbstractMarkdownPage.php
@@ -30,12 +30,12 @@ abstract class AbstractMarkdownPage extends AbstractPage
 
     public static string $fileExtension = '.md';
 
-    public function __construct(array $matter = [], string $body = '', ?string $title = null, string $slug = '', ?MarkdownDocument $markdownDocument = null)
+    public function __construct(array $matter = [], string $body = '', ?string $title = null, string $identifier = '', ?MarkdownDocument $markdownDocument = null)
     {
         $this->matter = $matter;
         $this->body = $body;
         $this->title = $title ?? $matter['title'] ?? '';
-        $this->slug = $slug;
+        $this->slug = $identifier;
 
         $this->markdown = $markdownDocument ?? new MarkdownDocument($matter, $body);
     }

--- a/packages/framework/src/Contracts/AbstractPage.php
+++ b/packages/framework/src/Contracts/AbstractPage.php
@@ -89,12 +89,12 @@ abstract class AbstractPage implements PageContract, CompilableContract
         ).'.html';
     }
 
-    public string $slug;
+    public string $identifier;
 
     /** @inheritDoc */
     public function getSourcePath(): string
     {
-        return static::qualifyBasename($this->slug);
+        return static::qualifyBasename($this->identifier);
     }
 
     /** @inheritDoc */
@@ -106,7 +106,7 @@ abstract class AbstractPage implements PageContract, CompilableContract
     /** @inheritDoc */
     public function getCurrentPagePath(): string
     {
-        return trim(static::getOutputDirectory().'/'.$this->slug, '/');
+        return trim(static::getOutputDirectory().'/'.$this->identifier, '/');
     }
 
     /** @inheritDoc */

--- a/packages/framework/src/Models/DocumentationSidebar.php
+++ b/packages/framework/src/Models/DocumentationSidebar.php
@@ -49,7 +49,7 @@ class DocumentationSidebar extends NavigationMenu
 
     protected function getPriorityForRoute(Route $route): int
     {
-        return $route->getSourceModel()->matter('priority') ?? $this->findPriorityInConfig($route->getSourceModel()->slug);
+        return $route->getSourceModel()->matter('priority') ?? $this->findPriorityInConfig($route->getSourceModel()->identifier);
     }
 
     protected function findPriorityInConfig(string $slug): int

--- a/packages/framework/src/Models/Pages/BladePage.php
+++ b/packages/framework/src/Models/Pages/BladePage.php
@@ -25,7 +25,7 @@ class BladePage extends AbstractPage
      *
      * @var string
      */
-    public string $slug;
+    public string $identifier;
 
     /**
      * @param  string  $view
@@ -33,7 +33,7 @@ class BladePage extends AbstractPage
     public function __construct(string $view)
     {
         $this->view = $view;
-        $this->slug = $view;
+        $this->identifier = $view;
     }
 
     public static string $sourceDirectory = '_pages';

--- a/packages/framework/src/Models/Pages/DocumentationPage.php
+++ b/packages/framework/src/Models/Pages/DocumentationPage.php
@@ -20,9 +20,9 @@ class DocumentationPage extends AbstractMarkdownPage
      */
     public ?string $category;
 
-    public function __construct(array $matter = [], string $body = '', string $title = '', string $slug = '')
+    public function __construct(array $matter = [], string $body = '', string $title = '', string $identifier = '')
     {
-        parent::__construct($matter, $body, $title, $slug);
+        parent::__construct($matter, $body, $title, $identifier);
     }
 
     /** @inheritDoc */

--- a/packages/framework/src/Models/Pages/DocumentationPage.php
+++ b/packages/framework/src/Models/Pages/DocumentationPage.php
@@ -28,7 +28,7 @@ class DocumentationPage extends AbstractMarkdownPage
     /** @inheritDoc */
     public function getCurrentPagePath(): string
     {
-        return trim(static::getOutputDirectory().'/'.basename($this->slug), '/');
+        return trim(static::getOutputDirectory().'/'.basename($this->identifier), '/');
     }
 
     /** @internal */
@@ -38,7 +38,7 @@ class DocumentationPage extends AbstractMarkdownPage
             return false;
         }
 
-        return trim(config('docs.source_file_location_base'), '/').'/'.$this->slug.'.md';
+        return trim(config('docs.source_file_location_base'), '/').'/'.$this->identifier.'.md';
     }
 
     public static function home(): ?RouteContract

--- a/packages/framework/src/Models/Pages/MarkdownPost.php
+++ b/packages/framework/src/Models/Pages/MarkdownPost.php
@@ -23,9 +23,9 @@ class MarkdownPost extends AbstractMarkdownPage
     public static string $outputDirectory = 'posts';
     public static string $template = 'hyde::layouts/post';
 
-    public function __construct(array $matter = [], string $body = '', string $title = '', string $slug = '')
+    public function __construct(array $matter = [], string $body = '', string $title = '', string $identifier = '')
     {
-        parent::__construct($matter, $body, $title, $slug);
+        parent::__construct($matter, $body, $title, $identifier);
 
         $this->constructAuthor();
         $this->constructMetadata();

--- a/packages/framework/src/Services/SitemapService.php
+++ b/packages/framework/src/Services/SitemapService.php
@@ -58,7 +58,7 @@ class SitemapService
         $urlItem->addChild('lastmod', htmlentities($this->getLastModDate($route->getSourceFilePath())));
         $urlItem->addChild('changefreq', 'daily');
         if (config('hyde.sitemap.dynamic_priority', true)) {
-            $urlItem->addChild('priority', $this->getPriority($route->getPageType(), $route->getSourceModel()->slug));
+            $urlItem->addChild('priority', $this->getPriority($route->getPageType(), $route->getSourceModel()->identifier));
         }
     }
 

--- a/packages/framework/tests/Feature/AbstractPageTest.php
+++ b/packages/framework/tests/Feature/AbstractPageTest.php
@@ -160,7 +160,7 @@ class AbstractPageTest extends TestCase
     {
         $this->assertEquals(
             MarkdownPage::qualifyBasename('foo'),
-            (new MarkdownPage(slug: 'foo'))->getSourcePath()
+            (new MarkdownPage(identifier: 'foo'))->getSourcePath()
         );
     }
 

--- a/packages/framework/tests/Feature/AbstractPageTest.php
+++ b/packages/framework/tests/Feature/AbstractPageTest.php
@@ -69,7 +69,7 @@ class AbstractPageTest extends TestCase
         Hyde::touch(('_pages/foo.md'));
 
         $this->assertInstanceOf(MarkdownPage::class, $page = MarkdownPage::parse('foo'));
-        $this->assertEquals('foo', $page->slug);
+        $this->assertEquals('foo', $page->identifier);
 
         unlink(Hyde::path('_pages/foo.md'));
     }

--- a/packages/framework/tests/Feature/Concerns/CanBeInNavigationTest.php
+++ b/packages/framework/tests/Feature/Concerns/CanBeInNavigationTest.php
@@ -24,7 +24,7 @@ class CanBeInNavigationTest extends TestCase
     public function test_show_in_navigation_returns_true_for_documentation_page_if_slug_is_index()
     {
         $page = $this->mock(DocumentationPage::class)->makePartial();
-        $page->slug = 'index';
+        $page->identifier = 'index';
 
         $this->assertTrue($page->showInNavigation());
     }
@@ -32,7 +32,7 @@ class CanBeInNavigationTest extends TestCase
     public function test_show_in_navigation_returns_false_for_documentation_page_if_slug_is_not_index()
     {
         $page = $this->mock(DocumentationPage::class)->makePartial();
-        $page->slug = 'not-index';
+        $page->identifier = 'not-index';
 
         $this->assertFalse($page->showInNavigation());
     }
@@ -49,7 +49,7 @@ class CanBeInNavigationTest extends TestCase
     public function test_show_in_navigation_returns_true_for_abstract_markdown_page_if_matter_navigation_hidden_is_false()
     {
         $page = $this->mock(AbstractMarkdownPage::class)->makePartial();
-        $page->slug = 'foo';
+        $page->identifier = 'foo';
         $page->markdown = $this->mock(MarkdownDocument::class)->makePartial();
         $page->markdown->shouldReceive('matter')->with('navigation.hidden', false)->andReturn(false);
 
@@ -59,7 +59,7 @@ class CanBeInNavigationTest extends TestCase
     public function test_show_in_navigation_returns_true_for_abstract_markdown_page_if_matter_navigation_hidden_is_not_set()
     {
         $page = $this->mock(AbstractMarkdownPage::class)->makePartial();
-        $page->slug = 'foo';
+        $page->identifier = 'foo';
         $page->markdown = $this->mock(MarkdownDocument::class)->makePartial();
         $page->markdown->shouldReceive('matter')->with('navigation.hidden', false)->andReturn(null);
 
@@ -70,7 +70,7 @@ class CanBeInNavigationTest extends TestCase
     {
         $page = $this->mock(MarkdownPage::class)->makePartial();
         $page->markdown = new MarkdownDocument();
-        $page->slug = 'foo';
+        $page->identifier = 'foo';
 
         $this->assertTrue($page->showInNavigation());
 
@@ -82,7 +82,7 @@ class CanBeInNavigationTest extends TestCase
     {
         $page = $this->mock(MarkdownPage::class)->makePartial();
         $page->markdown = new MarkdownDocument();
-        $page->slug = '404';
+        $page->identifier = '404';
 
         $this->assertFalse($page->showInNavigation());
     }
@@ -91,7 +91,7 @@ class CanBeInNavigationTest extends TestCase
     {
         $page = $this->mock(MarkdownPage::class)->makePartial();
         $page->markdown = new MarkdownDocument();
-        $page->slug = 'foo';
+        $page->identifier = 'foo';
 
         $this->assertTrue($page->showInNavigation());
     }
@@ -108,7 +108,7 @@ class CanBeInNavigationTest extends TestCase
     {
         $page = $this->mock(MarkdownPage::class)->makePartial();
         $page->markdown = new MarkdownDocument();
-        $page->slug = 'foo';
+        $page->identifier = 'foo';
 
         $this->assertEquals(999, $page->navigationMenuPriority());
 
@@ -121,7 +121,7 @@ class CanBeInNavigationTest extends TestCase
         $page = $this->mock(AbstractMarkdownPage::class)->makePartial();
         $page->markdown = $this->mock(MarkdownDocument::class)->makePartial();
         $page->markdown->shouldReceive('matter')->with('navigation.priority', null)->andReturn(1);
-        $page->slug = 'foo';
+        $page->identifier = 'foo';
 
         $this->assertEquals(1, $page->navigationMenuPriority());
 
@@ -133,7 +133,7 @@ class CanBeInNavigationTest extends TestCase
     {
         $page = $this->mock(DocumentationPage::class)->makePartial();
         $page->markdown = new MarkdownDocument();
-        $page->slug = 'foo';
+        $page->identifier = 'foo';
 
         $this->assertEquals(100, $page->navigationMenuPriority());
     }
@@ -142,7 +142,7 @@ class CanBeInNavigationTest extends TestCase
     {
         $page = $this->mock(MarkdownPage::class)->makePartial();
         $page->markdown = new MarkdownDocument();
-        $page->slug = 'index';
+        $page->identifier = 'index';
 
         $this->assertEquals(0, $page->navigationMenuPriority());
     }
@@ -151,7 +151,7 @@ class CanBeInNavigationTest extends TestCase
     {
         $page = $this->mock(DocumentationPage::class)->makePartial();
         $page->markdown = new MarkdownDocument();
-        $page->slug = 'index';
+        $page->identifier = 'index';
 
         $this->assertEquals(100, $page->navigationMenuPriority());
     }
@@ -160,7 +160,7 @@ class CanBeInNavigationTest extends TestCase
     {
         $page = $this->mock(MarkdownPage::class)->makePartial();
         $page->markdown = new MarkdownDocument();
-        $page->slug = 'posts';
+        $page->identifier = 'posts';
 
         $this->assertEquals(10, $page->navigationMenuPriority());
     }
@@ -169,7 +169,7 @@ class CanBeInNavigationTest extends TestCase
     {
         $page = $this->mock(MarkdownPage::class)->makePartial();
         $page->markdown = new MarkdownDocument();
-        $page->slug = 'foo';
+        $page->identifier = 'foo';
 
         $this->assertEquals(999, $page->navigationMenuPriority());
     }
@@ -202,7 +202,7 @@ class CanBeInNavigationTest extends TestCase
     {
         $page = $this->mock(DocumentationPage::class)->makePartial();
         $page->markdown = new MarkdownDocument();
-        $page->slug = 'index';
+        $page->identifier = 'index';
 
         $this->assertEquals('Docs', $page->navigationMenuTitle());
     }
@@ -211,7 +211,7 @@ class CanBeInNavigationTest extends TestCase
     {
         $page = $this->mock(MarkdownPage::class)->makePartial();
         $page->markdown = new MarkdownDocument();
-        $page->slug = 'index';
+        $page->identifier = 'index';
 
         $this->assertEquals('Home', $page->navigationMenuTitle());
     }
@@ -221,7 +221,7 @@ class CanBeInNavigationTest extends TestCase
         $page = $this->mock(MarkdownPage::class)->makePartial();
         $page->markdown = new MarkdownDocument();
         $page->title = 'foo';
-        $page->slug = 'bar';
+        $page->identifier = 'bar';
 
         $this->assertEquals('foo', $page->navigationMenuTitle());
     }
@@ -230,7 +230,7 @@ class CanBeInNavigationTest extends TestCase
     {
         $page = $this->mock(MarkdownPage::class)->makePartial();
         $page->markdown = new MarkdownDocument();
-        $page->slug = 'foo';
+        $page->identifier = 'foo';
 
         $this->assertEquals('Foo', $page->navigationMenuTitle());
     }

--- a/packages/framework/tests/Feature/Concerns/HasArticleMetadataTest.php
+++ b/packages/framework/tests/Feature/Concerns/HasArticleMetadataTest.php
@@ -80,7 +80,7 @@ class HasArticleMetadataTest extends TestCase
     public function test_get_meta_properties_contains_og_url_when_uri_path_set()
     {
         Config::set('site.url', 'https://example.com/foo');
-        $this->route = new Route(new MarkdownPost(slug: 'bar'));
+        $this->route = new Route(new MarkdownPost(identifier: 'bar'));
         $this->constructMetadata();
 
         $this->assertEquals([

--- a/packages/framework/tests/Feature/Concerns/HasPageMetadataTest.php
+++ b/packages/framework/tests/Feature/Concerns/HasPageMetadataTest.php
@@ -25,7 +25,7 @@ class HasPageMetadataTest extends TestCase
 
     protected function makePage(string $slug = 'foo'): MarkdownPage
     {
-        return new MarkdownPage(slug: $slug);
+        return new MarkdownPage(identifier: $slug);
     }
 
     public function test_get_canonical_url_returns_url_for_top_level_page()

--- a/packages/framework/tests/Feature/MarkdownPageTest.php
+++ b/packages/framework/tests/Feature/MarkdownPageTest.php
@@ -46,6 +46,6 @@ class MarkdownPageTest extends TestCase
 
         $this->assertEquals('PHPUnit Test File', $page->title);
         $this->assertEquals("# PHPUnit Test File \n Hello World!", $page->body);
-        $this->assertEquals('test-post', $page->slug);
+        $this->assertEquals('test-post', $page->identifier);
     }
 }

--- a/packages/framework/tests/Feature/RouteTest.php
+++ b/packages/framework/tests/Feature/RouteTest.php
@@ -138,21 +138,21 @@ class RouteTest extends TestCase
 
     public function test_get_link_returns_correct_path_for_root_pages()
     {
-        $route = new Route(new MarkdownPage(slug: 'foo'));
+        $route = new Route(new MarkdownPage(identifier: 'foo'));
         $this->assertEquals(Hyde::relativeLink($route->getOutputFilePath()), $route->getLink());
         $this->assertEquals('foo.html', $route->getLink());
     }
 
     public function test_get_link_returns_correct_path_for_nested_pages()
     {
-        $route = new Route(new MarkdownPage(slug: 'foo/bar'));
+        $route = new Route(new MarkdownPage(identifier: 'foo/bar'));
         $this->assertEquals(Hyde::relativeLink($route->getOutputFilePath()), $route->getLink());
         $this->assertEquals('foo/bar.html', $route->getLink());
     }
 
     public function test_get_link_returns_correct_path_for_nested_current_page()
     {
-        $route = new Route(new MarkdownPage(slug: 'foo'));
+        $route = new Route(new MarkdownPage(identifier: 'foo'));
         view()->share('currentPage', 'foo/bar');
         $this->assertEquals(Hyde::relativeLink($route->getOutputFilePath()), $route->getLink());
         $this->assertEquals('../foo.html', $route->getLink());
@@ -161,33 +161,33 @@ class RouteTest extends TestCase
     public function test_get_link_returns_pretty_url_if_enabled()
     {
         config(['site.pretty_urls' => true]);
-        $route = new Route(new MarkdownPage(slug: 'foo'));
+        $route = new Route(new MarkdownPage(identifier: 'foo'));
         $this->assertEquals(Hyde::relativeLink($route->getOutputFilePath()), $route->getLink());
         $this->assertEquals('foo', $route->getLink());
     }
 
     public function test_to_string_is_alias_for_get_link()
     {
-        $route = new Route(new MarkdownPage(slug: 'foo'));
+        $route = new Route(new MarkdownPage(identifier: 'foo'));
         $this->assertEquals($route->getLink(), (string) $route);
     }
 
     public function test_get_qualified_url_returns_hyde_url_for_output_file_path()
     {
-        $route = new Route(new MarkdownPage(slug: 'foo'));
+        $route = new Route(new MarkdownPage(identifier: 'foo'));
         $this->assertEquals(Hyde::url('foo.html'), $route->getQualifiedUrl());
     }
 
     public function test_get_qualified_url_returns_hyde_url_for_nested_pages()
     {
-        $route = new Route(new MarkdownPage(slug: 'foo/bar'));
+        $route = new Route(new MarkdownPage(identifier: 'foo/bar'));
         $this->assertEquals(Hyde::url('foo/bar.html'), $route->getQualifiedUrl());
     }
 
     public function test_get_qualified_url_returns_pretty_url_if_enabled()
     {
         config(['site.pretty_urls' => true]);
-        $route = new Route(new MarkdownPage(slug: 'foo'));
+        $route = new Route(new MarkdownPage(identifier: 'foo'));
         $this->assertEquals(Hyde::url('foo'), $route->getQualifiedUrl());
     }
 
@@ -195,13 +195,13 @@ class RouteTest extends TestCase
     {
         config(['site.url' => null]);
         $this->expectException(BaseUrlNotSetException::class);
-        $route = new Route(new MarkdownPage(slug: 'foo'));
+        $route = new Route(new MarkdownPage(identifier: 'foo'));
         $route->getQualifiedUrl();
     }
 
     public function test_current_returns_current_route()
     {
-        $route = new Route(new MarkdownPage(slug: 'foo'));
+        $route = new Route(new MarkdownPage(identifier: 'foo'));
         view()->share('currentRoute', $route);
         $this->assertEquals($route, Route::current());
     }

--- a/packages/framework/tests/Feature/SourceFileParserTest.php
+++ b/packages/framework/tests/Feature/SourceFileParserTest.php
@@ -22,7 +22,7 @@ class SourceFileParserTest extends TestCase
         $parser = new SourceFileParser(BladePage::class, 'foo');
         $page = $parser->get();
         $this->assertInstanceOf(BladePage::class, $page);
-        $this->assertEquals('foo', $page->slug);
+        $this->assertEquals('foo', $page->identifier);
     }
 
     public function test_markdown_page_parser()
@@ -32,7 +32,7 @@ class SourceFileParserTest extends TestCase
         $parser = new SourceFileParser(MarkdownPage::class, 'foo');
         $page = $parser->get();
         $this->assertInstanceOf(MarkdownPage::class, $page);
-        $this->assertEquals('foo', $page->slug);
+        $this->assertEquals('foo', $page->identifier);
         $this->assertEquals('# Foo Bar', $page->body);
         $this->assertEquals('Foo Bar Baz', $page->title);
     }
@@ -44,7 +44,7 @@ class SourceFileParserTest extends TestCase
         $parser = new SourceFileParser(MarkdownPost::class, 'foo');
         $page = $parser->get();
         $this->assertInstanceOf(MarkdownPost::class, $page);
-        $this->assertEquals('foo', $page->slug);
+        $this->assertEquals('foo', $page->identifier);
         $this->assertEquals('# Foo Bar', $page->body);
         $this->assertEquals('Foo Bar Baz', $page->title);
     }
@@ -56,7 +56,7 @@ class SourceFileParserTest extends TestCase
         $parser = new SourceFileParser(DocumentationPage::class, 'foo');
         $page = $parser->get();
         $this->assertInstanceOf(DocumentationPage::class, $page);
-        $this->assertEquals('foo', $page->slug);
+        $this->assertEquals('foo', $page->identifier);
         $this->assertEquals('# Foo Bar', $page->body);
         $this->assertEquals('Foo Bar Baz', $page->title);
     }

--- a/packages/framework/tests/Unit/DocumentationPageTest.php
+++ b/packages/framework/tests/Unit/DocumentationPageTest.php
@@ -87,7 +87,7 @@ class DocumentationPageTest extends TestCase
     {
         $this->assertEquals(
             DocumentationPage::qualifyBasename('foo'),
-            (new DocumentationPage(slug: 'foo'))->getSourcePath()
+            (new DocumentationPage(identifier: 'foo'))->getSourcePath()
         );
     }
 
@@ -95,7 +95,7 @@ class DocumentationPageTest extends TestCase
     {
         $this->assertEquals(
             DocumentationPage::qualifyBasename('foo/bar'),
-            (new DocumentationPage(slug: 'foo/bar'))->getSourcePath()
+            (new DocumentationPage(identifier: 'foo/bar'))->getSourcePath()
         );
     }
 

--- a/packages/framework/tests/Unit/GetLatestMarkdownPostsTest.php
+++ b/packages/framework/tests/Unit/GetLatestMarkdownPostsTest.php
@@ -22,8 +22,8 @@ class GetLatestMarkdownPostsTest extends TestCase
         $this->assertInstanceOf(Collection::class, $collection);
         $this->assertContainsOnlyInstancesOf(MarkdownPost::class, $collection);
 
-        $this->assertEquals('new', $collection->first()->slug);
-        $this->assertEquals('old', $collection->last()->slug);
+        $this->assertEquals('new', $collection->first()->identifier);
+        $this->assertEquals('old', $collection->last()->identifier);
 
         unlink(Hyde::path('_posts/new.md'));
         unlink(Hyde::path('_posts/old.md'));

--- a/packages/framework/tests/Unit/HasPageMetadataRssFeedLinkTest.php
+++ b/packages/framework/tests/Unit/HasPageMetadataRssFeedLinkTest.php
@@ -31,7 +31,7 @@ class HasPageMetadataRssFeedLinkTest extends TestCase
 
     public function test_can_use_rss_feed_link_adds_meta_link_for_post_related_pages()
     {
-        $page = new MarkdownPage([], '', slug: 'posts');
+        $page = new MarkdownPage([], '', identifier: 'posts');
 
         $this->assertStringContainsString(
             '<link rel="alternate" type="application/rss+xml" title="HydePHP RSS Feed" href="foo/feed.xml" />',
@@ -41,7 +41,7 @@ class HasPageMetadataRssFeedLinkTest extends TestCase
 
     public function test_can_use_rss_feed_link_adds_meta_link_for_markdown_index_page()
     {
-        $page = new MarkdownPage([], '', slug: 'index');
+        $page = new MarkdownPage([], '', identifier: 'index');
 
         $this->assertStringContainsString(
             '<link rel="alternate" type="application/rss+xml" title="HydePHP RSS Feed" href="foo/feed.xml" />',

--- a/packages/framework/tests/Unit/MarkdownPostParserTest.php
+++ b/packages/framework/tests/Unit/MarkdownPostParserTest.php
@@ -32,9 +32,9 @@ class MarkdownPostParserTest extends TestCase
         $this->assertCount(3, ($post->matter));
         $this->assertIsArray($post->matter);
         $this->assertIsString($post->body);
-        $this->assertIsString($post->slug);
+        $this->assertIsString($post->identifier);
         $this->assertTrue(strlen($post->body) > 32);
-        $this->assertTrue(strlen($post->slug) > 8);
+        $this->assertTrue(strlen($post->identifier) > 8);
     }
 
     public function test_parsed_markdown_post_contains_valid_front_matter()


### PR DESCRIPTION
### About

This update contains **breaking changes** to the internal API regarding page models. This should only affect you directly if you've written any code that interacts with the internal page models, such as constructing them using non-built-in Hyde helpers.

#### Rename slugs to identifiers

Previously internally called `slug(s)`, are now called `identifier(s)`. In all honestly, this has 90% to do with the fact that I hate the word "slug".
I considered using `basename` as an alternative, but that does not fit with nested pages. Here instead is the definition of an `identifier` in the context of HydePHP:

> An identifier is a string that is in essence everything in the filepath between the source directory and the file extension.

So, for example, a page source file stored as `_pages/foo/bar.md` would have the identifier `foo/bar`. Each page type can only have one identifier of the same name.
But since you could have a file with the same identifier in the `_posts` directory, we internally always need to specify what source model we are using.

The identifier property is closely related to the page model's route key property, which consists of the site output directory followed by the identifier. 
