### PR TITLE
Bring out the HydeKernel singleton from the service container

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -22,6 +22,7 @@ The RoutingService class remains for compatibility with existing code, but now o
 - Refactored RoutingService to use the new RouteCollection class
 - AbstractPage::all() now returns a PageCollection, and includes the source file path as the array key
 - Improved ConvertsArrayToFrontMatter action, which now supports nested arrays
+- internal: The HydeKernel is now stored as a singleton within the kernel class, instead of the service container
 
 ### Deprecated
 - Deprecated interface RoutingServiceContract

--- a/app/bootstrap.php
+++ b/app/bootstrap.php
@@ -55,6 +55,8 @@ $app->instance(
     Hyde\Framework\Contracts\HydeKernelContract::class, $hyde
 );
 
+Hyde\Framework\HydeKernel::setInstance($hyde);
+
 /*
 |--------------------------------------------------------------------------
 | Return The Application

--- a/app/bootstrap.php
+++ b/app/bootstrap.php
@@ -51,8 +51,10 @@ $hyde = new Hyde\Framework\HydeKernel(
     dirname(__DIR__)
 );
 
-$app->instance(
-    Hyde\Framework\Contracts\HydeKernelContract::class, $hyde
+$app->singleton(
+    Hyde\Framework\Contracts\HydeKernelContract::class, function () {
+        return \Hyde\Framework\HydeKernel::getInstance();
+    }
 );
 
 Hyde\Framework\HydeKernel::setInstance($hyde);

--- a/app/bootstrap.php
+++ b/app/bootstrap.php
@@ -53,7 +53,7 @@ $hyde = new Hyde\Framework\HydeKernel(
 
 $app->singleton(
     Hyde\Framework\Contracts\HydeKernelContract::class, function () {
-        return \Hyde\Framework\HydeKernel::getInstance();
+        return Hyde\Framework\HydeKernel::getInstance();
     }
 );
 

--- a/packages/framework/src/Hyde.php
+++ b/packages/framework/src/Hyde.php
@@ -58,4 +58,9 @@ class Hyde extends Facade
     {
         return HydeKernel::version();
     }
+
+    public static function getFacadeRoot()
+    {
+        return HydeKernel::getInstance();
+    }
 }

--- a/packages/framework/src/HydeKernel.php
+++ b/packages/framework/src/HydeKernel.php
@@ -30,6 +30,8 @@ class HydeKernel implements HydeKernelContract, Arrayable, \JsonSerializable
     use Macroable;
     use JsonSerializesArrayable;
 
+    protected static HydeKernelContract $instance;
+
     protected string $basePath;
     protected Filesystem $filesystem;
     protected Hyperlinks $hyperlinks;
@@ -52,9 +54,14 @@ class HydeKernel implements HydeKernelContract, Arrayable, \JsonSerializable
         $this->routes = RouteCollection::boot($this);
     }
 
+    public static function setInstance(HydeKernelContract $instance): void
+    {
+        static::$instance = $instance;
+    }
+
     public static function getInstance(): HydeKernelContract
     {
-        return app(HydeKernelContract::class);
+        return static::$instance;
     }
 
     public static function version(): string

--- a/packages/framework/src/HydeKernel.php
+++ b/packages/framework/src/HydeKernel.php
@@ -52,11 +52,6 @@ class HydeKernel implements HydeKernelContract, Arrayable, \JsonSerializable
         $this->routes = RouteCollection::boot($this);
     }
 
-    public static function boot(): void
-    {
-        static::getInstance()->bootKernel();
-    }
-
     public static function getInstance(): HydeKernelContract
     {
         return app(HydeKernelContract::class);

--- a/packages/framework/src/HydeKernel.php
+++ b/packages/framework/src/HydeKernel.php
@@ -45,7 +45,7 @@ class HydeKernel implements HydeKernelContract, Arrayable, \JsonSerializable
         $this->hyperlinks = new Hyperlinks($this);
     }
 
-    public function bootKernel(): void
+    public function boot(): void
     {
         $this->booted = true;
         $this->pages = PageCollection::boot();
@@ -95,7 +95,7 @@ class HydeKernel implements HydeKernelContract, Arrayable, \JsonSerializable
     public function pages(): PageCollection
     {
         if (! $this->booted) {
-            $this->bootKernel();
+            $this->boot();
         }
 
         return $this->pages;
@@ -104,7 +104,7 @@ class HydeKernel implements HydeKernelContract, Arrayable, \JsonSerializable
     public function routes(): RouteCollection
     {
         if (! $this->booted) {
-            $this->bootKernel();
+            $this->boot();
         }
 
         return $this->routes;

--- a/packages/framework/src/HydeKernel.php
+++ b/packages/framework/src/HydeKernel.php
@@ -45,7 +45,7 @@ class HydeKernel implements HydeKernelContract, Arrayable, \JsonSerializable
         $this->hyperlinks = new Hyperlinks($this);
     }
 
-    protected function bootKernel(): void
+    public function bootKernel(): void
     {
         $this->booted = true;
         $this->pages = PageCollection::boot();

--- a/packages/framework/src/HydeServiceProvider.php
+++ b/packages/framework/src/HydeServiceProvider.php
@@ -84,7 +84,7 @@ class HydeServiceProvider extends ServiceProvider
 
         Blade::component('link', LinkComponent::class);
 
-        HydeKernel::getInstance()->bootKernel();
+        HydeKernel::getInstance()->boot();
     }
 
     /**

--- a/packages/framework/src/HydeServiceProvider.php
+++ b/packages/framework/src/HydeServiceProvider.php
@@ -84,7 +84,7 @@ class HydeServiceProvider extends ServiceProvider
 
         Blade::component('link', LinkComponent::class);
 
-        HydeKernel::boot();
+        HydeKernel::getInstance()->bootKernel();
     }
 
     /**

--- a/packages/framework/tests/Feature/Foundation/FilesystemTest.php
+++ b/packages/framework/tests/Feature/Foundation/FilesystemTest.php
@@ -23,7 +23,6 @@ class FilesystemTest extends TestCase
 
         $this->originalBasePath = Hyde::getBasePath();
         $this->filesystem = new Filesystem(Hyde::getInstance());
-        Hyde::getInstance()->setBasePath('/foo');
     }
 
     protected function tearDown(): void
@@ -35,6 +34,7 @@ class FilesystemTest extends TestCase
 
     public function test_get_base_path_returns_kernels_base_path()
     {
+        Hyde::getInstance()->setBasePath('/foo');
         $this->assertEquals('/foo', $this->filesystem->getBasePath());
     }
 
@@ -50,31 +50,37 @@ class FilesystemTest extends TestCase
 
     public function test_path_method_returns_base_path_when_not_supplied_with_argument()
     {
+        Hyde::getInstance()->setBasePath('/foo');
         $this->assertEquals('/foo', $this->filesystem->path());
     }
 
     public function test_path_method_returns_path_relative_to_base_path_when_supplied_with_argument()
     {
+        Hyde::getInstance()->setBasePath('/foo');
         $this->assertEquals('/foo'.DIRECTORY_SEPARATOR.'foo/bar.php', $this->filesystem->path('foo/bar.php'));
     }
 
     public function test_path_method_returns_qualified_file_path_when_supplied_with_argument()
     {
+        Hyde::getInstance()->setBasePath('/foo');
         $this->assertEquals('/foo'.DIRECTORY_SEPARATOR.'file.php', $this->filesystem->path('file.php'));
     }
 
     public function test_path_method_returns_expected_value_for_nested_path_arguments()
     {
+        Hyde::getInstance()->setBasePath('/foo');
         $this->assertEquals('/foo'.DIRECTORY_SEPARATOR.'directory/file.php', $this->filesystem->path('directory/file.php'));
     }
 
     public function test_path_method_strips_trailing_directory_separators_from_argument()
     {
+        Hyde::getInstance()->setBasePath('/foo');
         $this->assertEquals('/foo'.DIRECTORY_SEPARATOR.'file.php', $this->filesystem->path('\\/file.php/'));
     }
 
     public function test_path_method_returns_expected_value_regardless_of_trailing_directory_separators_in_argument()
     {
+        Hyde::getInstance()->setBasePath('/foo');
         $this->assertEquals('/foo'.DIRECTORY_SEPARATOR.'bar/file.php', $this->filesystem->path('\\/bar/file.php/'));
     }
 
@@ -95,6 +101,7 @@ class FilesystemTest extends TestCase
 
     public function test_vendor_path_method_returns_expected_value_regardless_of_trailing_directory_separators_in_argument()
     {
+        Hyde::getInstance()->setBasePath('/foo');
         $this->assertEquals('/foo'.DIRECTORY_SEPARATOR.'vendor/hyde/framework/file.php', $this->filesystem->vendorPath('\\//file.php/'));
     }
 

--- a/packages/framework/tests/Feature/HydeKernelTest.php
+++ b/packages/framework/tests/Feature/HydeKernelTest.php
@@ -21,6 +21,7 @@ use Illuminate\Support\Facades\View;
  * as most of the logic actually resides in linked service classes.
  *
  * @covers \Hyde\Framework\HydeKernel
+ * @covers \Hyde\Framework\Hyde
  *
  * @see \Hyde\Framework\Testing\Unit\HydeHelperFacadeMakeTitleTest
  */
