### PR TITLE
Generate a build manifest after the build

### DIFF
--- a/packages/framework/src/Actions/PostBuildTasks/GenerateBuildManifest.php
+++ b/packages/framework/src/Actions/PostBuildTasks/GenerateBuildManifest.php
@@ -3,8 +3,33 @@
 namespace Hyde\Framework\Actions\PostBuildTasks;
 
 use Hyde\Framework\Contracts\AbstractBuildTask;
+use Hyde\Framework\Hyde;
+use Illuminate\Support\Collection;
 
 class GenerateBuildManifest extends AbstractBuildTask
 {
-    //
+    public static string $description = 'Generating build manifest';
+
+    protected static string $manifestPath = 'storage/framework/cache/build-manifest.json';
+
+    public function run(): void
+    {
+        $manifest = new Collection();
+
+        /** @var \Hyde\Framework\Contracts\AbstractPage $page */
+        foreach (Hyde::pages() as $page) {
+            $manifest->push([
+                'page' => $page->getSourcePath(),
+                'input_hash' => md5(Hyde::path($page->getSourcePath())),
+                'output_hash' => md5(Hyde::path($page->getOutputPath())),
+            ]);
+        }
+
+        file_put_contents(Hyde::path(static::$manifestPath), $manifest->toJson());
+    }
+
+    public function then(): void
+    {
+        $this->createdSiteFile(static::$manifestPath)->withExecutionTime();
+    }
 }

--- a/packages/framework/src/Actions/PostBuildTasks/GenerateBuildManifest.php
+++ b/packages/framework/src/Actions/PostBuildTasks/GenerateBuildManifest.php
@@ -9,8 +9,6 @@ use Illuminate\Support\Collection;
 
 class GenerateBuildManifest extends AbstractBuildTask
 {
-    public static string $description = 'Generating build manifest';
-
     protected static string $manifestPath = 'storage/framework/cache/build-manifest.json';
 
     public function __construct(?OutputStyle $output = null)
@@ -33,10 +31,5 @@ class GenerateBuildManifest extends AbstractBuildTask
         }
 
         file_put_contents(Hyde::path(static::$manifestPath), $manifest->toJson());
-    }
-
-    public function then(): void
-    {
-        $this->createdSiteFile(static::$manifestPath)->withExecutionTime();
     }
 }

--- a/packages/framework/src/Actions/PostBuildTasks/GenerateBuildManifest.php
+++ b/packages/framework/src/Actions/PostBuildTasks/GenerateBuildManifest.php
@@ -9,8 +9,6 @@ use Illuminate\Support\Collection;
 
 class GenerateBuildManifest extends AbstractBuildTask
 {
-    protected static string $manifestPath = 'storage/framework/cache/build-manifest.json';
-
     public function __construct(?OutputStyle $output = null)
     {
         parent::__construct($output);
@@ -30,6 +28,8 @@ class GenerateBuildManifest extends AbstractBuildTask
             ]);
         }
 
-        file_put_contents(Hyde::path(static::$manifestPath), $manifest->toJson());
+        file_put_contents(Hyde::path(config('hyde.build_manifest_path',
+            'storage/framework/cache/build-manifest.json')
+        ), $manifest->toJson());
     }
 }

--- a/packages/framework/src/Actions/PostBuildTasks/GenerateBuildManifest.php
+++ b/packages/framework/src/Actions/PostBuildTasks/GenerateBuildManifest.php
@@ -23,7 +23,7 @@ class GenerateBuildManifest extends AbstractBuildTask
         foreach (Hyde::pages() as $page) {
             $manifest->push([
                 'page' => $page->getSourcePath(),
-                'input_hash' => md5(Hyde::path($page->getSourcePath())),
+                'source_hash' => md5(Hyde::path($page->getSourcePath())),
                 'output_hash' => md5(Hyde::path($page->getOutputPath())),
             ]);
         }

--- a/packages/framework/src/Actions/PostBuildTasks/GenerateBuildManifest.php
+++ b/packages/framework/src/Actions/PostBuildTasks/GenerateBuildManifest.php
@@ -4,6 +4,7 @@ namespace Hyde\Framework\Actions\PostBuildTasks;
 
 use Hyde\Framework\Contracts\AbstractBuildTask;
 use Hyde\Framework\Hyde;
+use Illuminate\Console\OutputStyle;
 use Illuminate\Support\Collection;
 
 class GenerateBuildManifest extends AbstractBuildTask
@@ -11,6 +12,12 @@ class GenerateBuildManifest extends AbstractBuildTask
     public static string $description = 'Generating build manifest';
 
     protected static string $manifestPath = 'storage/framework/cache/build-manifest.json';
