### PR TITLE
Refactor HydeKernel code to organized single-used traits

### DIFF
--- a/packages/framework/src/Foundation/Concerns/ForwardsFilesystem.php
+++ b/packages/framework/src/Foundation/Concerns/ForwardsFilesystem.php
@@ -4,6 +4,7 @@ namespace Hyde\Framework\Foundation\Concerns;
 
 /**
  * @internal Single-use trait for the HydeKernel class.
+ *
  * @see \Hyde\Framework\HydeKernel
  */
 trait ForwardsFilesystem

--- a/packages/framework/src/Foundation/Concerns/ForwardsFilesystem.php
+++ b/packages/framework/src/Foundation/Concerns/ForwardsFilesystem.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace Hyde\Framework\Foundation\Concerns;
+
+/**
+ * @internal Single-use trait for the HydeKernel class.
+ * @see \Hyde\Framework\HydeKernel
+ */
+trait ForwardsFilesystem
+{
+    public function path(string $path = ''): string
+    {
+        return $this->filesystem->path($path);
+    }
+
+    public function vendorPath(string $path = ''): string
+    {
+        return $this->filesystem->vendorPath($path);
+    }
+
+    public function copy(string $from, string $to): bool
+    {
+        return $this->filesystem->copy($from, $to);
+    }
+
+    public function touch(string|array $path): bool
+    {
+        return $this->filesystem->touch($path);
+    }
+
+    public function unlink(string|array $path): bool
+    {
+        return $this->filesystem->unlink($path);
+    }
+
+    public function getModelSourcePath(string $model, string $path = ''): string
+    {
+        return $this->filesystem->getModelSourcePath($model, $path);
+    }
+
+    public function getBladePagePath(string $path = ''): string
+    {
+        return $this->filesystem->getBladePagePath($path);
+    }
+
+    public function getMarkdownPagePath(string $path = ''): string
+    {
+        return $this->filesystem->getMarkdownPagePath($path);
+    }
+
+    public function getMarkdownPostPath(string $path = ''): string
+    {
+        return $this->filesystem->getMarkdownPostPath($path);
+    }
+
+    public function getDocumentationPagePath(string $path = ''): string
+    {
+        return $this->filesystem->getDocumentationPagePath($path);
+    }
+
+    public function getSiteOutputPath(string $path = ''): string
+    {
+        return $this->filesystem->getSiteOutputPath($path);
+    }
+
+    public function pathToRelative(string $path): string
+    {
+        return $this->filesystem->pathToRelative($path);
+    }
+}

--- a/packages/framework/src/Foundation/Concerns/ForwardsHyperlinks.php
+++ b/packages/framework/src/Foundation/Concerns/ForwardsHyperlinks.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace Hyde\Framework\Foundation\Concerns;
+
+/**
+ * @internal Single-use trait for the HydeKernel class.
+ * @see \Hyde\Framework\HydeKernel
+ */
+trait ForwardsHyperlinks
+{
+    public function formatHtmlPath(string $destination): string
+    {
+        return $this->hyperlinks->formatHtmlPath($destination);
+    }
+
+    public function relativeLink(string $destination): string
+    {
+        return $this->hyperlinks->relativeLink($destination);
+    }
+
+    public function image(string $name, bool $preferQualifiedUrl = false): string
+    {
+        return $this->hyperlinks->image($name, $preferQualifiedUrl);
+    }
+
+    public function hasSiteUrl(): bool
+    {
+        return $this->hyperlinks->hasSiteUrl();
+    }
+
+    public function url(string $path = '', ?string $default = null): string
+    {
+        return $this->hyperlinks->url($path, $default);
+    }
+}

--- a/packages/framework/src/Foundation/Concerns/ForwardsHyperlinks.php
+++ b/packages/framework/src/Foundation/Concerns/ForwardsHyperlinks.php
@@ -4,6 +4,7 @@ namespace Hyde\Framework\Foundation\Concerns;
 
 /**
  * @internal Single-use trait for the HydeKernel class.
+ *
  * @see \Hyde\Framework\HydeKernel
  */
 trait ForwardsHyperlinks

