### PR TITLE
Deprecate unnecessary contracts

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -13,7 +13,7 @@ Creates a new foundation class, the FileCollection. Which like the other foundat
 - Move class RouteCollection into Foundation namespace
 
 ### Deprecated
-- for soon-to-be removed features.
+- Deprecate interface HydeKernelContract, type hint the HydeKernel::class instead
 
 ### Removed
 - for now removed features.

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -2,12 +2,11 @@
 
 ### About
 
-Keep an Unreleased section at the top to track upcoming changes.
+This update deprecates two interfaces (contracts) and inlines them into their implementations.
 
-This serves two purposes:
+The following interfaces are affected: `HydeKernelContract` and `AssetServiceContract`. These interfaces were used to access the service container bindings. Instead, you would now type hint the implementation class instead of the contract.
 
-1. People can see what changes they might expect in upcoming releases
-2. At release time, you can move the Unreleased section changes into a new release version section.
+This update will only affect those who have written custom code that uses or type hints these interfaces, which is unlikely. If this does affect you, you can see this diff to see how to upgrade. https://github.com/hydephp/develop/pull/428/commits/68d2974d54345ec7c12fedb098f6030b2c2e85ee. In short, simply replace `HydeKernelContract` and `AssetServiceContract` with `HydeKernel` and `AssetService`.
 
 ### Added
 - for new features.

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -14,7 +14,8 @@ Creates a new foundation class, the FileCollection. Which like the other foundat
 
 ### Deprecated
 - Deprecate interface HydeKernelContract, type hint the HydeKernel::class instead
-
+- Deprecate interface AssetServiceContract, type hint the AssetService::class instead
+  
 ### Removed
 - for now removed features.
 

