### PR TITLE
Rename Hyde method getSiteOutputPath to sitePath

### DIFF
--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -24,7 +24,7 @@
       <entry_point TYPE="phpMethod" FQNAME="\Hyde\Framework\HydeKernel getMarkdownPagePath" />
       <entry_point TYPE="phpMethod" FQNAME="\Hyde\Framework\HydeKernel getMarkdownPostPath" />
       <entry_point TYPE="phpMethod" FQNAME="\Hyde\Framework\HydeKernel getModelSourcePath" />
-      <entry_point TYPE="phpMethod" FQNAME="\Hyde\Framework\HydeKernel getSiteOutputPath" />
+      <entry_point TYPE="phpMethod" FQNAME="\Hyde\Framework\HydeKernel sitePath" />
       <entry_point TYPE="phpMethod" FQNAME="\Hyde\Framework\HydeKernel hasFeature" />
       <entry_point TYPE="phpMethod" FQNAME="\Hyde\Framework\HydeKernel hasSiteUrl" />
       <entry_point TYPE="phpMethod" FQNAME="\Hyde\Framework\HydeKernel image" />
@@ -57,7 +57,7 @@
     <pattern value="\Hyde\Framework\HydeKernel" member="getMarkdownPagePath" />
     <pattern value="\Hyde\Framework\HydeKernel" member="getMarkdownPostPath" />
     <pattern value="\Hyde\Framework\HydeKernel" member="getModelSourcePath" />
-    <pattern value="\Hyde\Framework\HydeKernel" member="getSiteOutputPath" />
+    <pattern value="\Hyde\Framework\HydeKernel" member="sitePath" />
     <pattern value="\Hyde\Framework\HydeKernel" member="hasFeature" />
     <pattern value="\Hyde\Framework\HydeKernel" member="hasSiteUrl" />
     <pattern value="\Hyde\Framework\HydeKernel" member="image" />

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -24,6 +24,7 @@ In general, these changes should only affect those who have written custom code 
 - Merged interface RouteFacadeContract into existing interface RouteContract
 - Renamed HydeBuildStaticSiteCommand to HydeBuildSiteCommand
 - Renamed legacy FileCacheService to ViewDiffService
+- Renamed method Hyde::getSiteOutputPath() to Hyde::sitePath()
 - Extracted all constructor methods in page schema traits to a new single trait ConstructPageSchemas
 - The StaticPageBuilder::$outputPath property is now a relative path instead of absolute
   

--- a/packages/framework/src/Actions/PostBuildTasks/GenerateBuildManifest.php
+++ b/packages/framework/src/Actions/PostBuildTasks/GenerateBuildManifest.php
@@ -29,7 +29,7 @@ class GenerateBuildManifest extends AbstractBuildTask
             $manifest->push([
                 'page' => $page->getSourcePath(),
                 'source_hash' => md5_file(Hyde::path($page->getSourcePath())),
-                'output_hash' => $this->hashOutputPath(Hyde::getSiteOutputPath($page->getOutputPath())),
+                'output_hash' => $this->hashOutputPath(Hyde::sitePath($page->getOutputPath())),
             ]);
         }
 

--- a/packages/framework/src/Actions/PostBuildTasks/GenerateRssFeed.php
+++ b/packages/framework/src/Actions/PostBuildTasks/GenerateRssFeed.php
@@ -13,7 +13,7 @@ class GenerateRssFeed extends AbstractBuildTask
     public function run(): void
     {
         file_put_contents(
-            Hyde::getSiteOutputPath(RssFeedService::getDefaultOutputFilename()),
+            Hyde::sitePath(RssFeedService::getDefaultOutputFilename()),
             RssFeedService::generateFeed()
         );
     }

--- a/packages/framework/src/Actions/PostBuildTasks/GenerateSitemap.php
+++ b/packages/framework/src/Actions/PostBuildTasks/GenerateSitemap.php
@@ -13,7 +13,7 @@ class GenerateSitemap extends AbstractBuildTask
     public function run(): void
     {
         file_put_contents(
-            Hyde::getSiteOutputPath('sitemap.xml'),
+            Hyde::sitePath('sitemap.xml'),
             SitemapService::generateSitemap()
         );
     }

