### PR TITLE
Consistently use image paths relative to _media directory as described in the documentation

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -23,6 +23,7 @@ The way metadata tags are handled internally is also refactored. The rendered re
 - Major: Restructure internal page data to use new front matter schema traits 
 - Begin changing references to slugs to identifiers, see motivation below
 - Makes some helpers in SourceFileParser public static allowing them to be used outside the class
+- The Image model and featured blog post image helpers now consistently use image paths relative to the `_media` directory as is described in the documentation 
 
 ### Deprecated
 - Deprecated `Facades\Markdown::parse()`, use `Facades\Markdown::render()` instead

--- a/packages/framework/src/Actions/FindsContentLengthForImageObject.php
+++ b/packages/framework/src/Actions/FindsContentLengthForImageObject.php
@@ -65,7 +65,7 @@ class FindsContentLengthForImageObject implements ActionContract
 
     protected function fetchLocalImageInformation(): int
     {
-        $path = Hyde::path('_media/' . $this->image->getSource());
+        $path = Hyde::path('_media/'.$this->image->getSource());
 
         if (! file_exists($path)) {
             $this->write(' > <comment>Warning:</comment> Could not find image file at '.$path.'!');

--- a/packages/framework/src/Actions/FindsContentLengthForImageObject.php
+++ b/packages/framework/src/Actions/FindsContentLengthForImageObject.php
@@ -3,6 +3,7 @@
 namespace Hyde\Framework\Actions;
 
 use Hyde\Framework\Contracts\ActionContract;
+use Hyde\Framework\Hyde;
 use Hyde\Framework\Models\Image;
 use Illuminate\Support\Facades\Http;
 use Symfony\Component\Console\Output\ConsoleOutput;
@@ -64,14 +65,16 @@ class FindsContentLengthForImageObject implements ActionContract
 
     protected function fetchLocalImageInformation(): int
     {
-        if (! file_exists($this->image->getSource())) {
-            $this->write(' > <comment>Warning:</comment> Could not find image file at '.$this->image->getSource().'!');
+        $path = Hyde::path('_media/' . $this->image->getSource());
+
+        if (! file_exists($path)) {
+            $this->write(' > <comment>Warning:</comment> Could not find image file at '.$path.'!');
             $this->write('         <fg=gray>   Using default content length of 0. '.'</>');
 
             return 0;
         }
 
-        return filesize($this->image->getSource());
+        return filesize($path);
     }
 
     protected function write(string $string): void

--- a/packages/framework/src/Models/Image.php
+++ b/packages/framework/src/Models/Image.php
@@ -104,7 +104,7 @@ class Image implements \Stringable
         }
 
         if (isset($this->path)) {
-            $this->normalizePath();
+            $this->path = basename($this->path);
         }
     }
 
@@ -224,20 +224,5 @@ class Image implements \Stringable
         $metadata['contentUrl'] = $this->getSource();
 
         return $metadata;
-    }
-
-    protected function normalizePath(): void
-    {
-        $path = $this->path;
-
-        if (str_starts_with($path, '_media/')) {
-            $path = substr($path, 7);
-        }
-
-        if (str_starts_with($path, 'media/')) {
-            $path = substr($path, 6);
-        }
-
-        $this->path = $path;
     }
 }

--- a/packages/framework/src/Models/Image.php
+++ b/packages/framework/src/Models/Image.php
@@ -133,7 +133,7 @@ class Image implements \Stringable
 
     public function getSource(): ?string
     {
-        return $this->uri ?? $this->path ?? null;
+        return $this->uri ?? $this->getPath() ?? null;
     }
 
     public function getLink(): string
@@ -224,5 +224,14 @@ class Image implements \Stringable
         $metadata['contentUrl'] = $this->getSource();
 
         return $metadata;
+    }
+
+    protected function getPath(): ?string
+    {
+        if (isset($this->path)) {
+            return basename($this->path);
+        }
+
+        return null;
     }
 }

--- a/packages/framework/src/Models/Image.php
+++ b/packages/framework/src/Models/Image.php
@@ -20,7 +20,7 @@ use Hyde\Framework\Hyde;
  *    'credit'       => '?string'
  * ];
  */
