### PR TITLE
Fix #410: Search index generator breaks when storing documentation page source files in subdirectories

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -40,6 +40,8 @@ The RoutingService class remains for compatibility with existing code, but now o
 - Fix [#385](https://github.com/hydephp/develop/issues/385): `DocumentationPage::home()` did not work for custom documentation page output directories
 - Fix [#386](https://github.com/hydephp/develop/issues/386): Documentation page sidebar labels were not constructed from front matter
 - Fix bugs relating to the documentation sidebar labels that appeared in the last release
+- Fix [#410](https://github.com/hydephp/develop/issues/410): Search index generator breaks when storing documentation page source files in subdirectories
+
 
 ### Security
 - in case of vulnerabilities.

--- a/packages/framework/src/Actions/GeneratesDocumentationSearchIndexFile.php
+++ b/packages/framework/src/Actions/GeneratesDocumentationSearchIndexFile.php
@@ -62,10 +62,10 @@ class GeneratesDocumentationSearchIndexFile implements ActionContract
     public function generatePageObject(DocumentationPage $page): object
     {
         return (object) [
-            'slug' => $page->identifier,
+            'slug' => basename($page->identifier),
             'title' => $page->title,
             'content' => trim($this->getSearchContentForDocument($page)),
-            'destination' => $this->getDestinationForSlug($page->identifier),
+            'destination' => $this->getDestinationForSlug(basename($page->identifier)),
         ];
     }
 

--- a/packages/framework/tests/Feature/Actions/GeneratesDocumentationSearchIndexFileTest.php
+++ b/packages/framework/tests/Feature/Actions/GeneratesDocumentationSearchIndexFileTest.php
@@ -138,4 +138,15 @@ class GeneratesDocumentationSearchIndexFileTest extends TestCase
 
         unlink(Hyde::path('_docs/excluded.md'));
     }
+
+    public function test_nested_source_files_do_not_retain_directory_name_in_search_index()
+    {
+        mkdir(Hyde::path('_docs/foo'));
+        touch(Hyde::path('_docs/foo/bar.md'));
+
+        $this->assertStringNotContainsString('foo', (new Action())->generate()->getJson());
+
+        unlink(Hyde::path('_docs/foo/bar.md'));
+        rmdir(Hyde::path('_docs/foo'));
+    }
 }


### PR DESCRIPTION
Fixes https://github.com/hydephp/develop/issues/410