### PR TITLE
Discover filesystem upon booting the framework

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -2,15 +2,11 @@
 
 ### About
 
-Keep an Unreleased section at the top to track upcoming changes.
-
-This serves two purposes:
-
-1. People can see what changes they might expect in upcoming releases
-2. At release time, you can move the Unreleased section changes into a new release version section.
+Creates a new foundation class, the FileCollection. Which like the other foundation collections, discovers all the files. Running this part of the autodiscovery will further enrich the Hyde Kernel, and allow greater insight into the application. The end user experience should not be affected by this.
 
 ### Added
-- for new features.
+- Adds a new FileCollection class to hold all discovered source and asset files
+- Adds a new File model as an object-oriented way of representing a project file
 
 ### Changed
 - Move class PageCollection into Foundation namespace

--- a/packages/framework/src/Foundation/BaseSystemCollection.php
+++ b/packages/framework/src/Foundation/BaseSystemCollection.php
@@ -5,6 +5,13 @@ namespace Hyde\Framework\Foundation;
 use Illuminate\Support\Collection;
 use Hyde\Framework\Contracts\HydeKernelContract;
 
+/**
+ * @internal Base class for the system collections.
+ *
+ * @see \Hyde\Framework\Foundation\FileCollection
+ * @see \Hyde\Framework\Foundation\PageCollection
+ * @see \Hyde\Framework\Foundation\RouteCollection
+ */
 abstract class BaseSystemCollection extends Collection
 {
     protected HydeKernelContract $kernel;

--- a/packages/framework/src/Foundation/BaseSystemCollection.php
+++ b/packages/framework/src/Foundation/BaseSystemCollection.php
@@ -2,8 +2,8 @@
 
 namespace Hyde\Framework\Foundation;
 
-use Illuminate\Support\Collection;
 use Hyde\Framework\Contracts\HydeKernelContract;
+use Illuminate\Support\Collection;
 
 /**
  * @internal Base class for the system collections.
@@ -29,6 +29,7 @@ abstract class BaseSystemCollection extends Collection
     protected function setKernel(HydeKernelContract $kernel): static
     {
         $this->kernel = $kernel;
+
         return $this;
     }
 

--- a/packages/framework/src/Foundation/BaseSystemCollection.php
+++ b/packages/framework/src/Foundation/BaseSystemCollection.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Hyde\Framework\Foundation;
+
+use Illuminate\Support\Collection;
+use Hyde\Framework\Contracts\HydeKernelContract;
+
+abstract class BaseSystemCollection extends Collection
+{
+    protected HydeKernelContract $kernel;
+
+    public static function boot(HydeKernelContract $kernel): static
+    {
+        return (new static())->setKernel($kernel)->runDiscovery();
+    }
+
+    protected function __construct($items = [])
+    {
+        parent::__construct($items);
+    }
+
+    protected function setKernel(HydeKernelContract $kernel): static
+    {
+        $this->kernel = $kernel;
+        return $this;
+    }
+}

--- a/packages/framework/src/Foundation/BaseSystemCollection.php
+++ b/packages/framework/src/Foundation/BaseSystemCollection.php
@@ -16,6 +16,8 @@ abstract class BaseSystemCollection extends Collection
 {
     protected HydeKernelContract $kernel;
 
+    abstract protected function runDiscovery(): self;
+
     public static function boot(HydeKernelContract $kernel): static
     {
         return (new static())->setKernel($kernel)->runDiscovery();
@@ -32,6 +34,4 @@ abstract class BaseSystemCollection extends Collection
 
         return $this;
     }
-
-    abstract protected function runDiscovery(): self;
 }

--- a/packages/framework/src/Foundation/BaseSystemCollection.php
+++ b/packages/framework/src/Foundation/BaseSystemCollection.php
@@ -31,4 +31,6 @@ abstract class BaseSystemCollection extends Collection
         $this->kernel = $kernel;
         return $this;
     }
+
+    abstract protected function runDiscovery(): self;
 }

--- a/packages/framework/src/Foundation/FileCollection.php
+++ b/packages/framework/src/Foundation/FileCollection.php
@@ -2,11 +2,14 @@
 
 namespace Hyde\Framework\Foundation;
 
+use Hyde\Framework\Contracts\AbstractPage;
 use Hyde\Framework\Helpers\Features;
+use Hyde\Framework\Hyde;
 use Hyde\Framework\Models\Pages\BladePage;
 use Hyde\Framework\Models\Pages\DocumentationPage;
 use Hyde\Framework\Models\Pages\MarkdownPage;
 use Hyde\Framework\Models\Pages\MarkdownPost;
+use Hyde\Framework\Services\DiscoveryService;
 
 final class FileCollection extends BaseSystemCollection
 {
@@ -29,5 +32,15 @@ final class FileCollection extends BaseSystemCollection
         }
 
         return $this;
+    }
+
+    /** @param string<AbstractPage> $pageClass */
+    protected function discoverFilesFor(string $pageClass): void
+    {
+        foreach (glob($this->kernel->path($pageClass::qualifyBasename('{*,**/*}')), GLOB_BRACE) as $filepath) {
+            if (! str_starts_with(basename($filepath), '_')) {
+                $this->put($this->kernel->pathToRelative($filepath), DiscoveryService::formatSlugForModel($pageClass, $filepath));
+            }
+        }
     }
 }

--- a/packages/framework/src/Foundation/FileCollection.php
+++ b/packages/framework/src/Foundation/FileCollection.php
@@ -2,9 +2,27 @@
 
 namespace Hyde\Framework\Foundation;
 
+use Hyde\Framework\Contracts\HydeKernelContract;
 use Illuminate\Support\Collection;
 
 final class FileCollection extends Collection
 {
-    //
+    protected HydeKernelContract $kernel;
+
+    public static function boot(HydeKernelContract $kernel): self
+    {
+        return (new self())->setKernel($kernel)->discoverFiles();
+    }
+
+    protected function __construct($items = [])
+    {
+        parent::__construct($items);
+    }
+
+    protected function setKernel(HydeKernelContract $kernel): self
+    {
+        $this->kernel = $kernel;
+
+        return $this;
+    }
 }

--- a/packages/framework/src/Foundation/FileCollection.php
+++ b/packages/framework/src/Foundation/FileCollection.php
@@ -5,6 +5,7 @@ namespace Hyde\Framework\Foundation;
 use Hyde\Framework\Contracts\AbstractPage;
 use Hyde\Framework\Helpers\Features;
 use Hyde\Framework\Hyde;
+use Hyde\Framework\Models\File;
 use Hyde\Framework\Models\Pages\BladePage;
 use Hyde\Framework\Models\Pages\DocumentationPage;
 use Hyde\Framework\Models\Pages\MarkdownPage;
@@ -39,7 +40,7 @@ final class FileCollection extends BaseSystemCollection
     {
         foreach (glob($this->kernel->path($pageClass::qualifyBasename('{*,**/*}')), GLOB_BRACE) as $filepath) {
             if (! str_starts_with(basename($filepath), '_')) {
-                $this->put($this->kernel->pathToRelative($filepath), DiscoveryService::formatSlugForModel($pageClass, $filepath));
+                $this->put($this->kernel->pathToRelative($filepath), File::make($filepath));
             }
         }
     }

