### PR TITLE
Reduce complexity by using route keys to get navigation menu priorities from config

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -18,6 +18,7 @@ The RoutingService class remains for compatibility with existing code, but now o
 - Added new internal helpers to improve serialization of object models
 
 ### Changed
+- **breaking**: Navigation menu priorities now use route keys instead of slugs, see upgrade notes below
 - Removed constructor from RoutingServiceContract interface
 - Refactored RoutingService to use the new RouteCollection class
 - AbstractPage::all() now returns a PageCollection, and includes the source file path as the array key
@@ -41,3 +42,22 @@ The RoutingService class remains for compatibility with existing code, but now o
 
 ### Security
 - in case of vulnerabilities.
+
+### Upgrade notes
+
+#### Route keys are now used in navigation config
+
+Prior to this release, the navigation menu priorities were based on the page slug. This has been changed to the route key. A route key in Hyde is in short the compiled page's path, relative to the site's root. For example, `_site/foo/bar.html` has the route key `foo/bar`.
+
+This change is breaking as it requires the configuration to be updated. However, this is really easy. Just change `docs` to `docs/index` in the `config/hyde.php` file.
+
+```diff
+'navigation' => [
+	'order' => [
+		'index' => 0,
+		'posts' => 10,
+-		'docs' => 100,
++		'docs/index' => 100,
+	],
+],
+```

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -61,3 +61,5 @@ This change is breaking as it requires the configuration to be updated. However,
 	],
 ],
 ```
+
+If you have used the config to hide the documentation page from the navigation menu, you also need to use the route key by changing `'exclude' => ['docs']` to `'exclude' => ['docs/index']`.

--- a/config/hyde.php
+++ b/config/hyde.php
@@ -125,10 +125,11 @@ return [
     'navigation' => [
         // This configuration sets the priorities used to determine the order of the menu.
         // The default values have been added below for reference and easy editing.
+        // The array key should match the page's route key (slug).
         'order' => [
             'index' => 0,
             'posts' => 10,
-            'docs' => 100,
+            'docs/index' => 100,
         ],
 
         // These are the pages that should not show up in the navigation menu.

--- a/packages/framework/src/Actions/Constructors/FindsNavigationDataForPage.php
+++ b/packages/framework/src/Actions/Constructors/FindsNavigationDataForPage.php
@@ -58,7 +58,7 @@ class FindsNavigationDataForPage
         }
 
         if ($this->page instanceof DocumentationPage) {
-            return $this->page->identifier === 'index' && ! in_array('docs', config('hyde.navigation.exclude', []));
+            return $this->page->identifier === 'index' && ! in_array($this->page->routeKey, config('hyde.navigation.exclude', []));
         }
 
         if ($this->page instanceof AbstractMarkdownPage) {

--- a/packages/framework/src/Actions/Constructors/FindsNavigationDataForPage.php
+++ b/packages/framework/src/Actions/Constructors/FindsNavigationDataForPage.php
@@ -82,20 +82,8 @@ class FindsNavigationDataForPage
             }
         }
 
-        if ($this->page instanceof DocumentationPage) {
-            return (int) config('hyde.navigation.order.docs', 100);
-        }
-
-        if ($this->page->identifier === 'index') {
-            return (int) config('hyde.navigation.order.index', 0);
-        }
-
-        if ($this->page->identifier === 'posts') {
-            return (int) config('hyde.navigation.order.posts', 10);
-        }
-
-        if (array_key_exists($this->page->identifier, config('hyde.navigation.order', []))) {
-            return (int) config('hyde.navigation.order.'.$this->page->identifier);
+        if (array_key_exists($this->page->routeKey, config('hyde.navigation.order', []))) {
+            return (int) config('hyde.navigation.order.'.$this->page->routeKey);
         }
 
         return 999;

--- a/packages/framework/tests/Feature/AbstractPageTest.php
+++ b/packages/framework/tests/Feature/AbstractPageTest.php
@@ -445,7 +445,7 @@ class AbstractPageTest extends TestCase
 
     public function test_navigation_menu_priority_returns_100_for_documentation_page()
     {
-        $page = DocumentationPage::make('foo');
+        $page = DocumentationPage::make('index');
         $this->assertEquals(100, $page->navigationMenuPriority());
     }
 
@@ -453,12 +453,6 @@ class AbstractPageTest extends TestCase
     {
         $page = MarkdownPage::make('index');
         $this->assertEquals(0, $page->navigationMenuPriority());
-    }
-
-    public function test_navigation_menu_priority_does_not_return_0_if_slug_is_index_but_model_is_documentation_page()
-    {
-        $page = DocumentationPage::make('index');
-        $this->assertEquals(100, $page->navigationMenuPriority());
     }
 
     public function test_navigation_menu_priority_returns_10_if_slug_is_posts()

--- a/packages/framework/tests/Feature/AbstractPageTest.php
+++ b/packages/framework/tests/Feature/AbstractPageTest.php
@@ -509,6 +509,13 @@ class AbstractPageTest extends TestCase
         $this->assertEquals('Foo', $page->navigationMenuTitle());
     }
 
+    public function test_documentation_page_can_be_hidden_from_navigation_using_config()
+    {
+        config(['hyde.navigation.exclude' => ['docs/index']]);
+        $page = DocumentationPage::make('index');
+        $this->assertFalse($page->showInNavigation());
+    }
+
     public function test_get_canonical_url_returns_url_for_top_level_page()
     {
         config(['site.url' => 'https://example.com']);


### PR DESCRIPTION
Prior to this release, the navigation menu priorities were based on the page slug. This has been changed to the route key. A route key in Hyde is in short the compiled page's path, relative to the site's root. For example, `_site/foo/bar.html` has the route key `foo/bar`.

This change is breaking as it requires the configuration to be updated. However, this is really easy. Just change `docs` to `docs/index` in the `config/hyde.php` file.

```diff
'navigation' => [
	'order' => [
		'index' => 0,
		'posts' => 10,
-		'docs' => 100,
+		'docs/index' => 100,
	],
],
```