--- a/packages/framework/src/Foundation/Concerns/ImplementsStringHelpers.php
+++ b/packages/framework/src/Foundation/Concerns/ImplementsStringHelpers.php
@@ -6,6 +6,7 @@ use Illuminate\Support\Str;
 
 /**
  * @internal Single-use trait for the HydeKernel class.
+ *
  * @see \Hyde\Framework\HydeKernel
  */
 trait ImplementsStringHelpers

--- a/packages/framework/src/Foundation/Concerns/ImplementsStringHelpers.php
+++ b/packages/framework/src/Foundation/Concerns/ImplementsStringHelpers.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Hyde\Framework\Foundation\Concerns;
+
+use Illuminate\Support\Str;
+
+/**
+ * @internal Single-use trait for the HydeKernel class.
+ * @see \Hyde\Framework\HydeKernel
+ */
+trait ImplementsStringHelpers
+{
+    public function makeTitle(string $slug): string
+    {
+        $alwaysLowercase = ['a', 'an', 'the', 'in', 'on', 'by', 'with', 'of', 'and', 'or', 'but'];
+
+        return ucfirst(str_ireplace(
+            $alwaysLowercase,
+            $alwaysLowercase,
+            Str::headline($slug)
+        ));
+    }
+}

--- a/packages/framework/src/HydeKernel.php
+++ b/packages/framework/src/HydeKernel.php
@@ -29,12 +29,12 @@ use Illuminate\Support\Traits\Macroable;
  */
 class HydeKernel implements HydeKernelContract, Arrayable, \JsonSerializable
 {
-    use Macroable;
-    use JsonSerializesArrayable;
-
     use Foundation\Concerns\ImplementsStringHelpers;
     use Foundation\Concerns\ForwardsHyperlinks;
     use Foundation\Concerns\ForwardsFilesystem;
+
+    use JsonSerializesArrayable;
+    use Macroable;
 
     protected static HydeKernel $instance;
 

--- a/packages/framework/src/HydeKernel.php
+++ b/packages/framework/src/HydeKernel.php
@@ -33,6 +33,7 @@ class HydeKernel implements HydeKernelContract, Arrayable, \JsonSerializable
     use JsonSerializesArrayable;
 
     use Foundation\Concerns\ImplementsStringHelpers;
+    use Foundation\Concerns\ForwardsHyperlinks;
 
     protected static HydeKernel $instance;
 
@@ -133,31 +134,6 @@ class HydeKernel implements HydeKernelContract, Arrayable, \JsonSerializable
         }
 
         return $this->routes;
-    }
-
-    public function formatHtmlPath(string $destination): string
-    {
-        return $this->hyperlinks->formatHtmlPath($destination);
-    }
-
-    public function relativeLink(string $destination): string
-    {
-        return $this->hyperlinks->relativeLink($destination);
-    }
-
-    public function image(string $name, bool $preferQualifiedUrl = false): string
-    {
-        return $this->hyperlinks->image($name, $preferQualifiedUrl);
-    }
-
-    public function hasSiteUrl(): bool
-    {
-        return $this->hyperlinks->hasSiteUrl();
-    }
-
-    public function url(string $path = '', ?string $default = null): string
-    {
-        return $this->hyperlinks->url($path, $default);
     }
 
     public function path(string $path = ''): string

--- a/packages/framework/src/HydeKernel.php
+++ b/packages/framework/src/HydeKernel.php
@@ -34,6 +34,7 @@ class HydeKernel implements HydeKernelContract, Arrayable, \JsonSerializable
 
     use Foundation\Concerns\ImplementsStringHelpers;
     use Foundation\Concerns\ForwardsHyperlinks;
+    use Foundation\Concerns\ForwardsFilesystem;
 
     protected static HydeKernel $instance;
 
@@ -134,66 +135,6 @@ class HydeKernel implements HydeKernelContract, Arrayable, \JsonSerializable
         }
 
         return $this->routes;
