### PR TITLE
Change documentation page label fallback to previous behaviour

### DIFF
--- a/packages/framework/src/Concerns/FrontMatter/Schemas/DocumentationPageSchema.php
+++ b/packages/framework/src/Concerns/FrontMatter/Schemas/DocumentationPageSchema.php
@@ -2,6 +2,7 @@
 
 namespace Hyde\Framework\Concerns\FrontMatter\Schemas;
 
+use Hyde\Framework\Hyde;
 use Illuminate\Support\Str;
 
 trait DocumentationPageSchema
@@ -33,7 +34,7 @@ trait DocumentationPageSchema
     {
         $this->category = static::getDocumentationPageCategory();
 
-        $this->label = $this->matter('label', $this->title);
+        $this->label = $this->matter('label', Hyde::makeTitle(basename($this->identifier)));
         $this->hidden = $this->matter('hidden', $this->identifier === 'index');
         $this->priority = $this->matter('priority', $this->findPriorityInConfig());
     }

--- a/packages/framework/src/Models/DocumentationSidebar.php
+++ b/packages/framework/src/Models/DocumentationSidebar.php
@@ -14,7 +14,9 @@ class DocumentationSidebar extends NavigationMenu
     {
         RoutingService::getInstance()->getRoutesForModel(DocumentationPage::class)->each(function (Route $route) {
             if (! $route->getSourceModel()->get('hidden', false)) {
-                $this->items->push(NavItem::fromRoute($route)->setPriority($this->getPriorityForRoute($route)));
+                $this->items->push(tap(NavItem::fromRoute($route)->setPriority($this->getPriorityForRoute($route)), function (NavItem $item) {
+                    $item->title =  $item->route->getSourceModel()->get('label');
+                }));
             }
         });
 

--- a/packages/framework/src/Models/DocumentationSidebar.php
+++ b/packages/framework/src/Models/DocumentationSidebar.php
@@ -15,7 +15,7 @@ class DocumentationSidebar extends NavigationMenu
         RoutingService::getInstance()->getRoutesForModel(DocumentationPage::class)->each(function (Route $route) {
             if (! $route->getSourceModel()->get('hidden', false)) {
                 $this->items->push(tap(NavItem::fromRoute($route)->setPriority($this->getPriorityForRoute($route)), function (NavItem $item) {
-                    $item->title =  $item->route->getSourceModel()->get('label');
+                    $item->title = $item->route->getSourceModel()->get('label');
                 }));
             }
         });


### PR DESCRIPTION
Previously, when a documentation page did not have a label front matter, it defaulted to a title generated from the slug/identifier. This was intentional, as the page titles may be too long to comfortably fit in the sidebar. This PR reverts this behaviour which was inadvertently changed in v0.58.0-beta. It also fixes a bug where the sidebar label was actually not used in the resulting view.