### PR TITLE
Replace Markdown::parse() with Markdown::render()

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -17,7 +17,7 @@ But since you could have a file with the same identifier in the `_posts` directo
 The identifier property is closely related to the page model's route key property, which consists of the site output directory followed by the identifier. 
 
 ### Added
-- for new features.
+- Added render() method to Facades\Markdown, replacing the parse() method of the same class
 
 ### Changed
 - Breaking: Rename AbstractMarkdownPage constructor parameter `slug` to `identifier`

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -17,7 +17,7 @@ But since you could have a file with the same identifier in the `_posts` directo
 The identifier property is closely related to the page model's route key property, which consists of the site output directory followed by the identifier. 
 
 ### Added
-- Added render() method to Facades\Markdown, replacing the parse() method of the same class
+- Added `render()` method to `Facades\Markdown`, replacing the `parse()` method of the same class
 
 ### Changed
 - Breaking: Rename AbstractMarkdownPage constructor parameter `slug` to `identifier`
@@ -27,7 +27,7 @@ The identifier property is closely related to the page model's route key propert
 - Makes some helpers in SourceFileParser public static allowing them to be used outside the class
 
 ### Deprecated
-- Deprecated Facades\Markdown::parse(), use Facades\Markdown::render() instead
+- Deprecated `Facades\Markdown::parse()`, use `Facades\Markdown::render()` instead
 
 ### Removed
 - for now removed features.

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -27,7 +27,7 @@ The identifier property is closely related to the page model's route key propert
 - Makes some helpers in SourceFileParser public static allowing them to be used outside the class
 
 ### Deprecated
-- for soon-to-be removed features.
+- Deprecated Facades\Markdown::parse(), use Facades\Markdown::render() instead
 
 ### Removed
 - for now removed features.

--- a/packages/framework/src/Facades/Markdown.php
+++ b/packages/framework/src/Facades/Markdown.php
@@ -13,6 +13,8 @@ class Markdown
     /**
      * Parse a Markdown string into HTML.
      *
+     * @deprecated v0.58.0-beta use Markdown::render() instead.
+     *
      * If a source model is provided, the Markdown will be converted using the dynamic MarkdownService,
      * otherwise, the pre-configured singleton from the service container will be used instead.
      *

--- a/packages/framework/src/Facades/Markdown.php
+++ b/packages/framework/src/Facades/Markdown.php
@@ -11,16 +11,22 @@ use Hyde\Framework\Services\MarkdownService;
 class Markdown
 {
     /**
-     * Parse a Markdown string into HTML.
-     *
      * @deprecated v0.58.0-beta use Markdown::render() instead.
+     */
+    public static function parse(string $markdown, ?string $sourceModel = null): string
+    {
+        return static::render($markdown, $sourceModel);
+    }
+
+    /**
+     * Render a Markdown string into HTML.
      *
      * If a source model is provided, the Markdown will be converted using the dynamic MarkdownService,
      * otherwise, the pre-configured singleton from the service container will be used instead.
      *
      * @return string $html
      */
-    public static function parse(string $markdown, ?string $sourceModel = null): string
+    public static function render(string $markdown, ?string $sourceModel = null): string
     {
         return $sourceModel !== null
             ? (new MarkdownService($markdown, $sourceModel))->parse()

--- a/packages/framework/tests/Unit/MarkdownFacadeTest.php
+++ b/packages/framework/tests/Unit/MarkdownFacadeTest.php
@@ -12,7 +12,7 @@ use Hyde\Testing\TestCase;
  */
 class MarkdownFacadeTest extends TestCase
 {
-    public function test_parse(): void
+    public function test_render(): void
     {
         $markdown = '# Hello World!';
 


### PR DESCRIPTION
Deprecates Facades\Markdown::parse(), and adds a new Markdown::render() method instead.

The reason for this is that parsing in Hyde commonly is used to take a source file and parse it into an object. Since this method does the reverse (taking a Markdown string and compiling it to HTML), having it named render would make more sense, and also match the view render method.