--- a/packages/framework/src/Foundation/FileCollection.php
+++ b/packages/framework/src/Foundation/FileCollection.php
@@ -14,6 +14,13 @@ use Hyde\Framework\Services\DiscoveryService;
 
 final class FileCollection extends BaseSystemCollection
 {
+    public function getSourceFiles(?string $pageClass = null): self
+    {
+        return ! $pageClass ? $this : $this->filter(function (File $file) use ($pageClass): bool {
+            return $file->belongsTo() === $pageClass;
+        });
+    }
+
     protected function runDiscovery(): self
     {
         if (Features::hasBladePages()) {

--- a/packages/framework/src/Foundation/FileCollection.php
+++ b/packages/framework/src/Foundation/FileCollection.php
@@ -43,7 +43,7 @@ final class FileCollection extends BaseSystemCollection
         // Scan the source directory, and directories therein, for files that match the model's file extension.
         foreach (glob($this->kernel->path($pageClass::qualifyBasename('{*,**/*}')), GLOB_BRACE) as $filepath) {
             if (! str_starts_with(basename($filepath), '_')) {
-                $this->put($this->kernel->pathToRelative($filepath), File::make($filepath));
+                $this->put($this->kernel->pathToRelative($filepath), File::make($filepath)->belongsTo($pageClass));
             }
         }
     }

--- a/packages/framework/src/Foundation/FileCollection.php
+++ b/packages/framework/src/Foundation/FileCollection.php
@@ -18,7 +18,9 @@ final class FileCollection extends BaseSystemCollection
 {
     public function getSourceFiles(?string $pageClass = null): self
     {
-        return ! $pageClass ? $this : $this->filter(function (File $file) use ($pageClass): bool {
+        return ! $pageClass ? $this->filter(function (File $file) {
+            return $file->belongsTo !== null;
+        }) : $this->filter(function (File $file) use ($pageClass): bool {
             return $file->belongsTo() === $pageClass;
         });
     }

--- a/packages/framework/src/Foundation/FileCollection.php
+++ b/packages/framework/src/Foundation/FileCollection.php
@@ -2,27 +2,7 @@
 
 namespace Hyde\Framework\Foundation;
 
-use Hyde\Framework\Contracts\HydeKernelContract;
-use Illuminate\Support\Collection;
-
-final class FileCollection extends Collection
+final class FileCollection extends BaseSystemCollection
 {
-    protected HydeKernelContract $kernel;
-
-    public static function boot(HydeKernelContract $kernel): self
-    {
-        return (new self())->setKernel($kernel)->discoverFiles();
-    }
-
-    protected function __construct($items = [])
-    {
-        parent::__construct($items);
-    }
-
-    protected function setKernel(HydeKernelContract $kernel): self
-    {
-        $this->kernel = $kernel;
-
-        return $this;
-    }
+    //
 }

--- a/packages/framework/src/Foundation/FileCollection.php
+++ b/packages/framework/src/Foundation/FileCollection.php
@@ -4,7 +4,6 @@ namespace Hyde\Framework\Foundation;
 
 use Hyde\Framework\Contracts\AbstractPage;
 use Hyde\Framework\Helpers\Features;
-use Hyde\Framework\Hyde;
 use Hyde\Framework\Models\File;
 use Hyde\Framework\Models\Pages\BladePage;
 use Hyde\Framework\Models\Pages\DocumentationPage;

--- a/packages/framework/src/Foundation/FileCollection.php
+++ b/packages/framework/src/Foundation/FileCollection.php
@@ -38,6 +38,7 @@ final class FileCollection extends BaseSystemCollection
     /** @param string<AbstractPage> $pageClass */
     protected function discoverFilesFor(string $pageClass): void
     {
+        // Scan the source directory, and directories therein, for files that match the model's file extension.
         foreach (glob($this->kernel->path($pageClass::qualifyBasename('{*,**/*}')), GLOB_BRACE) as $filepath) {
             if (! str_starts_with(basename($filepath), '_')) {
                 $this->put($this->kernel->pathToRelative($filepath), File::make($filepath));

--- a/packages/framework/src/Foundation/FileCollection.php
+++ b/packages/framework/src/Foundation/FileCollection.php
@@ -32,6 +32,8 @@ final class FileCollection extends BaseSystemCollection
             $this->discoverFilesFor(DocumentationPage::class);
         }
 
+        $this->discoverMediaAssetFiles();
+
         return $this;
     }
 
@@ -43,6 +45,13 @@ final class FileCollection extends BaseSystemCollection
             if (! str_starts_with(basename($filepath), '_')) {
                 $this->put($this->kernel->pathToRelative($filepath), File::make($filepath));
             }
+        }
+    }
+
+    protected function discoverMediaAssetFiles(): void
+    {
+        foreach (DiscoveryService::getMediaAssetFiles() as $filepath) {
+            $this->put($this->kernel->pathToRelative($filepath), File::make($filepath));
         }
     }
 }

--- a/packages/framework/src/Foundation/FileCollection.php
+++ b/packages/framework/src/Foundation/FileCollection.php
@@ -2,7 +2,32 @@
 
 namespace Hyde\Framework\Foundation;
 
+use Hyde\Framework\Helpers\Features;
+use Hyde\Framework\Models\Pages\BladePage;
+use Hyde\Framework\Models\Pages\DocumentationPage;
+use Hyde\Framework\Models\Pages\MarkdownPage;
+use Hyde\Framework\Models\Pages\MarkdownPost;
+
 final class FileCollection extends BaseSystemCollection
 {
-    //
+    protected function runDiscovery(): self
+    {
+        if (Features::hasBladePages()) {
+            $this->discoverFilesFor(BladePage::class);
+        }
+
+        if (Features::hasMarkdownPages()) {
+            $this->discoverFilesFor(MarkdownPage::class);
+        }
+
+        if (Features::hasBlogPosts()) {
+            $this->discoverFilesFor(MarkdownPost::class);
+        }
+
+        if (Features::hasDocumentationPages()) {
+            $this->discoverFilesFor(DocumentationPage::class);
+        }
+
+        return $this;
+    }
 }

--- a/packages/framework/src/Foundation/FileCollection.php
+++ b/packages/framework/src/Foundation/FileCollection.php
@@ -35,6 +35,13 @@ final class FileCollection extends BaseSystemCollection
         });
     }
 
