### PR TITLE
Remove `body` property from Markdown 

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -24,6 +24,7 @@ This update contains **breaking changes** to the internal API regarding page mod
 ### Removed
 - Removed `Facades\Markdown.php`, merged into `Models\Markdown.php`
 - Removed `body()` method from `MarkdownDocumentContract` interface and all its implementations. Use `markdown()->body()` (or cast to string) instead
+- Removed `body` property from Markdown pages. Use `markdown()->body()` (or cast to string) instead
 
 ### Fixed
 - for any bug fixes.

--- a/packages/framework/src/Actions/GeneratesDocumentationSearchIndexFile.php
+++ b/packages/framework/src/Actions/GeneratesDocumentationSearchIndexFile.php
@@ -115,7 +115,7 @@ class GeneratesDocumentationSearchIndexFile implements ActionContract
         // This is compiles the Markdown body into HTML, and then strips out all
         // HTML tags to get a plain text version of the body. This takes a long
         // site, but is the simplest implementation I've found so far.
-        return preg_replace('/<(.|\n)*?>/', ' ', Str::markdown($page->body));
+        return preg_replace('/<(.|\n)*?>/', ' ', Str::markdown($page->markdown));
     }
 
     public function getDestinationForSlug(string $slug): string

--- a/packages/framework/src/Actions/GeneratesDocumentationSearchIndexFile.php
+++ b/packages/framework/src/Actions/GeneratesDocumentationSearchIndexFile.php
@@ -110,12 +110,12 @@ class GeneratesDocumentationSearchIndexFile implements ActionContract
      * Returning $document->body as is: 500ms
      * Returning $document->body as Str::markdown(): 920ms + 10ms for regex
      */
-    public function getSearchContentForDocument(DocumentationPage $document): string
+    public function getSearchContentForDocument(DocumentationPage $page): string
     {
         // This is compiles the Markdown body into HTML, and then strips out all
         // HTML tags to get a plain text version of the body. This takes a long
         // site, but is the simplest implementation I've found so far.
-        return preg_replace('/<(.|\n)*?>/', ' ', Str::markdown($document->body));
+        return preg_replace('/<(.|\n)*?>/', ' ', Str::markdown($page->body));
     }
 
     public function getDestinationForSlug(string $slug): string

--- a/packages/framework/src/Concerns/HasTableOfContents.php
+++ b/packages/framework/src/Concerns/HasTableOfContents.php
@@ -15,6 +15,6 @@ trait HasTableOfContents
 {
     public function getTableOfContents(): string
     {
-        return (new GeneratesSidebarTableOfContents($this->body))->execute();
+        return (new GeneratesSidebarTableOfContents($this->markdown))->execute();
     }
 }

--- a/packages/framework/src/Contracts/AbstractMarkdownPage.php
+++ b/packages/framework/src/Contracts/AbstractMarkdownPage.php
@@ -27,9 +27,6 @@ abstract class AbstractMarkdownPage extends AbstractPage implements MarkdownDocu
     public Markdown $markdown;
 
     /** @deprecated */
-    public string $body;
-
-    /** @deprecated */
     public string $title;
 
     public static string $fileExtension = '.md';
@@ -48,8 +45,6 @@ abstract class AbstractMarkdownPage extends AbstractPage implements MarkdownDocu
         $this->identifier = $identifier;
         $this->matter = $matter ?? new FrontMatter();
         $this->markdown = $markdown ?? new Markdown();
-
-        $this->body = $this->markdown->body;
     }
 
     /** @inheritDoc */

--- a/packages/framework/src/Contracts/MarkdownPageContract.php
+++ b/packages/framework/src/Contracts/MarkdownPageContract.php
@@ -21,8 +21,9 @@ interface MarkdownPageContract
     /**
      * Construct a new MarkdownPage object from constructed data types.
      * Normally, this is done by the SourceFileParser.
+     *
      * @see \Hyde\Framework\Actions\SourceFileParser
-     * 
+     *
      * The types are strictly enforced to ensure a predictable behavior and constant access interface.
      *
      * @param  string  $identifier

--- a/packages/framework/src/Models/Pages/MarkdownPost.php
+++ b/packages/framework/src/Models/Pages/MarkdownPost.php
@@ -44,7 +44,7 @@ class MarkdownPost extends AbstractMarkdownPage
 
     public function getPostDescription(): string
     {
-        return $this->matter('description') ?? substr($this->body, 0, 125).'...';
+        return $this->matter('description') ?? substr($this->markdown, 0, 125).'...';
     }
 
     public static function getLatestPosts(): Collection

--- a/packages/framework/src/Modules/Markdown/MarkdownFileParser.php
+++ b/packages/framework/src/Modules/Markdown/MarkdownFileParser.php
@@ -24,7 +24,7 @@ class MarkdownFileParser
      *
      * @var string
      */
-    public string $body = '';
+    public string $markdown = '';
 
     public function __construct(string $filepath)
     {
@@ -42,10 +42,10 @@ class MarkdownFileParser
             }
 
             if ($object->body()) {
-                $this->body = $object->body();
+                $this->markdown = $object->body();
             }
         } else {
-            $this->body = $stream;
+            $this->markdown = $stream;
         }
     }
 
