### PR TITLE
Add test to ensure pre-computed relative links are retained when rendering new pages

### DIFF
--- a/packages/framework/tests/Feature/RelativeLinksAcrossPagesRetainsIntegrityTest.php
+++ b/packages/framework/tests/Feature/RelativeLinksAcrossPagesRetainsIntegrityTest.php
@@ -54,7 +54,7 @@ class RelativeLinksAcrossPagesRetainsIntegrityTest extends TestCase
         $this->assertSee('root', [
             '<link rel="stylesheet" href="media/app.css">',
             '<a href="index.html"',
-            '<a href="root.html"',
+            '<a href="root.html" aria-current="page"',
             '<a href="root1.html"',
             '<a href="nested/level1.html"',
             '<a href="nested/level1b.html"',
@@ -65,7 +65,7 @@ class RelativeLinksAcrossPagesRetainsIntegrityTest extends TestCase
             '<a href="../index.html"',
             '<a href="../root.html"',
             '<a href="../root1.html"',
-            '<a href="../nested/level1.html"',
+            '<a href="../nested/level1.html" aria-current="page"',
             '<a href="../nested/level1b.html"',
         ]);
     }

--- a/packages/framework/tests/Feature/RelativeLinksAcrossPagesRetainsIntegrityTest.php
+++ b/packages/framework/tests/Feature/RelativeLinksAcrossPagesRetainsIntegrityTest.php
@@ -20,6 +20,9 @@ class RelativeLinksAcrossPagesRetainsIntegrityTest extends TestCase
         $this->file('_pages/root1.md');
         Hyde::touch('_pages/nested/level1.md');
         Hyde::touch('_pages/nested/level1b.md');
+
+        $this->mockConsoleOutput = false;
+        $this->artisan('make:post -n');
     }
 
     protected function tearDown(): void

--- a/packages/framework/tests/Feature/RelativeLinksAcrossPagesRetainsIntegrityTest.php
+++ b/packages/framework/tests/Feature/RelativeLinksAcrossPagesRetainsIntegrityTest.php
@@ -59,6 +59,7 @@ class RelativeLinksAcrossPagesRetainsIntegrityTest extends TestCase
         $this->assertSee('root', [
             '<link rel="stylesheet" href="media/app.css">',
             '<a href="index.html"',
+            '<a href="docs/index.html"',
             '<a href="root.html" aria-current="page"',
             '<a href="root1.html"',
             '<a href="nested/level1.html"',
@@ -68,10 +69,18 @@ class RelativeLinksAcrossPagesRetainsIntegrityTest extends TestCase
         $this->assertSee('nested/level1', [
             '<link rel="stylesheet" href="../media/app.css">',
             '<a href="../index.html"',
+            '<a href="../docs/index.html"',
             '<a href="../root.html"',
             '<a href="../root1.html"',
             '<a href="../nested/level1.html" aria-current="page"',
             '<a href="../nested/level1b.html"',
+        ]);
+
+        $this->assertSee('docs/index', [
+            '<link rel="stylesheet" href="../media/app.css">',
+            '<a href="../docs/index.html">',
+            '<a href="../docs/docs.html"',
+            '<a href="../index.html">Back to home page</a>',
         ]);
     }
 }

--- a/packages/framework/tests/Feature/RelativeLinksAcrossPagesRetainsIntegrityTest.php
+++ b/packages/framework/tests/Feature/RelativeLinksAcrossPagesRetainsIntegrityTest.php
@@ -15,7 +15,7 @@ class RelativeLinksAcrossPagesRetainsIntegrityTest extends TestCase
     {
         parent::setUp();
 
-        $this->needsDirectory('_pages/nested/sub-nested');
+        $this->needsDirectory('_pages/nested');
     }
 
     protected function tearDown(): void
@@ -34,7 +34,6 @@ class RelativeLinksAcrossPagesRetainsIntegrityTest extends TestCase
         $this->file('_pages/root1.md');
         Hyde::touch('_pages/nested/level1.md');
         Hyde::touch('_pages/nested/level1b.md');
-        Hyde::touch('_pages/nested/sub-nested/level2.md');
 
         $this->artisan('build');
     }

--- a/packages/framework/tests/Feature/RelativeLinksAcrossPagesRetainsIntegrityTest.php
+++ b/packages/framework/tests/Feature/RelativeLinksAcrossPagesRetainsIntegrityTest.php
@@ -16,6 +16,10 @@ class RelativeLinksAcrossPagesRetainsIntegrityTest extends TestCase
         parent::setUp();
 
         $this->needsDirectory('_pages/nested');
+        $this->file('_pages/root.md');
+        $this->file('_pages/root1.md');
+        Hyde::touch('_pages/nested/level1.md');
+        Hyde::touch('_pages/nested/level1b.md');
     }
 
     protected function tearDown(): void
