### PR TITLE
Create method to construct schemas to control the call order

### DIFF
--- a/packages/framework/src/Contracts/AbstractPage.php
+++ b/packages/framework/src/Contracts/AbstractPage.php
@@ -97,6 +97,11 @@ abstract class AbstractPage implements PageContract, CompilableContract
     {
         $this->identifier = $identifier;
         $this->matter = $matter instanceof FrontMatter ? $matter : new FrontMatter($matter);
+        $this->constructPageSchemas();
+    }
+
+    protected function constructPageSchemas(): void
+    {
         $this->constructPageSchema();
     }
 

--- a/packages/framework/src/Models/Pages/MarkdownPost.php
+++ b/packages/framework/src/Models/Pages/MarkdownPost.php
@@ -23,9 +23,13 @@ class MarkdownPost extends AbstractMarkdownPage
     public function __construct(string $identifier = '', ?FrontMatter $matter = null, ?Markdown $markdown = null)
     {
         parent::__construct($identifier, $matter, $markdown);
-
-        $this->constructBlogPostSchema();
         $this->constructMetadata();
+    }
+
+    protected function constructPageSchemas(): void
+    {
+        parent::constructPageSchemas();
+        $this->constructBlogPostSchema();
     }
 
     /** @deprecated v0.58.x-beta (may be moved to BlogPostSchema) */


### PR DESCRIPTION
This was cause to a weird issue where some data was not present in some places. This is of course because the data had not been constructed yet. As long as each child that has a schema adds it to the new construct method (and calls the parent) this issue should be fixed.