### PR TITLE
Add option to Hyde::image() helper to prefer full URI paths

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -11,7 +11,6 @@ This serves two purposes:
 
 ### Added
 - Adds an option to the `Hyde::image()` helper to request the returned image path use the configured base URL if it's set
-- The Image model will now be resolved using the configured base URL if it's set, otherwise it falls back to default relative path
 
 ### Changed
 - for changes in existing functionality.

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -10,7 +10,8 @@ This serves two purposes:
 2. At release time, you can move the Unreleased section changes into a new release version section.
 
 ### Added
-- for new features.
+- Adds an option to the `Hyde::image()` helper to request the returned image path use the configured base URL if it's set
+- The Image model will now be resolved using the configured base URL if it's set, otherwise it falls back to default relative path
 
 ### Changed
 - for changes in existing functionality.

--- a/packages/framework/src/Foundation/Hyperlinks.php
+++ b/packages/framework/src/Foundation/Hyperlinks.php
@@ -71,6 +71,7 @@ class Hyperlinks
 
     /**
      * Gets a relative web link to the given image stored in the _site/media folder.
+     * If the image is remote (starts with http) it will be returned as is.
      */
     public function image(string $name): string
     {

--- a/packages/framework/src/Foundation/Hyperlinks.php
+++ b/packages/framework/src/Foundation/Hyperlinks.php
@@ -72,11 +72,18 @@ class Hyperlinks
     /**
      * Gets a relative web link to the given image stored in the _site/media folder.
      * If the image is remote (starts with http) it will be returned as is.
+     *
+     * If true is passed as the second argument, and a base URL is set,
+     * the image will be returned with a qualified Absolute URI.
      */
-    public function image(string $name): string
+    public function image(string $name, bool $preferQualifiedUrl = false): string
     {
         if (str_starts_with($name, 'http')) {
             return $name;
+        }
+
+        if ($preferQualifiedUrl && $this->hasSiteUrl()) {
+            return $this->url('media/'.basename($name));
         }
 
         return $this->relativeLink('media/'.basename($name));

--- a/packages/framework/src/Hyde.php
+++ b/packages/framework/src/Hyde.php
@@ -30,7 +30,7 @@ use Illuminate\Support\Facades\Facade;
  * @method static string getMarkdownPostPath(string $path = '')
  * @method static bool|int copy(string $from, string $to, bool $force = false)
  * @method static string getModelSourcePath(string $model, string $path = '')
- * @method static string image(string $name)
+ * @method static string image(string $name,  bool $preferQualifiedUrl = false)
  * @method static RouteContract|null currentRoute()
  * @method static string currentPage()
  * @method static string url(string $path = '', null|string $default = null)

--- a/packages/framework/src/HydeKernel.php
+++ b/packages/framework/src/HydeKernel.php
@@ -99,9 +99,9 @@ class HydeKernel implements HydeKernelContract
         return $this->hyperlinks->relativeLink($destination);
     }
 
-    public function image(string $name): string
+    public function image(string $name, bool $preferQualifiedUrl = false): string
     {
-        return $this->hyperlinks->image($name);
+        return $this->hyperlinks->image($name, $preferQualifiedUrl);
     }
 
     public function hasSiteUrl(): bool

--- a/packages/framework/src/Models/Image.php
+++ b/packages/framework/src/Models/Image.php
@@ -142,7 +142,7 @@ class Image implements \Stringable
             return '';
         }
 
-        return Hyde::image($this->getSource());
+        return Hyde::image($this->getSource(), true);
     }
 
     public function getContentLength(): int

--- a/packages/framework/src/Models/Image.php
+++ b/packages/framework/src/Models/Image.php
@@ -142,7 +142,7 @@ class Image implements \Stringable
             return '';
         }
 
-        return Hyde::image($this->getSource(), true);
+        return Hyde::image($this->getSource());
     }
 
     public function getContentLength(): int

--- a/packages/framework/tests/Feature/Foundation/HyperlinksTest.php
+++ b/packages/framework/tests/Feature/Foundation/HyperlinksTest.php
@@ -48,4 +48,20 @@ class HyperlinksTest extends TestCase
             $this->assertEquals($this->class->image($input), $expected);
         }
     }
+
+    public function test_image_helper_returns_qualified_absolute_uri_when_requested_and_site_has_base_url()
+    {
+        $this->assertEquals('http://localhost/media/test.jpg', $this->class->image('test.jpg', true));
+    }
+
+    public function test_image_helper_returns_default_relative_path_when_qualified_absolute_uri_is_requested_but_site_has_no_base_url()
+    {
+        config(['site.url' => null]);
+        $this->assertEquals('media/test.jpg', $this->class->image('test.jpg', true));
+    }
+
+    public function test_image_helper_returns_input_when_qualified_absolute_uri_is_requested_but_image_is_already_qualified()
+    {
+        $this->assertEquals('http://localhost/media/test.jpg', $this->class->image('http://localhost/media/test.jpg', true));
+    }
 }


### PR DESCRIPTION
If true is passed as the second argument, and a base URL is set, the image will be returned with a qualified Absolute URI.