+    public function getMediaFiles(): self
+    {
+        return $this->filter(function (File $file): bool {
+            return str_starts_with($file, '_media');
+        });
+    }
+
     protected function runDiscovery(): self
     {
         if (Features::hasBladePages()) {

--- a/packages/framework/src/Foundation/FileCollection.php
+++ b/packages/framework/src/Foundation/FileCollection.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Hyde\Framework\Foundation;
+
+use Illuminate\Support\Collection;
+
+final class FileCollection extends Collection
+{
+    //
+}

--- a/packages/framework/src/Foundation/FileCollection.php
+++ b/packages/framework/src/Foundation/FileCollection.php
@@ -11,6 +11,9 @@ use Hyde\Framework\Models\Pages\MarkdownPage;
 use Hyde\Framework\Models\Pages\MarkdownPost;
 use Hyde\Framework\Services\DiscoveryService;
 
+/**
+ * @see \Hyde\Framework\Foundation\FileCollection
+ */
 final class FileCollection extends BaseSystemCollection
 {
     public function getSourceFiles(?string $pageClass = null): self

--- a/packages/framework/src/Foundation/FileCollection.php
+++ b/packages/framework/src/Foundation/FileCollection.php
@@ -18,9 +18,19 @@ final class FileCollection extends BaseSystemCollection
 {
     public function getSourceFiles(?string $pageClass = null): self
     {
-        return ! $pageClass ? $this->filter(function (File $file) {
+        return ! $pageClass ? $this->getAllSourceFiles() : $this->getSourceFilesFor($pageClass);
+    }
+
+    public function getAllSourceFiles(): self
+    {
+        return $this->filter(function (File $file) {
             return $file->belongsTo !== null;
-        }) : $this->filter(function (File $file) use ($pageClass): bool {
+        });
+    }
+
+    public function getSourceFilesFor(string $pageClass): self
+    {
+        return $this->filter(function (File $file) use ($pageClass): bool {
             return $file->belongsTo() === $pageClass;
         });
     }

--- a/packages/framework/src/Foundation/PageCollection.php
+++ b/packages/framework/src/Foundation/PageCollection.php
@@ -19,7 +19,7 @@ final class PageCollection extends Collection
 {
     public static function boot(): self
     {
-        return (new self())->discoverPages();
+        return (new self())->runDiscovery();
     }
 
     protected function __construct($items = [])
@@ -39,7 +39,7 @@ final class PageCollection extends Collection
         });
     }
 
-    protected function discoverPages(): self
+    protected function runDiscovery(): self
     {
         if (Features::hasBladePages()) {
             $this->discoverPagesFor(BladePage::class);

--- a/packages/framework/src/Foundation/PageCollection.php
+++ b/packages/framework/src/Foundation/PageCollection.php
@@ -15,18 +15,8 @@ use Illuminate\Support\Collection;
  * @see \Hyde\Framework\Foundation\RouteCollection
  * @see \Hyde\Framework\Testing\Feature\PageCollectionTest
  */
-final class PageCollection extends Collection
+final class PageCollection extends BaseSystemCollection
 {
-    public static function boot(): self
-    {
-        return (new self())->runDiscovery();
-    }
-
-    protected function __construct($items = [])
-    {
-        parent::__construct($items);
-    }
-
     public function getPage(string $sourcePath): PageContract
     {
         return $this->items[$sourcePath] ?? throw new FileNotFoundException($sourcePath.' in page collection');

--- a/packages/framework/src/Foundation/RouteCollection.php
+++ b/packages/framework/src/Foundation/RouteCollection.php
@@ -36,7 +36,7 @@ final class RouteCollection extends Collection
 
     public static function boot(HydeKernelContract $kernel): self
     {
-        return (new self())->setKernel($kernel)->discoverRoutes();
+        return (new self())->setKernel($kernel)->runDiscovery();
     }
 
     protected function __construct($items = [])
@@ -77,7 +77,7 @@ final class RouteCollection extends Collection
         return $this;
     }
 
-    protected function discoverRoutes(): self
+    protected function runDiscovery(): self
     {
         $this->kernel->pages()->each(function (PageContract $page) {
             $this->discover($page);

--- a/packages/framework/src/Foundation/RouteCollection.php
+++ b/packages/framework/src/Foundation/RouteCollection.php
@@ -2,11 +2,9 @@
 
 namespace Hyde\Framework\Foundation;
 
-use Hyde\Framework\Contracts\HydeKernelContract;
 use Hyde\Framework\Contracts\PageContract;
 use Hyde\Framework\Contracts\RouteContract;
 use Hyde\Framework\Models\Route;
-use Illuminate\Support\Collection;
 
 /**
  * Pseudo-Router for Hyde.
@@ -30,27 +28,8 @@ use Illuminate\Support\Collection;
  * determine where a source file will be compiled to, and where a compiled
  * file was generated from.
  */
-final class RouteCollection extends Collection
+final class RouteCollection extends BaseSystemCollection
 {
-    protected HydeKernelContract $kernel;
-
-    public static function boot(HydeKernelContract $kernel): self
-    {
-        return (new self())->setKernel($kernel)->runDiscovery();
-    }
-
-    protected function __construct($items = [])
-    {
-        parent::__construct($items);
-    }
-
-    protected function setKernel(HydeKernelContract $kernel): self
-    {
-        $this->kernel = $kernel;
-
-        return $this;
-    }
-
     public function getRoutes(?string $pageClass = null): self
     {
         return ! $pageClass ? $this : $this->filter(function (RouteContract $route) use ($pageClass) {

--- a/packages/framework/src/Foundation/RouteCollection.php
+++ b/packages/framework/src/Foundation/RouteCollection.php
@@ -11,6 +11,7 @@ use Hyde\Framework\Models\Route;
  *
  * @see \Hyde\Framework\Foundation\PageCollection
  * @see \Hyde\Framework\Testing\Feature\RouteTest
+ * @see \Hyde\Framework\Testing\Feature\RouteCollectionTest
  *
  * This is not a router in the traditional sense that it decides where to go.
  * Instead, it creates a pre-generated object encapsulating the Hyde autodiscovery.

--- a/packages/framework/src/Hyde.php
+++ b/packages/framework/src/Hyde.php
@@ -4,6 +4,7 @@ namespace Hyde\Framework;
 
 use Hyde\Framework\Contracts\HydeKernelContract;
 use Hyde\Framework\Contracts\RouteContract;
+use Hyde\Framework\Foundation\FileCollection;
 use Hyde\Framework\Foundation\PageCollection;
 use Hyde\Framework\Foundation\RouteCollection;
 use Hyde\Framework\Helpers\Features;
@@ -29,6 +30,7 @@ use Illuminate\Support\Facades\Facade;
  * @method static string path(string $path = '')
  * @method static string relativeLink(string $destination)
  * @method static PageCollection pages()
+ * @method static FileCollection files()
  * @method static string getMarkdownPostPath(string $path = '')
  * @method static bool copy(string $from, string $to)
  * @method static void boot()

--- a/packages/framework/src/HydeKernel.php
+++ b/packages/framework/src/HydeKernel.php
@@ -36,8 +36,10 @@ class HydeKernel implements HydeKernelContract, Arrayable, \JsonSerializable
     protected static HydeKernelContract $instance;
 
     protected string $basePath;
+
     protected Filesystem $filesystem;
     protected Hyperlinks $hyperlinks;
+
     protected FileCollection $files;
     protected PageCollection $pages;
     protected RouteCollection $routes;
@@ -54,6 +56,7 @@ class HydeKernel implements HydeKernelContract, Arrayable, \JsonSerializable
     public function boot(): void
     {
         $this->booted = true;
+
         $this->files = FileCollection::boot($this);
         $this->pages = PageCollection::boot();
         $this->routes = RouteCollection::boot($this);

--- a/packages/framework/src/HydeKernel.php
+++ b/packages/framework/src/HydeKernel.php
@@ -107,6 +107,15 @@ class HydeKernel implements HydeKernelContract, Arrayable, \JsonSerializable
         return View::shared('currentRoute');
     }
 
+    public function files(): FileCollection
+    {
+        if (! $this->booted) {
+            $this->boot();
+        }
+
+        return $this->files;
+    }
+
     public function pages(): PageCollection
     {
         if (! $this->booted) {
@@ -231,6 +240,7 @@ class HydeKernel implements HydeKernelContract, Arrayable, \JsonSerializable
         return [
             'basePath' => $this->basePath,
             'features' => $this->features(),
+            'files' => $this->files(),
             'pages' => $this->pages(),
             'routes' => $this->routes(),
         ];

--- a/packages/framework/src/HydeKernel.php
+++ b/packages/framework/src/HydeKernel.php
@@ -58,7 +58,7 @@ class HydeKernel implements HydeKernelContract, Arrayable, \JsonSerializable
         $this->booted = true;
 
         $this->files = FileCollection::boot($this);
-        $this->pages = PageCollection::boot();
+        $this->pages = PageCollection::boot($this);
         $this->routes = RouteCollection::boot($this);
     }
 

--- a/packages/framework/src/HydeKernel.php
+++ b/packages/framework/src/HydeKernel.php
@@ -6,6 +6,7 @@ use Composer\InstalledVersions;
 use Hyde\Framework\Concerns\JsonSerializesArrayable;
 use Hyde\Framework\Contracts\HydeKernelContract;
 use Hyde\Framework\Contracts\RouteContract;
+use Hyde\Framework\Foundation\FileCollection;
 use Hyde\Framework\Foundation\Filesystem;
 use Hyde\Framework\Foundation\Hyperlinks;
 use Hyde\Framework\Foundation\PageCollection;
@@ -37,6 +38,7 @@ class HydeKernel implements HydeKernelContract, Arrayable, \JsonSerializable
     protected string $basePath;
     protected Filesystem $filesystem;
     protected Hyperlinks $hyperlinks;
+    protected FileCollection $files;
     protected PageCollection $pages;
     protected RouteCollection $routes;
 
@@ -52,6 +54,7 @@ class HydeKernel implements HydeKernelContract, Arrayable, \JsonSerializable
     public function boot(): void
     {
         $this->booted = true;
+        $this->files = FileCollection::boot($this);
         $this->pages = PageCollection::boot();
         $this->routes = RouteCollection::boot($this);
     }

--- a/packages/framework/src/Models/File.php
+++ b/packages/framework/src/Models/File.php
@@ -31,19 +31,23 @@ class File implements Arrayable, \JsonSerializable, \Stringable
     public ?string $belongsTo = null;
 
     /**
-     * @param  string  $path  The path relative to the project root.
+     * @param string $path The path relative to the project root.
+     * @param string<\Hyde\Framework\Contracts\AbstractPage>|null $belongsToClass
+     * @return \Hyde\Framework\Models\File
      */
-    public static function make(string $path): static
+    public static function make(string $path, ?string $belongsToClass = null): static
     {
-        return new static($path);
+        return new static($path, $belongsToClass);
     }
 
     /**
-     * @param  string  $path  The path relative to the project root.
+     * @param string $path The path relative to the project root.
+     * @param string<\Hyde\Framework\Contracts\AbstractPage>|null $belongsToClass
      */
-    public function __construct(string $path)
+    public function __construct(string $path, ?string $belongsToClass = null)
     {
         $this->path = Hyde::pathToRelative($path);
+        $this->belongsTo = $belongsToClass;
     }
 
     /**
@@ -58,7 +62,7 @@ class File implements Arrayable, \JsonSerializable, \Stringable
      * Supply a page class to associate with this file,
      * or leave blank to get the file's associated class.
      *
-     * @param  string|null  $class
+     * @param string<\Hyde\Framework\Contracts\AbstractPage>|null $class
      * @return string|$this|null
      */
     public function belongsTo(?string $class = null): null|string|static

--- a/packages/framework/src/Models/File.php
+++ b/packages/framework/src/Models/File.php
@@ -143,6 +143,11 @@ class File implements Arrayable, \JsonSerializable, \Stringable
 
     public function withoutDirectoryPrefix(): string
     {
-        return substr($this, strlen($this->belongsTo ? $this->belongsTo::$sourceDirectory : Str::before($this, '/')));
+        if ($this->belongsTo) {
+            // If a model is set, use that to remove the directory, so and subdirectories within is retained
+            return substr($this, strlen($this->belongsTo::$sourceDirectory));
+        }
+
+        return Str::afterLast($this, '/');
     }
 }

--- a/packages/framework/src/Models/File.php
+++ b/packages/framework/src/Models/File.php
@@ -15,18 +15,20 @@ class File implements Arrayable, \JsonSerializable, \Stringable
 
     /**
      * @var string The path relative to the project root.
+     *
      * @example `_pages/index.blade.php`
      */
     public string $path;
 
     /**
      * If the file is associated with a page, the class can be specified here.
+     *
      * @var string<\Hyde\Framework\Contracts\AbstractPage>|null
      */
     public ?string $belongsTo = null;
 
     /**
-     * @param string $path The path relative to the project root.
+     * @param  string  $path  The path relative to the project root.
      */
     public static function make(string $path): static
     {
@@ -34,7 +36,7 @@ class File implements Arrayable, \JsonSerializable, \Stringable
     }
 
     /**
-     * @param string $path The path relative to the project root.
+     * @param  string  $path  The path relative to the project root.
      */
     public function __construct(string $path)
     {
@@ -53,13 +55,14 @@ class File implements Arrayable, \JsonSerializable, \Stringable
      * Supply a page class to associate with this file,
      * or leave blank to get the file's associated class.
      *
-     * @param string|null $class
+     * @param  string|null  $class
      * @return string|$this|null
      */
     public function belongsTo(?string $class = null): null|string|static
     {
         if ($class) {
             $this->belongsTo = $class;
+
             return $this;
         }
 

--- a/packages/framework/src/Models/File.php
+++ b/packages/framework/src/Models/File.php
@@ -20,6 +20,12 @@ class File implements Arrayable, \JsonSerializable
     public string $path;
 
     /**
+     * If the file is associated with a page, the class can be specified here.
+     * @var string<\Hyde\Framework\Contracts\AbstractPage>
+     */
+    public string $belongsTo;
+
+    /**
      * @param string $path The path relative to the project root.
      */
     public static function make(string $path): static
@@ -33,6 +39,23 @@ class File implements Arrayable, \JsonSerializable
     public function __construct(string $path)
     {
         $this->path = Hyde::pathToRelative($path);
+    }
+
+    /**
+     * Supply a page class to associate with this file,
+     * or leave blank to get the file's associated class.
+     *
+     * @param string|null $class
+     * @return string|$this|null
+     */
+    public function belongsTo(?string $class): null|string|static
+    {
+        if ($class) {
+            $this->belongsTo = $class;
+            return $this;
+        }
+
+        return $this->belongsTo;
     }
 
     public function getName(): string

--- a/packages/framework/src/Models/File.php
+++ b/packages/framework/src/Models/File.php
@@ -5,7 +5,6 @@ namespace Hyde\Framework\Models;
 use Hyde\Framework\Concerns\JsonSerializesArrayable;
 use Hyde\Framework\Hyde;
 use Illuminate\Contracts\Support\Arrayable;
-use Illuminate\Support\Str;
 
 /**
  * Filesystem abstraction for a file stored in the project.
@@ -31,8 +30,8 @@ class File implements Arrayable, \JsonSerializable, \Stringable
     public ?string $belongsTo = null;
 
     /**
-     * @param string $path The path relative to the project root.
-     * @param string<\Hyde\Framework\Contracts\AbstractPage>|null $belongsToClass
+     * @param  string  $path  The path relative to the project root.
+     * @param  string<\Hyde\Framework\Contracts\AbstractPage>|null  $belongsToClass
      * @return \Hyde\Framework\Models\File
      */
     public static function make(string $path, ?string $belongsToClass = null): static
@@ -41,8 +40,8 @@ class File implements Arrayable, \JsonSerializable, \Stringable
     }
 
     /**
-     * @param string $path The path relative to the project root.
-     * @param string<\Hyde\Framework\Contracts\AbstractPage>|null $belongsToClass
+     * @param  string  $path  The path relative to the project root.
+     * @param  string<\Hyde\Framework\Contracts\AbstractPage>|null  $belongsToClass
      */
     public function __construct(string $path, ?string $belongsToClass = null)
     {
@@ -62,7 +61,7 @@ class File implements Arrayable, \JsonSerializable, \Stringable
      * Supply a page class to associate with this file,
      * or leave blank to get the file's associated class.
      *
-     * @param string<\Hyde\Framework\Contracts\AbstractPage>|null $class
+     * @param  string<\Hyde\Framework\Contracts\AbstractPage>|null  $class
      * @return string|$this|null
      */
     public function belongsTo(?string $class = null): null|string|static
@@ -137,7 +136,7 @@ class File implements Arrayable, \JsonSerializable, \Stringable
     {
         return [
             'path' => $this->path,
-            'model' => $this->belongsTo
+            'model' => $this->belongsTo,
         ];
     }
 

--- a/packages/framework/src/Models/File.php
+++ b/packages/framework/src/Models/File.php
@@ -9,6 +9,8 @@ use Illuminate\Support\Str;
 
 /**
  * Filesystem abstraction for a file stored in the project.
+ *
+ * @see \Hyde\Framework\Testing\Feature\FileTest
  */
 class File implements Arrayable, \JsonSerializable, \Stringable
 {

--- a/packages/framework/src/Models/File.php
+++ b/packages/framework/src/Models/File.php
@@ -145,7 +145,7 @@ class File implements Arrayable, \JsonSerializable, \Stringable
     {
         if ($this->belongsTo) {
             // If a model is set, use that to remove the directory, so any subdirectories within is retained
-            return substr($this, strlen($this->belongsTo::$sourceDirectory));
+            return substr($this, strlen($this->belongsTo::$sourceDirectory) + 1);
         }
 
         return basename($this);

--- a/packages/framework/src/Models/File.php
+++ b/packages/framework/src/Models/File.php
@@ -21,9 +21,9 @@ class File implements Arrayable, \JsonSerializable
 
     /**
      * If the file is associated with a page, the class can be specified here.
-     * @var string<\Hyde\Framework\Contracts\AbstractPage>
+     * @var string<\Hyde\Framework\Contracts\AbstractPage>|null
      */
-    public string $belongsTo;
+    public ?string $belongsTo = null;
 
     /**
      * @param string $path The path relative to the project root.

--- a/packages/framework/src/Models/File.php
+++ b/packages/framework/src/Models/File.php
@@ -125,7 +125,7 @@ class File implements Arrayable, \JsonSerializable, \Stringable
             return $lookup[$extension];
         }
 
-        if (extension_loaded('fileinfo')) {
+        if (extension_loaded('fileinfo') && file_exists($this->getAbsolutePath())) {
             return mime_content_type($this->path);
         }
 

--- a/packages/framework/src/Models/File.php
+++ b/packages/framework/src/Models/File.php
@@ -148,6 +148,6 @@ class File implements Arrayable, \JsonSerializable, \Stringable
             return substr($this, strlen($this->belongsTo::$sourceDirectory));
         }
 
-        return Str::afterLast($this, '/');
+        return basename($this);
     }
 }

--- a/packages/framework/src/Models/File.php
+++ b/packages/framework/src/Models/File.php
@@ -19,6 +19,22 @@ class File implements Arrayable, \JsonSerializable
      */
     public string $path;
 
+    /**
+     * @param string $path The path relative to the project root.
+     */
+    public static function make(string $path): static
+    {
+        return new static($path);
+    }
+
+    /**
+     * @param string $path The path relative to the project root.
+     */
+    public function __construct(string $path)
+    {
+        $this->path = $path;
+    }
+
     public function getName(): string
     {
         return basename($this->path);

--- a/packages/framework/src/Models/File.php
+++ b/packages/framework/src/Models/File.php
@@ -1,0 +1,85 @@
+<?php
+
+namespace Hyde\Framework\Models;
+
+use Hyde\Framework\Concerns\JsonSerializesArrayable;
+use Hyde\Framework\Hyde;
+use Illuminate\Contracts\Support\Arrayable;
+
+/**
+ * Filesystem abstraction for a file stored in the project.
+ */
+class File implements Arrayable, \JsonSerializable
+{
+    use JsonSerializesArrayable;
+
+    /**
+     * @var string The path relative to the project root.
+     * @example `_pages/index.blade.php`
+     */
+    public string $path;
+
+    public function getName(): string
+    {
+        return basename($this->path);
+    }
+
+    public function getPath(): string
+    {
+        return $this->path;
+    }
+
+    public function getAbsolutePath(): string
+    {
+        return Hyde::path($this->path);
+    }
+
+    public function getContents(): string
+    {
+        return file_get_contents($this->path);
+    }
+
+    public function getContentLength(): int
+    {
+        return filesize($this->path);
+    }
+
+    public function getMimeType(): string
+    {
+        $extension = pathinfo($this->path, PATHINFO_EXTENSION);
+
+        // See if we can find a mime type for the extension,
+        // instead of having to rely on a PHP extension.
+        $lookup = [
+            'txt'  => 'text/plain',
+            'md'   => 'text/markdown',
+            'html' => 'text/html',
+            'css'  => 'text/css',
+            'svg'  => 'image/svg+xml',
+            'png'  => 'image/png',
+            'jpg'  => 'image/jpeg',
+            'jpeg' => 'image/jpeg',
+            'gif'  => 'image/gif',
+            'json' => 'application/json',
+            'js'   => 'application/javascript',
+        ];
+
+        if (isset($lookup[$extension])) {
+            return $lookup[$extension];
+        }
+
+        if (extension_loaded('fileinfo')) {
+            return mime_content_type($this->path);
+        }
+
+        return 'text/plain';
+    }
+
+    /** @inheritDoc */
+    public function toArray(): array
+    {
+        return [
+            'path' => $this->path,
+        ];
+    }
+}

--- a/packages/framework/src/Models/File.php
+++ b/packages/framework/src/Models/File.php
@@ -9,7 +9,7 @@ use Illuminate\Contracts\Support\Arrayable;
 /**
  * Filesystem abstraction for a file stored in the project.
  */
-class File implements Arrayable, \JsonSerializable
+class File implements Arrayable, \JsonSerializable, \Stringable
 {
     use JsonSerializesArrayable;
 
@@ -39,6 +39,14 @@ class File implements Arrayable, \JsonSerializable
     public function __construct(string $path)
     {
         $this->path = Hyde::pathToRelative($path);
+    }
+
+    /**
+     * @return string The path relative to the project root.
+     */
+    public function __toString(): string
+    {
+        return $this->path;
     }
 
     /**

--- a/packages/framework/src/Models/File.php
+++ b/packages/framework/src/Models/File.php
@@ -144,7 +144,7 @@ class File implements Arrayable, \JsonSerializable, \Stringable
     public function withoutDirectoryPrefix(): string
     {
         if ($this->belongsTo) {
-            // If a model is set, use that to remove the directory, so and subdirectories within is retained
+            // If a model is set, use that to remove the directory, so any subdirectories within is retained
             return substr($this, strlen($this->belongsTo::$sourceDirectory));
         }
 

--- a/packages/framework/src/Models/File.php
+++ b/packages/framework/src/Models/File.php
@@ -32,7 +32,7 @@ class File implements Arrayable, \JsonSerializable
      */
     public function __construct(string $path)
     {
-        $this->path = $path;
+        $this->path = Hyde::pathToRelative($path);
     }
 
     public function getName(): string

--- a/packages/framework/src/Models/File.php
+++ b/packages/framework/src/Models/File.php
@@ -136,6 +136,6 @@ class File implements Arrayable, \JsonSerializable, \Stringable
 
     public function withoutDirectoryPrefix(): string
     {
-        return substr($this, strlen(Str::before($this, '/')));
+        return substr($this, strlen($this->belongsTo ? $this->belongsTo::$sourceDirectory : Str::before($this, '/')));
     }
 }

--- a/packages/framework/src/Models/File.php
+++ b/packages/framework/src/Models/File.php
@@ -131,6 +131,7 @@ class File implements Arrayable, \JsonSerializable, \Stringable
     {
         return [
             'path' => $this->path,
+            'model' => $this->belongsTo
         ];
     }
 

--- a/packages/framework/src/Models/File.php
+++ b/packages/framework/src/Models/File.php
@@ -48,7 +48,7 @@ class File implements Arrayable, \JsonSerializable
      * @param string|null $class
      * @return string|$this|null
      */
-    public function belongsTo(?string $class): null|string|static
+    public function belongsTo(?string $class = null): null|string|static
     {
         if ($class) {
             $this->belongsTo = $class;

--- a/packages/framework/src/Models/File.php
+++ b/packages/framework/src/Models/File.php
@@ -5,6 +5,7 @@ namespace Hyde\Framework\Models;
 use Hyde\Framework\Concerns\JsonSerializesArrayable;
 use Hyde\Framework\Hyde;
 use Illuminate\Contracts\Support\Arrayable;
+use Illuminate\Support\Str;
 
 /**
  * Filesystem abstraction for a file stored in the project.
@@ -131,5 +132,10 @@ class File implements Arrayable, \JsonSerializable, \Stringable
         return [
             'path' => $this->path,
         ];
+    }
+
+    public function withoutDirectoryPrefix(): string
+    {
+        return substr($this, strlen(Str::before($this, '/')));
     }
 }

--- a/packages/framework/src/Services/DiscoveryService.php
+++ b/packages/framework/src/Services/DiscoveryService.php
@@ -122,7 +122,7 @@ class DiscoveryService
 
     protected static function getMediaGlobPattern(): string
     {
-        return sprintf("_media/*.{%s}", str_replace(' ', '',
+        return sprintf('_media/*.{%s}', str_replace(' ', '',
             config('hyde.media_extensions', 'png,svg,jpg,jpeg,gif,ico,css,js')
         ));
     }

--- a/packages/framework/src/Services/DiscoveryService.php
+++ b/packages/framework/src/Services/DiscoveryService.php
@@ -5,6 +5,7 @@ namespace Hyde\Framework\Services;
 use Hyde\Framework\Contracts\AbstractPage;
 use Hyde\Framework\Exceptions\UnsupportedPageTypeException;
 use Hyde\Framework\Hyde;
+use Hyde\Framework\Models\File;
 use Hyde\Framework\Models\Pages\BladePage;
 use Hyde\Framework\Models\Pages\DocumentationPage;
 use Hyde\Framework\Models\Pages\MarkdownPage;
@@ -39,14 +40,10 @@ class DiscoveryService
             throw new UnsupportedPageTypeException($model);
         }
 
-        // Scan the source directory, and directories therein, for files that match the model's file extension.
-
         $files = [];
-        foreach (glob(Hyde::path($model::qualifyBasename('{*,**/*}')), GLOB_BRACE) as $filepath) {
-            if (! str_starts_with(basename($filepath), '_')) {
-                $files[] = self::formatSlugForModel($model, $filepath);
-            }
-        }
+        Hyde::files()->getSourceFiles($model)->each(function (File $file) use (&$files, $model) {
+            $files[] = self::formatSlugForModel($model, basename($file));
+        });
 
         return $files;
     }

--- a/packages/framework/src/Services/DiscoveryService.php
+++ b/packages/framework/src/Services/DiscoveryService.php
@@ -42,7 +42,7 @@ class DiscoveryService
 
         $files = [];
         Hyde::files()->getSourceFiles($model)->each(function (File $file) use (&$files, $model) {
-            $files[] = self::formatSlugForModel($model, basename($file));
+            $files[] = self::formatSlugForModel($model, $file->withoutDirectoryPrefix());
         });
 
         return $files;

--- a/packages/framework/src/Services/DiscoveryService.php
+++ b/packages/framework/src/Services/DiscoveryService.php
@@ -87,11 +87,7 @@ class DiscoveryService
      */
     public static function getMediaAssetFiles(): array
     {
-        return glob(Hyde::path('_media/*.{'.str_replace(
-            ' ',
-            '',
-            config('hyde.media_extensions', 'png,svg,jpg,jpeg,gif,ico,css,js')
-        ).'}'), GLOB_BRACE) ?: [];
+        return glob(Hyde::path(static::getMediaGlobPattern()), GLOB_BRACE) ?: [];
     }
 
     /**
@@ -123,5 +119,12 @@ class DiscoveryService
         }
 
         return unslash($slug);
+    }
+
+    protected static function getMediaGlobPattern(): string
+    {
+        return sprintf("_media/*.{%s}", str_replace(' ', '',
+            config('hyde.media_extensions', 'png,svg,jpg,jpeg,gif,ico,css,js')
+        ));
     }
 }

--- a/packages/framework/src/Services/DiscoveryService.php
+++ b/packages/framework/src/Services/DiscoveryService.php
@@ -18,6 +18,8 @@ use Hyde\Framework\Models\Pages\MarkdownPost;
  * building process to determine where files are located and how to parse them.
  *
  * The CollectionService was in v0.53.0 merged into this class.
+ *
+ * @see \Hyde\Framework\Testing\Feature\DiscoveryServiceTest
  */
 class DiscoveryService
 {

--- a/packages/framework/tests/Feature/DiscoveryServiceTest.php
+++ b/packages/framework/tests/Feature/DiscoveryServiceTest.php
@@ -226,6 +226,7 @@ class DiscoveryServiceTest extends TestCase
     protected function unitTestMarkdownBasedPageList(string $model, string $path, ?string $expected = null)
     {
         Hyde::touch(($path));
+        Hyde::boot(); // Reboot to rediscover new pages
 
         $expected = $expected ?? basename($path, '.md');
 

--- a/packages/framework/tests/Feature/DiscoveryServiceTest.php
+++ b/packages/framework/tests/Feature/DiscoveryServiceTest.php
@@ -96,6 +96,12 @@ class DiscoveryServiceTest extends TestCase
         $this->assertEquals(['foo'], DiscoveryService::getSourceFileListForModel(MarkdownPage::class));
     }
 
+    public function test_get_source_file_list_for_blade_page_model()
+    {
+        $this->file('_pages/foo.blade.php');
+        $this->assertEquals(['404', 'foo', 'index'], DiscoveryService::getSourceFileListForModel(BladePage::class));
+    }
+    
     public function test_get_source_file_list_for_markdown_post_model()
     {
         $this->file('_posts/foo.md');

--- a/packages/framework/tests/Feature/DiscoveryServiceTest.php
+++ b/packages/framework/tests/Feature/DiscoveryServiceTest.php
@@ -89,7 +89,6 @@ class DiscoveryServiceTest extends TestCase
         unlink(Hyde::path('_docs/foo.md'));
     }
 
-
     public function test_get_source_file_list_for_markdown_page_model()
     {
         $this->file('_pages/foo.md');
@@ -101,12 +100,13 @@ class DiscoveryServiceTest extends TestCase
         $this->file('_pages/foo.blade.php');
         $this->assertEquals(['404', 'foo', 'index'], DiscoveryService::getSourceFileListForModel(BladePage::class));
     }
-    
+
     public function test_get_source_file_list_for_markdown_post_model()
     {
         $this->file('_posts/foo.md');
         $this->assertEquals(['foo'], DiscoveryService::getSourceFileListForModel(MarkdownPost::class));
     }
+
     public function test_get_source_file_list_for_documentation_page_model()
     {
         $this->file('_docs/foo.md');

--- a/packages/framework/tests/Feature/DiscoveryServiceTest.php
+++ b/packages/framework/tests/Feature/DiscoveryServiceTest.php
@@ -89,11 +89,22 @@ class DiscoveryServiceTest extends TestCase
         unlink(Hyde::path('_docs/foo.md'));
     }
 
-    public function test_get_source_file_list_for_model_method()
+
+    public function test_get_source_file_list_for_markdown_page_model()
     {
-        $this->unitTestMarkdownBasedPageList(MarkdownPage::class, '_pages/foo.md');
-        $this->unitTestMarkdownBasedPageList(MarkdownPost::class, '_posts/foo.md');
-        $this->unitTestMarkdownBasedPageList(DocumentationPage::class, '_docs/foo.md');
+        $this->file('_pages/foo.md');
+        $this->assertEquals(['foo'], DiscoveryService::getSourceFileListForModel(MarkdownPage::class));
+    }
+
+    public function test_get_source_file_list_for_markdown_post_model()
+    {
+        $this->file('_posts/foo.md');
+        $this->assertEquals(['foo'], DiscoveryService::getSourceFileListForModel(MarkdownPost::class));
+    }
+    public function test_get_source_file_list_for_documentation_page_model()
+    {
+        $this->file('_docs/foo.md');
+        $this->assertEquals(['foo'], DiscoveryService::getSourceFileListForModel(DocumentationPage::class));
     }
 
     public function test_get_source_file_list_for_model_method_finds_customized_model_properties()

--- a/packages/framework/tests/Feature/FileCollectionTest.php
+++ b/packages/framework/tests/Feature/FileCollectionTest.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Hyde\Framework\Testing\Feature;
+
+use Hyde\Framework\Foundation\FileCollection;
+use Hyde\Testing\TestCase;
+
+/**
+ * @covers \Hyde\Framework\Foundation\FileCollection
+ */
+class FileCollectionTest extends TestCase
+{
+    //
+}

--- a/packages/framework/tests/Feature/FileCollectionTest.php
+++ b/packages/framework/tests/Feature/FileCollectionTest.php
@@ -3,12 +3,112 @@
 namespace Hyde\Framework\Testing\Feature;
 
 use Hyde\Framework\Foundation\FileCollection;
+use Hyde\Framework\Hyde;
+use Hyde\Framework\Models\File;
+use Hyde\Framework\Models\Pages\BladePage;
+use Hyde\Framework\Models\Pages\DocumentationPage;
+use Hyde\Framework\Models\Pages\MarkdownPage;
+use Hyde\Framework\Models\Pages\MarkdownPost;
 use Hyde\Testing\TestCase;
+use Illuminate\Support\Collection;
 
 /**
  * @covers \Hyde\Framework\Foundation\FileCollection
+ * @covers \Hyde\Framework\Foundation\BaseSystemCollection
  */
 class FileCollectionTest extends TestCase
 {
-    //
+    protected function withoutDefaultPages(): void
+    {
+        Hyde::unlink('_pages/404.blade.php');
+        Hyde::unlink('_pages/index.blade.php');
+    }
+
+    public function test_boot_method_creates_new_page_collection_and_discovers_pages_automatically()
+    {
+        $collection = FileCollection::boot(Hyde::getInstance());
+        $this->assertInstanceOf(FileCollection::class, $collection);
+        $this->assertInstanceOf(Collection::class, $collection);
+
+        $this->assertEquals([
+            '_pages/404.blade.php' => new File('_pages/404.blade.php', BladePage::class),
+            '_pages/index.blade.php' => new File('_pages/index.blade.php', BladePage::class),
+            '_media/app.css' => new File('_media/app.css')
+        ], $collection->all());
+    }
+
+    public function test_get_source_files_returns_all_discovered_source_files_when_no_parameter_is_supplied()
+    {
+        $collection = FileCollection::boot(Hyde::getInstance());
+
+        $this->assertEquals([
+            '_pages/404.blade.php' => new File('_pages/404.blade.php', BladePage::class),
+            '_pages/index.blade.php' => new File('_pages/index.blade.php', BladePage::class),
+        ], $collection->getSourceFiles()->all());
+    }
+
+    public function test_get_source_files_does_not_include_non_page_source_files()
+    {
+        $this->withoutDefaultPages();
+        $this->file('_pages/foo.txt');
+
+        $collection = FileCollection::boot(Hyde::getInstance());
+        $this->assertEquals([], $collection->getSourceFiles()->all());
+
+        $this->restoreDefaultPages();
+    }
+
+    public function test_get_media_files_returns_all_discovered_media_files()
+    {
+        $this->markTestSkipped('Not yet implemented.');
+
+        $collection = FileCollection::boot(Hyde::getInstance());
+        $this->assertEquals([
+            '_media/app.css' => new File('_media/app.css')
+        ], $collection->getMediaFiles()->all());
+    }
+
+    public function test_get_media_files_does_not_include_non_media_files()
+    {
+        $this->markTestSkipped('Not yet implemented.');
+
+        $this->file('_media/foo.blade.php');
+        $collection = FileCollection::boot(Hyde::getInstance());
+        $this->assertEquals([], $collection->getMediaFiles()->all());
+    }
+
+    public function test_blade_pages_are_discovered()
+    {
+        $this->file('_pages/foo.blade.php');
+        $collection = FileCollection::boot(Hyde::getInstance());
+
+        $this->assertArrayHasKey('_pages/foo.blade.php', $collection->toArray());
+        $this->assertEquals(new File('_pages/foo.blade.php', BladePage::class), $collection->get('_pages/foo.blade.php'));
+    }
+
+    public function test_markdown_pages_are_discovered()
+    {
+        $this->file('_pages/foo.md');
+        $collection = FileCollection::boot(Hyde::getInstance());
+
+        $this->assertArrayHasKey('_pages/foo.md', $collection->toArray());
+        $this->assertEquals(new File('_pages/foo.md', MarkdownPage::class), $collection->get('_pages/foo.md'));
+    }
+
+    public function test_markdown_posts_are_discovered()
+    {
+        $this->file('_posts/foo.md');
+        $collection = FileCollection::boot(Hyde::getInstance());
+
+        $this->assertArrayHasKey('_posts/foo.md', $collection->toArray());
+        $this->assertEquals(new File('_posts/foo.md', MarkdownPost::class), $collection->get('_posts/foo.md'));
+    }
+
+    public function test_documentation_pages_are_discovered()
+    {
+        $this->file('_docs/foo.md');
+        $collection = FileCollection::boot(Hyde::getInstance());
+        $this->assertArrayHasKey('_docs/foo.md', $collection->toArray());
+        $this->assertEquals(new File('_docs/foo.md', DocumentationPage::class), $collection->get('_docs/foo.md'));
+    }
 }

--- a/packages/framework/tests/Feature/FileCollectionTest.php
+++ b/packages/framework/tests/Feature/FileCollectionTest.php
@@ -27,7 +27,7 @@ class FileCollectionTest extends TestCase
         $this->assertEquals([
             '_pages/404.blade.php' => new File('_pages/404.blade.php', BladePage::class),
             '_pages/index.blade.php' => new File('_pages/index.blade.php', BladePage::class),
-            '_media/app.css' => new File('_media/app.css')
+            '_media/app.css' => new File('_media/app.css'),
         ], $collection->all());
     }
 
@@ -58,7 +58,7 @@ class FileCollectionTest extends TestCase
 
         $collection = FileCollection::boot(Hyde::getInstance());
         $this->assertEquals([
-            '_media/app.css' => new File('_media/app.css')
+            '_media/app.css' => new File('_media/app.css'),
         ], $collection->getMediaFiles()->all());
     }
 

--- a/packages/framework/tests/Feature/FileCollectionTest.php
+++ b/packages/framework/tests/Feature/FileCollectionTest.php
@@ -18,12 +18,6 @@ use Illuminate\Support\Collection;
  */
 class FileCollectionTest extends TestCase
 {
-    protected function withoutDefaultPages(): void
-    {
-        Hyde::unlink('_pages/404.blade.php');
-        Hyde::unlink('_pages/index.blade.php');
-    }
-
     public function test_boot_method_creates_new_page_collection_and_discovers_pages_automatically()
     {
         $collection = FileCollection::boot(Hyde::getInstance());

--- a/packages/framework/tests/Feature/FileCollectionTest.php
+++ b/packages/framework/tests/Feature/FileCollectionTest.php
@@ -54,8 +54,6 @@ class FileCollectionTest extends TestCase
 
     public function test_get_media_files_returns_all_discovered_media_files()
     {
-        $this->markTestSkipped('Not yet implemented.');
-
         $collection = FileCollection::boot(Hyde::getInstance());
         $this->assertEquals([
             '_media/app.css' => new File('_media/app.css'),
@@ -64,11 +62,11 @@ class FileCollectionTest extends TestCase
 
     public function test_get_media_files_does_not_include_non_media_files()
     {
-        $this->markTestSkipped('Not yet implemented.');
-
         $this->file('_media/foo.blade.php');
         $collection = FileCollection::boot(Hyde::getInstance());
-        $this->assertEquals([], $collection->getMediaFiles()->all());
+        $this->assertEquals([
+            '_media/app.css' => new File('_media/app.css'),
+        ], $collection->getMediaFiles()->all());
     }
 
     public function test_blade_pages_are_discovered()

--- a/packages/framework/tests/Feature/FileTest.php
+++ b/packages/framework/tests/Feature/FileTest.php
@@ -2,7 +2,9 @@
 
 namespace Hyde\Framework\Testing\Feature;
 
+use Hyde\Framework\Hyde;
 use Hyde\Framework\Models\File;
+use Hyde\Framework\Models\Pages\MarkdownPage;
 use Hyde\Testing\TestCase;
 
 /**
@@ -10,5 +12,148 @@ use Hyde\Testing\TestCase;
  */
 class FileTest extends TestCase
 {
-    //
+    // make
+    public function test_make_method_creates_new_file_object_with_path()
+    {
+        $file = File::make('path/to/file.txt');
+        $this->assertInstanceOf(File::class, $file);
+        $this->assertEquals('path/to/file.txt', $file->path);
+    }
+
+    // make alias constructor
+    public function test_make_method_gives_same_result_as_constructor()
+    {
+        $this->assertEquals(File::make('foo'), new File('foo'));
+    }
+
+    public function test_absolute_path_is_normalized_to_relative()
+    {
+        $this->assertEquals('foo', File::make(Hyde::path('foo'))->path);
+    }
+
+    public function test_to_string_returns_path()
+    {
+        $this->assertSame('foo', (string) File::make('foo'));
+    }
+
+    public function test_belongs_to_returns_null_when_no_relation_or_parameter_is_set()
+    {
+        $this->assertNull(File::make('foo')->belongsTo());
+    }
+
+    public function test_belongs_to_returns_class_name_when_relation_is_set()
+    {
+        $this->assertSame('bar', File::make('foo', 'bar')->belongsTo());
+    }
+
+    public function test_belongs_to_returns_self_when_parameter_is_set()
+    {
+        $this->assertInstanceOf(File::class, File::make('foo')->belongsTo('bar'));
+        $this->assertEquals(File::make('foo', 'bar'), File::make('foo')->belongsTo('bar'));
+    }
+
+    public function test_class_name_can_be_set_using_belongs_to_method()
+    {
+        $this->assertSame('baz', File::make('foo', 'bar')->belongsTo('baz')->belongsTo());
+    }
+
+    public function test_get_name_returns_name_of_file()
+    {
+        $this->assertSame('foo.txt', File::make('foo.txt')->getName());
+        $this->assertSame('bar.txt', File::make('foo/bar.txt')->getName());
+    }
+
+    public function test_get_path_returns_path_of_file()
+    {
+        $this->assertSame('foo.txt', File::make('foo.txt')->getPath());
+        $this->assertSame('foo/bar.txt', File::make('foo/bar.txt')->getPath());
+    }
+
+    public function test_get_absolute_path_returns_absolute_path_of_file()
+    {
+        $this->assertSame(Hyde::path('foo.txt'), File::make('foo.txt')->getAbsolutePath());
+        $this->assertSame(Hyde::path('foo/bar.txt'), File::make('foo/bar.txt')->getAbsolutePath());
+    }
+
+    public function test_get_contents_returns_contents_of_file()
+    {
+        $this->file('foo.txt', 'foo bar');
+        $this->assertSame('foo bar', File::make('foo.txt')->getContents());
+    }
+
+    public function test_get_content_length_returns_length_of_file()
+    {
+        $this->file('foo.txt', 'foo bar');
+        $this->assertSame(7, File::make('foo.txt')->getContentLength());
+    }
+
+    public function test_get_mime_type_returns_mime_type_of_file_using_lookup_table()
+    {
+        $lookup = [
+            'txt'  => 'text/plain',
+            'md'   => 'text/markdown',
+            'html' => 'text/html',
+            'css'  => 'text/css',
+            'svg'  => 'image/svg+xml',
+            'png'  => 'image/png',
+            'jpg'  => 'image/jpeg',
+            'jpeg' => 'image/jpeg',
+            'gif'  => 'image/gif',
+            'json' => 'application/json',
+            'js'   => 'application/javascript',
+        ];
+
+        foreach ($lookup as $extension => $mimeType) {
+            $this->assertSame($mimeType, File::make('foo.'.$extension)->getMimeType());
+        }        
+    }
+
+    public function test_get_mime_type_returns_filetype_if_file_exists()
+    {
+        $this->file('foo.bar', 'foo');
+        $this->assertSame('text/plain', File::make('foo.bar')->getMimeType());
+
+        $this->file('foo');
+        $this->assertSame('application/x-empty', File::make('foo')->getMimeType());
+    }
+
+    public function test_get_mime_type_returns_text_plain_if_file_does_not_exist_and_is_not_in_lookup_table()
+    {
+        $this->assertSame('text/plain', File::make('foo')->getMimeType());
+        $this->assertSame('text/plain', File::make('foo.bar')->getMimeType());
+    }
+
+    public function test_to_array_returns_array_of_file_properties()
+    {
+        $this->file('foo.txt', 'foo bar');
+        // $this->assertSame([
+        //     'name'     => 'foo.txt',
+        //     'path'     => 'foo.txt',
+        //     'contents' => 'foo bar',
+        //     'length'   => 7,
+        //     'mimeType' => 'text/plain',
+        // ], File::make('foo.txt')->toArray());
+
+        $this->assertSame([
+            'path' => 'foo',
+            'model'    => null,
+        ], File::make('foo')->toArray());
+
+        $this->assertSame([
+            'path' => 'foo/bar.txt',
+            'model'    => 'baz',
+        ], File::make('foo/bar.txt', 'baz')->toArray());
+    }
+
+    public function test_without_directory_prefix_returns_file_without_directory_prefix()
+    {
+        $this->assertSame('baz.txt', File::make('foo/bar/baz.txt')->withoutDirectoryPrefix());
+    }
+
+    public function test_without_directory_prefix_retains_subdirectories_when_a_page_model_class_is_set()
+    {
+        $this->assertSame('foo/bar.txt',
+            File::make('_pages/foo/bar.txt', MarkdownPage::class)->withoutDirectoryPrefix()
+        );
+    }
 }

--- a/packages/framework/tests/Feature/FileTest.php
+++ b/packages/framework/tests/Feature/FileTest.php
@@ -105,7 +105,7 @@ class FileTest extends TestCase
 
         foreach ($lookup as $extension => $mimeType) {
             $this->assertSame($mimeType, File::make('foo.'.$extension)->getMimeType());
-        }        
+        }
     }
 
     public function test_get_mime_type_returns_filetype_if_file_exists()

--- a/packages/framework/tests/Feature/FileTest.php
+++ b/packages/framework/tests/Feature/FileTest.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Hyde\Framework\Testing\Feature;
+
+use Hyde\Framework\Models\File;
+use Hyde\Testing\TestCase;
+
+/**
+ * @covers \Hyde\Framework\Models\File
+ */
+class FileTest extends TestCase
+{
+    //
+}

--- a/packages/framework/tests/Feature/HydeKernelTest.php
+++ b/packages/framework/tests/Feature/HydeKernelTest.php
@@ -203,21 +203,24 @@ class HydeKernelTest extends TestCase
         $array = Hyde::toArray();
 
         $this->assertTrue(is_array($array));
-        $this->assertCount(4, $array);
+        $this->assertCount(5, $array);
 
         $this->assertArrayHasKey('basePath', $array);
         $this->assertArrayHasKey('features', $array);
+        $this->assertArrayHasKey('files', $array);
         $this->assertArrayHasKey('pages', $array);
         $this->assertArrayHasKey('routes', $array);
 
         $this->assertEquals(Hyde::getBasePath(), $array['basePath']);
         $this->assertEquals(Hyde::features(), $array['features']);
+        $this->assertEquals(Hyde::files(), $array['files']);
         $this->assertEquals(Hyde::pages(), $array['pages']);
         $this->assertEquals(Hyde::routes(), $array['routes']);
 
         $this->assertEquals([
             'basePath' => Hyde::getBasePath(),
             'features' => Hyde::features(),
+            'files' => Hyde::files(),
             'pages' => Hyde::pages(),
             'routes' => Hyde::routes(),
         ], Hyde::toArray());

--- a/packages/framework/tests/Feature/PageCollectionTest.php
+++ b/packages/framework/tests/Feature/PageCollectionTest.php
@@ -17,12 +17,6 @@ use Illuminate\Support\Collection;
  */
 class PageCollectionTest extends TestCase
 {
-    protected function withoutDefaultPages(): void
-    {
-        Hyde::unlink('_pages/404.blade.php');
-        Hyde::unlink('_pages/index.blade.php');
-    }
-
     public function test_boot_method_creates_new_page_collection_and_discovers_pages_automatically()
     {
         $collection = PageCollection::boot(Hyde::getInstance());

--- a/packages/framework/tests/Feature/PageCollectionTest.php
+++ b/packages/framework/tests/Feature/PageCollectionTest.php
@@ -24,7 +24,7 @@ class PageCollectionTest extends TestCase
 
     public function test_boot_method_creates_new_page_collection_and_discovers_pages_automatically()
     {
-        $collection = PageCollection::boot();
+        $collection = PageCollection::boot(Hyde::getInstance());
         $this->assertInstanceOf(PageCollection::class, $collection);
         $this->assertInstanceOf(Collection::class, $collection);
 
@@ -37,7 +37,7 @@ class PageCollectionTest extends TestCase
     public function test_blade_pages_are_discovered()
     {
         $this->file('_pages/foo.blade.php');
-        $collection = PageCollection::boot();
+        $collection = PageCollection::boot(Hyde::getInstance());
 
         $this->assertArrayHasKey('_pages/foo.blade.php', $collection->toArray());
         $this->assertEquals(new BladePage('foo'), $collection->get('_pages/foo.blade.php'));
@@ -46,7 +46,7 @@ class PageCollectionTest extends TestCase
     public function test_markdown_pages_are_discovered()
     {
         $this->file('_pages/foo.md');
-        $collection = PageCollection::boot();
+        $collection = PageCollection::boot(Hyde::getInstance());
 
         $this->assertArrayHasKey('_pages/foo.md', $collection->toArray());
         $this->assertEquals(new MarkdownPage('foo'), $collection->get('_pages/foo.md'));
@@ -55,7 +55,7 @@ class PageCollectionTest extends TestCase
     public function test_markdown_posts_are_discovered()
     {
         $this->file('_posts/foo.md');
-        $collection = PageCollection::boot();
+        $collection = PageCollection::boot(Hyde::getInstance());
 
         $this->assertArrayHasKey('_posts/foo.md', $collection->toArray());
         $this->assertEquals(new MarkdownPost('foo'), $collection->get('_posts/foo.md'));
@@ -64,7 +64,7 @@ class PageCollectionTest extends TestCase
     public function test_documentation_pages_are_discovered()
     {
         $this->file('_docs/foo.md');
-        $collection = PageCollection::boot();
+        $collection = PageCollection::boot(Hyde::getInstance());
         $this->assertArrayHasKey('_docs/foo.md', $collection->toArray());
         $this->assertEquals(new DocumentationPage('foo'), $collection->get('_docs/foo.md'));
     }
@@ -72,7 +72,7 @@ class PageCollectionTest extends TestCase
     public function test_get_page_returns_parsed_page_object_for_given_source_path()
     {
         $this->file('_pages/foo.blade.php');
-        $collection = PageCollection::boot();
+        $collection = PageCollection::boot(Hyde::getInstance());
         $this->assertEquals(new BladePage('foo'), $collection->getPage('_pages/foo.blade.php'));
     }
 
@@ -84,7 +84,7 @@ class PageCollectionTest extends TestCase
         $this->file('_pages/foo.md');
         $this->file('_posts/foo.md');
         $this->file('_docs/foo.md');
-        $collection = PageCollection::boot();
+        $collection = PageCollection::boot(Hyde::getInstance());
         $this->assertCount(4, $collection);
 
         $this->assertContainsOnlyInstancesOf(BladePage::class, $collection->getPages(BladePage::class));
@@ -108,7 +108,7 @@ class PageCollectionTest extends TestCase
         $this->file('_pages/foo.md');
         $this->file('_posts/foo.md');
         $this->file('_docs/foo.md');
-        $collection = PageCollection::boot()->getPages();
+        $collection = PageCollection::boot(Hyde::getInstance())->getPages();
         $this->assertCount(4, $collection);
 
         $this->assertEquals(new BladePage('foo'), $collection->get('_pages/foo.blade.php'));
@@ -122,7 +122,7 @@ class PageCollectionTest extends TestCase
     public function test_get_pages_returns_empty_collection_when_no_pages_are_discovered()
     {
         $this->withoutDefaultPages();
-        $collection = PageCollection::boot();
+        $collection = PageCollection::boot(Hyde::getInstance());
         $this->assertEmpty($collection->getPages());
         $this->restoreDefaultPages();
     }
@@ -136,7 +136,7 @@ class PageCollectionTest extends TestCase
         touch('_posts/post.md');
         touch('_docs/doc.md');
 
-        $this->assertEmpty(PageCollection::boot());
+        $this->assertEmpty(PageCollection::boot(Hyde::getInstance()));
 
         unlink('_pages/blade.blade.php');
         unlink('_pages/markdown.md');

--- a/packages/framework/tests/Feature/PageCollectionTest.php
+++ b/packages/framework/tests/Feature/PageCollectionTest.php
@@ -13,6 +13,7 @@ use Illuminate\Support\Collection;
 
 /**
  * @covers \Hyde\Framework\Foundation\PageCollection
+ * @covers \Hyde\Framework\Foundation\BaseSystemCollection
  */
 class PageCollectionTest extends TestCase
 {

--- a/packages/framework/tests/Feature/RouteCollectionTest.php
+++ b/packages/framework/tests/Feature/RouteCollectionTest.php
@@ -18,12 +18,6 @@ use Illuminate\Support\Collection;
  */
 class RouteCollectionTest extends TestCase
 {
-    protected function withoutDefaultPages(): void
-    {
-        Hyde::unlink('_pages/404.blade.php');
-        Hyde::unlink('_pages/index.blade.php');
-    }
-
     protected function test_boot_method_discovers_all_pages()
     {
         $collection = RouteCollection::boot(Hyde::getInstance());

--- a/packages/framework/tests/Feature/RouteCollectionTest.php
+++ b/packages/framework/tests/Feature/RouteCollectionTest.php
@@ -14,6 +14,7 @@ use Illuminate\Support\Collection;
 
 /**
  * @covers \Hyde\Framework\Foundation\RouteCollection
+ * @covers \Hyde\Framework\Foundation\BaseSystemCollection
  */
 class RouteCollectionTest extends TestCase
 {

--- a/packages/testing/src/ResetsApplication.php
+++ b/packages/testing/src/ResetsApplication.php
@@ -46,6 +46,12 @@ trait ResetsApplication
         array_map('unlinkUnlessDefault', glob(Hyde::path('_site/*.xml')));
     }
 
+    protected function withoutDefaultPages(): void
+    {
+        Hyde::unlink('_pages/404.blade.php');
+        Hyde::unlink('_pages/index.blade.php');
+    }
+
     public function restoreDefaultPages(): void
     {
         copy(Hyde::vendorPath('resources/views/homepages/welcome.blade.php'), Hyde::path('_pages/index.blade.php'));


### PR DESCRIPTION
## About

Creates a new foundation class, the FileCollection. Which like the other foundation collections, discovers all the files. Running this part of the autodiscovery will further enrich the Hyde Kernel, and allow greater insight into the application. The end user experience should not be affected by this.

It also adds a new model, `File`, as an object-oriented way of representing a project file on the disk.


#### Minor note about testing
Note that having the filesystem pre-discovered means that changing the discovery rules at runtime after the framework has booted, means that you need to reboot the framework. I think this would ever really happen during testing when changing a directory mid-test. If it happens in actual code you are probably doing something wrong (registering in boot method instead of register method for example). See [this commit](https://github.com/hydephp/develop/pull/426/commits/60a3b40232e78cc9fbbb32b99b9a15ca54a8b555) where this problem was encountered and addressed.