### PR TITLE
Decouple full page search page to be a Blade page stored in subdirectory

### DIFF
--- a/config/docs.php
+++ b/config/docs.php
@@ -114,6 +114,7 @@ return [
     */
 
     // Should a docs/search.html page be generated?
+    /** @deprecated v0.63.x */
     'create_search_page' => true,
 
     // Are there any pages you don't want to show in the search results?

--- a/packages/framework/src/Actions/PostBuildTasks/GenerateSearch.php
+++ b/packages/framework/src/Actions/PostBuildTasks/GenerateSearch.php
@@ -24,6 +24,7 @@ class GenerateSearch extends AbstractBuildTask
 
         GeneratesDocumentationSearchIndexFile::run();
 
+        /** @deprecated v0.63.x */
         if (config('docs.create_search_page', true)) {
             $outputDirectory = Hyde::pathToRelative(Hyde::getSiteOutputPath(DocumentationPage::getOutputDirectory()));
             $this->needsDirectory(Hyde::path($outputDirectory));

--- a/packages/framework/src/Actions/PostBuildTasks/GenerateSearch.php
+++ b/packages/framework/src/Actions/PostBuildTasks/GenerateSearch.php
@@ -23,20 +23,6 @@ class GenerateSearch extends AbstractBuildTask
         }
 
         GeneratesDocumentationSearchIndexFile::run();
-
-        /** @deprecated v0.63.x */
-        if (config('docs.create_search_page', true)) {
-            $outputDirectory = Hyde::pathToRelative(Hyde::getSiteOutputPath(DocumentationPage::getOutputDirectory()));
-            $this->needsDirectory(Hyde::path($outputDirectory));
-            file_put_contents(
-                Hyde::path($outputDirectory.'/search.html'),
-                view('hyde::pages.documentation-search')->render()
-            );
-            $this->write(sprintf(
-                "\n > Created <info>_site/%s/search.html</info>",
-                config('docs.output_directory', 'docs')
-            ));
-        }
     }
 
     public function then(): void

--- a/packages/framework/src/Actions/PostBuildTasks/GenerateSearch.php
+++ b/packages/framework/src/Actions/PostBuildTasks/GenerateSearch.php
@@ -5,8 +5,6 @@ namespace Hyde\Framework\Actions\PostBuildTasks;
 use Hyde\Framework\Actions\GeneratesDocumentationSearchIndexFile;
 use Hyde\Framework\Concerns\InteractsWithDirectories;
 use Hyde\Framework\Contracts\AbstractBuildTask;
-use Hyde\Framework\Hyde;
-use Hyde\Framework\Models\Pages\DocumentationPage;
 use Hyde\Framework\Services\DiscoveryService;
 
 class GenerateSearch extends AbstractBuildTask

--- a/packages/realtime-compiler/src/Actions/RendersSearchPage.php
+++ b/packages/realtime-compiler/src/Actions/RendersSearchPage.php
@@ -6,6 +6,9 @@ use Hyde\Framework\Hyde;
 use Hyde\RealtimeCompiler\Concerns\InteractsWithLaravel;
 use Illuminate\Support\Facades\Blade;
 
+/**
+ * @deprecated v0.63.x
+ */
 class RendersSearchPage
 {
     use InteractsWithLaravel;


### PR DESCRIPTION
This will make it more predictable and intuitive where the search.html page is coming from. See https://github.com/hydephp/develop/issues/452