### PR TITLE
Add navigation menu dropdown component

### DIFF
--- a/packages/framework/resources/views/components/navigation/dropdown.blade.php
+++ b/packages/framework/resources/views/components/navigation/dropdown.blade.php
@@ -1,8 +1,9 @@
-<div class="dropdown-container relative">
-    <button class="dropdown-button block my-2 md:my-0 md:inline-block py-1 text-gray-700 hover:text-gray-900 dark:text-gray-100">
+<div class="dropdown-container relative" x-data="{ open: false }">
+    <button class="dropdown-button block my-2 md:my-0 md:inline-block py-1 text-gray-700 hover:text-gray-900 dark:text-gray-100"
+            x-on:click="open = ! open">
         {{ $label }}
     </button>
-    <ul class="dropdown-items absolute">
+    <ul class="dropdown-items absolute" :class="open ? '' : 'hidden'">
         {{ $slot }}
     </ul>
 </div>

--- a/packages/framework/resources/views/components/navigation/dropdown.blade.php
+++ b/packages/framework/resources/views/components/navigation/dropdown.blade.php
@@ -2,7 +2,7 @@
     <button class="dropdown-button block my-2 md:my-0 md:inline-block py-1 text-gray-700 hover:text-gray-900 dark:text-gray-100"
             x-on:click="open = ! open">
         {{ $label }}
-        <svg class="inline" xmlns="http://www.w3.org/2000/svg" height="24px" viewBox="0 0 24 24" width="24px" fill="#000000"><path d="M0 0h24v24H0z" fill="none"/><path d="M7 10l5 5 5-5z"/></svg>
+        <svg class="inline transition-all" x-bind:style="open ? { transform: 'rotate(180deg)' } : ''" xmlns="http://www.w3.org/2000/svg" height="24px" viewBox="0 0 24 24" width="24px" fill="#000000"><path d="M0 0h24v24H0z" fill="none"/><path d="M7 10l5 5 5-5z"/></svg>
     </button>
     <ul class="dropdown-items absolute" :class="open ? '' : 'hidden'">
         {{ $slot }}

--- a/packages/framework/resources/views/components/navigation/dropdown.blade.php
+++ b/packages/framework/resources/views/components/navigation/dropdown.blade.php
@@ -2,6 +2,7 @@
     <button class="dropdown-button block my-2 md:my-0 md:inline-block py-1 text-gray-700 hover:text-gray-900 dark:text-gray-100"
             x-on:click="open = ! open">
         {{ $label }}
+        <svg class="inline" xmlns="http://www.w3.org/2000/svg" height="24px" viewBox="0 0 24 24" width="24px" fill="#000000"><path d="M0 0h24v24H0z" fill="none"/><path d="M7 10l5 5 5-5z"/></svg>
     </button>
     <ul class="dropdown-items absolute" :class="open ? '' : 'hidden'">
         {{ $slot }}

--- a/packages/framework/resources/views/components/navigation/dropdown.blade.php
+++ b/packages/framework/resources/views/components/navigation/dropdown.blade.php
@@ -1,0 +1,8 @@
+<div class="dropdown-container relative">
+    <button class="dropdown-button block my-2 md:my-0 md:inline-block py-1 text-gray-700 hover:text-gray-900 dark:text-gray-100">
+        {{ $label }}
+    </button>
+    <ul class="dropdown-items absolute">
+        {{ $slot }}
+    </ul>
+</div>

--- a/packages/framework/resources/views/components/navigation/dropdown.blade.php
+++ b/packages/framework/resources/views/components/navigation/dropdown.blade.php
@@ -4,7 +4,9 @@
         {{ $label }}
         <svg class="inline transition-all" x-bind:style="open ? { transform: 'rotate(180deg)' } : ''" xmlns="http://www.w3.org/2000/svg" height="24px" viewBox="0 0 24 24" width="24px" fill="#000000"><path d="M0 0h24v24H0z" fill="none"/><path d="M7 10l5 5 5-5z"/></svg>
     </button>
-    <ul class="dropdown-items absolute" :class="open ? '' : 'hidden'">
-        {{ $slot }}
-    </ul>
+    <div class="dropdown absolute shadow-lg bg-white z-50" :class="open ? '' : 'hidden'">
+        <ul class="dropdown-items px-3 py-2">
+            {{ $slot }}
+        </ul>
+    </div>
 </div>

