### PR TITLE
Improve model serializations

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -15,6 +15,7 @@ The RoutingService class remains for compatibility with existing code, but now o
 - The page and route collections are now stored as properties of the HydeKernel
 - Adds an option to the `Hyde::image()` helper to request the returned image path use the configured base URL if it's set
 - Adds a new `save()` method to Markdown-based pages, to save the page object to the filesystem
+- Added new internal helpers to improve serialization of object models
 
 ### Changed
 - Removed constructor from RoutingServiceContract interface

--- a/packages/framework/src/Concerns/JsonSerializesArrayable.php
+++ b/packages/framework/src/Concerns/JsonSerializesArrayable.php
@@ -5,7 +5,7 @@ namespace Hyde\Framework\Concerns;
 trait JsonSerializesArrayable
 {
     /** @inheritDoc */
-    function jsonSerialize()
+    public function jsonSerialize()
     {
         return $this->toArray();
     }

--- a/packages/framework/src/Concerns/JsonSerializesArrayable.php
+++ b/packages/framework/src/Concerns/JsonSerializesArrayable.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Hyde\Framework\Concerns;
+
+trait JsonSerializesArrayable
+{
+    /** @inheritDoc */
+    function jsonSerialize()
+    {
+        return $this->toArray();
+    }
+}

--- a/packages/framework/src/Helpers/Features.php
+++ b/packages/framework/src/Helpers/Features.php
@@ -4,6 +4,7 @@ namespace Hyde\Framework\Helpers;
 
 use Hyde\Framework\Hyde;
 use Illuminate\Contracts\Support\Arrayable;
+use Illuminate\Support\Str;
 
 /**
  * Allows features to be enabled and disabled in a simple object-oriented manner.
@@ -13,7 +14,7 @@ use Illuminate\Contracts\Support\Arrayable;
  * Based entirely on Laravel Jetstream (License MIT)
  * @see https://jetstream.laravel.com/
  */
-class Features implements Arrayable
+class Features implements Arrayable, \JsonSerializable
 {
     /**
      * Determine if the given specified is enabled.
@@ -169,5 +170,10 @@ class Features implements Arrayable
             'sitemap' => static::sitemap(),
             'rss' => static::rss(),
         ];
+    }
+
+    public function jsonSerialize()
+    {
+        return $this->toArray();
     }
 }

--- a/packages/framework/src/Helpers/Features.php
+++ b/packages/framework/src/Helpers/Features.php
@@ -2,6 +2,7 @@
 
 namespace Hyde\Framework\Helpers;
 
+use Hyde\Framework\Concerns\JsonSerializesArrayable;
 use Hyde\Framework\Hyde;
 use Illuminate\Contracts\Support\Arrayable;
 use Illuminate\Support\Str;
@@ -16,6 +17,8 @@ use Illuminate\Support\Str;
  */
 class Features implements Arrayable, \JsonSerializable
 {
+    use JsonSerializesArrayable;
+    
     /**
      * Determine if the given specified is enabled.
      *
@@ -167,11 +170,5 @@ class Features implements Arrayable, \JsonSerializable
             }
         }
         return $array;
-    }
-
-    /** @inheritDoc */
-    public function jsonSerialize()
-    {
-        return $this->toArray();
     }
 }

--- a/packages/framework/src/Helpers/Features.php
+++ b/packages/framework/src/Helpers/Features.php
@@ -3,6 +3,7 @@
 namespace Hyde\Framework\Helpers;
 
 use Hyde\Framework\Hyde;
+use Illuminate\Contracts\Support\Arrayable;
 
 /**
  * Allows features to be enabled and disabled in a simple object-oriented manner.
@@ -12,7 +13,7 @@ use Hyde\Framework\Hyde;
  * Based entirely on Laravel Jetstream (License MIT)
  * @see https://jetstream.laravel.com/
  */
-class Features
+class Features implements Arrayable
 {
     /**
      * Determine if the given specified is enabled.
@@ -153,5 +154,20 @@ class Features
             && static::hasBlogPosts()
             && config('hyde.generate_rss_feed', true)
             && extension_loaded('simplexml');
+    }
+
+    public function toArray()
+    {
+        return [
+            'blog-posts' => static::hasBlogPosts(),
+            'blade-pages' => static::hasBladePages(),
+            'markdown-pages' => static::hasMarkdownPages(),
+            'documentation-pages' => static::hasDocumentationPages(),
+            'documentation-search' => static::hasDocumentationSearch(),
+            'darkmode' => static::hasDarkmode(),
+            'torchlight' => static::hasTorchlight(),
+            'sitemap' => static::sitemap(),
+            'rss' => static::rss(),
+        ];
     }
 }

--- a/packages/framework/src/Helpers/Features.php
+++ b/packages/framework/src/Helpers/Features.php
@@ -159,17 +159,13 @@ class Features implements Arrayable, \JsonSerializable
 
     public function toArray()
     {
-        return [
-            'blog-posts' => static::hasBlogPosts(),
-            'blade-pages' => static::hasBladePages(),
-            'markdown-pages' => static::hasMarkdownPages(),
-            'documentation-pages' => static::hasDocumentationPages(),
-            'documentation-search' => static::hasDocumentationSearch(),
-            'darkmode' => static::hasDarkmode(),
-            'torchlight' => static::hasTorchlight(),
-            'sitemap' => static::sitemap(),
-            'rss' => static::rss(),
-        ];
+        $array = [];
+        foreach (get_class_methods(static::class) as $method) {
+            if (str_starts_with($method, 'has')) {
+                $array[Str::kebab(substr($method, 3))] = static::{$method}();
+            }
+        }
+        return $array;
     }
 
     public function jsonSerialize()

--- a/packages/framework/src/Helpers/Features.php
+++ b/packages/framework/src/Helpers/Features.php
@@ -157,6 +157,7 @@ class Features implements Arrayable, \JsonSerializable
             && extension_loaded('simplexml');
     }
 
+    /** @inheritDoc */
     public function toArray()
     {
         $array = [];
@@ -168,6 +169,7 @@ class Features implements Arrayable, \JsonSerializable
         return $array;
     }
 
+    /** @inheritDoc */
     public function jsonSerialize()
     {
         return $this->toArray();

--- a/packages/framework/src/Helpers/Features.php
+++ b/packages/framework/src/Helpers/Features.php
@@ -18,7 +18,7 @@ use Illuminate\Support\Str;
 class Features implements Arrayable, \JsonSerializable
 {
     use JsonSerializesArrayable;
-    
+
     /**
      * Determine if the given specified is enabled.
      *
@@ -169,6 +169,7 @@ class Features implements Arrayable, \JsonSerializable
                 $array[Str::kebab(substr($method, 3))] = static::{$method}();
             }
         }
+
         return $array;
     }
 }

--- a/packages/framework/src/HydeKernel.php
+++ b/packages/framework/src/HydeKernel.php
@@ -24,7 +24,7 @@ use Illuminate\Support\Traits\Macroable;
  *
  * @link https://hydephp.com/
  */
-class HydeKernel implements HydeKernelContract, Arrayable
+class HydeKernel implements HydeKernelContract, Arrayable, \JsonSerializable
 {
     use Macroable;
 
@@ -218,5 +218,11 @@ class HydeKernel implements HydeKernelContract, Arrayable
             'pages' => $this->pages(),
             'routes' => $this->routes(),
         ];
+    }
+
+    /** @inheritDoc */
+    function jsonSerialize()
+    {
+        return $this->toArray();
     }
 }

--- a/packages/framework/src/HydeKernel.php
+++ b/packages/framework/src/HydeKernel.php
@@ -8,6 +8,7 @@ use Hyde\Framework\Contracts\RouteContract;
 use Hyde\Framework\Foundation\Filesystem;
 use Hyde\Framework\Foundation\Hyperlinks;
 use Hyde\Framework\Helpers\Features;
+use Illuminate\Contracts\Support\Arrayable;
 use Illuminate\Support\Facades\View;
 use Illuminate\Support\Str;
 use Illuminate\Support\Traits\Macroable;
@@ -23,7 +24,7 @@ use Illuminate\Support\Traits\Macroable;
  *
  * @link https://hydephp.com/
  */
-class HydeKernel implements HydeKernelContract
+class HydeKernel implements HydeKernelContract, Arrayable
 {
     use Macroable;
 
@@ -206,5 +207,16 @@ class HydeKernel implements HydeKernelContract
     public function pathToRelative(string $path): string
     {
         return $this->filesystem->pathToRelative($path);
+    }
+
+    /** @inheritDoc */
+    public function toArray()
+    {
+        return [
+            'basePath' => $this->basePath,
+            'features' => $this->features(),
+            'pages' => $this->pages(),
+            'routes' => $this->routes(),
+        ];
     }
 }

--- a/packages/framework/src/HydeKernel.php
+++ b/packages/framework/src/HydeKernel.php
@@ -3,6 +3,7 @@
 namespace Hyde\Framework;
 
 use Composer\InstalledVersions;
+use Hyde\Framework\Concerns\JsonSerializesArrayable;
 use Hyde\Framework\Contracts\HydeKernelContract;
 use Hyde\Framework\Contracts\RouteContract;
 use Hyde\Framework\Foundation\Filesystem;
@@ -27,6 +28,7 @@ use Illuminate\Support\Traits\Macroable;
 class HydeKernel implements HydeKernelContract, Arrayable, \JsonSerializable
 {
     use Macroable;
+    use JsonSerializesArrayable;
 
     protected string $basePath;
     protected Filesystem $filesystem;
@@ -218,11 +220,5 @@ class HydeKernel implements HydeKernelContract, Arrayable, \JsonSerializable
             'pages' => $this->pages(),
             'routes' => $this->routes(),
         ];
-    }
-
-    /** @inheritDoc */
-    function jsonSerialize()
-    {
-        return $this->toArray();
     }
 }

--- a/packages/framework/src/Models/FrontMatter.php
+++ b/packages/framework/src/Models/FrontMatter.php
@@ -3,6 +3,7 @@
 namespace Hyde\Framework\Models;
 
 use Hyde\Framework\Actions\ConvertsArrayToFrontMatter;
+use Hyde\Framework\Concerns\JsonSerializesArrayable;
 use Illuminate\Contracts\Support\Arrayable;
 use Illuminate\Support\Arr;
 
@@ -19,8 +20,10 @@ use Illuminate\Support\Arr;
  *
  * @see \Hyde\Framework\Testing\Unit\FrontMatterModelTest
  */
-class FrontMatter implements Arrayable, \Stringable
+class FrontMatter implements Arrayable, \Stringable, \JsonSerializable
 {
+    use JsonSerializesArrayable;
+
     public array $data;
 
     public function __construct(array $matter = [])

--- a/packages/framework/src/Models/Route.php
+++ b/packages/framework/src/Models/Route.php
@@ -2,19 +2,23 @@
 
 namespace Hyde\Framework\Models;
 
+use Hyde\Framework\Concerns\JsonSerializesArrayable;
 use Hyde\Framework\Contracts\PageContract;
 use Hyde\Framework\Contracts\RouteContract;
 use Hyde\Framework\Contracts\RouteFacadeContract;
 use Hyde\Framework\Exceptions\RouteNotFoundException;
 use Hyde\Framework\Hyde;
 use Hyde\Framework\Services\RoutingService;
+use Illuminate\Contracts\Support\Arrayable;
 use Illuminate\Support\Collection;
 
 /**
  * @see \Hyde\Framework\Testing\Feature\RouteTest
  */
-class Route implements RouteContract, RouteFacadeContract, \Stringable
+class Route implements RouteContract, RouteFacadeContract, \Stringable, \JsonSerializable, Arrayable
 {
+    use JsonSerializesArrayable;
+
     /**
      * The source model for the route.
      *
@@ -34,6 +38,16 @@ class Route implements RouteContract, RouteFacadeContract, \Stringable
     {
         $this->sourceModel = $sourceModel;
         $this->routeKey = $this->constructRouteKey();
+    }
+
+    /** @inheritDoc */
+    public function toArray()
+    {
+        return [
+            'routeKey' => $this->routeKey,
+            'sourceModelPath' => $this->sourceModel->getSourcePath(),
+            'sourceModelType' => $this->sourceModel::class,
+        ];
     }
 
     /** @inheritDoc */

--- a/packages/framework/tests/Feature/RouteCollectionTest.php
+++ b/packages/framework/tests/Feature/RouteCollectionTest.php
@@ -41,7 +41,7 @@ class RouteCollectionTest extends TestCase
         $this->assertEquals([
             '404' => (new Route(new BladePage('404'))),
             'index' => (new Route(new BladePage('index'))),
-        ], $collection->toArray());
+        ], $collection->all());
     }
 
     public function test_boot_method_discovers_all_page_types()
@@ -63,7 +63,7 @@ class RouteCollectionTest extends TestCase
             'markdown' => (new Route(new MarkdownPage('markdown'))),
             'posts/post' => (new Route(new MarkdownPost('post'))),
             'docs/docs' => (new Route(new DocumentationPage('docs'))),
-        ], $collection->toArray());
+        ], $collection->all());
 
         $this->restoreDefaultPages();
     }


### PR DESCRIPTION
Implements interfaces to convert models into arrays and JSON.

Be mindful that this can cause issues (as seen in the failing tests) when serializing a parent object. For example, calling toArray() on a Laravel collection containing one of the affected models will bubble and use the array representation of the model, which may not be what you always want.