### PR TITLE
Fix #383: Navigation menu titles can't be set in BladeMatter

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -22,7 +22,7 @@ This serves two purposes:
 - for now removed features.
 
 ### Fixed
-- for any bug fixes.
+- Fix [#383](https://github.com/hydephp/develop/issues/383): Navigation menu titles can't be set in BladeMatter
 
 ### Security
 - in case of vulnerabilities.

--- a/packages/framework/src/Actions/Constructors/FindsNavigationDataForPage.php
+++ b/packages/framework/src/Actions/Constructors/FindsNavigationDataForPage.php
@@ -32,14 +32,8 @@ class FindsNavigationDataForPage
 
     protected function getNavigationMenuTitle(): string
     {
-        if ($this->page instanceof AbstractMarkdownPage) {
-            if ($this->page->matter('navigation.title') !== null) {
-                return $this->page->matter('navigation.title');
-            }
-
-            if ($this->page->matter('title') !== null) {
-                return $this->page->matter('title');
-            }
+        if ($this->page->matter('navigation.title') !== null) {
+            return $this->page->matter('navigation.title');
         }
 
         if ($this->page->identifier === 'index') {
@@ -48,6 +42,10 @@ class FindsNavigationDataForPage
             }
 
             return config('hyde.navigation.labels.home', 'Home');
+        }
+
+        if ($this->page->matter('title') !== null) {
+            return $this->page->matter('title');
         }
 
         return $this->page->title;

--- a/packages/framework/tests/Unit/Views/NavigationMenuViewTest.php
+++ b/packages/framework/tests/Unit/Views/NavigationMenuViewTest.php
@@ -2,6 +2,7 @@
 
 namespace Hyde\Framework\Testing\Unit\Views;
 
+use Hyde\Framework\Hyde;
 use Hyde\Testing\TestCase;
 
 /**
@@ -49,5 +50,30 @@ class NavigationMenuViewTest extends TestCase
     public function test_component_not_contains_404_html_link()
     {
         $this->assertStringNotContainsString('href="404.html"', $this->render());
+    }
+
+    public function test_navigation_menu_label_can_be_changed_in_front_matter()
+    {
+        $this->file('_pages/foo.md', '---
+navigation: 
+  title: "My custom title"
+---
+');
+        $this->artisan('rebuild _pages/foo.md');
+        $this->assertStringContainsString('My custom title', file_get_contents(Hyde::path('_site/foo.html')));
+        Hyde::unlink('_site/foo.html');
+    }
+
+    public function test_navigation_menu_label_can_be_changed_in_blade_matter()
+    {
+        $this->file('_pages/foo.blade.php', <<<'BLADE'
+@extends('hyde::layouts.app')
+@php($navigation = ['title' => 'My custom title'])
+BLADE
+);
+
+        $this->artisan('rebuild _pages/foo.blade.php');
+        $this->assertStringContainsString('My custom title', file_get_contents(Hyde::path('_site/foo.html')));
+        Hyde::unlink('_site/foo.html');
     }
 }


### PR DESCRIPTION
This is caused in FindsNavigationDataForPage.php where the front matter is only read for Markdown pages.

> ```php
> if ($this->page instanceof AbstractMarkdownPage) {
>     if ($this->page->matter('navigation.title') !== null) {
>         return $this->page->matter('navigation.title');
>     }
> 
>     if ($this->page->matter('title') !== null) {
>         return $this->page->matter('title');
>     }
> }
> ```