### PR TITLE
Make file parser helpers public

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -24,6 +24,7 @@ The identifier property is closely related to the page model's route key propert
 - Breaking: Rename AbstractPage property `slug` to `identifier`
 - Breaking: Change `AbstractMarkdownPage` constructor argument positions, putting `identifier` first
 - Begin changing references to slugs to identifiers, see motivation above
+- Makes some helpers in SourceFileParser public static allowing them to be used outside the class
 
 ### Deprecated
 - for soon-to-be removed features.

--- a/packages/framework/src/Actions/SourceFileParser.php
+++ b/packages/framework/src/Actions/SourceFileParser.php
@@ -75,7 +75,7 @@ class SourceFileParser
         }
     }
 
-    protected function findTitleForPage(): string
+    public function findTitleForPage(): string
     {
         if ($this->page instanceof BladePage) {
             return Hyde::makeTitle($this->slug);
@@ -88,7 +88,7 @@ class SourceFileParser
         return $this->findTitleFromMarkdownHeadings() ?? Hyde::makeTitle($this->slug);
     }
 
-    protected function findTitleFromMarkdownHeadings(): ?string
+    public function findTitleFromMarkdownHeadings(): ?string
     {
         foreach ($this->page->markdown()->toArray() as $line) {
             if (str_starts_with($line, '# ')) {
@@ -99,7 +99,7 @@ class SourceFileParser
         return null;
     }
 
-    protected function getDocumentationPageCategory(): ?string
+    public function getDocumentationPageCategory(): ?string
     {
         // If the documentation page is in a subdirectory,
         // then we can use that as the category name.

--- a/packages/framework/src/Actions/SourceFileParser.php
+++ b/packages/framework/src/Actions/SourceFileParser.php
@@ -68,29 +68,29 @@ class SourceFileParser
 
     protected function constructDynamicData(): void
     {
-        $this->page->title = $this->findTitleForPage();
+        $this->page->title = static::findTitleForPage($this->page, $this->slug);
 
         if ($this->page instanceof DocumentationPage) {
-            $this->page->category = $this->getDocumentationPageCategory();
+            $this->page->category = static::getDocumentationPageCategory($this->slug, $this->page);
         }
     }
 
-    public function findTitleForPage(): string
+    public static function findTitleForPage($page, $slug): string
     {
-        if ($this->page instanceof BladePage) {
-            return Hyde::makeTitle($this->slug);
+        if ($page instanceof BladePage) {
+            return Hyde::makeTitle($slug);
         }
 
-        if ($this->page->matter('title')) {
-            return $this->page->matter('title');
+        if ($page->matter('title')) {
+            return $page->matter('title');
         }
 
-        return $this->findTitleFromMarkdownHeadings() ?? Hyde::makeTitle($this->slug);
+        return static::findTitleFromMarkdownHeadings($page) ?? Hyde::makeTitle($slug);
     }
 
-    public function findTitleFromMarkdownHeadings(): ?string
+    public static function findTitleFromMarkdownHeadings($page): ?string
     {
-        foreach ($this->page->markdown()->toArray() as $line) {
+        foreach ($page->markdown()->toArray() as $line) {
             if (str_starts_with($line, '# ')) {
                 return trim(substr($line, 2), ' ');
             }
@@ -99,15 +99,15 @@ class SourceFileParser
         return null;
     }
 
-    public function getDocumentationPageCategory(): ?string
+    public static function getDocumentationPageCategory($slug, $page): ?string
     {
         // If the documentation page is in a subdirectory,
         // then we can use that as the category name.
         // Otherwise, we look in the front matter.
 
-        return str_contains($this->slug, '/')
-            ? Str::before($this->slug, '/')
-            : $this->page->matter('category');
+        return str_contains($slug, '/')
+            ? Str::before($slug, '/')
+            : $page->matter('category');
     }
 
     public function get(): PageContract


### PR DESCRIPTION
Makes some helpers in SourceFileParser public static allowing them to be used outside the class

The following are changed

- findTitleForPage
- findTitleFromMarkdownHeadings
- getDocumentationPageCategory

The actual usage of them is not affected.