@@ -44,11 +48,6 @@ class RelativeLinksAcrossPagesRetainsIntegrityTest extends TestCase
 
     public function test_relative_links_across_pages_retains_integrity()
     {
-        $this->file('_pages/root.md');
-        $this->file('_pages/root1.md');
-        Hyde::touch('_pages/nested/level1.md');
-        Hyde::touch('_pages/nested/level1b.md');
-
         $this->artisan('build');
 
         $this->assertSee('root', [

--- a/packages/framework/tests/Feature/RelativeLinksAcrossPagesRetainsIntegrityTest.php
+++ b/packages/framework/tests/Feature/RelativeLinksAcrossPagesRetainsIntegrityTest.php
@@ -2,9 +2,35 @@
 
 namespace Hyde\Framework\Testing\Feature;
 
+use Hyde\Framework\Concerns\InteractsWithDirectories;
+use Hyde\Framework\Hyde;
 use Hyde\Testing\TestCase;
+use Illuminate\Support\Facades\File;
 
 class RelativeLinksAcrossPagesRetainsIntegrityTest extends TestCase
 {
-    //
+    use InteractsWithDirectories;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->needsDirectory('_pages/nested/sub-nested');
+    }
+
+    protected function tearDown(): void
+    {
+        File::deleteDirectory(Hyde::path('_pages/nested'));
+
+        parent::tearDown();
+    }
+
+    public function test_relative_links_across_pages_retains_integrity()
+    {
+        Hyde::touch('_pages/root.md');
+        Hyde::touch('_pages/root1.md');
+        Hyde::touch('_pages/nested/level1.md');
+        Hyde::touch('_pages/nested/level1b.md');
+        Hyde::touch('_pages/nested/sub-nested/level2.md');
+    }
 }

--- a/packages/framework/tests/Feature/RelativeLinksAcrossPagesRetainsIntegrityTest.php
+++ b/packages/framework/tests/Feature/RelativeLinksAcrossPagesRetainsIntegrityTest.php
@@ -34,6 +34,7 @@ class RelativeLinksAcrossPagesRetainsIntegrityTest extends TestCase
         Hyde::unlink('_site/root.html');
         Hyde::unlink('_site/root1.html');
         $this->resetSite();
+        $this->resetPosts();
 
         parent::tearDown();
     }

--- a/packages/framework/tests/Feature/RelativeLinksAcrossPagesRetainsIntegrityTest.php
+++ b/packages/framework/tests/Feature/RelativeLinksAcrossPagesRetainsIntegrityTest.php
@@ -21,16 +21,21 @@ class RelativeLinksAcrossPagesRetainsIntegrityTest extends TestCase
     protected function tearDown(): void
     {
         File::deleteDirectory(Hyde::path('_pages/nested'));
+        Hyde::unlink('_site/root.html');
+        Hyde::unlink('_site/root1.html');
+        $this->resetSite();
 
         parent::tearDown();
     }
 
     public function test_relative_links_across_pages_retains_integrity()
     {
-        Hyde::touch('_pages/root.md');
-        Hyde::touch('_pages/root1.md');
+        $this->file('_pages/root.md');
+        $this->file('_pages/root1.md');
         Hyde::touch('_pages/nested/level1.md');
         Hyde::touch('_pages/nested/level1b.md');
         Hyde::touch('_pages/nested/sub-nested/level2.md');
+
+        $this->artisan('build');
     }
 }

--- a/packages/framework/tests/Feature/RelativeLinksAcrossPagesRetainsIntegrityTest.php
+++ b/packages/framework/tests/Feature/RelativeLinksAcrossPagesRetainsIntegrityTest.php
@@ -21,6 +21,9 @@ class RelativeLinksAcrossPagesRetainsIntegrityTest extends TestCase
         Hyde::touch('_pages/nested/level1.md');
         Hyde::touch('_pages/nested/level1b.md');
 
+        $this->file('_docs/index.md');
+        $this->file('_docs/docs.md');
+
         $this->mockConsoleOutput = false;
         $this->artisan('make:post -n');
     }

--- a/packages/framework/tests/Feature/RelativeLinksAcrossPagesRetainsIntegrityTest.php
+++ b/packages/framework/tests/Feature/RelativeLinksAcrossPagesRetainsIntegrityTest.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Hyde\Framework\Testing\Feature;
+
+use Hyde\Testing\TestCase;
+
+class RelativeLinksAcrossPagesRetainsIntegrityTest extends TestCase
+{
+    //
+}

--- a/packages/framework/tests/Feature/RelativeLinksAcrossPagesRetainsIntegrityTest.php
+++ b/packages/framework/tests/Feature/RelativeLinksAcrossPagesRetainsIntegrityTest.php
@@ -50,5 +50,23 @@ class RelativeLinksAcrossPagesRetainsIntegrityTest extends TestCase
         Hyde::touch('_pages/nested/level1b.md');
 
         $this->artisan('build');
+
+        $this->assertSee('root', [
+            '<link rel="stylesheet" href="media/app.css">',
+            '<a href="index.html"',
+            '<a href="root.html"',
+            '<a href="root1.html"',
+            '<a href="nested/level1.html"',
+            '<a href="nested/level1b.html"',
+        ]);
+
+        $this->assertSee('nested/level1', [
+            '<link rel="stylesheet" href="../media/app.css">',
+            '<a href="../index.html"',
+            '<a href="../root.html"',
+            '<a href="../root1.html"',
+            '<a href="../nested/level1.html"',
+            '<a href="../nested/level1b.html"',
+        ]);
     }
 }

--- a/packages/framework/tests/Feature/RelativeLinksAcrossPagesRetainsIntegrityTest.php
+++ b/packages/framework/tests/Feature/RelativeLinksAcrossPagesRetainsIntegrityTest.php
@@ -28,6 +28,20 @@ class RelativeLinksAcrossPagesRetainsIntegrityTest extends TestCase
         parent::tearDown();
     }
 
+    protected function assertSee(string $page, string|array $text): void
+    {
+        if (is_array($text)) {
+            foreach ($text as $string) {
+                $this->assertSee($page, $string);
+            }
+            return;
+        }
+
+        $this->assertStringContainsString($text,
+            file_get_contents(Hyde::path("_site/$page.html")),
+            "Failed asserting that the page '$page' contains the text '$text'");
+    }
+
     public function test_relative_links_across_pages_retains_integrity()
     {
         $this->file('_pages/root.md');


### PR DESCRIPTION
See https://github.com/hydephp/develop/issues/371

> We must make sure this does not break relative links. We may need to force a recompute of relative links each time the current page property is set.
> 
> Originally posted by @caendesilva in https://github.com/hydephp/develop/pull/367#issuecomment-1207925899