### PR TITLE
Implement Stringable interface in classes using toString magic method

### DIFF
--- a/packages/framework/src/Models/FrontMatter.php
+++ b/packages/framework/src/Models/FrontMatter.php
@@ -11,7 +11,7 @@ use Illuminate\Support\Arr;
  *
  * @see \Hyde\Framework\Testing\Unit\FrontMatterModelTest
  */
-class FrontMatter implements Arrayable
+class FrontMatter implements Arrayable, \Stringable
 {
     public array $matter;
 

--- a/packages/framework/src/Models/Markdown.php
+++ b/packages/framework/src/Models/Markdown.php
@@ -11,7 +11,7 @@ use Illuminate\Contracts\Support\Arrayable;
  *
  * @see \Hyde\Framework\Testing\Unit\MarkdownDocumentTest
  */
-class Markdown implements Arrayable
+class Markdown implements Arrayable, \Stringable
 {
     public string $body;
 

--- a/packages/framework/src/Models/MarkdownDocument.php
+++ b/packages/framework/src/Models/MarkdownDocument.php
@@ -13,7 +13,7 @@ use Hyde\Framework\Modules\Markdown\MarkdownFileParser;
  *
  * @see \Hyde\Framework\Testing\Unit\MarkdownDocumentTest
  */
-class MarkdownDocument implements MarkdownDocumentContract
+class MarkdownDocument implements MarkdownDocumentContract, \Stringable
 {
     public FrontMatter $matter;
     public Markdown $markdown;

--- a/packages/framework/src/Models/NavItem.php
+++ b/packages/framework/src/Models/NavItem.php
@@ -15,7 +15,7 @@ use Illuminate\Support\Str;
  *   2. You can use NavItem::fromRoute() to use data from the route
  *   3. You can use NavItem::leadsTo(URI, Title, ?priority) for an external or un-routed link
  */
-class NavItem implements Stringable
+class NavItem implements \Stringable
 {
     public RouteContract $route;
     public string $href;

--- a/packages/framework/src/Models/NavItem.php
+++ b/packages/framework/src/Models/NavItem.php
@@ -15,7 +15,7 @@ use Illuminate\Support\Str;
  *   2. You can use NavItem::fromRoute() to use data from the route
  *   3. You can use NavItem::leadsTo(URI, Title, ?priority) for an external or un-routed link
  */
-class NavItem
+class NavItem implements Stringable
 {
     public RouteContract $route;
     public string $href;

--- a/packages/framework/src/Models/Route.php
+++ b/packages/framework/src/Models/Route.php
@@ -13,7 +13,7 @@ use Illuminate\Support\Collection;
 /**
  * @see \Hyde\Framework\Testing\Feature\RouteTest
  */
-class Route implements RouteContract, RouteFacadeContract
+class Route implements RouteContract, RouteFacadeContract, \Stringable
 {
     /**
      * The source model for the route.


### PR DESCRIPTION
As per the manual:
> As of PHP 8.0.0, any class that contains a [__toString()](https://www.php.net/manual/en/language.oop5.magic.php#object.tostring) method will also implicitly implement the [Stringable](https://www.php.net/manual/en/class.stringable.php) interface, and will thus pass type checks for that interface. Explicitly implementing the interface anyway is recommended. https://www.php.net/manual/en/language.oop5.magic.php