+
+    public function __construct(?OutputStyle $output = null)
+    {
+        parent::__construct($output);
+        $this->output = null;
+    }
 
     public function run(): void
     {

--- a/packages/framework/src/Actions/PostBuildTasks/GenerateBuildManifest.php
+++ b/packages/framework/src/Actions/PostBuildTasks/GenerateBuildManifest.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Hyde\Framework\Actions\PostBuildTasks;
+
+use Hyde\Framework\Contracts\AbstractBuildTask;
+
+class GenerateBuildManifest extends AbstractBuildTask
+{
+    //
+}

--- a/packages/framework/src/Commands/HydeBuildStaticSiteCommand.php
+++ b/packages/framework/src/Commands/HydeBuildStaticSiteCommand.php
@@ -3,7 +3,6 @@
 namespace Hyde\Framework\Commands;
 
 use Exception;
-use Hyde\Framework\Actions\PostBuildTasks\GenerateBuildManifest;
 use Hyde\Framework\Actions\PostBuildTasks\GenerateRssFeed;
 use Hyde\Framework\Actions\PostBuildTasks\GenerateSearch;
 use Hyde\Framework\Actions\PostBuildTasks\GenerateSitemap;
@@ -119,7 +118,6 @@ class HydeBuildStaticSiteCommand extends Command
         $service->runIf(GenerateSitemap::class, $this->canGenerateSitemap());
         $service->runIf(GenerateRssFeed::class, $this->canGenerateFeed());
         $service->runIf(GenerateSearch::class, $this->canGenerateSearch());
-        $service->runIf(GenerateBuildManifest::class, config('hyde.build_manifest', true));
 
         $service->runPostBuildTasks();
     }

--- a/packages/framework/src/Commands/HydeBuildStaticSiteCommand.php
+++ b/packages/framework/src/Commands/HydeBuildStaticSiteCommand.php
@@ -3,6 +3,7 @@
 namespace Hyde\Framework\Commands;
 
 use Exception;
+use Hyde\Framework\Actions\PostBuildTasks\GenerateBuildManifest;
 use Hyde\Framework\Actions\PostBuildTasks\GenerateRssFeed;
 use Hyde\Framework\Actions\PostBuildTasks\GenerateSearch;
 use Hyde\Framework\Actions\PostBuildTasks\GenerateSitemap;
@@ -118,6 +119,7 @@ class HydeBuildStaticSiteCommand extends Command
         $service->runIf(GenerateSitemap::class, $this->canGenerateSitemap());
         $service->runIf(GenerateRssFeed::class, $this->canGenerateFeed());
         $service->runIf(GenerateSearch::class, $this->canGenerateSearch());
+        $service->runIf(GenerateBuildManifest::class, config('hyde.build_manifest', true));
 
         $service->runPostBuildTasks();
     }

--- a/packages/framework/src/Services/BuildTaskService.php
+++ b/packages/framework/src/Services/BuildTaskService.php
@@ -33,7 +33,7 @@ class BuildTaskService
             $this->run($task);
         }
 
-        $this->runIf(GenerateBuildManifest::class, config('hyde.build_manifest', true));
+        $this->runIf(GenerateBuildManifest::class, config('hyde.generate_build_manifest', true));
     }
 
     public function getPostBuildTasks(): array

--- a/packages/framework/src/Services/BuildTaskService.php
+++ b/packages/framework/src/Services/BuildTaskService.php
@@ -2,6 +2,7 @@
 
 namespace Hyde\Framework\Services;
 
+use Hyde\Framework\Actions\PostBuildTasks\GenerateBuildManifest;
 use Hyde\Framework\Contracts\BuildTaskContract;
 use Hyde\Framework\Hyde;
 use Illuminate\Console\OutputStyle;
@@ -31,6 +32,8 @@ class BuildTaskService
         foreach ($this->getPostBuildTasks() as $task) {
             $this->run($task);
         }
+
+        $this->runIf(GenerateBuildManifest::class, config('hyde.build_manifest', true));
     }
 
     public function getPostBuildTasks(): array


### PR DESCRIPTION
## About
Adds a silent (as it takes less than 1ms) post-build task to generate a simple JSON manifest of the MD5 hashes of the source file and the compiled HTML file. This can then be used to see if a page needs to be recompiled. MD5 was chosen for its speed and size and I think it's fine for this use since it's not used for anything cryptographic. 

### Usage scenarion

This can be used to determine if a compiled page is up to date with the source file by comparing if the input and output hashes match.

## Configuration

The feature can be disabled in the configuration, as can output path. The defaults are seen below. They are not in the default config file, instead these are simply the fallback values internally.

```php
// config/hyde.php
'generate_build_manifest' => true,
'build_manifest_path' => 'storage/framework/cache/build-manifest.json,
```

## Example output

Here's the output for the base install, with formatted JSON

```json
[
  {
    "page": "_pages/404.blade.php",
    "input_hash": "7b547049190f6f1ce70dceddab794326",
    "output_hash": "968d221de7edfb39bfdcb4ffda9dbb0e"
  },
  {
    "page": "_pages/index.blade.php",
    "input_hash": "05e29782724141145bc81bc7bba6024c",
    "output_hash": "6d92038753099941300ace4340e0cc97"
  }
]
```