--- a/packages/framework/src/Actions/StaticPageBuilder.php
+++ b/packages/framework/src/Actions/StaticPageBuilder.php
@@ -43,8 +43,8 @@ class StaticPageBuilder
         view()->share('currentPage', $this->page->getCurrentPagePath());
         view()->share('currentRoute', $this->page->getRoute());
 
-        $this->needsDirectory(Hyde::getSiteOutputPath());
-        $this->needsDirectory(dirname(Hyde::getSiteOutputPath($this->page->getOutputPath())));
+        $this->needsDirectory(Hyde::sitePath());
+        $this->needsDirectory(dirname(Hyde::sitePath($this->page->getOutputPath())));
 
         return $this->save($this->page->compile());
     }
@@ -57,7 +57,7 @@ class StaticPageBuilder
      */
     protected function save(string $contents): string
     {
-        $path = Hyde::getSiteOutputPath($this->page->getOutputPath());
+        $path = Hyde::sitePath($this->page->getOutputPath());
 
         file_put_contents($path, $contents);
 

--- a/packages/framework/src/Commands/HydeBuildSiteCommand.php
+++ b/packages/framework/src/Commands/HydeBuildSiteCommand.php
@@ -101,7 +101,7 @@ class HydeBuildSiteCommand extends Command
 
         if ($this->option('run-prettier')) {
             $this->runNodeCommand(
-                'npx prettier '.Hyde::pathToRelative(Hyde::getSiteOutputPath()).'/**/*.html --write --bracket-same-line',
+                'npx prettier '.Hyde::pathToRelative(Hyde::sitePath()).'/**/*.html --write --bracket-same-line',
                 'Prettifying code!',
                 'prettify code'
             );
@@ -135,7 +135,7 @@ class HydeBuildSiteCommand extends Command
         $this->info('Congratulations! 🎉 Your static site has been built!');
         $this->line(
             'Your new homepage is stored here -> '.
-            DiscoveryService::createClickableFilepath(Hyde::getSiteOutputPath('index.html'))
+            DiscoveryService::createClickableFilepath(Hyde::sitePath('index.html'))
         );
     }
 

--- a/packages/framework/src/Foundation/Concerns/ForwardsFilesystem.php
+++ b/packages/framework/src/Foundation/Concerns/ForwardsFilesystem.php
@@ -59,9 +59,9 @@ trait ForwardsFilesystem
         return $this->filesystem->getDocumentationPagePath($path);
     }
 
-    public function getSiteOutputPath(string $path = ''): string
+    public function sitePath(string $path = ''): string
     {
-        return $this->filesystem->getSiteOutputPath($path);
+        return $this->filesystem->sitePath($path);
     }
 
     public function pathToRelative(string $path): string

--- a/packages/framework/src/Foundation/Filesystem.php
+++ b/packages/framework/src/Foundation/Filesystem.php
@@ -148,7 +148,7 @@ class Filesystem
     /**
      * Get the absolute path to the compiled site directory, or a file within it.
      */