-class Image
+class Image implements \Stringable
 {
     /**
      * The image's path (if it is stored locally (in the _media directory)).
@@ -106,6 +106,12 @@ class Image
         if (isset($this->path)) {
             $this->normalizePath();
         }
+    }
+
+    /** @inheritDoc */
+    public function __toString()
+    {
+        return $this->getLink();
     }
 
     /** Dynamically create an image based on string or front matter array */

--- a/packages/framework/src/Models/Image.php
+++ b/packages/framework/src/Models/Image.php
@@ -220,8 +220,8 @@ class Image implements \Stringable
             $metadata['name'] = $this->title;
         }
 
-        $metadata['url'] = $this->getSource();
-        $metadata['contentUrl'] = $this->getSource();
+        $metadata['url'] = $this->getLink();
+        $metadata['contentUrl'] = $this->getLink();
 
         return $metadata;
     }

--- a/packages/framework/src/Models/Image.php
+++ b/packages/framework/src/Models/Image.php
@@ -138,7 +138,11 @@ class Image implements \Stringable
 
     public function getLink(): string
     {
-        return Hyde::image($this->getSource() ?? '');
+        if (! $this->getSource()) {
+            return '';
+        }
+
+        return Hyde::image($this->getSource());
     }
 
     public function getContentLength(): int

--- a/packages/framework/src/Models/Image.php
+++ b/packages/framework/src/Models/Image.php
@@ -102,6 +102,10 @@ class Image
         foreach ($data as $key => $value) {
             $this->{$key} = $value;
         }
+
+        if (isset($this->path)) {
+            $this->normalizePath();
+        }
     }
 
     /** Dynamically create an image based on string or front matter array */
@@ -214,5 +218,20 @@ class Image
         $metadata['contentUrl'] = $this->getSource();
 
         return $metadata;
+    }
+
+    protected function normalizePath(): void
+    {
+        $path = $this->path;
+
+        if (str_starts_with($path, '_media/')) {
+            $path = substr($path, 7);
+        }
+
+        if (str_starts_with($path, 'media/')) {
+            $path = substr($path, 6);
+        }
+
+        $this->path = $path;
     }
 }

--- a/packages/framework/src/Models/Image.php
+++ b/packages/framework/src/Models/Image.php
@@ -23,8 +23,8 @@ use Hyde\Framework\Hyde;
 class Image
 {
     /**
-     * The image's path (if it is stored locally).
-     * Example: _media/image.jpg.
+     * The image's path (if it is stored locally (in the _media directory)).
+     * Example: image.jpg.
      *
      * @var string|null
      */

--- a/packages/framework/src/Models/Pages/MarkdownPost.php
+++ b/packages/framework/src/Models/Pages/MarkdownPost.php
@@ -116,7 +116,7 @@ class MarkdownPost extends AbstractMarkdownPage
     protected function setImageMetadata(): void
     {
         if ($this->image) {
-            $this->properties['og:image'] = str_starts_with('http', $this->image->getLink()) ? $this->image->getLink() :'../'.$this->image->getLink();
+            $this->properties['og:image'] = str_starts_with('http', $this->image->getLink()) ? $this->image->getLink() : '../'.$this->image->getLink();
         }
     }
 }

--- a/packages/framework/src/Models/Pages/MarkdownPost.php
+++ b/packages/framework/src/Models/Pages/MarkdownPost.php
@@ -116,7 +116,11 @@ class MarkdownPost extends AbstractMarkdownPage
     protected function setImageMetadata(): void
     {
         if ($this->image) {
-            $this->properties['og:image'] = str_starts_with('http', $this->image->getLink()) ? $this->image->getLink() : '../'.$this->image->getLink();
+            if (str_starts_with($this->image->getLink(), 'http')) {
+                $this->properties['og:image'] = $this->image->getLink();
+            } else {
+                $this->properties['og:image'] = '../media/'.basename($this->image->getLink());
+            }
         }
     }
 }

--- a/packages/framework/src/Models/Pages/MarkdownPost.php
+++ b/packages/framework/src/Models/Pages/MarkdownPost.php
@@ -116,7 +116,7 @@ class MarkdownPost extends AbstractMarkdownPage
     protected function setImageMetadata(): void
     {
         if ($this->image) {
-            $this->properties['og:image'] = '../'.$this->image->getLink();
+            $this->properties['og:image'] = str_starts_with('http', $this->image->getLink()) ? $this->image->getLink() :'../'.$this->image->getLink();
         }
     }
 }

