### PR TITLE
Add a default category property value for documentation pages

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -29,6 +29,7 @@ The way metadata tags are handled internally is also refactored. The rendered re
 - Page metadata is now stored as a page property, making it easier to see and understand
 - Page metadata is now generated at compile time instead of build time
 - Page metadata types are now strongly typed, however all types are String able, so end usage is not affected
+- Documentation pages now have the default category 'other'
 
 ### Deprecated
 - Deprecated `Facades\Markdown::parse()`, use `Facades\Markdown::render()` instead

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -29,7 +29,6 @@ The way metadata tags are handled internally is also refactored. The rendered re
 - Page metadata is now stored as a page property, making it easier to see and understand
 - Page metadata is now generated at compile time instead of build time
 - Page metadata types are now strongly typed, however all types are String able, so end usage is not affected
-- Documentation pages now have the default category 'other'
 
 ### Deprecated
 - Deprecated `Facades\Markdown::parse()`, use `Facades\Markdown::render()` instead

--- a/packages/framework/resources/views/components/docs/grouped-sidebar.blade.php
+++ b/packages/framework/resources/views/components/docs/grouped-sidebar.blade.php
@@ -1,7 +1,7 @@
 <ul id="sidebar" role="list">
 	@foreach ($sidebar->getGroups() as $group)
 	<li class="sidebar-category mb-4 mt-4 first:mt-0" role="listitem">
-		<h4 class="sidebar-category-heading text-base font-semibold mb-2 -ml-1">{{ Hyde::makeTitle($group ?? 'Other') }}</h4>
+		<h4 class="sidebar-category-heading text-base font-semibold mb-2 -ml-1">{{ Hyde::makeTitle($group) }}</h4>
 		<ul class="sidebar-category-list ml-4" role="list">
 			@foreach ($sidebar->getItemsInGroup($group) as $item)
 				<x-hyde::docs.grouped-sidebar-item :item="$item" :active="$item->route->getRouteKey() === $currentRoute->getRouteKey()" />

--- a/packages/framework/src/Concerns/FrontMatter/Schemas/DocumentationPageSchema.php
+++ b/packages/framework/src/Concerns/FrontMatter/Schemas/DocumentationPageSchema.php
@@ -14,7 +14,7 @@ trait DocumentationPageSchema
     /**
      * The label for the page shown in the sidebar.
      */
-    public ?string $label;
+    public ?string $label = null;
 
     /**
      * Hides the page from the sidebar.

--- a/packages/framework/src/Concerns/FrontMatter/Schemas/DocumentationPageSchema.php
+++ b/packages/framework/src/Concerns/FrontMatter/Schemas/DocumentationPageSchema.php
@@ -8,6 +8,9 @@ trait DocumentationPageSchema
 {
     /**
      * The sidebar category group, if any.
+     *
+     * Can be overridden in front matter, or by putting the
+     * source file in a subdirectory of the same category name.
      */
     public ?string $category = null;
 

--- a/packages/framework/src/Concerns/FrontMatter/Schemas/DocumentationPageSchema.php
+++ b/packages/framework/src/Concerns/FrontMatter/Schemas/DocumentationPageSchema.php
@@ -45,7 +45,7 @@ trait DocumentationPageSchema
 
         return str_contains($this->identifier, '/')
             ? Str::before($this->identifier, '/')
-            : $this->matter('category');
+            : $this->matter('category', 'other');
     }
 
     protected function findPriorityInConfig(): int

--- a/packages/framework/src/Models/DocumentationSidebar.php
+++ b/packages/framework/src/Models/DocumentationSidebar.php
@@ -23,7 +23,7 @@ class DocumentationSidebar extends NavigationMenu
 
     public function hasGroups(): bool
     {
-       return count($this->getGroups()) >= 1 && $this->getGroups() !== [0 => 'other'];
+        return count($this->getGroups()) >= 1 && $this->getGroups() !== [0 => 'other'];
     }
 
     public function getGroups(): array

--- a/packages/framework/src/Models/DocumentationSidebar.php
+++ b/packages/framework/src/Models/DocumentationSidebar.php
@@ -23,9 +23,7 @@ class DocumentationSidebar extends NavigationMenu
 
     public function hasGroups(): bool
     {
-        return $this->items->map(function (NavItem $item) {
-            return $item->getGroup() !== null;
-        })->contains(true);
+       return count($this->getGroups()) > 1;
     }
 
     public function getGroups(): array

--- a/packages/framework/src/Models/DocumentationSidebar.php
+++ b/packages/framework/src/Models/DocumentationSidebar.php
@@ -23,7 +23,7 @@ class DocumentationSidebar extends NavigationMenu
 
     public function hasGroups(): bool
     {
-       return count($this->getGroups()) > 1;
+       return count($this->getGroups()) >= 1 && $this->getGroups() !== [0 => 'other'];
     }
 
     public function getGroups(): array

--- a/packages/framework/tests/Feature/Services/DocumentationSidebarTest.php
+++ b/packages/framework/tests/Feature/Services/DocumentationSidebarTest.php
@@ -161,6 +161,23 @@ class DocumentationSidebarTest extends TestCase
         $this->assertTrue(DocumentationSidebar::create()->hasGroups());
     }
 
+    public function test_has_groups_returns_true_when_there_are_multiple_groups()
+    {
+        $this->makePage('foo', ['category' => 'bar']);
+        $this->makePage('bar', ['category' => 'baz']);
+
+        $this->assertTrue(DocumentationSidebar::create()->hasGroups());
+    }
+
+    public function test_has_groups_returns_true_when_there_are_multiple_groups_mixed_with_defaults()
+    {
+        $this->makePage('foo', ['category' => 'bar']);
+        $this->makePage('bar', ['category' => 'baz']);
+        $this->makePage('baz');
+
+        $this->assertTrue(DocumentationSidebar::create()->hasGroups());
+    }
+
     public function test_get_groups_returns_empty_array_when_there_are_no_groups()
     {
         $this->assertEquals([], DocumentationSidebar::create()->getGroups());


### PR DESCRIPTION
This is more predictable than assigning "other" at runtime. The logic determining if the categorized layout should be used has been updated, so this PR should have no effect on the actual rendered pages and their behaviour.