### PR TITLE
Remove title property from Markdown pages

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -25,6 +25,7 @@ This update contains **breaking changes** to the internal API regarding page mod
 - Removed `Facades\Markdown.php`, merged into `Models\Markdown.php`
 - Removed `body()` method from `MarkdownDocumentContract` interface and all its implementations. Use `markdown()->body()` (or cast to string) instead
 - Removed `body` property from Markdown pages. Use `markdown()->body()` (or cast to string) instead
+- Removed `title` property from Markdown pages. (No change in behaviour as it is accessed through front matter magic method)
 
 ### Fixed
 - for any bug fixes.

--- a/packages/framework/src/Actions/PageModelConstructor.php
+++ b/packages/framework/src/Actions/PageModelConstructor.php
@@ -34,7 +34,7 @@ class PageModelConstructor
 
     protected function constructDynamicData(): void
     {
-        $this->page->title = static::findTitleForPage();
+        $this->page->matter->set('title', static::findTitleForPage());
 
         if ($this->page instanceof DocumentationPage) {
             $this->page->category = static::getDocumentationPageCategory();

--- a/packages/framework/src/Actions/PageModelConstructor.php
+++ b/packages/framework/src/Actions/PageModelConstructor.php
@@ -34,7 +34,8 @@ class PageModelConstructor
 
     protected function constructDynamicData(): void
     {
-        $this->page->matter->set('title', static::findTitleForPage());
+        // @todo $this->page->matter->set('title', static::findTitleForPage());
+        $this->page->title = static::findTitleForPage();
 
         if ($this->page instanceof DocumentationPage) {
             $this->page->category = static::getDocumentationPageCategory();

--- a/packages/framework/src/Concerns/CanBeInNavigation.php
+++ b/packages/framework/src/Concerns/CanBeInNavigation.php
@@ -84,10 +84,6 @@ trait CanBeInNavigation
             if ($this->matter('navigation.title') !== null) {
                 return $this->matter('navigation.title');
             }
-
-            if ($this->matter('title') !== null) {
-                return $this->matter('title');
-            }
         }
 
         if ($this->identifier === 'index') {
@@ -96,6 +92,10 @@ trait CanBeInNavigation
             }
 
             return config('hyde.navigation.labels.home', 'Home');
+        }
+
+        if ($this->matter('title') !== null) {
+            return $this->matter('title');
         }
 
         return $this->title;

--- a/packages/framework/src/Concerns/HasPageMetadata.php
+++ b/packages/framework/src/Concerns/HasPageMetadata.php
@@ -46,7 +46,7 @@ trait HasPageMetadata
             $array[] = $this->makeRssFeedLink();
         }
 
-        if (isset($this->title)) {
+        if ($this->matter('title') !== null) {
             if ($this->hasTwitterTitleInConfig()) {
                 $array[] = '<meta name="twitter:title" content="'.$this->htmlTitle().'" />';
             }

--- a/packages/framework/src/Concerns/HasPageMetadata.php
+++ b/packages/framework/src/Concerns/HasPageMetadata.php
@@ -46,7 +46,8 @@ trait HasPageMetadata
             $array[] = $this->makeRssFeedLink();
         }
 
-        if ($this->matter('title') !== null) {
+        // @todo if ($this->matter('title') !== null) {
+        if ($this->title !== null) {
             if ($this->hasTwitterTitleInConfig()) {
                 $array[] = '<meta name="twitter:title" content="'.$this->htmlTitle().'" />';
             }

--- a/packages/framework/src/Contracts/AbstractMarkdownPage.php
+++ b/packages/framework/src/Contracts/AbstractMarkdownPage.php
@@ -26,9 +26,6 @@ abstract class AbstractMarkdownPage extends AbstractPage implements MarkdownDocu
     public FrontMatter $matter;
     public Markdown $markdown;
 
-    /** @deprecated */
-    public string $title;
-
     public static string $fileExtension = '.md';
 
     /** @interitDoc */

--- a/packages/framework/src/Contracts/AbstractPage.php
+++ b/packages/framework/src/Contracts/AbstractPage.php
@@ -19,6 +19,8 @@ use Illuminate\Support\Collection;
  * @see \Hyde\Framework\Contracts\PageContract
  * @see \Hyde\Framework\Contracts\AbstractMarkdownPage
  * @test \Hyde\Framework\Testing\Feature\AbstractPageTest
+ *
+ * @property string $title The title of the HTML page.
  */
 abstract class AbstractPage implements PageContract, CompilableContract
 {

--- a/packages/framework/src/Models/Pages/BladePage.php
+++ b/packages/framework/src/Models/Pages/BladePage.php
@@ -23,6 +23,9 @@ class BladePage extends AbstractPage
      */
     public string $identifier;
 
+    /** @deprecated - for backwards compatibility */
+    public string $title = '';
+
     /**
      * @param  string  $view
      */


### PR DESCRIPTION
No change in behaviour as it is accessed through front matter magic method