### PR TITLE
Add a YAML configuration file

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -10,7 +10,7 @@ This serves two purposes:
 2. At release time, you can move the Unreleased section changes into a new release version section.
 
 ### Added
-- for new features.
+- Added the option to define some site configuration settings in a `hyde.yml` file. See [#449](https://github.com/hydephp/develop/pull/449)
 
 ### Changed
 - Renamed HydeSmartDocs.php to SemanticDocumentationArticle.php

--- a/config/site.php
+++ b/config/site.php
@@ -17,7 +17,7 @@
 |
 | Tip: The settings here can also be overridden by creating a hyde.yml file
 | in the root of your project directory. Note that these cannot reference
-| environment variables, and their values override any made here. 
+| environment variables, and their values override any made here.
 |
 */
 

--- a/config/site.php
+++ b/config/site.php
@@ -15,6 +15,10 @@
 | no configuration out of the box to get started. Though, you may want to
 | change the options to personalize your site and make it your own!
 |
+| Tip: The settings here can also be overridden by creating a hyde.yml file
+| in the root of your project directory. Note that these cannot reference
+| environment variables, and their values override any made here. 
+|
 */
 
 return [

--- a/docs/digging-deeper/customization.md
+++ b/docs/digging-deeper/customization.md
@@ -36,6 +36,7 @@ These are the main configuration files for HydePHP and lets you customize the lo
 | <a href="https://github.com/hydephp/hyde/blob/master/config/markdown.php" rel="nofollow noopener">markdown.php</a> | Configure Markdown related services, as well as change the CommonMark extensions.   |
 {.align-top}
 
+>info Tip: The values in site.php can also be set in YAML by creating a hyde.yml file in the root of your project. See [#yaml-configuration](#yaml-configuration) for more information.
 
 ### Laravel & Package Configuration Files
 
@@ -307,4 +308,25 @@ In the same file you can also change the config to be passed to the CommonMark e
 		'disallowed_tags' => [],
 	],
 ],
+```
+
+## YAML Configuration
+
+As a relatively new and experimental feature, the settings in the config/site.php can also be overridden by creating
+a hyde.yml file in the root of your project directory. Note that these cannot reference environment variables, 
+and their values override any made in the PHP config.
+
+Here is an example hyde.yml file matching the default site.yml:
+
+```yaml
+# filepath hyde.yml
+name: HydePHP
+url: http://localhost
+pretty_urls: false
+generate_sitemap: true
+generate_rss_feed: true
+rss_filename: feed.xml
+# rss_description:
+language: en
+output_directory: _site
 ```

--- a/packages/framework/config/site.php
+++ b/packages/framework/config/site.php
@@ -15,6 +15,10 @@
 | no configuration out of the box to get started. Though, you may want to
 | change the options to personalize your site and make it your own!
 |
+| Tip: The settings here can also be overridden by creating a hyde.yml file
+| in the root of your project directory. Note that these cannot reference
+| environment variables, and their values override any made here.
+|
 */
 
 return [

--- a/packages/framework/src/HydeServiceProvider.php
+++ b/packages/framework/src/HydeServiceProvider.php
@@ -91,7 +91,7 @@ class HydeServiceProvider extends ServiceProvider
 
     protected function initializeConfiguration()
     {
-        if (file_exists(Hyde::path('hyde.yml'))) {
+        if (YamlConfigurationService::hasFile()) {
             YamlConfigurationService::boot();
         }
     }

--- a/packages/framework/src/HydeServiceProvider.php
+++ b/packages/framework/src/HydeServiceProvider.php
@@ -8,6 +8,7 @@ use Hyde\Framework\Models\Pages\DocumentationPage;
 use Hyde\Framework\Models\Pages\MarkdownPage;
 use Hyde\Framework\Models\Pages\MarkdownPost;
 use Hyde\Framework\Services\AssetService;
+use Hyde\Framework\Services\YamlConfigurationService;
 use Hyde\Framework\Views\Components\LinkComponent;
 use Illuminate\Support\Facades\Blade;
 use Illuminate\Support\ServiceProvider;
@@ -26,6 +27,8 @@ class HydeServiceProvider extends ServiceProvider
      */
     public function register(): void
     {
+        $this->initializeConfiguration();
+
         $this->app->singleton(AssetService::class, AssetService::class);
 
         $this->registerSourceDirectories([
@@ -84,6 +87,13 @@ class HydeServiceProvider extends ServiceProvider
         Blade::component('link', LinkComponent::class);
 
         HydeKernel::getInstance()->boot();
+    }
+
+    protected function initializeConfiguration()
+    {
+        if (file_exists(Hyde::path('hyde.yml'))) {
+            YamlConfigurationService::boot();
+        }
     }
 
     /**

--- a/packages/framework/src/Services/YamlConfigurationService.php
+++ b/packages/framework/src/Services/YamlConfigurationService.php
@@ -37,6 +37,7 @@ class YamlConfigurationService
     protected static function getYaml(): array
     {
         $yaml = Yaml::parse(file_get_contents(static::getFile()));
+
         return is_array($yaml) ? $yaml : [];
     }
 }

--- a/packages/framework/src/Services/YamlConfigurationService.php
+++ b/packages/framework/src/Services/YamlConfigurationService.php
@@ -23,7 +23,8 @@ class YamlConfigurationService
 
     public static function hasFile(): bool
     {
-        return file_exists(Hyde::path('hyde.yml')) || file_exists(Hyde::path('hyde.yaml'));
+        return file_exists(Hyde::path('hyde.yml'))
+            || file_exists(Hyde::path('hyde.yaml'));
     }
 
     protected static function getFile(): string

--- a/packages/framework/src/Services/YamlConfigurationService.php
+++ b/packages/framework/src/Services/YamlConfigurationService.php
@@ -2,6 +2,8 @@
 
 namespace Hyde\Framework\Services;
 
+use Hyde\Framework\Hyde;
+
 /**
  * @see \Hyde\Framework\Testing\Feature\YamlConfigurationServiceTest
  */
@@ -10,5 +12,10 @@ class YamlConfigurationService
     public function boot(): void
     {
         // TODO: Merge configuration files.
+    }
+
+    public function hasFile(): bool
+    {
+        return file_exists(Hyde::path('hyde.yml'));
     }
 }

--- a/packages/framework/src/Services/YamlConfigurationService.php
+++ b/packages/framework/src/Services/YamlConfigurationService.php
@@ -18,4 +18,11 @@ class YamlConfigurationService
     {
         return file_exists(Hyde::path('hyde.yml')) || file_exists(Hyde::path('hyde.yaml'));
     }
+
+    protected function getFile(): string
+    {
+        return file_exists(Hyde::path('hyde.yml'))
+            ? Hyde::path('hyde.yml')
+            : Hyde::path('hyde.yaml');
+    }
 }

--- a/packages/framework/src/Services/YamlConfigurationService.php
+++ b/packages/framework/src/Services/YamlConfigurationService.php
@@ -19,7 +19,7 @@ class YamlConfigurationService
         return file_exists(Hyde::path('hyde.yml')) || file_exists(Hyde::path('hyde.yaml'));
     }
 
-    protected function getFile(): string
+    protected static function getFile(): string
     {
         return file_exists(Hyde::path('hyde.yml'))
             ? Hyde::path('hyde.yml')

--- a/packages/framework/src/Services/YamlConfigurationService.php
+++ b/packages/framework/src/Services/YamlConfigurationService.php
@@ -3,6 +3,8 @@
 namespace Hyde\Framework\Services;
 
 use Hyde\Framework\Hyde;
+use Illuminate\Support\Facades\Config;
+use Symfony\Component\Yaml\Yaml;
 
 /**
  * @see \Hyde\Framework\Testing\Feature\YamlConfigurationServiceTest
@@ -11,7 +13,11 @@ class YamlConfigurationService
 {
     public static function boot(): void
     {
-        // TODO: Merge configuration files.
+        $yaml = Yaml::parse(file_get_contents(static::getFile()));
+        Config::set('site', array_merge(
+            Config::get('site', []),
+            $yaml
+        ));
     }
 
     public static function hasFile(): bool

--- a/packages/framework/src/Services/YamlConfigurationService.php
+++ b/packages/framework/src/Services/YamlConfigurationService.php
@@ -17,7 +17,7 @@ class YamlConfigurationService
             $yaml = Yaml::parse(file_get_contents(static::getFile()));
             Config::set('site', array_merge(
                 Config::get('site', []),
-                $yaml ?? []
+                is_array($yaml) ? $yaml : []
             ));
         }
     }

--- a/packages/framework/src/Services/YamlConfigurationService.php
+++ b/packages/framework/src/Services/YamlConfigurationService.php
@@ -17,7 +17,7 @@ class YamlConfigurationService
             $yaml = Yaml::parse(file_get_contents(static::getFile()));
             Config::set('site', array_merge(
                 Config::get('site', []),
-                $yaml
+                $yaml ?? []
             ));
         }
     }

--- a/packages/framework/src/Services/YamlConfigurationService.php
+++ b/packages/framework/src/Services/YamlConfigurationService.php
@@ -16,6 +16,6 @@ class YamlConfigurationService
 
     public function hasFile(): bool
     {
-        return file_exists(Hyde::path('hyde.yml'));
+        return file_exists(Hyde::path('hyde.yml')) || file_exists(Hyde::path('hyde.yaml'));
     }
 }

--- a/packages/framework/src/Services/YamlConfigurationService.php
+++ b/packages/framework/src/Services/YamlConfigurationService.php
@@ -13,11 +13,13 @@ class YamlConfigurationService
 {
     public static function boot(): void
     {
-        $yaml = Yaml::parse(file_get_contents(static::getFile()));
-        Config::set('site', array_merge(
-            Config::get('site', []),
-            $yaml
-        ));
+        if (static::hasFile()) {
+            $yaml = Yaml::parse(file_get_contents(static::getFile()));
+            Config::set('site', array_merge(
+                Config::get('site', []),
+                $yaml
+            ));
+        }
     }
 
     public static function hasFile(): bool

--- a/packages/framework/src/Services/YamlConfigurationService.php
+++ b/packages/framework/src/Services/YamlConfigurationService.php
@@ -14,10 +14,9 @@ class YamlConfigurationService
     public static function boot(): void
     {
         if (static::hasFile()) {
-            $yaml = Yaml::parse(file_get_contents(static::getFile()));
             Config::set('site', array_merge(
                 Config::get('site', []),
-                is_array($yaml) ? $yaml : []
+                static::getYaml()
             ));
         }
     }
@@ -32,5 +31,11 @@ class YamlConfigurationService
         return file_exists(Hyde::path('hyde.yml'))
             ? Hyde::path('hyde.yml')
             : Hyde::path('hyde.yaml');
+    }
+
+    protected static function getYaml(): array
+    {
+        $yaml = Yaml::parse(file_get_contents(static::getFile()));
+        return is_array($yaml) ? $yaml : [];
     }
 }

--- a/packages/framework/src/Services/YamlConfigurationService.php
+++ b/packages/framework/src/Services/YamlConfigurationService.php
@@ -9,12 +9,12 @@ use Hyde\Framework\Hyde;
  */
 class YamlConfigurationService
 {
-    public function boot(): void
+    public static function boot(): void
     {
         // TODO: Merge configuration files.
     }
 
-    public function hasFile(): bool
+    public static function hasFile(): bool
     {
         return file_exists(Hyde::path('hyde.yml')) || file_exists(Hyde::path('hyde.yaml'));
     }

--- a/packages/framework/src/Services/YamlConfigurationService.php
+++ b/packages/framework/src/Services/YamlConfigurationService.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Hyde\Framework\Services;
+
+class YamlConfigurationService
+{
+    public function boot(): void
+    {
+        // TODO: Merge configuration files.
+    }
+}

--- a/packages/framework/src/Services/YamlConfigurationService.php
+++ b/packages/framework/src/Services/YamlConfigurationService.php
@@ -2,6 +2,9 @@
 
 namespace Hyde\Framework\Services;
 
+/**
+ * @see \Hyde\Framework\Testing\Feature\YamlConfigurationServiceTest
+ */
 class YamlConfigurationService
 {
     public function boot(): void

--- a/packages/framework/tests/Feature/YamlConfigurationServiceTest.php
+++ b/packages/framework/tests/Feature/YamlConfigurationServiceTest.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Hyde\Framework\Testing\Feature;
+
+use Hyde\Framework\Services\YamlConfigurationService;
+use Hyde\Testing\TestCase;
+
+/**
+ * @covers \Hyde\Framework\Services\YamlConfigurationService
+ */
+class YamlConfigurationServiceTest extends TestCase
+{
+    //
+}

--- a/packages/framework/tests/Feature/YamlConfigurationServiceTest.php
+++ b/packages/framework/tests/Feature/YamlConfigurationServiceTest.php
@@ -33,4 +33,11 @@ class YamlConfigurationServiceTest extends TestCase
         YamlConfigurationService::boot();
         $this->assertEquals('HydePHP', Config::get('site.name'));
     }
+
+    public function test_service_gracefully_handles_empty_file()
+    {
+        $this->file('hyde.yml', '');
+        YamlConfigurationService::boot();
+        $this->assertEquals('HydePHP', Config::get('site.name'));
+    }
 }

--- a/packages/framework/tests/Feature/YamlConfigurationServiceTest.php
+++ b/packages/framework/tests/Feature/YamlConfigurationServiceTest.php
@@ -7,6 +7,7 @@ use Hyde\Testing\TestCase;
 
 /**
  * @covers \Hyde\Framework\Services\YamlConfigurationService
+ * @see \Hyde\Framework\Testing\Unit\HydeServiceProviderTest as it determines if this service should be booted.
  */
 class YamlConfigurationServiceTest extends TestCase
 {

--- a/packages/framework/tests/Feature/YamlConfigurationServiceTest.php
+++ b/packages/framework/tests/Feature/YamlConfigurationServiceTest.php
@@ -8,6 +8,7 @@ use Illuminate\Support\Facades\Config;
 
 /**
  * @covers \Hyde\Framework\Services\YamlConfigurationService
+ *
  * @see \Hyde\Framework\Testing\Unit\HydeServiceProviderTest as it determines if this service should be booted.
  */
 class YamlConfigurationServiceTest extends TestCase

--- a/packages/framework/tests/Feature/YamlConfigurationServiceTest.php
+++ b/packages/framework/tests/Feature/YamlConfigurationServiceTest.php
@@ -27,4 +27,10 @@ class YamlConfigurationServiceTest extends TestCase
         YamlConfigurationService::boot();
         $this->assertEquals('Foo', Config::get('site.name'));
     }
+
+    public function test_service_gracefully_handles_missing_file()
+    {
+        YamlConfigurationService::boot();
+        $this->assertEquals('HydePHP', Config::get('site.name'));
+    }
 }

--- a/packages/framework/tests/Feature/YamlConfigurationServiceTest.php
+++ b/packages/framework/tests/Feature/YamlConfigurationServiceTest.php
@@ -4,6 +4,7 @@ namespace Hyde\Framework\Testing\Feature;
 
 use Hyde\Framework\Services\YamlConfigurationService;
 use Hyde\Testing\TestCase;
+use Illuminate\Support\Facades\Config;
 
 /**
  * @covers \Hyde\Framework\Services\YamlConfigurationService
@@ -11,5 +12,19 @@ use Hyde\Testing\TestCase;
  */
 class YamlConfigurationServiceTest extends TestCase
 {
-    //
+    public function test_changes_in_yaml_file_override_changes_in_site_config()
+    {
+        $this->assertEquals('HydePHP', Config::get('site.name'));
+        $this->file('hyde.yml', 'name: Foo');
+        YamlConfigurationService::boot();
+        $this->assertEquals('Foo', Config::get('site.name'));
+    }
+
+    public function test_changes_in_yaml_file_override_changes_in_site_config_when_using_yaml_extension()
+    {
+        $this->assertEquals('HydePHP', Config::get('site.name'));
+        $this->file('hyde.yaml', 'name: Foo');
+        YamlConfigurationService::boot();
+        $this->assertEquals('Foo', Config::get('site.name'));
+    }
 }

--- a/packages/framework/tests/Unit/HydeServiceProviderTest.php
+++ b/packages/framework/tests/Unit/HydeServiceProviderTest.php
@@ -51,7 +51,7 @@ class HydeServiceProviderTest extends TestCase
         $this->provider->register();
         $this->assertEquals('Foo', config('site.name'));
     }
-    
+
     public function test_provider_registers_asset_service_contract()
     {
         $this->assertTrue($this->app->bound(AssetService::class));

--- a/packages/framework/tests/Unit/HydeServiceProviderTest.php
+++ b/packages/framework/tests/Unit/HydeServiceProviderTest.php
@@ -44,6 +44,14 @@ class HydeServiceProviderTest extends TestCase
         $this->assertTrue(method_exists($this->provider, 'boot'));
     }
 
+    public function test_provider_applies_yaml_configuration_when_present()
+    {
+        $this->assertEquals('HydePHP', config('site.name'));
+        $this->file('hyde.yml', 'name: Foo');
+        $this->provider->register();
+        $this->assertEquals('Foo', config('site.name'));
+    }
+    
     public function test_provider_registers_asset_service_contract()
     {
         $this->assertTrue($this->app->bound(AssetService::class));


### PR DESCRIPTION
This file will work as a superset of the site config file, and allow some basic site configuration to be managed with YAML. The YAML options are then be merged taking priority over other settings at runtime using a service provider. This allows for easier static analysis of the configuration file, as well as better interoperability. 
