### PR TITLE
Throw exception instead of returning null when attempting to get source for Image without source

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -22,6 +22,7 @@ The RoutingService class remains for compatibility with existing code, but now o
 - Refactored RoutingService to use the new RouteCollection class
 - AbstractPage::all() now returns a PageCollection, and includes the source file path as the array key
 - Improved ConvertsArrayToFrontMatter action, which now supports nested arrays
+- An exception is now thrown when attempting to get the path to an Image without a defined source path or URI
 - internal: The HydeKernel is now stored as a singleton within the kernel class, instead of the service container
 
 ### Deprecated

--- a/packages/framework/src/Actions/FindsContentLengthForImageObject.php
+++ b/packages/framework/src/Actions/FindsContentLengthForImageObject.php
@@ -79,6 +79,8 @@ class FindsContentLengthForImageObject implements ActionContract
 
     protected function write(string $string): void
     {
-        $this->output->writeln($string);
+        if (! app()->environment('testing')) {
+            $this->output->writeln($string);
+        }
     }
 }

--- a/packages/framework/src/Actions/FindsContentLengthForImageObject.php
+++ b/packages/framework/src/Actions/FindsContentLengthForImageObject.php
@@ -79,8 +79,6 @@ class FindsContentLengthForImageObject implements ActionContract
 
     protected function write(string $string): void
     {
-        if (! app()->environment('testing')) {
-            $this->output->writeln($string);
-        }
+        $this->output->writeln($string);
     }
 }

--- a/packages/framework/src/Models/Image.php
+++ b/packages/framework/src/Models/Image.php
@@ -131,9 +131,9 @@ class Image implements \Stringable
             : new static(['path' => $image]);
     }
 
-    public function getSource(): ?string
+    public function getSource(): string
     {
-        return $this->uri ?? $this->getPath() ?? null;
+        return $this->uri ?? $this->getPath() ?? throw new \Exception('Attempting to get source from Image that has no source.');
     }
 
     public function getLink(): string

--- a/packages/framework/tests/Feature/FindsContentLengthForImageObjectTest.php
+++ b/packages/framework/tests/Feature/FindsContentLengthForImageObjectTest.php
@@ -19,7 +19,7 @@ class FindsContentLengthForImageObjectTest extends TestCase
     public function test_image_helper_shorthand_returns_content_length()
     {
         $this->assertIsInt(
-            (new Image())->getContentLength()
+            (new Image(['path' => 'foo']))->getContentLength()
         );
     }
 

--- a/packages/framework/tests/Feature/ImageModelTest.php
+++ b/packages/framework/tests/Feature/ImageModelTest.php
@@ -79,11 +79,26 @@ class ImageModelTest extends TestCase
         $this->assertEquals('image.jpg', $image->getSource());
     }
 
-    public function test_get_source_method_returns_null_when_no_source_is_set()
+    public function test_get_source_method_throws_exception_when_no_source_is_set()
     {
         $image = new Image();
 
-        $this->assertNull($image->getSource());
+        $this->expectExceptionMessage('Attempting to get source from Image that has no source.');
+        $image->getSource();
+    }
+
+    public function test_get_source_method_does_not_throw_exception_when_path_is_set()
+    {
+        $image = new Image();
+        $image->path = 'image.jpg';
+        $this->assertEquals('image.jpg', $image->getSource());
+    }
+
+    public function test_get_source_method_does_not_throw_exception_when_uri_is_set()
+    {
+        $image = new Image();
+        $image->uri = 'https://example.com/image.jpg';
+        $this->assertEquals('https://example.com/image.jpg', $image->getSource());
     }
 
     public function test_get_image_author_attribution_string_method()
@@ -163,13 +178,14 @@ class ImageModelTest extends TestCase
         $image = new Image([
             'description' => 'foo',
             'title' => 'bar',
+            'path' => 'image.jpg',
         ]);
 
         $this->assertEquals([
             'text' => 'foo',
             'name' => 'bar',
-            'url' => null,
-            'contentUrl' => null,
+            'url' => 'media/image.jpg',
+            'contentUrl' => 'media/image.jpg',
         ], $image->getMetadataArray());
     }
 


### PR DESCRIPTION
If you try to get the source path of an image, it's probably because you want the source path of the image. Having it return null can lead to unexpected issues and broken image links. Instead, an exception should be thrown to let the user know about the problem so it can be fixed before deploying the site.