@@ -44,6 +45,18 @@ class HydeKernelTest extends TestCase
     public function test_kernel_singleton_can_be_accessed_by_helper_function()
     {
         $this->assertSame(app(HydeKernelContract::class), hyde());
+    }
+
+    public function test_hyde_facade_version_method_returns_kernel_version()
+    {
+        $this->assertSame(HydeKernel::version(), Hyde::version());
+    }
+
+    public function test_hyde_facade_get_facade_root_method_returns_kernel_singleton()
+    {
+        $this->assertSame(app(HydeKernelContract::class), Hyde::getFacadeRoot());
+        $this->assertSame(HydeKernel::getInstance(), Hyde::getFacadeRoot());
+        $this->assertSame(Hyde::getInstance(), Hyde::getFacadeRoot());
     }
 
     public function test_features_helper_returns_new_features_instance()

--- a/packages/testing/src/CreatesApplication.php
+++ b/packages/testing/src/CreatesApplication.php
@@ -2,6 +2,8 @@
 
 namespace Hyde\Testing;
 
+use Hyde\Framework\Hyde;
+use Hyde\Framework\HydeKernel;
 use Illuminate\Contracts\Console\Kernel;
 use Illuminate\Foundation\Application;
 
@@ -17,6 +19,8 @@ trait CreatesApplication
         $app = require file_exists(__DIR__.'/../../../app/bootstrap.php') ? __DIR__.'/../../../app/bootstrap.php' : getcwd().'/app/bootstrap.php';
 
         $app->make(Kernel::class)->bootstrap();
+
+        HydeKernel::setInstance(new HydeKernel(Hyde::path()));
 
         return $app;
     }


### PR DESCRIPTION
## About
This PR restructures how the HydeKernel singleton (and by proxy, facade) internally are stored.

This makes the framework more modular and allows it to be operated more independently from the service container.

## What's changed

It partially reverts to the original behaviour, while retaining compatibility with the current service container behaviour. The PR does as follows:

- The HydeKernel singleton is now stored as a static property of the kernel class
- The service container now points to the aforementioned singleton instance when calling the contract
- The Hyde facade now calls members on the new singleton instead of the service container making it work outside the container
- The kernel instance can be set using the new setInstance method
- The boot and bootKernel methods have been merged

In most cases, this will not affect existing applications, however, the Hyde/Hyde bootstrap file needs to be updated alongside the framework version.