### PR TITLE
Move core collections into foundation namespace

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -13,7 +13,8 @@ This serves two purposes:
 - for new features.
 
 ### Changed
-- for changes in existing functionality.
+- Move class PageCollection into Foundation namespace
+- Move class RouteCollection into Foundation namespace
 
 ### Deprecated
 - for soon-to-be removed features.
@@ -26,3 +27,18 @@ This serves two purposes:
 
 ### Security
 - in case of vulnerabilities.
+
+### Upgrade guide
+
+#### Collection namespace change
+
+> You only need to do this if you have written custom code that uses the old namespace.
+
+To upgrade the moved collection namespaces, simply replace the following namespace imports:
+
+```diff
+-use Hyde\Framework\PageCollection;
++use Hyde\Framework\Foundation\PageCollection;
+-use Hyde\Framework\RouteCollection;
++use Hyde\Framework\Foundation\RouteCollection;
+```

--- a/packages/framework/src/Contracts/AbstractPage.php
+++ b/packages/framework/src/Contracts/AbstractPage.php
@@ -8,7 +8,7 @@ use Hyde\Framework\Hyde;
 use Hyde\Framework\Models\FrontMatter;
 use Hyde\Framework\Models\Metadata\Metadata;
 use Hyde\Framework\Models\Route;
-use Hyde\Framework\PageCollection;
+use Hyde\Framework\Foundation\PageCollection;
 use Hyde\Framework\Services\DiscoveryService;
 
 /**

--- a/packages/framework/src/Contracts/AbstractPage.php
+++ b/packages/framework/src/Contracts/AbstractPage.php
@@ -4,11 +4,11 @@ namespace Hyde\Framework\Contracts;
 
 use Hyde\Framework\Actions\SourceFileParser;
 use Hyde\Framework\Concerns\FrontMatter\Schemas\PageSchema;
+use Hyde\Framework\Foundation\PageCollection;
 use Hyde\Framework\Hyde;
 use Hyde\Framework\Models\FrontMatter;
 use Hyde\Framework\Models\Metadata\Metadata;
 use Hyde\Framework\Models\Route;
-use Hyde\Framework\Foundation\PageCollection;
 use Hyde\Framework\Services\DiscoveryService;
 
 /**

--- a/packages/framework/src/Contracts/PageContract.php
+++ b/packages/framework/src/Contracts/PageContract.php
@@ -2,7 +2,7 @@
 
 namespace Hyde\Framework\Contracts;
 
-use Hyde\Framework\PageCollection;
+use Hyde\Framework\Foundation\PageCollection;
 
 interface PageContract
 {
@@ -73,9 +73,9 @@ interface PageContract
     /**
      * Get a collection of all pages, parsed into page models.
      *
-     * @since v0.59.0-beta the returned collection is a PageCollection, and now includes the source file path as the array key
+     * @return \Hyde\Framework\Foundation\PageCollection<\Hyde\Framework\Contracts\PageContract
      *
-     * @return \Hyde\Framework\PageCollection<\Hyde\Framework\Contracts\PageContract
+     * @since v0.59.0-beta the returned collection is a PageCollection, and now includes the source file path as the array key
      *
      * @see \Hyde\Framework\Testing\Unit\PageModelGetHelperTest
      */

--- a/packages/framework/src/Contracts/PageContract.php
+++ b/packages/framework/src/Contracts/PageContract.php
@@ -76,7 +76,6 @@ interface PageContract
      * @return \Hyde\Framework\Foundation\PageCollection<\Hyde\Framework\Contracts\PageContract
      *
      * @since v0.59.0-beta the returned collection is a PageCollection, and now includes the source file path as the array key
-     *
      * @see \Hyde\Framework\Testing\Unit\PageModelGetHelperTest
      */
     public static function all(): PageCollection;

--- a/packages/framework/src/Contracts/RouteFacadeContract.php
+++ b/packages/framework/src/Contracts/RouteFacadeContract.php
@@ -56,7 +56,7 @@ interface RouteFacadeContract
     /**
      * Get all routes from the Router index.
      *
-     * @return \Hyde\Framework\RouteCollection<\Hyde\Framework\Contracts\RouteContract>
+     * @return \Hyde\Framework\Foundation\RouteCollection<\Hyde\Framework\Contracts\RouteContract>
      */
     public static function all(): Collection;
 

