### PR TITLE
Remove body() method from Markdown pages

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -21,14 +21,13 @@ This update contains **breaking changes** to the internal API regarding page mod
 
 ### Removed
 - Removed `Facades\Markdown.php`, merged into `Models\Markdown.php`
-- Removed `body()` method from `MarkdownDocumentContract` interface and all its implementations. Use `markdown()->body()` instead
+- Removed `body()` method from `MarkdownDocumentContract` interface and all its implementations. Use `markdown()->body()` (or cast to string) instead
 
 ### Fixed
 - for any bug fixes.
 
 ### Security
 - in case of vulnerabilities.
-
 
 ### Upgrade guide and extra information
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -21,6 +21,7 @@ This update contains **breaking changes** to the internal API regarding page mod
 
 ### Removed
 - Removed `Facades\Markdown.php`, merged into `Models\Markdown.php`
+- Removed `body()` method from `MarkdownDocumentContract` interface and all its implementations. Use `markdown()->body()` instead
 
 ### Fixed
 - for any bug fixes.

--- a/packages/framework/src/Contracts/AbstractMarkdownPage.php
+++ b/packages/framework/src/Contracts/AbstractMarkdownPage.php
@@ -61,12 +61,6 @@ abstract class AbstractMarkdownPage extends AbstractPage implements MarkdownDocu
         return $this->matter->get($key, $default);
     }
 
-    /** @deprecated  */
-    public function body(): string
-    {
-        return $this->markdown->body();
-    }
-
     /** @inheritDoc */
     public function compile(): string
     {

--- a/packages/framework/src/Contracts/MarkdownDocumentContract.php
+++ b/packages/framework/src/Contracts/MarkdownDocumentContract.php
@@ -19,12 +19,4 @@ interface MarkdownDocumentContract
      * @return \Hyde\Framework\Models\Markdown
      */
     public function markdown(): Markdown;
-
-    /**
-     * Get the Markdown text body.
-     *
-     * @deprecated Use markdown()->body instead.
-     * @return string
-     */
-    public function body(): string;
 }

--- a/packages/framework/src/Models/MarkdownDocument.php
+++ b/packages/framework/src/Models/MarkdownDocument.php
@@ -44,12 +44,6 @@ class MarkdownDocument implements MarkdownDocumentContract
         return $this->markdown;
     }
 
-    /** @deprecated  */
-    public function body(): string
-    {
-        return $this->body;
-    }
-
     /**
      * @deprecated v0.56.0 - Use static::parse() instead
      */

--- a/packages/framework/tests/Feature/AbstractPageTest.php
+++ b/packages/framework/tests/Feature/AbstractPageTest.php
@@ -339,6 +339,6 @@ class AbstractPageTest extends TestCase
     public function test_body_helper_returns_markdown_document_body_in_markdown_pages()
     {
         $page = new MarkdownPage(markdown: new Markdown(body: '# Foo'));
-        $this->assertEquals('# Foo', $page->body());
+        $this->assertEquals('# Foo', $page->markdown->body());
     }
 }

--- a/packages/framework/tests/Unit/MarkdownDocumentTest.php
+++ b/packages/framework/tests/Unit/MarkdownDocumentTest.php
@@ -50,7 +50,7 @@ class MarkdownDocumentTest extends TestCase
         file_put_contents('_pages/foo.md', "---\nfoo: bar\n---\nHello, world!");
         $document = MarkdownDocument::parseFile('_pages/foo.md');
         $this->assertInstanceOf(MarkdownDocument::class, $document);
-        $this->assertEquals('Hello, world!', $document->body());
+        $this->assertEquals('Hello, world!', $document->markdown()->body());
         $this->assertEquals(FrontMatter::fromArray(['foo' => 'bar']), $document->matter());
         unlink(Hyde::path('_pages/foo.md'));
     }


### PR DESCRIPTION
Removes the body() method from Markdown pages, you can use markdown()->body() or cast the markdown property to string.