--- a/packages/framework/src/Models/Pages/MarkdownPost.php
+++ b/packages/framework/src/Models/Pages/MarkdownPost.php
@@ -116,7 +116,7 @@ class MarkdownPost extends AbstractMarkdownPage
     protected function setImageMetadata(): void
     {
         if ($this->image) {
-            $this->properties['og:image'] = $this->image->getLink();
+            $this->properties['og:image'] = '../'.$this->image->getLink();
         }
     }
 }

--- a/packages/framework/tests/Feature/Commands/StaticSiteBuilderPostModuleTest.php
+++ b/packages/framework/tests/Feature/Commands/StaticSiteBuilderPostModuleTest.php
@@ -26,6 +26,7 @@ class StaticSiteBuilderPostModuleTest extends TestCase
             'category' => 'novels',
             'author' => 'Lewis Carroll',
             'date' => '1865-11-18 18:52',
+            'image' => 'image.png',
         ], "## CHAPTER I. DOWN THE RABBIT-HOLE. \n\nSo she was considering in her own mind, as well as she could, for the hot day made her feel very sleepy and stupid.", 'Test Title');
 
         // Make sure no file exists which could cause unintended results.
@@ -119,6 +120,15 @@ class StaticSiteBuilderPostModuleTest extends TestCase
             'role="doc-pageheader"',
             'role="doc-introduction"',
             'aria-label="About the post"',
+        ]);
+    }
+
+    public function test_post_image_is_resolved_relatively()
+    {
+        $this->inspectHtml([
+            '<meta property="og:image" content="../media/image.png">',
+            '<meta itemprop="url" content="../media/image.png">',
+            '<meta itemprop="contentUrl" content="../media/image.png">',
         ]);
     }
 }

--- a/packages/framework/tests/Feature/FindsContentLengthForImageObjectTest.php
+++ b/packages/framework/tests/Feature/FindsContentLengthForImageObjectTest.php
@@ -4,7 +4,6 @@ namespace Hyde\Framework\Testing\Feature;
 
 use Hyde\Framework\Models\Image;
 use Hyde\Testing\TestCase;
