### PR TITLE
Breaking: Reorder AbstractMarkdownPage constructor argument positions, putting the identifier first

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -22,6 +22,7 @@ The identifier property is closely related to the page model's route key propert
 ### Changed
 - Breaking: Rename AbstractMarkdownPage constructor parameter `slug` to `identifier`
 - Breaking: Rename AbstractPage property `slug` to `identifier`
+- Breaking: Change `AbstractMarkdownPage` constructor argument positions, putting `identifier` first
 - Begin changing references to slugs to identifiers, see motivation above
 
 ### Deprecated

--- a/packages/framework/src/Contracts/AbstractMarkdownPage.php
+++ b/packages/framework/src/Contracts/AbstractMarkdownPage.php
@@ -30,7 +30,7 @@ abstract class AbstractMarkdownPage extends AbstractPage
 
     public static string $fileExtension = '.md';
 
-    public function __construct(array $matter = [], string $body = '', ?string $title = null, string $identifier = '', ?MarkdownDocument $markdownDocument = null)
+    public function __construct(string $identifier = '', array $matter = [], string $body = '', ?string $title = null, ?MarkdownDocument $markdownDocument = null)
     {
         $this->matter = $matter;
         $this->body = $body;

--- a/packages/framework/src/Models/Pages/DocumentationPage.php
+++ b/packages/framework/src/Models/Pages/DocumentationPage.php
@@ -22,7 +22,7 @@ class DocumentationPage extends AbstractMarkdownPage
 
     public function __construct(array $matter = [], string $body = '', string $title = '', string $identifier = '')
     {
-        parent::__construct($matter, $body, $title, $identifier);
+        parent::__construct($identifier, $matter, $body, $title);
     }
 
     /** @inheritDoc */

--- a/packages/framework/src/Models/Pages/MarkdownPost.php
+++ b/packages/framework/src/Models/Pages/MarkdownPost.php
@@ -25,7 +25,7 @@ class MarkdownPost extends AbstractMarkdownPage
 
     public function __construct(array $matter = [], string $body = '', string $title = '', string $identifier = '')
     {
-        parent::__construct($matter, $body, $title, $identifier);
+        parent::__construct($identifier, $matter, $body, $title);
 
         $this->constructAuthor();
         $this->constructMetadata();

--- a/packages/framework/tests/Feature/AbstractPageTest.php
+++ b/packages/framework/tests/Feature/AbstractPageTest.php
@@ -85,7 +85,7 @@ class AbstractPageTest extends TestCase
     {
         Hyde::touch(('_pages/foo.md'));
         $this->assertEquals(
-            collect([new MarkdownPage([], '', 'Foo', 'foo')]),
+            collect([new MarkdownPage('foo', [], '', 'Foo')]),
             MarkdownPage::all()
         );
         unlink(Hyde::path('_pages/foo.md'));
@@ -132,27 +132,27 @@ class AbstractPageTest extends TestCase
 
     public function test_get_current_page_path_returns_output_directory_and_basename()
     {
-        $page = new MarkdownPage([], '', '', 'foo');
+        $page = new MarkdownPage('foo', [], '', '');
         $this->assertEquals('foo', $page->getCurrentPagePath());
     }
 
     public function test_get_current_page_path_returns_output_directory_and_basename_for_configured_directory()
     {
         MarkdownPage::$outputDirectory = 'foo';
-        $page = new MarkdownPage([], '', '', 'bar');
+        $page = new MarkdownPage('bar', [], '', '');
         $this->assertEquals('foo/bar', $page->getCurrentPagePath());
     }
 
     public function test_get_current_page_path_trims_trailing_slashes_from_directory_setting()
     {
         MarkdownPage::$outputDirectory = '/foo/\\';
-        $page = new MarkdownPage([], '', '', 'bar');
+        $page = new MarkdownPage('bar', [], '', '');
         $this->assertEquals('foo/bar', $page->getCurrentPagePath());
     }
 
     public function test_get_output_path_returns_current_page_path_with_html_extension_appended()
     {
-        $page = new MarkdownPage([], '', '', 'foo');
+        $page = new MarkdownPage('foo', [], '', '');
         $this->assertEquals('foo.html', $page->getOutputPath());
     }
 
@@ -160,7 +160,7 @@ class AbstractPageTest extends TestCase
     {
         $this->assertEquals(
             MarkdownPage::qualifyBasename('foo'),
-            (new MarkdownPage(identifier: 'foo'))->getSourcePath()
+            (new MarkdownPage('foo'))->getSourcePath()
         );
     }
 
@@ -285,7 +285,7 @@ class AbstractPageTest extends TestCase
 
     public function test_abstract_markdown_page_constructor_constructs_dynamic_title_automatically()
     {
-        $page = new MarkdownPage(['title' => 'Foo']);
+        $page = new MarkdownPage('', ['title' => 'Foo']);
         $this->assertEquals('Foo', $page->title);
     }
 
@@ -315,12 +315,12 @@ class AbstractPageTest extends TestCase
 
     public function test_html_title_returns_site_name_plus_page_title()
     {
-        $this->assertEquals('HydePHP - Foo', (new MarkdownPage(['title' => 'Foo']))->htmlTitle());
+        $this->assertEquals('HydePHP - Foo', (new MarkdownPage('', ['title' => 'Foo']))->htmlTitle());
     }
 
     public function test_html_title_can_be_overridden()
     {
-        $this->assertEquals('HydePHP - Bar', (new MarkdownPage(['title' => 'Foo']))->htmlTitle('Bar'));
+        $this->assertEquals('HydePHP - Bar', (new MarkdownPage('', ['title' => 'Foo']))->htmlTitle('Bar'));
     }
 
     public function test_html_title_returns_site_name_if_no_page_title()

--- a/packages/framework/tests/Feature/StaticPageBuilderTest.php
+++ b/packages/framework/tests/Feature/StaticPageBuilderTest.php
@@ -79,7 +79,7 @@ class StaticPageBuilderTest extends TestCase
 
     public function test_can_build_markdown_page()
     {
-        $page = new MarkdownPage([], '# Body', 'Title', 'foo');
+        $page = new MarkdownPage('foo', [], '# Body', 'Title');
 
         new StaticPageBuilder($page, true);
 

--- a/packages/framework/tests/Unit/HasPageMetadataRssFeedLinkTest.php
+++ b/packages/framework/tests/Unit/HasPageMetadataRssFeedLinkTest.php
@@ -31,7 +31,7 @@ class HasPageMetadataRssFeedLinkTest extends TestCase
 
     public function test_can_use_rss_feed_link_adds_meta_link_for_post_related_pages()
     {
-        $page = new MarkdownPage([], '', identifier: 'posts');
+        $page = new MarkdownPage(identifier: 'posts', matter: [], body: '', title: 'posts');
 
         $this->assertStringContainsString(
             '<link rel="alternate" type="application/rss+xml" title="HydePHP RSS Feed" href="foo/feed.xml" />',
@@ -41,7 +41,7 @@ class HasPageMetadataRssFeedLinkTest extends TestCase
 
     public function test_can_use_rss_feed_link_adds_meta_link_for_markdown_index_page()
     {
-        $page = new MarkdownPage([], '', identifier: 'index');
+        $page = new MarkdownPage(identifier: 'index', matter: [], body: '', title: 'index');
 
         $this->assertStringContainsString(
             '<link rel="alternate" type="application/rss+xml" title="HydePHP RSS Feed" href="foo/feed.xml" />',


### PR DESCRIPTION
### Before

```php
public function __construct(array $matter = [], string $body = '', ?string $title = null, string $identifier = '', ?MarkdownDocument $markdownDocument = null)
```

### After
```php
public function __construct(string $identifier = '', array $matter = [], string $body = '', ?string $title = null, ?MarkdownDocument $markdownDocument = null)
```