--- a/packages/framework/src/Foundation/PageCollection.php
+++ b/packages/framework/src/Foundation/PageCollection.php
@@ -12,7 +12,7 @@ use Hyde\Framework\Models\Pages\MarkdownPost;
 use Illuminate\Support\Collection;
 
 /**
- * @see \Hyde\Framework\RouteCollection
+ * @see \Hyde\Framework\Foundation\RouteCollection
  * @see \Hyde\Framework\Testing\Feature\PageCollectionTest
  */
 final class PageCollection extends Collection

--- a/packages/framework/src/Foundation/PageCollection.php
+++ b/packages/framework/src/Foundation/PageCollection.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Hyde\Framework;
+namespace Hyde\Framework\Foundation;
 
 use Hyde\Framework\Contracts\PageContract;
 use Hyde\Framework\Exceptions\FileNotFoundException;

--- a/packages/framework/src/Foundation/RouteCollection.php
+++ b/packages/framework/src/Foundation/RouteCollection.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Hyde\Framework;
+namespace Hyde\Framework\Foundation;
 
 use Hyde\Framework\Contracts\HydeKernelContract;
 use Hyde\Framework\Contracts\PageContract;

--- a/packages/framework/src/Hyde.php
+++ b/packages/framework/src/Hyde.php
@@ -4,6 +4,7 @@ namespace Hyde\Framework;
 
 use Hyde\Framework\Contracts\HydeKernelContract;
 use Hyde\Framework\Contracts\RouteContract;
+use Hyde\Framework\Foundation\PageCollection;
 use Hyde\Framework\Helpers\Features;
 use Illuminate\Support\Facades\Facade;
 

--- a/packages/framework/src/Hyde.php
+++ b/packages/framework/src/Hyde.php
@@ -5,6 +5,7 @@ namespace Hyde\Framework;
 use Hyde\Framework\Contracts\HydeKernelContract;
 use Hyde\Framework\Contracts\RouteContract;
 use Hyde\Framework\Foundation\PageCollection;
+use Hyde\Framework\Foundation\RouteCollection;
 use Hyde\Framework\Helpers\Features;
 use Illuminate\Support\Facades\Facade;
 

--- a/packages/framework/src/HydeKernel.php
+++ b/packages/framework/src/HydeKernel.php
@@ -8,6 +8,7 @@ use Hyde\Framework\Contracts\HydeKernelContract;
 use Hyde\Framework\Contracts\RouteContract;
 use Hyde\Framework\Foundation\Filesystem;
 use Hyde\Framework\Foundation\Hyperlinks;
+use Hyde\Framework\Foundation\PageCollection;
 use Hyde\Framework\Helpers\Features;
 use Illuminate\Contracts\Support\Arrayable;
 use Illuminate\Support\Facades\View;