--- a/packages/framework/resources/views/layouts/navigation.blade.php
+++ b/packages/framework/resources/views/layouts/navigation.blade.php
@@ -1,5 +1,5 @@
 @php
-	$navigation = \Hyde\Framework\Models\NavigationMenu::create($page->getRoute());
+	$navigation = \Hyde\Framework\Models\NavigationMenu::create();
 @endphp
 
 <nav aria-label="Main navigation" id="main-navigation"

--- a/packages/framework/src/Contracts/AbstractPage.php
+++ b/packages/framework/src/Contracts/AbstractPage.php
@@ -206,14 +206,4 @@ abstract class AbstractPage implements PageContract, CompilableContract
     {
         return $this->navigation['title'];
     }
-
-    /**
-     * If an item returns a route collection, it will automatically be made into a dropdown.
-     *
-     * @return ?\Illuminate\Support\Collection<\Hyde\Framework\Models\Route>
-     */
-    public function navigationMenuChildren(): ?Collection
-    {
-        return null;
-    }
 }

--- a/packages/framework/src/Contracts/AbstractPage.php
+++ b/packages/framework/src/Contracts/AbstractPage.php
@@ -13,10 +13,15 @@ use Hyde\Framework\Services\DiscoveryService;
 
 /**
  * To ensure compatibility with the Hyde Framework, all Page Models should extend this class.
- *
  * Markdown-based Pages can extend the AbstractMarkdownPage class to get relevant helpers.
- *
  * To learn about what the methods do, see the PHPDocs in the PageContract.
+ *
+ * Unlike other frameworks, in general you don't instantiate pages yourself in Hyde,
+ * instead, the page models acts as blueprints defining information for Hyde to
+ * know how to parse a file, and what data around it should be generated.
+ *
+ * To create a parsed file instance, you'd typically just create a source file,
+ * and you can then access the parsed file from the HydeKernel's page index.
  *
  * @see \Hyde\Framework\Contracts\PageContract
  * @see \Hyde\Framework\Contracts\AbstractMarkdownPage

--- a/packages/framework/src/Contracts/AbstractPage.php
+++ b/packages/framework/src/Contracts/AbstractPage.php
@@ -208,10 +208,7 @@ abstract class AbstractPage implements PageContract, CompilableContract
     }
 
     /**
-     * Not yet implemented.
-     *
-     * If an item returns a route collection,
-     * it will automatically be made into a dropdown.
+     * If an item returns a route collection, it will automatically be made into a dropdown.
      *
      * @return ?\Illuminate\Support\Collection<\Hyde\Framework\Models\Route>
      */

--- a/packages/framework/src/Contracts/AbstractPage.php
+++ b/packages/framework/src/Contracts/AbstractPage.php
@@ -10,6 +10,7 @@ use Hyde\Framework\Models\FrontMatter;
 use Hyde\Framework\Models\Metadata\Metadata;
 use Hyde\Framework\Models\Route;
 use Hyde\Framework\Services\DiscoveryService;
+use Illuminate\Support\Collection;
 
 /**
  * To ensure compatibility with the Hyde Framework, all Page Models should extend this class.
@@ -212,7 +213,10 @@ abstract class AbstractPage implements PageContract, CompilableContract
      * If an item returns a route collection,
      * it will automatically be made into a dropdown.
      *
-     * @return \Illuminate\Support\Collection<\Hyde\Framework\Models\Route>
+     * @return ?\Illuminate\Support\Collection<\Hyde\Framework\Models\Route>
      */
-    // public function navigationMenuChildren(): Collection;
+    public function navigationMenuChildren(): ?Collection
+    {
+        return null;
+    }
 }


### PR DESCRIPTION
Adds a simple component for navigation menu dropdowns. While it's not automatically generated in the code as of yet, it gives a quick way to add a dropdown to published views. 

> I actually can't think of a good way to implement automatic dropdowns in a way that works well without a bunch of complexity. The best I can see now is to add a Blade component that can be used in published views, and we'll take it from there. https://github.com/hydephp/develop/issues/76#issuecomment-1234222716

Here is an example usage:

```blade
@php
  $navigation = \Hyde\Framework\Models\NavigationMenu::create();
@endphp

<x-hyde::navigation.dropdown label="About us">
  @foreach ($navigation->items as $item)
    <li>
      @include('hyde::components.navigation.navigation-link')
    </li>
  @endforeach
</x-hyde::navigation.dropdown>
```