### PR TITLE
Add front matter support to Blade pages

### DIFF
--- a/docs/architecture-concepts.md
+++ b/docs/architecture-concepts.md
@@ -75,10 +75,17 @@ Take a look at the [customization and configuration guide](customization.html) t
 
 ## Front Matter
 
+### About
+
+Front matter is heavily used in HydePHP to store metadata about about pages. Hyde uses the front matter data to generate rich and dynamic content. For example, a blog post category, author website, or featured image.
+
+Using front matter is optional, as Hyde will dynamically generate data based on the content itself. (Though any matter you provide will take precedence over the automatically generated data.)
+
+### Markdown
+
 All Markdown content files support Front Matter. Blog posts for example make heavy use of it.
 
-The specific usage and schemas used for pages are documented in their respective documentation,
-however, here is a primer on the fundamentals.
+The specific usage and schemas used for pages are documented in their respective documentation, however, here is a primer on the fundamentals.
 
 - Front matter is stored in a block of YAML that starts and ends with a `---` line.
 - The front matter should be the very first thing in the Markdown file.
@@ -97,6 +104,21 @@ author:
 
 Lorem ipsum dolor sit amet, etc.
 ```
+
+### Blade
+
+>warning 🧪 This feature is experimental, and currently does not support arrays or multi-line directives as the BladeMatter is statically parsed.
+
+Hyde v0.58.0-beta brings experimental support for creating front-matter in Blade templates, called BladeMatter. The actual syntax is does not use YAML; but instead PHP. However, the parsed end result is the same.
+
+To create BladeMatter, you simply use the default Laravel Blade `@php` directive to declare a variable anywhere in the template.
+
+**Example:**
+```blade
+@php($title = 'BladeMatter Demo')
+```
+
+It will then be available through the global `$page` variable, `$page->matter('title')`.
 
 
 ## Automatic Routing

--- a/packages/framework/src/Actions/BladeMatterParser.php
+++ b/packages/framework/src/Actions/BladeMatterParser.php
@@ -26,6 +26,8 @@ class BladeMatterParser
 
     public function parse(): static
     {
+        $this->matter = [];
+
         $lines = explode("\n", $this->contents);
 
         foreach ($lines as $line) {
@@ -33,8 +35,6 @@ class BladeMatterParser
                 $this->matter[] = static::parseLine($line);
             }
         }
-
-        $this->matter = [];
 
         return $this;
     }

--- a/packages/framework/src/Actions/BladeMatterParser.php
+++ b/packages/framework/src/Actions/BladeMatterParser.php
@@ -7,6 +7,8 @@ namespace Hyde\Framework\Actions;
  *
  * Accepts a string to make it easier to mock when testing.
  *
+ * @see \Hyde\Framework\Testing\Feature\BladeMatterParserTest
+ *
  * === DOCUMENTATION (draft) ===
  *
  * ## Front Matter in Markdown

--- a/packages/framework/src/Actions/BladeMatterParser.php
+++ b/packages/framework/src/Actions/BladeMatterParser.php
@@ -17,6 +17,11 @@ class BladeMatterParser
         $this->contents = $contents;
     }
 
+    public function get(): array
+    {
+        return $this->matter;
+    }
+
     public function parse(): static
     {
         $lines = explode("\n", $this->contents);
@@ -30,11 +35,6 @@ class BladeMatterParser
         $this->matter = [];
 
         return $this;
-    }
-
-    public function get(): array
-    {
-        return $this->matter;
     }
 
     protected static function lineMatchesFrontMatter(string $line): bool

--- a/packages/framework/src/Actions/BladeMatterParser.php
+++ b/packages/framework/src/Actions/BladeMatterParser.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Hyde\Framework\Actions;
+
+/**
+ * Parse the front matter in a Blade file.
+ */
+class BladeMatterParser
+{
+    //
+}

--- a/packages/framework/src/Actions/BladeMatterParser.php
+++ b/packages/framework/src/Actions/BladeMatterParser.php
@@ -19,6 +19,14 @@ class BladeMatterParser
 
     public function parse(): static
     {
+        $lines = explode("\n", $this->contents);
+
+        foreach ($lines as $line) {
+            if (static::lineMatchesFrontMatter($line)) {
+                $this->matter[] = static::parseLine($line);
+            }
+        }
+
         $this->matter = [];
 
         return $this;
@@ -27,5 +35,15 @@ class BladeMatterParser
     public function get(): array
     {
         return $this->matter;
+    }
+
+    protected static function lineMatchesFrontMatter(string $line): bool
+    {
+        return false;
+    }
+
+    protected static function parseLine(string $line): array
+    {
+        return [];
     }
 }

--- a/packages/framework/src/Actions/BladeMatterParser.php
+++ b/packages/framework/src/Actions/BladeMatterParser.php
@@ -6,6 +6,23 @@ namespace Hyde\Framework\Actions;
  * Parse the front matter in a Blade file.
  *
  * Accepts a string to make it easier to mock when testing.
+ *
+ * === DOCUMENTATION (draft) ===
+ *
+ * ## Front Matter in Markdown
+ *
+ * HydePHP uses a special syntax called BladeMatter that allows you to define variables in a Blade file,
+ * and have Hyde statically parse them into the front matter of the page model. This allows metadata
+ * in your Blade pages to be used when Hyde generates dynamic data like page titles and SEO tags.
+ *
+ * ### Syntax
+ *
+ * Any line following the syntax below will be added to the parsed page object's front matter.
+ * @example `@php($title = 'BladeMatter Test')`
+ * This would then be parsed into the following array in the page model: ['title' => 'BladeMatter Test']
+ *
+ * ### Limitations
+ * Each directive must be on its own line, and start with `@php($.`. Arrays are currently not supported.
  */
 class BladeMatterParser
 {

--- a/packages/framework/src/Actions/BladeMatterParser.php
+++ b/packages/framework/src/Actions/BladeMatterParser.php
@@ -59,12 +59,14 @@ class BladeMatterParser
         return $this;
     }
 
-    protected static function lineMatchesFrontMatter(string $line): bool
+    /** @internal */
+    public static function lineMatchesFrontMatter(string $line): bool
     {
         return str_starts_with($line, static::SEARCH);
     }
 
-    protected static function extractKey(string $line): string
+    /** @internal */
+    public static function extractKey(string $line): string
     {
         // Remove search prefix
         $key = substr($line, strlen(static::SEARCH));
@@ -76,7 +78,8 @@ class BladeMatterParser
         return trim($key);
     }
 
-    protected static function extractValue(string $line): string
+    /** @internal */
+    public static function extractValue(string $line): string
     {
         // Trim any trailing spaces and newlines
         $key = trim($line);
@@ -94,7 +97,8 @@ class BladeMatterParser
         return trim($key);
     }
 
-    protected static function normalizeValue($value): mixed
+    /** @internal */
+    public static function normalizeValue($value): mixed
     {
         // This will cast integers, floats, and booleans to their respective types
         // Still working on a way to handle arrays and objects

--- a/packages/framework/src/Actions/BladeMatterParser.php
+++ b/packages/framework/src/Actions/BladeMatterParser.php
@@ -58,6 +58,19 @@ class BladeMatterParser
 
     protected static function extractValue(string $line): string
     {
-        return '';
+        // Trim any trailing spaces and newlines
+        $key = trim($line);
+
+        // Remove everything before the first equals sign
+        $key = substr($key, strpos($key, '=') + 1);
+
+        // Remove closing parenthesis
+        $key = substr($key, 0, strlen($key) - 1);
+
+        // Remove any quotes so we can normalize the value
+        $key = trim($key, ' "\'');
+
+        // Return trimmed line
+        return trim($key);
     }
 }

--- a/packages/framework/src/Actions/BladeMatterParser.php
+++ b/packages/framework/src/Actions/BladeMatterParser.php
@@ -34,6 +34,11 @@ class BladeMatterParser
 
     protected const SEARCH = '@php($';
 
+    public static function parseString(string $contents): array
+    {
+        return (new static($contents))->parse()->get();
+    }
+
     public function __construct(string $contents)
     {
         $this->contents = $contents;

--- a/packages/framework/src/Actions/BladeMatterParser.php
+++ b/packages/framework/src/Actions/BladeMatterParser.php
@@ -46,7 +46,14 @@ class BladeMatterParser
 
     protected static function extractKey(string $line): string
     {
-        return '';
+        // Remove search prefix
+        $key = substr($line, strlen(static::SEARCH));
+
+        // Remove everything after the first equals sign
+        $key = substr($key, 0, strpos($key, '='));
+
+        // Return trimmed line
+        return trim($key);
     }
 
     protected static function extractValue(string $line): string

--- a/packages/framework/src/Actions/BladeMatterParser.php
+++ b/packages/framework/src/Actions/BladeMatterParser.php
@@ -39,11 +39,21 @@ class BladeMatterParser
 
     protected static function lineMatchesFrontMatter(string $line): bool
     {
-        return false;
+        return str_starts_with($line, '@php($');
     }
 
     protected static function parseLine(string $line): array
     {
-        return [];
+        return [static::extractKey($line) => static::extractValue($line)];
+    }
+
+    protected static function extractKey(string $line): string
+    {
+        return '';
+    }
+
+    protected static function extractValue(string $line): string
+    {
+        return '';
     }
 }

--- a/packages/framework/src/Actions/BladeMatterParser.php
+++ b/packages/framework/src/Actions/BladeMatterParser.php
@@ -100,6 +100,10 @@ class BladeMatterParser
     /** @internal */
     public static function normalizeValue($value): mixed
     {
+        if ($value === 'null') {
+            return null;
+        }
+
         // This will cast integers, floats, and booleans to their respective types
         // Still working on a way to handle arrays and objects
         return json_decode($value) ?? $value;

--- a/packages/framework/src/Actions/BladeMatterParser.php
+++ b/packages/framework/src/Actions/BladeMatterParser.php
@@ -12,6 +12,8 @@ class BladeMatterParser
     protected string $contents;
     protected array $matter;
 
+    protected const SEARCH = '@php($';
+
     public function __construct(string $contents)
     {
         $this->contents = $contents;
@@ -39,7 +41,7 @@ class BladeMatterParser
 
     protected static function lineMatchesFrontMatter(string $line): bool
     {
-        return str_starts_with($line, '@php($');
+        return str_starts_with($line, static::SEARCH);
     }
 
     protected static function parseLine(string $line): array

--- a/packages/framework/src/Actions/BladeMatterParser.php
+++ b/packages/framework/src/Actions/BladeMatterParser.php
@@ -34,6 +34,7 @@ class BladeMatterParser
     protected string $contents;
     protected array $matter;
 
+    /** The directive signature used to determine if a line should be parsed. */
     protected const SEARCH = '@php($';
 
     public static function parseFile(string $localFilePath): array

--- a/packages/framework/src/Actions/BladeMatterParser.php
+++ b/packages/framework/src/Actions/BladeMatterParser.php
@@ -2,6 +2,8 @@
 
 namespace Hyde\Framework\Actions;
 
+use Hyde\Framework\Hyde;
+
 /**
  * Parse the front matter in a Blade file.
  *
@@ -33,6 +35,11 @@ class BladeMatterParser
     protected array $matter;
 
     protected const SEARCH = '@php($';
+
+    public static function parseFile(string $localFilePath): array
+    {
+        return static::parseString(file_get_contents(Hyde::path($localFilePath)));
+    }
 
     public static function parseString(string $contents): array
     {

--- a/packages/framework/src/Actions/BladeMatterParser.php
+++ b/packages/framework/src/Actions/BladeMatterParser.php
@@ -18,6 +18,7 @@ namespace Hyde\Framework\Actions;
  * ### Syntax
  *
  * Any line following the syntax below will be added to the parsed page object's front matter.
+ *
  * @example `@php($title = 'BladeMatter Test')`
  * This would then be parsed into the following array in the page model: ['title' => 'BladeMatter Test']
  *

--- a/packages/framework/src/Actions/BladeMatterParser.php
+++ b/packages/framework/src/Actions/BladeMatterParser.php
@@ -32,7 +32,7 @@ class BladeMatterParser
 
         foreach ($lines as $line) {
             if (static::lineMatchesFrontMatter($line)) {
-                $this->matter[static::extractKey($line)] = static::extractValue($line);
+                $this->matter[static::extractKey($line)] = static::normalizeValue(static::extractValue($line));
             }
         }
 
@@ -72,5 +72,12 @@ class BladeMatterParser
 
         // Return trimmed line
         return trim($key);
+    }
+
+    protected static function normalizeValue($value): mixed
+    {
+        // This will cast integers, floats, and booleans to their respective types
+        // Still working on a way to handle arrays and objects
+        return json_decode($value) ?? $value;
     }
 }

--- a/packages/framework/src/Actions/BladeMatterParser.php
+++ b/packages/framework/src/Actions/BladeMatterParser.php
@@ -32,7 +32,7 @@ class BladeMatterParser
 
         foreach ($lines as $line) {
             if (static::lineMatchesFrontMatter($line)) {
-                $this->matter[] = static::parseLine($line);
+                $this->matter[static::extractKey($line)] = static::extractValue($line);
             }
         }
 
@@ -42,11 +42,6 @@ class BladeMatterParser
     protected static function lineMatchesFrontMatter(string $line): bool
     {
         return str_starts_with($line, static::SEARCH);
-    }
-
-    protected static function parseLine(string $line): array
-    {
-        return [static::extractKey($line) => static::extractValue($line)];
     }
 
     protected static function extractKey(string $line): string

--- a/packages/framework/src/Actions/BladeMatterParser.php
+++ b/packages/framework/src/Actions/BladeMatterParser.php
@@ -4,8 +4,28 @@ namespace Hyde\Framework\Actions;
 
 /**
  * Parse the front matter in a Blade file.
+ *
+ * Accepts a string to make it easier to mock when testing.
  */
 class BladeMatterParser
 {
-    //
+    protected string $contents;
+    protected array $matter;
+
+    public function __construct(string $contents)
+    {
+        $this->contents = $contents;
+    }
+
+    public function parse(): static
+    {
+        $this->matter = [];
+
+        return $this;
+    }
+
+    public function get(): array
+    {
+        return $this->matter;
+    }
 }

--- a/packages/framework/src/Actions/PageModelConstructor.php
+++ b/packages/framework/src/Actions/PageModelConstructor.php
@@ -34,7 +34,9 @@ class PageModelConstructor
 
     protected function constructDynamicData(): void
     {
-        $this->page->title = static::findTitleForPage();
+        if (optional($this->page)->title === null) {
+            $this->page->title = static::findTitleForPage();
+        }
 
         if ($this->page instanceof DocumentationPage) {
             $this->page->category = static::getDocumentationPageCategory();

--- a/packages/framework/src/Actions/SourceFileParser.php
+++ b/packages/framework/src/Actions/SourceFileParser.php
@@ -5,7 +5,6 @@ namespace Hyde\Framework\Actions;
 use Hyde\Framework\Concerns\ValidatesExistence;
 use Hyde\Framework\Contracts\AbstractMarkdownPage;
 use Hyde\Framework\Contracts\PageContract;
-use Hyde\Framework\Hyde;
 use Hyde\Framework\Models\FrontMatter;
 use Hyde\Framework\Models\Pages\BladePage;
 use Hyde\Framework\Modules\Markdown\MarkdownFileParser;

--- a/packages/framework/src/Actions/SourceFileParser.php
+++ b/packages/framework/src/Actions/SourceFileParser.php
@@ -5,6 +5,8 @@ namespace Hyde\Framework\Actions;
 use Hyde\Framework\Concerns\ValidatesExistence;
 use Hyde\Framework\Contracts\AbstractMarkdownPage;
 use Hyde\Framework\Contracts\PageContract;
+use Hyde\Framework\Hyde;
+use Hyde\Framework\Models\FrontMatter;
 use Hyde\Framework\Models\Pages\BladePage;
 use Hyde\Framework\Modules\Markdown\MarkdownFileParser;
 
@@ -43,7 +45,16 @@ class SourceFileParser
 
     protected function parseBladePage(): BladePage
     {
-        return new BladePage($this->slug);
+        return tap(new BladePage($this->slug), function (BladePage $page) {
+            $page->matter = FrontMatter::fromArray(
+                $this->parseBladeMatter(file_get_contents($page->getSourcePath()))
+            );
+        });
+    }
+
+    protected function parseBladeMatter(string $contents): array
+    {
+        return (new BladeMatterParser($contents))->parse()->get();
     }
 
     protected function parseMarkdownPage(string $pageClass): AbstractMarkdownPage

--- a/packages/framework/src/Contracts/AbstractMarkdownPage.php
+++ b/packages/framework/src/Contracts/AbstractMarkdownPage.php
@@ -23,7 +23,6 @@ use Hyde\Framework\Models\Markdown;
 abstract class AbstractMarkdownPage extends AbstractPage implements MarkdownDocumentContract, MarkdownPageContract
 {
     public string $identifier;
-    public FrontMatter $matter;
     public Markdown $markdown;
 
     /** @deprecated */

--- a/packages/framework/src/Contracts/AbstractMarkdownPage.php
+++ b/packages/framework/src/Contracts/AbstractMarkdownPage.php
@@ -46,24 +46,6 @@ abstract class AbstractMarkdownPage extends AbstractPage implements MarkdownDocu
         $this->markdown = $markdown ?? new Markdown();
     }
 
-    /** @interitDoc */
-    public function __get(string $name)
-    {
-        return $this->matter->get($name);
-    }
-
-    /** @inheritDoc */
-    public function __set(string $name, $value): void
-    {
-        $this->matter->set($name, $value);
-    }
-
-    /** @inheritDoc */
-    public function matter(string $key = null, mixed $default = null): mixed
-    {
-        return $this->matter->get($key, $default);
-    }
-
     /** @inheritDoc */
     public function markdown(): Markdown
     {

--- a/packages/framework/src/Contracts/AbstractPage.php
+++ b/packages/framework/src/Contracts/AbstractPage.php
@@ -28,7 +28,6 @@ abstract class AbstractPage implements PageContract, CompilableContract
     public static string $sourceDirectory;
     public static string $outputDirectory;
     public static string $fileExtension;
-
     public static string $template;
 
     /** @inheritDoc */

--- a/packages/framework/src/Contracts/AbstractPage.php
+++ b/packages/framework/src/Contracts/AbstractPage.php
@@ -92,6 +92,12 @@ abstract class AbstractPage implements PageContract, CompilableContract
         ).'.html';
     }
 
+    public function __construct(string $identifier = '', FrontMatter|array $matter = [])
+    {
+        $this->identifier = $identifier;
+        $this->matter = $matter instanceof FrontMatter ? $matter : new FrontMatter($matter);
+    }
+
     /** @interitDoc */
     public function __get(string $name)
     {

--- a/packages/framework/src/Contracts/AbstractPage.php
+++ b/packages/framework/src/Contracts/AbstractPage.php
@@ -93,6 +93,24 @@ abstract class AbstractPage implements PageContract, CompilableContract
 
     public string $identifier;
 
+    /** @interitDoc */
+    public function __get(string $name)
+    {
+        return $this->matter->get($name);
+    }
+
+    /** @inheritDoc */
+    public function __set(string $name, $value): void
+    {
+        $this->matter->set($name, $value);
+    }
+
+    /** @inheritDoc */
+    public function matter(string $key = null, mixed $default = null): mixed
+    {
+        return $this->matter->get($key, $default);
+    }
+
     /** @inheritDoc */
     public function getSourcePath(): string
     {

--- a/packages/framework/src/Contracts/AbstractPage.php
+++ b/packages/framework/src/Contracts/AbstractPage.php
@@ -31,6 +31,7 @@ abstract class AbstractPage implements PageContract, CompilableContract
     public static string $fileExtension;
     public static string $template;
 
+    public string $identifier;
     public FrontMatter $matter;
 
     /** @inheritDoc */
@@ -90,8 +91,6 @@ abstract class AbstractPage implements PageContract, CompilableContract
             '/'
         ).'.html';
     }
-
-    public string $identifier;
 
     /** @interitDoc */
     public function __get(string $name)

--- a/packages/framework/src/Contracts/AbstractPage.php
+++ b/packages/framework/src/Contracts/AbstractPage.php
@@ -5,6 +5,7 @@ namespace Hyde\Framework\Contracts;
 use Hyde\Framework\Actions\SourceFileParser;
 use Hyde\Framework\Concerns\CanBeInNavigation;
 use Hyde\Framework\Concerns\HasPageMetadata;
+use Hyde\Framework\Models\FrontMatter;
 use Hyde\Framework\Models\Route;
 use Hyde\Framework\Services\DiscoveryService;
 use Illuminate\Support\Collection;
@@ -29,6 +30,8 @@ abstract class AbstractPage implements PageContract, CompilableContract
     public static string $outputDirectory;
     public static string $fileExtension;
     public static string $template;
+
+    public FrontMatter $matter;
 
     /** @inheritDoc */
     final public static function getSourceDirectory(): string

--- a/packages/framework/src/Contracts/MarkdownPageContract.php
+++ b/packages/framework/src/Contracts/MarkdownPageContract.php
@@ -31,21 +31,4 @@ interface MarkdownPageContract
      * @param  \Hyde\Framework\Models\Markdown|null  $markdown
      */
     public function __construct(string $identifier = '', ?FrontMatter $matter = null, ?Markdown $markdown = null);
-
-    /**
-     * Get the value of the specified key from the front matter.
-     *
-     * @param  string  $name
-     * @return mixed
-     */
-    public function __get(string $name);
-
-    /**
-     * Set the value of the specified key in the front matter.
-     *
-     * @param  string  $name
-     * @param  $value
-     * @return void
-     */
-    public function __set(string $name, $value): void;
 }

--- a/packages/framework/src/Contracts/PageContract.php
+++ b/packages/framework/src/Contracts/PageContract.php
@@ -24,6 +24,13 @@ interface PageContract
     public function __set(string $name, $value): void;
 
     /**
+     * Get the front matter object, or a value from within.
+     *
+     * @return \Hyde\Framework\Models\FrontMatter|mixed
+     */
+    public function matter(string $key = null, mixed $default = null): mixed;
+
+    /**
      * Get the directory in where source files are stored.
      *
      * @return string Path relative to the root of the project

--- a/packages/framework/src/Contracts/PageContract.php
+++ b/packages/framework/src/Contracts/PageContract.php
@@ -7,6 +7,23 @@ use Illuminate\Support\Collection;
 interface PageContract
 {
     /**
+     * Get the value of the specified key from the front matter.
+     *
+     * @param  string  $name
+     * @return mixed
+     */
+    public function __get(string $name);
+
+    /**
+     * Set the value of the specified key in the front matter.
+     *
+     * @param  string  $name
+     * @param  $value
+     * @return void
+     */
+    public function __set(string $name, $value): void;
+
+    /**
      * Get the directory in where source files are stored.
      *
      * @return string Path relative to the root of the project

--- a/packages/framework/src/Models/Pages/BladePage.php
+++ b/packages/framework/src/Models/Pages/BladePage.php
@@ -28,8 +28,8 @@ class BladePage extends AbstractPage
      */
     public function __construct(string $view)
     {
+        parent::__construct($view);
         $this->view = $view;
-        $this->identifier = $view;
     }
 
     public static string $sourceDirectory = '_pages';

--- a/packages/framework/tests/Feature/BladeMatterParserTest.php
+++ b/packages/framework/tests/Feature/BladeMatterParserTest.php
@@ -33,7 +33,7 @@ class BladeMatterParserTest extends TestCase
             BladeMatterParser::parseFile('foo')
         );
     }
-    
+
     public function test_can_parse_multiple_front_matter_lines()
     {
         $document = <<<'BLADE'
@@ -89,7 +89,7 @@ class BladeMatterParserTest extends TestCase
     public function test_normalize_value()
     {
         $this->assertSame('string', BladeMatterParser::normalizeValue('string'));
-        $this->assertSame("string", BladeMatterParser::normalizeValue("string"));
+        $this->assertSame('string', BladeMatterParser::normalizeValue('string'));
         $this->assertSame(true, BladeMatterParser::normalizeValue('true'));
         $this->assertSame(false, BladeMatterParser::normalizeValue('false'));
         $this->assertSame(1, BladeMatterParser::normalizeValue('1'));

--- a/packages/framework/tests/Feature/BladeMatterParserTest.php
+++ b/packages/framework/tests/Feature/BladeMatterParserTest.php
@@ -25,6 +25,15 @@ class BladeMatterParserTest extends TestCase
         );
     }
 
+    public function test_parse_file_helper_method()
+    {
+        $this->file('foo', 'foo');
+        $this->assertSame(
+            (new BladeMatterParser('foo'))->parse()->get(),
+            BladeMatterParser::parseFile('foo')
+        );
+    }
+    
     public function test_line_matches_front_matter()
     {
         $this->assertTrue(BladeMatterParser::lineMatchesFrontMatter('@php($title = "BladeMatter Test")'));

--- a/packages/framework/tests/Feature/BladeMatterParserTest.php
+++ b/packages/framework/tests/Feature/BladeMatterParserTest.php
@@ -10,6 +10,13 @@ use Hyde\Testing\TestCase;
  */
 class BladeMatterParserTest extends TestCase
 {
+    public function test_can_parse_front_matter()
+    {
+        $parser = new BladeMatterParser('@php($title = "BladeMatter Test")');
+        $parser->parse();
+        $this->assertEquals(['title' => 'BladeMatter Test'], $parser->get());
+    }
+
     public function test_line_matches_front_matter()
     {
         $this->assertTrue(BladeMatterParser::lineMatchesFrontMatter('@php($title = "BladeMatter Test")'));

--- a/packages/framework/tests/Feature/BladeMatterParserTest.php
+++ b/packages/framework/tests/Feature/BladeMatterParserTest.php
@@ -44,6 +44,20 @@ class BladeMatterParserTest extends TestCase
         $this->assertEquals(['foo' => 'bar', 'bar' => 'baz', 'baz' => 'qux'], BladeMatterParser::parseString($document));
     }
 
+    public function test_can_parse_front_matter_with_various_formats()
+    {
+        $matrix = [
+            '@php($foo = "bar")' => ['foo' => 'bar'],
+            '@php($foo = \'bar\')' => ['foo' => 'bar'],
+            '@php($foo="bar")' => ['foo' => 'bar'],
+            '@php($foo  =  "bar"  )  ' => ['foo' => 'bar'],
+        ];
+
+        foreach ($matrix as $input => $expected) {
+            $this->assertEquals($expected, BladeMatterParser::parseString($input));
+        }
+    }
+
     public function test_line_matches_front_matter()
     {
         $this->assertTrue(BladeMatterParser::lineMatchesFrontMatter('@php($foo = "bar")'));

--- a/packages/framework/tests/Feature/BladeMatterParserTest.php
+++ b/packages/framework/tests/Feature/BladeMatterParserTest.php
@@ -10,5 +10,33 @@ use Hyde\Testing\TestCase;
  */
 class BladeMatterParserTest extends TestCase
 {
+    public function test_line_matches_front_matter()
+    {
+        $this->assertTrue(BladeMatterParser::lineMatchesFrontMatter('@php($title = "BladeMatter Test")'));
+        $this->assertFalse(BladeMatterParser::lineMatchesFrontMatter('foo bar'));
+    }
 
+    public function test_extract_key()
+    {
+        $this->assertSame('title', BladeMatterParser::extractKey('@php($title = "BladeMatter Test")'));
+    }
+
+    public function test_extract_value()
+    {
+        $this->assertSame('BladeMatter Test', BladeMatterParser::extractValue('@php($title = "BladeMatter Test")'));
+    }
+
+    public function test_normalize_value()
+    {
+        $this->assertSame('string', BladeMatterParser::normalizeValue('string'));
+        $this->assertSame("string", BladeMatterParser::normalizeValue("string"));
+        $this->assertSame(true, BladeMatterParser::normalizeValue('true'));
+        $this->assertSame(false, BladeMatterParser::normalizeValue('false'));
+        $this->assertSame(1, BladeMatterParser::normalizeValue('1'));
+        $this->assertSame(0, BladeMatterParser::normalizeValue('0'));
+        $this->assertSame(1.0, BladeMatterParser::normalizeValue('1.0'));
+        $this->assertSame(0.0, BladeMatterParser::normalizeValue('0.0'));
+        $this->assertSame(null, BladeMatterParser::normalizeValue('null'));
+        $this->assertSame('["foo" => "bar"]', BladeMatterParser::normalizeValue('["foo" => "bar"]'));
+    }
 }

--- a/packages/framework/tests/Feature/BladeMatterParserTest.php
+++ b/packages/framework/tests/Feature/BladeMatterParserTest.php
@@ -12,9 +12,9 @@ class BladeMatterParserTest extends TestCase
 {
     public function test_can_parse_front_matter()
     {
-        $parser = new BladeMatterParser('@php($title = "BladeMatter Test")');
+        $parser = new BladeMatterParser('@php($foo = "bar")');
         $parser->parse();
-        $this->assertEquals(['title' => 'BladeMatter Test'], $parser->get());
+        $this->assertEquals(['foo' => 'bar'], $parser->get());
     }
 
     public function test_parse_string_helper_method()
@@ -46,7 +46,7 @@ class BladeMatterParserTest extends TestCase
 
     public function test_line_matches_front_matter()
     {
-        $this->assertTrue(BladeMatterParser::lineMatchesFrontMatter('@php($title = "BladeMatter Test")'));
+        $this->assertTrue(BladeMatterParser::lineMatchesFrontMatter('@php($foo = "bar")'));
         $this->assertFalse(BladeMatterParser::lineMatchesFrontMatter('foo bar'));
     }
 
@@ -64,12 +64,12 @@ class BladeMatterParserTest extends TestCase
 
     public function test_extract_key()
     {
-        $this->assertSame('title', BladeMatterParser::extractKey('@php($title = "BladeMatter Test")'));
+        $this->assertSame('foo', BladeMatterParser::extractKey('@php($foo = "bar")'));
     }
 
     public function test_extract_value()
     {
-        $this->assertSame('BladeMatter Test', BladeMatterParser::extractValue('@php($title = "BladeMatter Test")'));
+        $this->assertSame('bar', BladeMatterParser::extractValue('@php($foo = "bar")'));
     }
 
     public function test_normalize_value()

--- a/packages/framework/tests/Feature/BladeMatterParserTest.php
+++ b/packages/framework/tests/Feature/BladeMatterParserTest.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Hyde\Framework\Testing\Feature;
+
+use Hyde\Framework\Actions\BladeMatterParser;
+use Hyde\Testing\TestCase;
+
+/**
+ * @covers \Hyde\Framework\Actions\BladeMatterParser
+ */
+class BladeMatterParserTest extends TestCase
+{
+
+}

--- a/packages/framework/tests/Feature/BladeMatterParserTest.php
+++ b/packages/framework/tests/Feature/BladeMatterParserTest.php
@@ -34,6 +34,16 @@ class BladeMatterParserTest extends TestCase
         );
     }
     
+    public function test_can_parse_multiple_front_matter_lines()
+    {
+        $document = <<<'BLADE'
+        @php($foo = 'bar')
+        @php($bar = 'baz')
+        @php($baz = 'qux')
+        BLADE;
+        $this->assertEquals(['foo' => 'bar', 'bar' => 'baz', 'baz' => 'qux'], BladeMatterParser::parseString($document));
+    }
+
     public function test_line_matches_front_matter()
     {
         $this->assertTrue(BladeMatterParser::lineMatchesFrontMatter('@php($title = "BladeMatter Test")'));

--- a/packages/framework/tests/Feature/BladeMatterParserTest.php
+++ b/packages/framework/tests/Feature/BladeMatterParserTest.php
@@ -50,6 +50,18 @@ class BladeMatterParserTest extends TestCase
         $this->assertFalse(BladeMatterParser::lineMatchesFrontMatter('foo bar'));
     }
 
+    public function test_directive_cannot_have_leading_whitespace()
+    {
+        $this->assertFalse(BladeMatterParser::lineMatchesFrontMatter(' @php($foo = "bar")'));
+    }
+
+    public function test_directive_signature_cannot_contain_whitespace()
+    {
+        $this->assertFalse(BladeMatterParser::lineMatchesFrontMatter('@php( $foo = "bar")'));
+        $this->assertFalse(BladeMatterParser::lineMatchesFrontMatter('@ php($foo = "bar")'));
+        $this->assertFalse(BladeMatterParser::lineMatchesFrontMatter('@ php ($foo = "bar")'));
+    }
+
     public function test_extract_key()
     {
         $this->assertSame('title', BladeMatterParser::extractKey('@php($title = "BladeMatter Test")'));

--- a/packages/framework/tests/Feature/BladeMatterParserTest.php
+++ b/packages/framework/tests/Feature/BladeMatterParserTest.php
@@ -17,6 +17,14 @@ class BladeMatterParserTest extends TestCase
         $this->assertEquals(['title' => 'BladeMatter Test'], $parser->get());
     }
 
+    public function test_parse_string_helper_method()
+    {
+        $this->assertSame(
+            (new BladeMatterParser('foo'))->parse()->get(),
+            BladeMatterParser::parseString('foo')
+        );
+    }
+
     public function test_line_matches_front_matter()
     {
         $this->assertTrue(BladeMatterParser::lineMatchesFrontMatter('@php($title = "BladeMatter Test")'));

--- a/packages/framework/tests/Feature/SourceFileParserTest.php
+++ b/packages/framework/tests/Feature/SourceFileParserTest.php
@@ -66,4 +66,11 @@ class SourceFileParserTest extends TestCase
         $page = MarkdownPage::parse('foo');
         $this->assertEquals('Foo Bar Baz', $page->title);
     }
+
+    public function test_blade_page_data_is_parsed_to_front_matter()
+    {
+        $this->file('_pages/foo.blade.php', "@php(\$title = 'Foo Bar')\n");
+        $page = BladePage::parse('foo');
+        $this->assertEquals('Foo Bar', $page->matter('title'));
+    }
 }

--- a/packages/framework/tests/Feature/SourceFileParserTest.php
+++ b/packages/framework/tests/Feature/SourceFileParserTest.php
@@ -69,6 +69,13 @@ class SourceFileParserTest extends TestCase
 
     public function test_blade_page_data_is_parsed_to_front_matter()
     {
+        $this->file('_pages/foo.blade.php', "@php(\$foo = 'bar')\n");
+        $page = BladePage::parse('foo');
+        $this->assertEquals('bar', $page->matter('foo'));
+    }
+
+    public function test_blade_page_matter_is_used_for_the_page_title()
+    {
         $this->file('_pages/foo.blade.php', "@php(\$title = 'Foo Bar')\n");
         $page = BladePage::parse('foo');
         $this->assertEquals('Foo Bar', $page->matter('title'));


### PR DESCRIPTION
## About

Part one of this will be adding all the common methods currently in the Markdown pages. Then, write a parser to statically parse Blade files for properties. 

### Syntax

I have the following syntax suggestion, as it's actually already used in templates (and I don't want to add actual YAML blocks to Blade files)

```blade
@php($title = 'Latest Posts')
```

Which is equivalent to the following Markdown front matter
```markdown
---
title: Latest Posts
---
```

### Parsing

I think this could easily be parsed similar to how we do shortcodes, by scanning lines for patterns.

The algorithm could be roughly as follows (using `@php($foo = 'bar')` as the example)

1. Get blade file contents as text
2. Split each line into array
3. If line string starts with substring `@php($`
4. Call helper method with that line as a parameter
5. Extract the variable name and split out the value.
   -  We may need to tokenize, looking for something like `@php($`+`foo`+` = '`+`bar`+`')`, making sure to trim out whitespaces and the trailing newline
6. Add the results to the front matter