### PR TITLE
Only enable support files when there are related pages

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -15,6 +15,7 @@ This serves two purposes:
 ### Changed
 - Renamed HydeSmartDocs.php to SemanticDocumentationArticle.php
 - The RSS feed related generators are now only enabled when there are blog posts
+- The documentation search related generators are now only enabled when there are documentation pages
 
 ### Deprecated
 - for soon-to-be removed features.

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -15,7 +15,9 @@ This serves two purposes:
 ### Changed
 - Renamed HydeSmartDocs.php to SemanticDocumentationArticle.php
 - The RSS feed related generators are now only enabled when there are blog posts
+  - This means that no feed.xml will be generated, nor will there be any references (like meta tags) to it when there are no blog posts
 - The documentation search related generators are now only enabled when there are documentation pages
+  - This means that no search.json nor search.html nor any references to them will be generated when there are no documentation pages
 
 ### Deprecated
 - for soon-to-be removed features.

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -14,6 +14,7 @@ This serves two purposes:
 
 ### Changed
 - Renamed HydeSmartDocs.php to SemanticDocumentationArticle.php
+- The RSS feed related generators are now only enabled when there are blog posts
 
 ### Deprecated
 - for soon-to-be removed features.

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -24,7 +24,8 @@ This serves two purposes:
 - for now removed features.
 
 ### Fixed
-- for any bug fixes.
+- Fixed [#443](https://github.com/hydephp/develop/issues/443): RSS feed meta link should not be added if there is not a feed 
+
 
 ### Security
 - in case of vulnerabilities.

--- a/packages/framework/src/Commands/HydeBuildStaticSiteCommand.php
+++ b/packages/framework/src/Commands/HydeBuildStaticSiteCommand.php
@@ -173,7 +173,6 @@ class HydeBuildStaticSiteCommand extends Command
 
     protected function canGenerateSearch(): bool
     {
-        return Features::hasDocumentationSearch()
-            && count(DiscoveryService::getDocumentationPageFiles()) > 0;
+        return Features::hasDocumentationSearch();
     }
 }

--- a/packages/framework/src/Commands/HydeBuildStaticSiteCommand.php
+++ b/packages/framework/src/Commands/HydeBuildStaticSiteCommand.php
@@ -168,8 +168,7 @@ class HydeBuildStaticSiteCommand extends Command
 
     protected function canGenerateFeed(): bool
     {
-        return Features::rss()
-            && count(DiscoveryService::getMarkdownPostFiles()) > 0;
+        return Features::rss();
     }
 
     protected function canGenerateSearch(): bool

--- a/packages/framework/src/Helpers/Features.php
+++ b/packages/framework/src/Helpers/Features.php
@@ -4,6 +4,7 @@ namespace Hyde\Framework\Helpers;
 
 use Hyde\Framework\Concerns\JsonSerializesArrayable;
 use Hyde\Framework\Hyde;
+use Hyde\Framework\Services\DiscoveryService;
 use Illuminate\Contracts\Support\Arrayable;
 use Illuminate\Support\Str;
 
@@ -157,7 +158,8 @@ class Features implements Arrayable, \JsonSerializable
         return Hyde::hasSiteUrl()
             && static::hasBlogPosts()
             && config('hyde.generate_rss_feed', true)
-            && extension_loaded('simplexml');
+            && extension_loaded('simplexml')
+            && count(DiscoveryService::getMarkdownPostFiles()) > 0;
     }
 
     /** @inheritDoc */

--- a/packages/framework/src/Helpers/Features.php
+++ b/packages/framework/src/Helpers/Features.php
@@ -77,7 +77,8 @@ class Features implements Arrayable, \JsonSerializable
     public static function hasDocumentationSearch(): bool
     {
         return static::enabled(static::documentationSearch())
-            && static::hasDocumentationPages();
+            && static::hasDocumentationPages()
+            && count(DiscoveryService::getDocumentationPageFiles()) > 0;
     }
 
     public static function hasDarkmode(): bool