@@ -54,7 +54,7 @@ class MarkdownFileParser
      */
     public function get(): MarkdownDocument
     {
-        return new MarkdownDocument($this->matter, $this->body);
+        return new MarkdownDocument($this->matter, $this->markdown);
     }
 
     public static function parse(string $filepath): MarkdownDocument

--- a/packages/framework/tests/Feature/MarkdownPageTest.php
+++ b/packages/framework/tests/Feature/MarkdownPageTest.php
@@ -45,7 +45,7 @@ class MarkdownPageTest extends TestCase
         $page = MarkdownPage::parse('test-post');
 
         $this->assertEquals('PHPUnit Test File', $page->title);
-        $this->assertEquals("# PHPUnit Test File \n Hello World!", $page->body);
+        $this->assertEquals("# PHPUnit Test File \n Hello World!", $page->markdown);
         $this->assertEquals('test-post', $page->identifier);
     }
 }

--- a/packages/framework/tests/Feature/Services/HydeSmartDocsTest.php
+++ b/packages/framework/tests/Feature/Services/HydeSmartDocsTest.php
@@ -23,7 +23,7 @@ class HydeSmartDocsTest extends TestCase
 
         file_put_contents(Hyde::path('_docs/foo.md'), "# Foo\n\nHello world.");
         $this->mock = DocumentationPage::parse('foo');
-        $this->html = Markdown::render($this->mock->body);
+        $this->html = Markdown::render($this->mock->markdown->body);
     }
 
     protected function tearDown(): void

--- a/packages/framework/tests/Feature/SourceFileParserTest.php
+++ b/packages/framework/tests/Feature/SourceFileParserTest.php
@@ -32,7 +32,7 @@ class SourceFileParserTest extends TestCase
         $page = $parser->get();
         $this->assertInstanceOf(MarkdownPage::class, $page);
         $this->assertEquals('foo', $page->identifier);
-        $this->assertEquals('# Foo Bar', $page->body);
+        $this->assertEquals('# Foo Bar', $page->markdown);
         $this->assertEquals('Foo Bar Baz', $page->title);
     }
 
@@ -44,7 +44,7 @@ class SourceFileParserTest extends TestCase
         $page = $parser->get();
         $this->assertInstanceOf(MarkdownPost::class, $page);
         $this->assertEquals('foo', $page->identifier);
-        $this->assertEquals('# Foo Bar', $page->body);
+        $this->assertEquals('# Foo Bar', $page->markdown);
         $this->assertEquals('Foo Bar Baz', $page->title);
     }
 
@@ -56,7 +56,7 @@ class SourceFileParserTest extends TestCase
         $page = $parser->get();
         $this->assertInstanceOf(DocumentationPage::class, $page);
         $this->assertEquals('foo', $page->identifier);
-        $this->assertEquals('# Foo Bar', $page->body);
+        $this->assertEquals('# Foo Bar', $page->markdown);
         $this->assertEquals('Foo Bar Baz', $page->title);
     }
 

--- a/packages/framework/tests/Unit/HasTableOfContentsTest.php
+++ b/packages/framework/tests/Unit/HasTableOfContentsTest.php
@@ -18,7 +18,7 @@ class HasTableOfContentsTest extends TestCase
 
     public function testConstructorCreatesTableOfContentsString()
     {
-        $this->body = '## Title';
+        $this->markdown = '## Title';
         $this->assertEquals('<ul class="table-of-contents"><li><a href="#title">Title</a></li></ul>', str_replace("\n", '', $this->getTableOfContents()));
     }
 }

--- a/packages/framework/tests/Unit/MarkdownPostParserTest.php
+++ b/packages/framework/tests/Unit/MarkdownPostParserTest.php
@@ -4,6 +4,7 @@ namespace Hyde\Framework\Testing\Unit;
 
 use Hyde\Framework\Hyde;
 use Hyde\Framework\Models\FrontMatter;
+use Hyde\Framework\Models\Markdown;
 use Hyde\Framework\Models\Pages\MarkdownPost;
 use Hyde\Testing\TestCase;
 
@@ -32,9 +33,10 @@ class MarkdownPostParserTest extends TestCase
         $this->assertInstanceOf(MarkdownPost::class, $post);
         $this->assertCount(3, ($post->matter->toArray()));
         $this->assertInstanceOf(FrontMatter::class, $post->matter);
-        $this->assertIsString($post->body);
+        $this->assertInstanceOf(Markdown::class, $post->markdown);
+        $this->assertIsString($post->markdown->body);
         $this->assertIsString($post->identifier);
-        $this->assertTrue(strlen($post->body) > 32);
+        $this->assertTrue(strlen($post->markdown) > 32);
         $this->assertTrue(strlen($post->identifier) > 8);
     }
 


### PR DESCRIPTION
### About

Since the Markdown body is now strongly typed as a Markdown object, we have duplicate properties for the Markdown body (which is also stored in the Markdown object). This PR removes that.

#### Before
```
^ Hyde\Framework\Models\Pages\MarkdownPage^ {#3014
  +markdown: Hyde\Framework\Models\Markdown^ {#3009
    +body: "foo bar"
  }
  +body: "foo bar"
}
```

#### After
```
^ Hyde\Framework\Models\Pages\MarkdownPage^ {#3006
  +markdown: Hyde\Framework\Models\Markdown^ {#3014
    +body: "foo bar"
  }
}
```