--- a/app/bootstrap.php
+++ b/app/bootstrap.php
@@ -52,7 +52,7 @@ $hyde = new Hyde\Framework\HydeKernel(
 );
 
 $app->singleton(
-    Hyde\Framework\Contracts\HydeKernelContract::class, function () {
+    Hyde\Framework\HydeKernel::class, function () {
         return Hyde\Framework\HydeKernel::getInstance();
     }
 );

--- a/packages/framework/src/Contracts/AssetServiceContract.php
+++ b/packages/framework/src/Contracts/AssetServiceContract.php
@@ -2,6 +2,9 @@
 
 namespace Hyde\Framework\Contracts;
 
+/**
+ * @deprecated v0.61.0-beta - Type hint the AssetService::class instead
+ */
 interface AssetServiceContract
 {
     /**

--- a/packages/framework/src/Contracts/HydeKernelContract.php
+++ b/packages/framework/src/Contracts/HydeKernelContract.php
@@ -7,7 +7,6 @@ namespace Hyde\Framework\Contracts;
  * providing helpful methods for interacting with it.
  *
  * @deprecated v0.61.0-beta - Type hint the HydeKernel::class instead
- *
  * @see \Hyde\Framework\HydeKernel
  *
  * It is stored as a singleton in the HydeKernel class, and is bound into the

--- a/packages/framework/src/Contracts/HydeKernelContract.php
+++ b/packages/framework/src/Contracts/HydeKernelContract.php
@@ -2,6 +2,8 @@
 
 namespace Hyde\Framework\Contracts;
 
+use Hyde\Framework\HydeKernel;
+
 /**
  * The HydeKernel encapsulates a HydePHP project,
  * providing helpful methods for interacting with it.
@@ -18,7 +20,7 @@ namespace Hyde\Framework\Contracts;
  * @example \Hyde\Framework\Hyde::foo()
  *
  * - You can also use Dependency Injection to inject the Kernel into your own classes:
- * @example `__construct(HydeKernelContract $hyde)`
+ * @example `__construct(HydeKernel $hyde)`
  *
  * - Or, you can use the hyde() function to get the Kernel:
  * @example `$hyde = hyde();
@@ -30,9 +32,9 @@ interface HydeKernelContract
 {
     public function boot(): void;
 
-    public static function setInstance(HydeKernelContract $instance): void;
+    public static function setInstance(HydeKernel $instance): void;
 
-    public static function getInstance(): HydeKernelContract;
+    public static function getInstance(): HydeKernel;
 
     public function getBasePath(): string;
 

--- a/packages/framework/src/Contracts/HydeKernelContract.php
+++ b/packages/framework/src/Contracts/HydeKernelContract.php
@@ -6,6 +6,8 @@ namespace Hyde\Framework\Contracts;
  * The HydeKernel encapsulates a HydePHP project,
  * providing helpful methods for interacting with it.
  *
+ * @deprecated v0.61.0-beta - Type hint the HydeKernel::class instead
+ *
  * @see \Hyde\Framework\HydeKernel
  *
  * It is stored as a singleton in the HydeKernel class, and is bound into the

--- a/packages/framework/src/Facades/Asset.php
+++ b/packages/framework/src/Facades/Asset.php
@@ -2,7 +2,7 @@
 
 namespace Hyde\Framework\Facades;
 
-use Hyde\Framework\Contracts\AssetServiceContract;
+use Hyde\Framework\Services\AssetService;
 use Illuminate\Support\Facades\Facade;
 
 /**
@@ -16,9 +16,9 @@ use Illuminate\Support\Facades\Facade;
  */
 class Asset extends Facade
 {
-    /** @psalm-return AssetServiceContract::class */
+    /** @psalm-return AssetService::class */
     protected static function getFacadeAccessor(): string
     {
-        return AssetServiceContract::class;
+        return AssetService::class;
     }
 }

--- a/packages/framework/src/Foundation/BaseSystemCollection.php
+++ b/packages/framework/src/Foundation/BaseSystemCollection.php
@@ -2,7 +2,7 @@
 
 namespace Hyde\Framework\Foundation;
 
-use Hyde\Framework\Contracts\HydeKernelContract;
+use Hyde\Framework\HydeKernel;
 use Illuminate\Support\Collection;
 
 /**
@@ -14,11 +14,11 @@ use Illuminate\Support\Collection;
  */
 abstract class BaseSystemCollection extends Collection
 {
-    protected HydeKernelContract $kernel;
+    protected HydeKernel $kernel;
 
     abstract protected function runDiscovery(): self;
 
-    public static function boot(HydeKernelContract $kernel): static
+    public static function boot(HydeKernel $kernel): static
     {
         return (new static())->setKernel($kernel)->runDiscovery();
     }
@@ -28,7 +28,7 @@ abstract class BaseSystemCollection extends Collection
         parent::__construct($items);
     }
 
-    protected function setKernel(HydeKernelContract $kernel): static
+    protected function setKernel(HydeKernel $kernel): static
     {
         $this->kernel = $kernel;
 

--- a/packages/framework/src/Foundation/Filesystem.php
+++ b/packages/framework/src/Foundation/Filesystem.php
@@ -2,7 +2,7 @@
 
 namespace Hyde\Framework\Foundation;
 
-use Hyde\Framework\Contracts\HydeKernelContract;
+use Hyde\Framework\HydeKernel;
 use Hyde\Framework\Models\Pages\BladePage;
 use Hyde\Framework\Models\Pages\DocumentationPage;
 use Hyde\Framework\Models\Pages\MarkdownPage;
@@ -19,9 +19,9 @@ use Hyde\Framework\StaticPageBuilder;
  */
 class Filesystem
 {
-    protected HydeKernelContract $kernel;
+    protected HydeKernel $kernel;
 
-    public function __construct(HydeKernelContract $kernel)
+    public function __construct(HydeKernel $kernel)
     {
         $this->kernel = $kernel;
     }

--- a/packages/framework/src/Hyde.php
+++ b/packages/framework/src/Hyde.php
@@ -2,7 +2,7 @@
 
 namespace Hyde\Framework;
 
-use Hyde\Framework\Contracts\HydeKernelContract;
+use Hyde\Framework\HydeKernel;
 use Hyde\Framework\Contracts\RouteContract;
 use Hyde\Framework\Foundation\FileCollection;
 use Hyde\Framework\Foundation\PageCollection;
@@ -46,9 +46,9 @@ use Illuminate\Support\Facades\Facade;
  * @method static string makeTitle(string $slug)
  * @method static array toArray()
  * @method static bool hasSiteUrl()
- * @method static void setInstance(HydeKernelContract $instance)
+ * @method static void setInstance(HydeKernel $instance)
  * @method static string getBasePath()
- * @method static HydeKernelContract getInstance()
+ * @method static HydeKernel getInstance()
  * @method static string getDocumentationPagePath(string $path = '')
  */
 class Hyde extends Facade

--- a/packages/framework/src/Hyde.php
+++ b/packages/framework/src/Hyde.php
@@ -2,7 +2,6 @@
 
 namespace Hyde\Framework;
 
-use Hyde\Framework\HydeKernel;
 use Hyde\Framework\Contracts\RouteContract;
 use Hyde\Framework\Foundation\FileCollection;
 use Hyde\Framework\Foundation\PageCollection;

--- a/packages/framework/src/HydeKernel.php
+++ b/packages/framework/src/HydeKernel.php
@@ -33,7 +33,7 @@ class HydeKernel implements HydeKernelContract, Arrayable, \JsonSerializable
     use Macroable;
     use JsonSerializesArrayable;
 
-    protected static HydeKernelContract $instance;
+    protected static HydeKernel $instance;
 
     protected string $basePath;
 
@@ -62,12 +62,12 @@ class HydeKernel implements HydeKernelContract, Arrayable, \JsonSerializable
         $this->routes = RouteCollection::boot($this);
     }
 
-    public static function setInstance(HydeKernelContract $instance): void
+    public static function setInstance(HydeKernel $instance): void
     {
         static::$instance = $instance;
     }
 
-    public static function getInstance(): HydeKernelContract
+    public static function getInstance(): HydeKernel
     {
         return static::$instance;
     }

--- a/packages/framework/src/HydeServiceProvider.php
+++ b/packages/framework/src/HydeServiceProvider.php
@@ -3,12 +3,11 @@
 namespace Hyde\Framework;
 
 use Hyde\Framework\Concerns\RegistersFileLocations;
-use Hyde\Framework\Contracts\AssetServiceContract;
+use Hyde\Framework\Services\AssetService;
 use Hyde\Framework\Models\Pages\BladePage;
 use Hyde\Framework\Models\Pages\DocumentationPage;
 use Hyde\Framework\Models\Pages\MarkdownPage;
 use Hyde\Framework\Models\Pages\MarkdownPost;
-use Hyde\Framework\Services\AssetService;
 use Hyde\Framework\Views\Components\LinkComponent;
 use Illuminate\Support\Facades\Blade;
 use Illuminate\Support\ServiceProvider;
@@ -27,7 +26,7 @@ class HydeServiceProvider extends ServiceProvider
      */
     public function register(): void
     {
-        $this->app->singleton(AssetServiceContract::class, AssetService::class);
+        $this->app->singleton(AssetService::class, AssetService::class);
 
         $this->registerSourceDirectories([
             BladePage::class => '_pages',

--- a/packages/framework/src/HydeServiceProvider.php
+++ b/packages/framework/src/HydeServiceProvider.php
@@ -3,11 +3,11 @@
 namespace Hyde\Framework;
 
 use Hyde\Framework\Concerns\RegistersFileLocations;
-use Hyde\Framework\Services\AssetService;
 use Hyde\Framework\Models\Pages\BladePage;
 use Hyde\Framework\Models\Pages\DocumentationPage;
 use Hyde\Framework\Models\Pages\MarkdownPage;
 use Hyde\Framework\Models\Pages\MarkdownPost;
+use Hyde\Framework\Services\AssetService;
 use Hyde\Framework\Views\Components\LinkComponent;
 use Illuminate\Support\Facades\Blade;
 use Illuminate\Support\ServiceProvider;

--- a/packages/framework/src/helpers.php
+++ b/packages/framework/src/helpers.php
@@ -1,17 +1,17 @@
 <?php
 
-use Hyde\Framework\Contracts\HydeKernelContract;
+use Hyde\Framework\HydeKernel;
 use Illuminate\Contracts\Support\Arrayable;
 
 if (! function_exists('hyde')) {
     /**
      * Get the available HydeKernel instance.
      *
-     * @return \Hyde\Framework\Contracts\HydeKernelContract
+     * @return \Hyde\Framework\HydeKernel
      */
-    function hyde(): HydeKernelContract
+    function hyde(): HydeKernel
     {
-        return app(HydeKernelContract::class);
+        return app(HydeKernel::class);
     }
 }
 

--- a/packages/framework/tests/Feature/HydeKernelTest.php
+++ b/packages/framework/tests/Feature/HydeKernelTest.php
@@ -2,10 +2,10 @@
 
 namespace Hyde\Framework\Testing\Feature;
 
-use Hyde\Framework\HydeKernel;
 use Hyde\Framework\Contracts\RouteContract;
 use Hyde\Framework\Helpers\Features;
 use Hyde\Framework\Hyde;
+use Hyde\Framework\HydeKernel;
 use Hyde\Framework\HydeKernel;
 use Hyde\Framework\Models\Pages\BladePage;
 use Hyde\Framework\Models\Pages\DocumentationPage;

--- a/packages/framework/tests/Feature/HydeKernelTest.php
+++ b/packages/framework/tests/Feature/HydeKernelTest.php
@@ -2,7 +2,7 @@
 
 namespace Hyde\Framework\Testing\Feature;
 
-use Hyde\Framework\Contracts\HydeKernelContract;
+use Hyde\Framework\HydeKernel;
 use Hyde\Framework\Contracts\RouteContract;
 use Hyde\Framework\Helpers\Features;
 use Hyde\Framework\Hyde;
@@ -29,22 +29,22 @@ class HydeKernelTest extends TestCase
 {
     public function test_kernel_singleton_can_be_accessed_by_service_container()
     {
-        $this->assertSame(app(HydeKernelContract::class), app(HydeKernelContract::class));
+        $this->assertSame(app(HydeKernel::class), app(HydeKernel::class));
     }
 
     public function test_kernel_singleton_can_be_accessed_by_kernel_static_method()
     {
-        $this->assertSame(app(HydeKernelContract::class), HydeKernel::getInstance());
+        $this->assertSame(app(HydeKernel::class), HydeKernel::getInstance());
     }
 
     public function test_kernel_singleton_can_be_accessed_by_hyde_facade_method()
     {
-        $this->assertSame(app(HydeKernelContract::class), Hyde::getInstance());
+        $this->assertSame(app(HydeKernel::class), Hyde::getInstance());
     }
 
     public function test_kernel_singleton_can_be_accessed_by_helper_function()
     {
-        $this->assertSame(app(HydeKernelContract::class), hyde());
+        $this->assertSame(app(HydeKernel::class), hyde());
     }
 
     public function test_hyde_facade_version_method_returns_kernel_version()
@@ -54,7 +54,7 @@ class HydeKernelTest extends TestCase
 
     public function test_hyde_facade_get_facade_root_method_returns_kernel_singleton()
     {
-        $this->assertSame(app(HydeKernelContract::class), Hyde::getFacadeRoot());
+        $this->assertSame(app(HydeKernel::class), Hyde::getFacadeRoot());
         $this->assertSame(HydeKernel::getInstance(), Hyde::getFacadeRoot());
         $this->assertSame(Hyde::getInstance(), Hyde::getFacadeRoot());
     }

--- a/packages/framework/tests/Feature/HydeKernelTest.php
+++ b/packages/framework/tests/Feature/HydeKernelTest.php
@@ -6,7 +6,6 @@ use Hyde\Framework\Contracts\RouteContract;
 use Hyde\Framework\Helpers\Features;
 use Hyde\Framework\Hyde;
 use Hyde\Framework\HydeKernel;
-use Hyde\Framework\HydeKernel;
 use Hyde\Framework\Models\Pages\BladePage;
 use Hyde\Framework\Models\Pages\DocumentationPage;
 use Hyde\Framework\Models\Pages\MarkdownPage;

--- a/packages/framework/tests/Unit/AssetFacadeTest.php
+++ b/packages/framework/tests/Unit/AssetFacadeTest.php
@@ -2,9 +2,8 @@
 
 namespace Hyde\Framework\Testing\Unit;
 
-use Hyde\Framework\Contracts\AssetServiceContract;
-use Hyde\Framework\Facades\Asset;
 use Hyde\Framework\Services\AssetService;
+use Hyde\Framework\Facades\Asset;
 use Hyde\Testing\TestCase;
 
 /**
@@ -14,12 +13,12 @@ class AssetFacadeTest extends TestCase
 {
     public function test_asset_facade_returns_the_asset_service()
     {
-        $this->assertInstanceOf(AssetServiceContract::class, Asset::getFacadeRoot());
+        $this->assertInstanceOf(AssetService::class, Asset::getFacadeRoot());
     }
 
     public function test_facade_returns_same_instance_as_bound_by_the_container()
     {
-        $this->assertSame(Asset::getFacadeRoot(), app(AssetServiceContract::class));
+        $this->assertSame(Asset::getFacadeRoot(), app(AssetService::class));
     }
 
     public function test_asset_facade_can_call_methods_on_the_asset_service()

--- a/packages/framework/tests/Unit/AssetFacadeTest.php
+++ b/packages/framework/tests/Unit/AssetFacadeTest.php
@@ -2,8 +2,8 @@
 
 namespace Hyde\Framework\Testing\Unit;
 
-use Hyde\Framework\Services\AssetService;
 use Hyde\Framework\Facades\Asset;
+use Hyde\Framework\Services\AssetService;
 use Hyde\Testing\TestCase;
 
 /**

--- a/packages/framework/tests/Unit/HydeServiceProviderTest.php
+++ b/packages/framework/tests/Unit/HydeServiceProviderTest.php
@@ -2,7 +2,6 @@
 
 namespace Hyde\Framework\Testing\Unit;
 
-use Hyde\Framework\Services\AssetService;
 use Hyde\Framework\Hyde;
 use Hyde\Framework\HydeServiceProvider;
 use Hyde\Framework\Models\Pages\BladePage;
@@ -10,6 +9,7 @@ use Hyde\Framework\Models\Pages\DocumentationPage;
 use Hyde\Framework\Models\Pages\MarkdownPage;
 use Hyde\Framework\Models\Pages\MarkdownPost;
 use Hyde\Framework\Modules\DataCollections\DataCollectionServiceProvider;
+use Hyde\Framework\Services\AssetService;
 use Hyde\Framework\StaticPageBuilder;
 use Hyde\Testing\TestCase;
 use Illuminate\Support\Facades\Artisan;

--- a/packages/framework/tests/Unit/HydeServiceProviderTest.php
+++ b/packages/framework/tests/Unit/HydeServiceProviderTest.php
@@ -15,8 +15,6 @@ use Hyde\Testing\TestCase;
 use Illuminate\Support\Facades\Artisan;
 
 /**
- * @todo #162 Improve testing for this class.
- *
  * @covers \Hyde\Framework\HydeServiceProvider
  * @covers \Hyde\Framework\Concerns\RegistersFileLocations
  */

--- a/packages/framework/tests/Unit/HydeServiceProviderTest.php
+++ b/packages/framework/tests/Unit/HydeServiceProviderTest.php
@@ -2,7 +2,7 @@
 
 namespace Hyde\Framework\Testing\Unit;
 
-use Hyde\Framework\Contracts\AssetServiceContract;
+use Hyde\Framework\Services\AssetService;
 use Hyde\Framework\Hyde;
 use Hyde\Framework\HydeServiceProvider;
 use Hyde\Framework\Models\Pages\BladePage;
@@ -10,7 +10,6 @@ use Hyde\Framework\Models\Pages\DocumentationPage;
 use Hyde\Framework\Models\Pages\MarkdownPage;
 use Hyde\Framework\Models\Pages\MarkdownPost;
 use Hyde\Framework\Modules\DataCollections\DataCollectionServiceProvider;
-use Hyde\Framework\Services\AssetService;
 use Hyde\Framework\StaticPageBuilder;
 use Hyde\Testing\TestCase;
 use Illuminate\Support\Facades\Artisan;
@@ -49,9 +48,9 @@ class HydeServiceProviderTest extends TestCase
 
     public function test_provider_registers_asset_service_contract()
     {
-        $this->assertTrue($this->app->bound(AssetServiceContract::class));
-        $this->assertInstanceOf(AssetServiceContract::class, $this->app->make(AssetServiceContract::class));
-        $this->assertInstanceOf(AssetService::class, $this->app->make(AssetServiceContract::class));
+        $this->assertTrue($this->app->bound(AssetService::class));
+        $this->assertInstanceOf(AssetService::class, $this->app->make(AssetService::class));
+        $this->assertInstanceOf(AssetService::class, $this->app->make(AssetService::class));
     }
 
     public function test_provider_registers_source_directories()


### PR DESCRIPTION
These were originally added because I wrongly assumed the Laravel service container only accepted interfaces when type hinting. These classes aren't intended to be extended in the same ways other contracts are. Thus, having interfaces for these adds undue complexity.

The following interfaces are affected:
- HydeKernelContract, type hint the HydeKernel::class instead
- AssetServiceContract, type hint the AssetService::class instead
  