--- a/packages/framework/tests/Feature/Commands/HydeBuildRssFeedCommandTest.php
+++ b/packages/framework/tests/Feature/Commands/HydeBuildRssFeedCommandTest.php
@@ -28,6 +28,7 @@ class HydeBuildRssFeedCommandTest extends TestCase
     {
         config(['site.url' => 'https://example.com']);
         config(['hyde.generate_rss_feed' => true]);
+        $this->file('_posts/foo.md');
 
         unlinkIfExists(Hyde::path('_site/feed.xml'));
         $this->artisan('build:rss')
@@ -43,6 +44,7 @@ class HydeBuildRssFeedCommandTest extends TestCase
         config(['site.url' => 'https://example.com']);
         config(['hyde.generate_rss_feed' => true]);
         config(['hyde.rss_filename' => 'blog.xml']);
+        $this->file('_posts/foo.md');
 
         unlinkIfExists(Hyde::path('_site/feed.xml'));
         unlinkIfExists(Hyde::path('_site/blog.xml'));

--- a/packages/framework/tests/Feature/MetadataTest.php
+++ b/packages/framework/tests/Feature/MetadataTest.php
@@ -235,6 +235,8 @@ class MetadataTest extends TestCase
     {
         config(['site.url' => 'foo']);
         config(['hyde.generate_rss_feed' => true]);
+        $this->file('_posts/foo.md');
+
 
         $page = new MarkdownPage();
 
@@ -245,6 +247,8 @@ class MetadataTest extends TestCase
     {
         config(['site.url' => 'bar']);
         config(['hyde.generate_rss_feed' => true]);
+        $this->file('_posts/foo.md');
+
 
         $page = new MarkdownPage();
 
@@ -256,6 +260,8 @@ class MetadataTest extends TestCase
         config(['site.url' => 'foo']);
         config(['site.name' => 'Site']);
         config(['hyde.generate_rss_feed' => true]);
+        $this->file('_posts/foo.md');
+
 
         $page = new MarkdownPage();
 
@@ -267,6 +273,8 @@ class MetadataTest extends TestCase
         config(['site.url' => 'foo']);
         config(['hyde.rss_filename' => 'posts.rss']);
         config(['hyde.generate_rss_feed' => true]);
+        $this->file('_posts/foo.md');
+
         $page = new MarkdownPage();
 
         $this->assertStringContainsString(

--- a/packages/framework/tests/Feature/MetadataViewTest.php
+++ b/packages/framework/tests/Feature/MetadataViewTest.php
@@ -74,7 +74,6 @@ class MetadataViewTest extends TestCase
             '<meta name="viewport" content="width=device-width, initial-scale=1">',
             '<meta id="meta-color-scheme" name="color-scheme" content="light">',
             '<link rel="sitemap" href="http://localhost/sitemap.xml" type="application/xml" title="Sitemap">',
-            '<link rel="alternate" href="http://localhost/feed.xml" type="application/rss+xml" title="HydePHP RSS Feed">',
             '<meta name="generator" content="HydePHP dev-master">',
             '<meta property="og:site_name" content="HydePHP">',
         ];
@@ -135,6 +134,7 @@ class MetadataViewTest extends TestCase
 
         $assertions = $this->assertSee('posts/test', array_merge($this->getDefaultTags(), [
             '<title>HydePHP - Test</title>',
+            '<link rel="alternate" href="http://localhost/feed.xml" type="application/rss+xml" title="HydePHP RSS Feed">',
             '<link rel="stylesheet" href="../media/app.css">',
             '<link rel="canonical" href="http://localhost/posts/test.html">',
             '<meta name="twitter:title" content="HydePHP - Test">',
@@ -171,6 +171,7 @@ class MetadataViewTest extends TestCase
 
         $assertions = $this->assertSee('posts/test', array_merge($this->getDefaultTags(), [
             '<title>HydePHP - My title</title>',
+            '<link rel="alternate" href="http://localhost/feed.xml" type="application/rss+xml" title="HydePHP RSS Feed">',
             '<link rel="stylesheet" href="../media/app.css">',
             '<link rel="canonical" href="http://localhost/posts/test.html">',
             '<meta name="twitter:title" content="HydePHP - My title">',

--- a/packages/framework/tests/Feature/Services/RssFeedServiceTest.php
+++ b/packages/framework/tests/Feature/Services/RssFeedServiceTest.php
@@ -139,12 +139,14 @@ class RssFeedServiceTest extends TestCase
     public function test_can_generate_feed_helper_returns_true_if_hyde_has_base_url()
     {
         config(['site.url' => 'foo']);
+        $this->file('_posts/foo.md');
         $this->assertTrue(Features::rss());
     }
 
     public function test_can_generate_feed_helper_returns_false_if_hyde_does_not_have_base_url()
     {
         config(['site.url' => '']);
+        $this->file('_posts/foo.md');
         $this->assertFalse(Features::rss());
     }
 

--- a/packages/framework/tests/Feature/Services/RssFeedServiceTest.php
+++ b/packages/framework/tests/Feature/Services/RssFeedServiceTest.php
@@ -136,19 +136,19 @@ class RssFeedServiceTest extends TestCase
         $this->assertStringStartsWith('<?xml version="1.0" encoding="UTF-8"?>', (RssFeedService::generateFeed()));
     }
 
-    public function test_can_generate_sitemap_helper_returns_true_if_hyde_has_base_url()
+    public function test_can_generate_feed_helper_returns_true_if_hyde_has_base_url()
     {
         config(['site.url' => 'foo']);
         $this->assertTrue(Features::rss());
     }
 
-    public function test_can_generate_sitemap_helper_returns_false_if_hyde_does_not_have_base_url()
+    public function test_can_generate_feed_helper_returns_false_if_hyde_does_not_have_base_url()
     {
         config(['site.url' => '']);
         $this->assertFalse(Features::rss());
     }
 
-    public function test_can_generate_sitemap_helper_returns_false_if_sitemaps_are_disabled_in_config()
+    public function test_can_generate_feed_helper_returns_false_if_feeds_are_disabled_in_config()
     {
         config(['site.url' => 'foo']);
         config(['hyde.generate_rss_feed' => false]);

--- a/packages/framework/tests/Unit/Views/NavigationMenuViewTest.php
+++ b/packages/framework/tests/Unit/Views/NavigationMenuViewTest.php
@@ -3,7 +3,6 @@
 namespace Hyde\Framework\Testing\Unit\Views;
 
 use Hyde\Framework\Hyde;
-use Hyde\Framework\HydeKernel;
 use Hyde\Testing\TestCase;
 
 /**

--- a/packages/framework/tests/Unit/Views/NavigationMenuViewTest.php
+++ b/packages/framework/tests/Unit/Views/NavigationMenuViewTest.php
@@ -3,6 +3,7 @@
 namespace Hyde\Framework\Testing\Unit\Views;
 
 use Hyde\Framework\Hyde;
+use Hyde\Framework\HydeKernel;
 use Hyde\Testing\TestCase;
 
 /**
@@ -59,6 +60,8 @@ navigation:
   title: "My custom title"
 ---
 ');
+        HydeKernel::getInstance()->boot();
+
         $this->artisan('rebuild _pages/foo.md');
         $this->assertStringContainsString('My custom title', file_get_contents(Hyde::path('_site/foo.html')));
         Hyde::unlink('_site/foo.html');
@@ -71,6 +74,7 @@ navigation:
 @php($navigation = ['title' => 'My custom title'])
 BLADE
 );
+        HydeKernel::getInstance()->boot();
 
         $this->artisan('rebuild _pages/foo.blade.php');
         $this->assertStringContainsString('My custom title', file_get_contents(Hyde::path('_site/foo.html')));

--- a/packages/framework/tests/Unit/Views/NavigationMenuViewTest.php
+++ b/packages/framework/tests/Unit/Views/NavigationMenuViewTest.php
@@ -60,7 +60,7 @@ navigation:
   title: "My custom title"
 ---
 ');
-        HydeKernel::getInstance()->boot();
+        Hyde::boot();
 
         $this->artisan('rebuild _pages/foo.md');
         $this->assertStringContainsString('My custom title', file_get_contents(Hyde::path('_site/foo.html')));
@@ -74,7 +74,7 @@ navigation:
 @php($navigation = ['title' => 'My custom title'])
 BLADE
 );
-        HydeKernel::getInstance()->boot();
+        Hyde::boot();
 
         $this->artisan('rebuild _pages/foo.blade.php');
         $this->assertStringContainsString('My custom title', file_get_contents(Hyde::path('_site/foo.html')));


### PR DESCRIPTION
Fixes https://github.com/hydephp/develop/issues/443

- The RSS feed related generators are now only enabled when there are blog posts
- The documentation search related generators are now only enabled when there are documentation pages

This may seem like a big change, but in actuality, these files were not generated when running the standard build command unless the pages existed, so it makes no sense to have links to them in the site.

Comment related to the issue:

> Okay, so this was discovered when running `php hyde build` on a new project without any posts. An RSS feed is not generated then as the build command has an extra check to see if there are any posts. Same with documentation. This is of course inconsistent with how we handle it in other places. So something needs to be changed. It then begs the design question, should we add generate these files (rss and search) when there are no files for them to link to? I think no, but I could be wrong. For now, I think I will merge the extra checks in the build command to apply to the features check directly.

_Originally posted by @caendesilva in https://github.com/hydephp/develop/issues/443#issuecomment-1229525690_