@@ -216,7 +217,7 @@ class HydeKernel implements HydeKernelContract, Arrayable, \JsonSerializable
     /**
      * @inheritDoc
      *
-     * @return array{basePath: string, features: \Hyde\Framework\Helpers\Features, pages: \Hyde\Framework\PageCollection, routes: \Hyde\Framework\RouteCollection}
+     * @return array{basePath: string, features: \Hyde\Framework\Helpers\Features, pages: \Hyde\Framework\Foundation\PageCollection, routes: \Hyde\Framework\RouteCollection}
      */
     public function toArray(): array
     {

--- a/packages/framework/src/HydeKernel.php
+++ b/packages/framework/src/HydeKernel.php
@@ -9,6 +9,7 @@ use Hyde\Framework\Contracts\RouteContract;
 use Hyde\Framework\Foundation\Filesystem;
 use Hyde\Framework\Foundation\Hyperlinks;
 use Hyde\Framework\Foundation\PageCollection;
+use Hyde\Framework\Foundation\RouteCollection;
 use Hyde\Framework\Helpers\Features;
 use Illuminate\Contracts\Support\Arrayable;
 use Illuminate\Support\Facades\View;
@@ -217,7 +218,7 @@ class HydeKernel implements HydeKernelContract, Arrayable, \JsonSerializable
     /**
      * @inheritDoc
      *
-     * @return array{basePath: string, features: \Hyde\Framework\Helpers\Features, pages: \Hyde\Framework\Foundation\PageCollection, routes: \Hyde\Framework\RouteCollection}
+     * @return array{basePath: string, features: \Hyde\Framework\Helpers\Features, pages: \Hyde\Framework\Foundation\PageCollection, routes: \Hyde\Framework\Foundation\RouteCollection}
      */
     public function toArray(): array
     {

--- a/packages/framework/src/Models/Pages/MarkdownPost.php
+++ b/packages/framework/src/Models/Pages/MarkdownPost.php
@@ -6,7 +6,7 @@ use Hyde\Framework\Concerns\FrontMatter\Schemas\BlogPostSchema;
 use Hyde\Framework\Contracts\AbstractMarkdownPage;
 use Hyde\Framework\Models\FrontMatter;
 use Hyde\Framework\Models\Markdown;
-use Hyde\Framework\PageCollection;
+use Hyde\Framework\Foundation\PageCollection;
 
 /**
  * @see \Hyde\Framework\Testing\Feature\MarkdownPostTest
@@ -30,7 +30,7 @@ class MarkdownPost extends AbstractMarkdownPage
         $this->constructBlogPostSchema();
     }
 
-    /** @return \Hyde\Framework\PageCollection<\Hyde\Framework\Models\Pages\MarkdownPost> */
+    /** @return \Hyde\Framework\Foundation\PageCollection<\Hyde\Framework\Models\Pages\MarkdownPost> */
     public static function getLatestPosts(): PageCollection
     {
         return static::all()->sortByDesc('matter.date');

--- a/packages/framework/src/Models/Pages/MarkdownPost.php
+++ b/packages/framework/src/Models/Pages/MarkdownPost.php
@@ -4,9 +4,9 @@ namespace Hyde\Framework\Models\Pages;
 
 use Hyde\Framework\Concerns\FrontMatter\Schemas\BlogPostSchema;
 use Hyde\Framework\Contracts\AbstractMarkdownPage;
+use Hyde\Framework\Foundation\PageCollection;
 use Hyde\Framework\Models\FrontMatter;
 use Hyde\Framework\Models\Markdown;
-use Hyde\Framework\Foundation\PageCollection;
 
 /**
  * @see \Hyde\Framework\Testing\Feature\MarkdownPostTest

--- a/packages/framework/src/Models/Route.php
+++ b/packages/framework/src/Models/Route.php
@@ -7,8 +7,8 @@ use Hyde\Framework\Contracts\PageContract;
 use Hyde\Framework\Contracts\RouteContract;
 use Hyde\Framework\Contracts\RouteFacadeContract;
 use Hyde\Framework\Exceptions\RouteNotFoundException;
-use Hyde\Framework\Hyde;
 use Hyde\Framework\Foundation\RouteCollection;
+use Hyde\Framework\Hyde;
 use Illuminate\Contracts\Support\Arrayable;
 
 /**

--- a/packages/framework/src/Models/Route.php
+++ b/packages/framework/src/Models/Route.php
@@ -8,7 +8,7 @@ use Hyde\Framework\Contracts\RouteContract;
 use Hyde\Framework\Contracts\RouteFacadeContract;
 use Hyde\Framework\Exceptions\RouteNotFoundException;
 use Hyde\Framework\Hyde;
-use Hyde\Framework\RouteCollection;
+use Hyde\Framework\Foundation\RouteCollection;
 use Illuminate\Contracts\Support\Arrayable;
 
 /**

--- a/packages/framework/src/RouteCollection.php
+++ b/packages/framework/src/RouteCollection.php
@@ -11,7 +11,7 @@ use Illuminate\Support\Collection;
 /**
  * Pseudo-Router for Hyde.
  *
- * @see \Hyde\Framework\PageCollection
+ * @see \Hyde\Framework\Foundation\PageCollection
  * @see \Hyde\Framework\Testing\Feature\RouteTest
  *
  * This is not a router in the traditional sense that it decides where to go.

--- a/packages/framework/src/Services/BuildService.php
+++ b/packages/framework/src/Services/BuildService.php
@@ -4,8 +4,8 @@ namespace Hyde\Framework\Services;
 
 use Hyde\Framework\Concerns\InteractsWithDirectories;
 use Hyde\Framework\Contracts\RouteContract as Route;
-use Hyde\Framework\Hyde;
 use Hyde\Framework\Foundation\RouteCollection;
+use Hyde\Framework\Hyde;
 use Hyde\Framework\StaticPageBuilder;
 use Illuminate\Console\Concerns\InteractsWithIO;
 use Illuminate\Console\OutputStyle;

--- a/packages/framework/src/Services/BuildService.php
+++ b/packages/framework/src/Services/BuildService.php
@@ -5,7 +5,7 @@ namespace Hyde\Framework\Services;
 use Hyde\Framework\Concerns\InteractsWithDirectories;
 use Hyde\Framework\Contracts\RouteContract as Route;
 use Hyde\Framework\Hyde;
-use Hyde\Framework\RouteCollection;
+use Hyde\Framework\Foundation\RouteCollection;
 use Hyde\Framework\StaticPageBuilder;
 use Illuminate\Console\Concerns\InteractsWithIO;
 use Illuminate\Console\OutputStyle;
@@ -68,7 +68,7 @@ class BuildService
     }
 
     /**
-     * @return \Hyde\Framework\RouteCollection<array-key, class-string<\Hyde\Framework\Contracts\PageContract>>
+     * @return \Hyde\Framework\Foundation\RouteCollection<array-key, class-string<\Hyde\Framework\Contracts\PageContract>>
      */
     protected function getDiscoveredModels(): RouteCollection
     {

--- a/packages/framework/tests/Feature/PageCollectionTest.php
+++ b/packages/framework/tests/Feature/PageCollectionTest.php
@@ -7,12 +7,12 @@ use Hyde\Framework\Models\Pages\BladePage;
 use Hyde\Framework\Models\Pages\DocumentationPage;
 use Hyde\Framework\Models\Pages\MarkdownPage;
 use Hyde\Framework\Models\Pages\MarkdownPost;
-use Hyde\Framework\PageCollection;
+use Hyde\Framework\Foundation\PageCollection;
 use Hyde\Testing\TestCase;
 use Illuminate\Support\Collection;
 
 /**
- * @covers \Hyde\Framework\PageCollection
+ * @covers \Hyde\Framework\Foundation\PageCollection
  */
 class PageCollectionTest extends TestCase
 {

--- a/packages/framework/tests/Feature/PageCollectionTest.php
+++ b/packages/framework/tests/Feature/PageCollectionTest.php
@@ -2,12 +2,12 @@
 
 namespace Hyde\Framework\Testing\Feature;
 
+use Hyde\Framework\Foundation\PageCollection;
 use Hyde\Framework\Hyde;
 use Hyde\Framework\Models\Pages\BladePage;
 use Hyde\Framework\Models\Pages\DocumentationPage;
 use Hyde\Framework\Models\Pages\MarkdownPage;
 use Hyde\Framework\Models\Pages\MarkdownPost;
-use Hyde\Framework\Foundation\PageCollection;
 use Hyde\Testing\TestCase;
 use Illuminate\Support\Collection;
 

--- a/packages/framework/tests/Feature/RouteCollectionTest.php
+++ b/packages/framework/tests/Feature/RouteCollectionTest.php
@@ -8,12 +8,12 @@ use Hyde\Framework\Models\Pages\DocumentationPage;
 use Hyde\Framework\Models\Pages\MarkdownPage;
 use Hyde\Framework\Models\Pages\MarkdownPost;
 use Hyde\Framework\Models\Route;
-use Hyde\Framework\RouteCollection;
+use Hyde\Framework\Foundation\RouteCollection;
 use Hyde\Testing\TestCase;
 use Illuminate\Support\Collection;
 
 /**
- * @covers \Hyde\Framework\RouteCollection
+ * @covers \Hyde\Framework\Foundation\RouteCollection
  */
 class RouteCollectionTest extends TestCase
 {

--- a/packages/framework/tests/Feature/RouteCollectionTest.php
+++ b/packages/framework/tests/Feature/RouteCollectionTest.php
@@ -2,13 +2,13 @@
 
 namespace Hyde\Framework\Testing\Feature;
 
+use Hyde\Framework\Foundation\RouteCollection;
 use Hyde\Framework\Hyde;
 use Hyde\Framework\Models\Pages\BladePage;
 use Hyde\Framework\Models\Pages\DocumentationPage;
 use Hyde\Framework\Models\Pages\MarkdownPage;
 use Hyde\Framework\Models\Pages\MarkdownPost;
 use Hyde\Framework\Models\Route;
-use Hyde\Framework\Foundation\RouteCollection;
 use Hyde\Testing\TestCase;
 use Illuminate\Support\Collection;
 


### PR DESCRIPTION
To upgrade the moved collection namespaces, simply replace the following namespace imports:

```diff
-use Hyde\Framework\PageCollection;
+use Hyde\Framework\Foundation\PageCollection;
-use Hyde\Framework\RouteCollection;
+use Hyde\Framework\Foundation\RouteCollection;
```