-    public function getSiteOutputPath(string $path = ''): string
+    public function sitePath(string $path = ''): string
     {
         if (empty($path)) {
             return Hyde::path(StaticPageBuilder::$outputPath);

--- a/packages/framework/src/Hyde.php
+++ b/packages/framework/src/Hyde.php
@@ -26,7 +26,7 @@ use Illuminate\Support\Facades\Facade;
  * @method static string getMarkdownPagePath(string $path = '')
  * @method static string getMarkdownPostPath(string $path = '')
  * @method static string getDocumentationPagePath(string $path = '')
- * @method static string getSiteOutputPath(string $path = '')
+ * @method static string sitePath(string $path = '')
  * @method static string formatHtmlPath(string $destination)
  * @method static string relativeLink(string $destination)
  * @method static string image(string $name, bool $preferQualifiedUrl = false)

--- a/packages/framework/src/Services/BuildService.php
+++ b/packages/framework/src/Services/BuildService.php
@@ -45,15 +45,15 @@ class BuildService
             $this->warn('Removing all files from build directory.');
 
             if ($this->isItSafeToCleanOutputDirectory()) {
-                array_map('unlink', glob(Hyde::getSiteOutputPath('*.{html,json}'), GLOB_BRACE));
-                File::cleanDirectory(Hyde::getSiteOutputPath('media'));
+                array_map('unlink', glob(Hyde::sitePath('*.{html,json}'), GLOB_BRACE));
+                File::cleanDirectory(Hyde::sitePath('media'));
             }
         }
     }
 
     public function transferMediaAssets(): void
     {
-        $this->needsDirectory(Hyde::getSiteOutputPath('media'));
+        $this->needsDirectory(Hyde::sitePath('media'));
 
         $collection = DiscoveryService::getMediaAssetFiles();
         $this->comment('Transferring Media Assets...');
@@ -61,7 +61,7 @@ class BuildService
         $this->withProgressBar(
             $collection,
             function ($filepath) {
-                copy($filepath, Hyde::getSiteOutputPath('media/'.basename($filepath)));
+                copy($filepath, Hyde::sitePath('media/'.basename($filepath)));
             }
         );
         $this->newLine(2);
@@ -118,7 +118,7 @@ class BuildService
     protected function isOutputDirectoryWhitelisted(): bool
     {
         return in_array(
-            basename(Hyde::getSiteOutputPath()),
+            basename(Hyde::sitePath()),
             config('hyde.safe_output_directories', ['_site', 'docs', 'build'])
         );
     }

--- a/packages/framework/src/Services/DocumentationSearchService.php
+++ b/packages/framework/src/Services/DocumentationSearchService.php
@@ -28,7 +28,7 @@ final class DocumentationSearchService
 
     public static function generateSearchPage(): string
     {
-        $outputDirectory = Hyde::getSiteOutputPath(DocumentationPage::getOutputDirectory());
+        $outputDirectory = Hyde::sitePath(DocumentationPage::getOutputDirectory());
         self::needsDirectory(($outputDirectory));
 
         file_put_contents(
@@ -42,7 +42,7 @@ final class DocumentationSearchService
     public function __construct()
     {
         $this->searchIndex = new Collection();
-        self::$filePath = Hyde::pathToRelative(Hyde::getSiteOutputPath(
+        self::$filePath = Hyde::pathToRelative(Hyde::sitePath(
             DocumentationPage::getOutputDirectory().'/search.json'
         ));
     }

--- a/packages/framework/tests/Feature/Foundation/FilesystemTest.php
+++ b/packages/framework/tests/Feature/Foundation/FilesystemTest.php
@@ -232,7 +232,7 @@ class FilesystemTest extends TestCase
     {
         $this->assertEquals(
             Hyde::path('_site'),
-            Hyde::getSiteOutputPath()
+            Hyde::sitePath()
         );
     }
 
@@ -240,7 +240,7 @@ class FilesystemTest extends TestCase
     {
         $this->assertEquals(
             Hyde::path('_site'.DIRECTORY_SEPARATOR.'foo.html'),
-            Hyde::getSiteOutputPath('foo.html')
+            Hyde::sitePath('foo.html')
         );
     }
 
@@ -248,7 +248,7 @@ class FilesystemTest extends TestCase
     {
         $this->assertEquals(
             Hyde::path('_site'),
-            Hyde::getSiteOutputPath()
+            Hyde::sitePath()
         );
     }
 
@@ -256,7 +256,7 @@ class FilesystemTest extends TestCase
     {
         $this->assertEquals(
             Hyde::path('_site'.DIRECTORY_SEPARATOR.'foo.html'),
-            Hyde::getSiteOutputPath('/foo.html/')
+            Hyde::sitePath('/foo.html/')
         );
     }
 

--- a/packages/framework/tests/Feature/HydeKernelTest.php
+++ b/packages/framework/tests/Feature/HydeKernelTest.php
@@ -189,7 +189,7 @@ class HydeKernelTest extends TestCase
         $this->assertEquals(Hyde::path('_pages'), Hyde::getMarkdownPagePath());
         $this->assertEquals(Hyde::path('_posts'), Hyde::getMarkdownPostPath());
         $this->assertEquals(Hyde::path('_docs'), Hyde::getDocumentationPagePath());
-        $this->assertEquals(Hyde::path('_site'), Hyde::getSiteOutputPath());
+        $this->assertEquals(Hyde::path('_site'), Hyde::sitePath());
     }
 
     public function test_path_to_relative_helper_returns_relative_path_for_given_path()


### PR DESCRIPTION
Makes the method less verbose, and in my option makes it cleared that it's an absolute path like Hyde::path and Hyde::vendorPath