-use Illuminate\Http\Client\Request;
 use Illuminate\Support\Facades\Http;
 
 /**
@@ -39,7 +38,7 @@ class FindsContentLengthForImageObjectTest extends TestCase
 
     public function test_it_can_find_the_content_length_for_a_remote_image()
     {
-        Http::fake(function (Request $request) {
+        Http::fake(function () {
             return Http::response(null, 200, [
                 'Content-Length' => 16,
             ]);
@@ -65,7 +64,7 @@ class FindsContentLengthForImageObjectTest extends TestCase
 
     public function test_it_returns_0_if_remote_image_is_missing()
     {
-        Http::fake(function (Request $request) {
+        Http::fake(function () {
             return Http::response(null, 404);
         });
 

--- a/packages/framework/tests/Feature/ImageModelTest.php
+++ b/packages/framework/tests/Feature/ImageModelTest.php
@@ -215,4 +215,23 @@ class ImageModelTest extends TestCase
             'path' => 'media/image.jpg',
         ]))->path);
     }
+
+    public function test_to_string_returns_the_image_source()
+    {
+        $this->assertEquals('https://example.com/image.jpg', (string) (new Image([
+            'uri' => 'https://example.com/image.jpg',
+        ])));
+
+        $this->assertEquals('media/image.jpg', (string) (new Image([
+            'path' => 'image.jpg',
+        ])));
+    }
+
+    public function test_to_string_returns_the_image_source_for_nested_pages()
+    {
+        $this->mockCurrentPage('foo/bar');
+        $this->assertEquals('../media/image.jpg', (string) (new Image([
+            'path' => 'image.jpg',
+        ])));
+    }
 }

--- a/packages/framework/tests/Feature/ImageModelTest.php
+++ b/packages/framework/tests/Feature/ImageModelTest.php
@@ -200,4 +200,19 @@ class ImageModelTest extends TestCase
         $this->mockCurrentPage('foo/bar');
         $this->assertEquals('../media/image.jpg', $image->getLink());
     }
+
+    public function test_local_path_is_normalized_to_the_media_directory()
+    {
+        $this->assertEquals('image.jpg', (new Image([
+            'path' => 'image.jpg',
+        ]))->path);
+
+        $this->assertEquals('image.jpg', (new Image([
+            'path' => '_media/image.jpg',
+        ]))->path);
+
+        $this->assertEquals('image.jpg', (new Image([
+            'path' => 'media/image.jpg',
+        ]))->path);
+    }
 }

--- a/packages/framework/tests/Feature/ImageModelTest.php
+++ b/packages/framework/tests/Feature/ImageModelTest.php
@@ -173,6 +173,43 @@ class ImageModelTest extends TestCase
         ], $image->getMetadataArray());
     }
 
+    public function test_get_metadata_array_with_remote_url()
+    {
+        $image = new Image([
+            'uri' => 'https://foo/bar',
+        ]);
+
+        $this->assertEquals([
+            'url' => 'https://foo/bar',
+            'contentUrl' => 'https://foo/bar',
+        ], $image->getMetadataArray());
+    }
+
+    public function test_get_metadata_array_with_local_path()
+    {
+        $image = new Image([
+            'path' => 'foo.png',
+        ]);
+
+        $this->assertEquals([
+            'url' => 'media/foo.png',
+            'contentUrl' => 'media/foo.png',
+        ], $image->getMetadataArray());
+    }
+
+    public function test_get_metadata_array_with_local_path_when_on_nested_page()
+    {
+        $this->mockCurrentPage('foo/bar');
+        $image = new Image([
+            'path' => 'foo.png',
+        ]);
+
+        $this->assertEquals([
+            'url' => '../media/foo.png',
+            'contentUrl' => '../media/foo.png',
+        ], $image->getMetadataArray());
+    }
+
     public function test_get_link_resolves_remote_paths()
     {
         $image = new Image([

--- a/packages/framework/tests/Feature/ImageModelTest.php
+++ b/packages/framework/tests/Feature/ImageModelTest.php
@@ -48,7 +48,7 @@ class ImageModelTest extends TestCase
     public function test_array_data_can_be_used_to_initialize_properties_in_constructor()
     {
         $data = [
-            'path' => 'path/to/image.jpg',
+            'path' => 'image.jpg',
             'uri' => 'https://example.com/image.jpg',
             'description' => 'This is an image',
             'title' => 'Image Title',
@@ -66,7 +66,7 @@ class ImageModelTest extends TestCase
     {
         $image = new Image();
         $image->uri = 'https://example.com/image.jpg';
-        $image->path = 'path/to/image.jpg';
+        $image->path = 'image.jpg';
 
         $this->assertEquals('https://example.com/image.jpg', $image->getSource());
     }
@@ -74,9 +74,9 @@ class ImageModelTest extends TestCase
     public function test_get_source_method_returns_path_when_only_path_is_set()
     {
         $image = new Image();
-        $image->path = 'path/to/image.jpg';
+        $image->path = 'image.jpg';
 
-        $this->assertEquals('path/to/image.jpg', $image->getSource());
+        $this->assertEquals('image.jpg', $image->getSource());
     }
 
     public function test_get_source_method_returns_null_when_no_source_is_set()

--- a/packages/framework/tests/Unit/ArticleMetadataTest.php
+++ b/packages/framework/tests/Unit/ArticleMetadataTest.php
@@ -82,7 +82,7 @@ class ArticleMetadataTest extends TestCase
 
         $this->assertEquals([
             'og:type' => 'article',
-            'og:image' => 'media/foo.jpg',
+            'og:image' => '../media/foo.jpg',
         ], $page->getMetaProperties());
     }
 
@@ -110,7 +110,7 @@ class ArticleMetadataTest extends TestCase
 
         $this->assertEquals([
             'og:type' => 'article',
-            'og:image' => 'media/foo.jpg',
+            'og:image' => '../media/foo.jpg',
         ], $page->getMetaProperties());
     }
 


### PR DESCRIPTION
The docs explain that images using the Image object should be in the _media directory when they are referenced by a local path, but we are not consistently doing this. This PR fixes that.

Will fix the following:
- [x] Fix https://github.com/hydephp/develop/issues/359
- [x] Fix https://github.com/hydephp/develop/issues/370
- [x] Fix https://github.com/hydephp/develop/issues/374