-    }
-
-    public function path(string $path = ''): string
-    {
-        return $this->filesystem->path($path);
-    }
-
-    public function vendorPath(string $path = ''): string
-    {
-        return $this->filesystem->vendorPath($path);
-    }
-
-    public function copy(string $from, string $to): bool
-    {
-        return $this->filesystem->copy($from, $to);
-    }
-
-    public function touch(string|array $path): bool
-    {
-        return $this->filesystem->touch($path);
-    }
-
-    public function unlink(string|array $path): bool
-    {
-        return $this->filesystem->unlink($path);
-    }
-
-    public function getModelSourcePath(string $model, string $path = ''): string
-    {
-        return $this->filesystem->getModelSourcePath($model, $path);
-    }
-
-    public function getBladePagePath(string $path = ''): string
-    {
-        return $this->filesystem->getBladePagePath($path);
-    }
-
-    public function getMarkdownPagePath(string $path = ''): string
-    {
-        return $this->filesystem->getMarkdownPagePath($path);
-    }
-
-    public function getMarkdownPostPath(string $path = ''): string
-    {
-        return $this->filesystem->getMarkdownPostPath($path);
-    }
-
-    public function getDocumentationPagePath(string $path = ''): string
-    {
-        return $this->filesystem->getDocumentationPagePath($path);
-    }
-
-    public function getSiteOutputPath(string $path = ''): string
-    {
-        return $this->filesystem->getSiteOutputPath($path);
-    }
-
-    public function pathToRelative(string $path): string
-    {
-        return $this->filesystem->pathToRelative($path);
     }
 
     /**

--- a/packages/framework/src/HydeKernel.php
+++ b/packages/framework/src/HydeKernel.php
@@ -112,27 +112,21 @@ class HydeKernel implements HydeKernelContract, Arrayable, \JsonSerializable
 
     public function files(): FileCollection
     {
-        if (! $this->booted) {
-            $this->boot();
-        }
+        $this->needsToBeBooted();
 
         return $this->files;
     }
 
     public function pages(): PageCollection
     {
-        if (! $this->booted) {
-            $this->boot();
-        }
+        $this->needsToBeBooted();
 
         return $this->pages;
     }
 
     public function routes(): RouteCollection
     {
-        if (! $this->booted) {
-            $this->boot();
-        }
+        $this->needsToBeBooted();
 
         return $this->routes;
     }
@@ -151,5 +145,12 @@ class HydeKernel implements HydeKernelContract, Arrayable, \JsonSerializable
             'pages' => $this->pages(),
             'routes' => $this->routes(),
         ];
+    }
+
+    protected function needsToBeBooted(): void
+    {
+        if (! $this->booted) {
+            $this->boot();
+        }
     }
 }

--- a/packages/framework/src/HydeKernel.php
+++ b/packages/framework/src/HydeKernel.php
@@ -14,7 +14,6 @@ use Hyde\Framework\Foundation\RouteCollection;
 use Hyde\Framework\Helpers\Features;
 use Illuminate\Contracts\Support\Arrayable;
 use Illuminate\Support\Facades\View;
-use Illuminate\Support\Str;
 use Illuminate\Support\Traits\Macroable;
 
 /**
@@ -32,6 +31,8 @@ class HydeKernel implements HydeKernelContract, Arrayable, \JsonSerializable
 {
     use Macroable;
     use JsonSerializesArrayable;
+
+    use Foundation\Concerns\ImplementsStringHelpers;
 
     protected static HydeKernel $instance;
 
@@ -132,17 +133,6 @@ class HydeKernel implements HydeKernelContract, Arrayable, \JsonSerializable
         }
 
         return $this->routes;
-    }
-
-    public function makeTitle(string $slug): string
-    {
-        $alwaysLowercase = ['a', 'an', 'the', 'in', 'on', 'by', 'with', 'of', 'and', 'or', 'but'];
-
-        return ucfirst(str_ireplace(
-            $alwaysLowercase,
-            $alwaysLowercase,
-            Str::headline($slug)
-        ));
     }
 
     public function formatHtmlPath(string $destination): string


### PR DESCRIPTION
While I'm generally a bit weary of single-use traits (I love them, but feel that they can be a sign that the code needs to be split up into more classes), the HydeKernel is a vital part of the framework and cannot really be split up the same way as other classes can.

This PR moves logic to scoped internal traits in the Foundation\Concerns namespace. This will make it easier to get an overview of what's going on in each domain. This does not affect any of the logic itself or end usage of the framework, just how it is internally structured.