### PR TITLE
Breaking: Rename AbstractPage to HydePage

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -11,6 +11,7 @@ In general, these changes should only affect those who have written custom code 
 - Adds a helper class to get an object representation of the front matter schemas and their supported types [#484](https://github.com/hydephp/develop/pull/484)
 
 ### Changed
+- Renamed base class AbstractPage to HydePage
 - Moved class StaticPageBuilder to Actions namespace
 - Moved class AbstractBuildTask to Concerns namespace
 - Moved class AbstractMarkdownPage to Concerns namespace

--- a/packages/framework/src/Actions/Constructors/FindsNavigationDataForPage.php
+++ b/packages/framework/src/Actions/Constructors/FindsNavigationDataForPage.php
@@ -2,7 +2,7 @@
 
 namespace Hyde\Framework\Actions\Constructors;
 
-use Hyde\Framework\Concerns\AbstractPage;
+use Hyde\Framework\Concerns\HydePage;
 use Hyde\Framework\Models\Pages\DocumentationPage;
 use Hyde\Framework\Models\Pages\MarkdownPost;
 use JetBrains\PhpStorm\ArrayShape;
@@ -15,12 +15,12 @@ use JetBrains\PhpStorm\ArrayShape;
 class FindsNavigationDataForPage
 {
     #[ArrayShape(['title' => 'string', 'hidden' => 'bool', 'priority' => 'int'])]
-    public static function run(AbstractPage $page): array
+    public static function run(HydePage $page): array
     {
         return (new static($page))->getData();
     }
 
-    final protected function __construct(protected AbstractPage $page)
+    final protected function __construct(protected HydePage $page)
     {
     }
 

--- a/packages/framework/src/Actions/Constructors/FindsNavigationDataForPage.php
+++ b/packages/framework/src/Actions/Constructors/FindsNavigationDataForPage.php
@@ -10,7 +10,7 @@ use JetBrains\PhpStorm\ArrayShape;
 /**
  * Finds the appropriate navigation data for a page.
  *
- * @see \Hyde\Framework\Testing\Feature\AbstractPageTest
+ * @see \Hyde\Framework\Testing\Feature\HydePageTest
  */
 class FindsNavigationDataForPage
 {

--- a/packages/framework/src/Actions/Constructors/FindsTitleForPage.php
+++ b/packages/framework/src/Actions/Constructors/FindsTitleForPage.php
@@ -3,7 +3,7 @@
 namespace Hyde\Framework\Actions\Constructors;
 
 use Hyde\Framework\Concerns\AbstractMarkdownPage;
-use Hyde\Framework\Concerns\AbstractPage;
+use Hyde\Framework\Concerns\HydePage;
 use Hyde\Framework\Hyde;
 
 /**
@@ -13,12 +13,12 @@ use Hyde\Framework\Hyde;
  */
 final class FindsTitleForPage
 {
-    public static function run(AbstractPage $page): string
+    public static function run(HydePage $page): string
     {
         return trim((new self($page))->findTitleForPage());
     }
 
-    protected function __construct(protected AbstractPage $page)
+    protected function __construct(protected HydePage $page)
     {
     }
 

--- a/packages/framework/src/Actions/PostBuildTasks/GenerateBuildManifest.php
+++ b/packages/framework/src/Actions/PostBuildTasks/GenerateBuildManifest.php
@@ -24,7 +24,7 @@ class GenerateBuildManifest extends AbstractBuildTask
     {
         $manifest = new Collection();
 
-        /** @var \Hyde\Framework\Concerns\AbstractPage $page */
+        /** @var \Hyde\Framework\Concerns\HydePage $page */
         foreach (Hyde::pages() as $page) {
             $manifest->push([
                 'page' => $page->getSourcePath(),

--- a/packages/framework/src/Actions/SourceFileParser.php
+++ b/packages/framework/src/Actions/SourceFileParser.php
@@ -3,7 +3,7 @@
 namespace Hyde\Framework\Actions;
 
 use Hyde\Framework\Concerns\AbstractMarkdownPage;
-use Hyde\Framework\Concerns\AbstractPage;
+use Hyde\Framework\Concerns\HydePage;
 use Hyde\Framework\Concerns\ValidatesExistence;
 use Hyde\Framework\Models\Pages\BladePage;
 use Hyde\Framework\Modules\Markdown\MarkdownFileParser;
@@ -23,7 +23,7 @@ class SourceFileParser
     use ValidatesExistence;
 
     protected string $identifier;
-    protected AbstractPage $page;
+    protected HydePage $page;
 
     public function __construct(string $pageClass, string $identifier)
     {
@@ -57,7 +57,7 @@ class SourceFileParser
         );
     }
 
-    public function get(): AbstractPage
+    public function get(): HydePage
     {
         return $this->page;
     }

--- a/packages/framework/src/Actions/StaticPageBuilder.php
+++ b/packages/framework/src/Actions/StaticPageBuilder.php
@@ -2,7 +2,7 @@
 
 namespace Hyde\Framework\Actions;
 
-use Hyde\Framework\Concerns\AbstractPage;
+use Hyde\Framework\Concerns\HydePage;
 use Hyde\Framework\Concerns\InteractsWithDirectories;
 use Hyde\Framework\Hyde;
 
@@ -21,10 +21,10 @@ class StaticPageBuilder
     /**
      * Construct the class.
      *
-     * @param  \Hyde\Framework\Concerns\AbstractPage  $page  the Page to compile into HTML
+     * @param  \Hyde\Framework\Concerns\HydePage  $page  the Page to compile into HTML
      * @param  bool  $selfInvoke  if set to true the class will invoke when constructed
      */
-    public function __construct(protected AbstractPage $page, bool $selfInvoke = false)
+    public function __construct(protected HydePage $page, bool $selfInvoke = false)
     {
         if ($selfInvoke) {
             $this->__invoke();

--- a/packages/framework/src/Concerns/AbstractMarkdownPage.php
+++ b/packages/framework/src/Concerns/AbstractMarkdownPage.php
@@ -13,16 +13,16 @@ use Hyde\Framework\Models\Markdown;
  *
  * Normally, you would use the SourceFileParser to construct a MarkdownPage object.
  *
- * Extends the AbstractPage class to provide relevant
+ * Extends the HydePage class to provide relevant
  * helpers for Markdown-based page model classes.
  *
  * @see \Hyde\Framework\Models\Pages\MarkdownPage
  * @see \Hyde\Framework\Models\Pages\MarkdownPost
  * @see \Hyde\Framework\Models\Pages\DocumentationPage
- * @see \Hyde\Framework\Concerns\AbstractPage
+ * @see \Hyde\Framework\Concerns\HydePage
  * @see \Hyde\Framework\Testing\Feature\AbstractPageTest
  */
-abstract class AbstractMarkdownPage extends AbstractPage implements MarkdownDocumentContract, MarkdownPageContract
+abstract class AbstractMarkdownPage extends HydePage implements MarkdownDocumentContract, MarkdownPageContract
 {
     public string $identifier;
     public Markdown $markdown;

--- a/packages/framework/src/Concerns/AbstractMarkdownPage.php
+++ b/packages/framework/src/Concerns/AbstractMarkdownPage.php
@@ -20,7 +20,7 @@ use Hyde\Framework\Models\Markdown;
  * @see \Hyde\Framework\Models\Pages\MarkdownPost
  * @see \Hyde\Framework\Models\Pages\DocumentationPage
  * @see \Hyde\Framework\Concerns\HydePage
- * @see \Hyde\Framework\Testing\Feature\AbstractPageTest
+ * @see \Hyde\Framework\Testing\Feature\HydePageTest
  */
 abstract class AbstractMarkdownPage extends HydePage implements MarkdownDocumentContract, MarkdownPageContract
 {

--- a/packages/framework/src/Concerns/HydePage.php
+++ b/packages/framework/src/Concerns/HydePage.php
@@ -25,7 +25,7 @@ use Hyde\Framework\Services\DiscoveryService;
  * and you can then access the parsed file from the HydeKernel's page index.
  *
  * @see \Hyde\Framework\Concerns\AbstractMarkdownPage
- * @see \Hyde\Framework\Testing\Feature\AbstractPageTest
+ * @see \Hyde\Framework\Testing\Feature\HydePageTest
  */
 abstract class HydePage implements CompilableContract, PageSchema
 {

--- a/packages/framework/src/Concerns/HydePage.php
+++ b/packages/framework/src/Concerns/HydePage.php
@@ -27,7 +27,7 @@ use Hyde\Framework\Services\DiscoveryService;
  * @see \Hyde\Framework\Concerns\AbstractMarkdownPage
  * @see \Hyde\Framework\Testing\Feature\AbstractPageTest
  */
-abstract class AbstractPage implements CompilableContract, PageSchema
+abstract class HydePage implements CompilableContract, PageSchema
 {
     use ConstructsPageSchemas;
 
@@ -94,7 +94,7 @@ abstract class AbstractPage implements CompilableContract, PageSchema
      *
      * @see \Hyde\Framework\Testing\Unit\PageModelParseHelperTest
      */
-    public static function parse(string $slug): AbstractPage
+    public static function parse(string $slug): HydePage
     {
         return (new SourceFileParser(static::class, $slug))->get();
     }
@@ -115,7 +115,7 @@ abstract class AbstractPage implements CompilableContract, PageSchema
     /**
      * Get a collection of all pages, parsed into page models.
      *
-     * @return \Hyde\Framework\Foundation\PageCollection<\Hyde\Framework\Concerns\AbstractPage
+     * @return \Hyde\Framework\Foundation\PageCollection<\Hyde\Framework\Concerns\HydePage
      *
      * @since v0.59.0-beta the returned collection is a PageCollection, and now includes the source file path as the array key
      * @see \Hyde\Framework\Testing\Unit\PageModelGetHelperTest

--- a/packages/framework/src/Concerns/RegistersFileLocations.php
+++ b/packages/framework/src/Concerns/RegistersFileLocations.php
@@ -19,15 +19,15 @@ trait RegistersFileLocations
      * Register the default source directories for the given page classes.
      * Location string should be relative to the root of the application.
      *
-     * @example registerSourceDirectories([AbstractPage::class => '_pages'])
+     * @example registerSourceDirectories([HydePage::class => '_pages'])
      *
-     * @param  array  $directoryMapping{class:  string<AbstractPage>, location: string}
+     * @param  array  $directoryMapping{class:  string<HydePage>, location: string}
      * @return void
      */
     protected function registerSourceDirectories(array $directoryMapping): void
     {
         foreach ($directoryMapping as $class => $location) {
-            /** @var AbstractPage $class */
+            /** @var HydePage $class */
             $class::$sourceDirectory = unslash($location);
         }
     }
@@ -38,15 +38,15 @@ trait RegistersFileLocations
      * However, some pages, like docs and posts are in subdirectories of the _site/ directory.
      * Location string should be relative to the root of the application.
      *
-     * @example registerOutputDirectories([AbstractPage::class => 'docs'])
+     * @example registerOutputDirectories([HydePage::class => 'docs'])
      *
-     * @param  array  $directoryMapping{class: string<AbstractPage>, location: string}
+     * @param  array  $directoryMapping{class: string<HydePage>, location: string}
      * @return void
      */
     protected function registerOutputDirectories(array $directoryMapping): void
     {
         foreach ($directoryMapping as $class => $location) {
-            /** @var AbstractPage $class */
+            /** @var HydePage $class */
             $class::$outputDirectory = unslash($location);
         }
     }

--- a/packages/framework/src/Concerns/ValidatesExistence.php
+++ b/packages/framework/src/Concerns/ValidatesExistence.php
@@ -19,7 +19,7 @@ trait ValidatesExistence
      */
     public function validateExistence(string $model, string $slug): void
     {
-        /** @var \Hyde\Framework\Concerns\AbstractPage $model */
+        /** @var \Hyde\Framework\Concerns\HydePage $model */
         $filepath = $model::getSourceDirectory().'/'.
             $slug.$model::getFileExtension();
 

--- a/packages/framework/src/Contracts/FrontMatter/PageSchema.php
+++ b/packages/framework/src/Contracts/FrontMatter/PageSchema.php
@@ -5,7 +5,7 @@ namespace Hyde\Framework\Contracts\FrontMatter;
 /**
  * The front matter properties supported by the following HydePHP page types and their children.
  *
- * @see \Hyde\Framework\Concerns\AbstractPage
+ * @see \Hyde\Framework\Concerns\HydePage
  */
 interface PageSchema
 {

--- a/packages/framework/src/Contracts/RouteContract.php
+++ b/packages/framework/src/Contracts/RouteContract.php
@@ -2,7 +2,7 @@
 
 namespace Hyde\Framework\Contracts;
 
-use Hyde\Framework\Concerns\AbstractPage;
+use Hyde\Framework\Concerns\HydePage;
 use Illuminate\Support\Collection;
 
 /**
@@ -13,23 +13,23 @@ interface RouteContract
     /**
      * Construct a new Route instance for the given page model.
      *
-     * @param  \Hyde\Framework\Concerns\AbstractPage  $sourceModel
+     * @param  \Hyde\Framework\Concerns\HydePage  $sourceModel
      */
-    public function __construct(AbstractPage $sourceModel);
+    public function __construct(HydePage $sourceModel);
 
     /**
      * Get the page type for the route.
      *
-     * @return class-string<\Hyde\Framework\Concerns\AbstractPage>
+     * @return class-string<\Hyde\Framework\Concerns\HydePage>
      */
     public function getPageType(): string;
 
     /**
      * Get the source model for the route.
      *
-     * @return \Hyde\Framework\Concerns\AbstractPage
+     * @return \Hyde\Framework\Concerns\HydePage
      */
-    public function getSourceModel(): AbstractPage;
+    public function getSourceModel(): HydePage;
 
     /**
      * Get the unique route key for the route.
@@ -107,12 +107,12 @@ interface RouteContract
     /**
      * Get a route from the Router index for the supplied page model.
      *
-     * @param  \Hyde\Framework\Concerns\AbstractPage  $page
+     * @param  \Hyde\Framework\Concerns\HydePage  $page
      * @return \Hyde\Framework\Contracts\RouteContract
      *
      * @throws \Hyde\Framework\Exceptions\RouteNotFoundException
      */
-    public static function getFromModel(AbstractPage $page): RouteContract;
+    public static function getFromModel(HydePage $page): RouteContract;
 
     /**
      * Get all routes from the Router index.

--- a/packages/framework/src/Foundation/FileCollection.php
+++ b/packages/framework/src/Foundation/FileCollection.php
@@ -2,7 +2,7 @@
 
 namespace Hyde\Framework\Foundation;
 
-use Hyde\Framework\Concerns\AbstractPage;
+use Hyde\Framework\Concerns\HydePage;
 use Hyde\Framework\Foundation\Concerns\BaseFoundationCollection;
 use Hyde\Framework\Helpers\Features;
 use Hyde\Framework\Models\File;
@@ -66,7 +66,7 @@ final class FileCollection extends BaseFoundationCollection
         return $this;
     }
 
-    /** @param string<AbstractPage> $pageClass */
+    /** @param string<HydePage> $pageClass */
     protected function discoverFilesFor(string $pageClass): void
     {
         // Scan the source directory, and directories therein, for files that match the model's file extension.

--- a/packages/framework/src/Foundation/PageCollection.php
+++ b/packages/framework/src/Foundation/PageCollection.php
@@ -2,7 +2,7 @@
 
 namespace Hyde\Framework\Foundation;
 
-use Hyde\Framework\Concerns\AbstractPage;
+use Hyde\Framework\Concerns\HydePage;
 use Hyde\Framework\Exceptions\FileNotFoundException;
 use Hyde\Framework\Foundation\Concerns\BaseFoundationCollection;
 use Hyde\Framework\Helpers\Features;
@@ -18,14 +18,14 @@ use Illuminate\Support\Collection;
  */
 final class PageCollection extends BaseFoundationCollection
 {
-    public function getPage(string $sourcePath): AbstractPage
+    public function getPage(string $sourcePath): HydePage
     {
         return $this->items[$sourcePath] ?? throw new FileNotFoundException($sourcePath.' in page collection');
     }
 
     public function getPages(?string $pageClass = null): self
     {
-        return ! $pageClass ? $this : $this->filter(function (AbstractPage $page) use ($pageClass): bool {
+        return ! $pageClass ? $this : $this->filter(function (HydePage $page) use ($pageClass): bool {
             return $page instanceof $pageClass;
         });
     }
@@ -59,14 +59,14 @@ final class PageCollection extends BaseFoundationCollection
     }
 
     /**
-     * @param  string<\Hyde\Framework\Concerns\AbstractPage>  $pageClass
-     * @return \Illuminate\Support\Collection<\Hyde\Framework\Concerns\AbstractPage>
+     * @param  string<\Hyde\Framework\Concerns\HydePage>  $pageClass
+     * @return \Illuminate\Support\Collection<\Hyde\Framework\Concerns\HydePage>
      */
     protected function parsePagesFor(string $pageClass): Collection
     {
         $collection = new Collection();
 
-        /** @var AbstractPage $pageClass */
+        /** @var HydePage $pageClass */
         foreach ($pageClass::files() as $basename) {
             $collection->push($pageClass::parse($basename));
         }
@@ -74,7 +74,7 @@ final class PageCollection extends BaseFoundationCollection
         return $collection;
     }
 
-    protected function discover(AbstractPage $page): self
+    protected function discover(HydePage $page): self
     {
         // Create a new route for the given page, and add it to the index.
         $this->put($page->getSourcePath(), $page);

--- a/packages/framework/src/Foundation/RouteCollection.php
+++ b/packages/framework/src/Foundation/RouteCollection.php
@@ -2,7 +2,7 @@
 
 namespace Hyde\Framework\Foundation;
 
-use Hyde\Framework\Concerns\AbstractPage;
+use Hyde\Framework\Concerns\HydePage;
 use Hyde\Framework\Contracts\RouteContract;
 use Hyde\Framework\Foundation\Concerns\BaseFoundationCollection;
 use Hyde\Framework\Models\Route;
@@ -50,7 +50,7 @@ final class RouteCollection extends BaseFoundationCollection
         return $this;
     }
 
-    protected function discover(AbstractPage $page): self
+    protected function discover(HydePage $page): self
     {
         // Create a new route for the given page, and add it to the index.
         $this->addRoute(new Route($page));
@@ -60,7 +60,7 @@ final class RouteCollection extends BaseFoundationCollection
 
     protected function runDiscovery(): self
     {
-        $this->kernel->pages()->each(function (AbstractPage $page) {
+        $this->kernel->pages()->each(function (HydePage $page) {
             $this->discover($page);
         });
 

--- a/packages/framework/src/Models/File.php
+++ b/packages/framework/src/Models/File.php
@@ -25,13 +25,13 @@ class File implements Arrayable, \JsonSerializable, \Stringable
     /**
      * If the file is associated with a page, the class can be specified here.
      *
-     * @var string<\Hyde\Framework\Concerns\AbstractPage>|null
+     * @var string<\Hyde\Framework\Concerns\HydePage>|null
      */
     public ?string $belongsTo = null;
 
     /**
      * @param  string  $path  The path relative to the project root.
-     * @param  string<\Hyde\Framework\Concerns\AbstractPage>|null  $belongsToClass
+     * @param  string<\Hyde\Framework\Concerns\HydePage>|null  $belongsToClass
      * @return \Hyde\Framework\Models\File
      */
     public static function make(string $path, ?string $belongsToClass = null): static
@@ -41,7 +41,7 @@ class File implements Arrayable, \JsonSerializable, \Stringable
 
     /**
      * @param  string  $path  The path relative to the project root.
-     * @param  string<\Hyde\Framework\Concerns\AbstractPage>|null  $belongsToClass
+     * @param  string<\Hyde\Framework\Concerns\HydePage>|null  $belongsToClass
      */
     public function __construct(string $path, ?string $belongsToClass = null)
     {
@@ -61,7 +61,7 @@ class File implements Arrayable, \JsonSerializable, \Stringable
      * Supply a page class to associate with this file,
      * or leave blank to get the file's associated class.
      *
-     * @param  string<\Hyde\Framework\Concerns\AbstractPage>|null  $class
+     * @param  string<\Hyde\Framework\Concerns\HydePage>|null  $class
      * @return string|$this|null
      */
     public function belongsTo(?string $class = null): null|string|static

--- a/packages/framework/src/Models/Metadata/Metadata.php
+++ b/packages/framework/src/Models/Metadata/Metadata.php
@@ -2,7 +2,7 @@
 
 namespace Hyde\Framework\Models\Metadata;
 
-use Hyde\Framework\Concerns\AbstractPage;
+use Hyde\Framework\Concerns\HydePage;
 use Hyde\Framework\Contracts\MetadataItemContract;
 use Hyde\Framework\Helpers\Features;
 use Hyde\Framework\Helpers\Meta;
@@ -15,14 +15,14 @@ use Hyde\Framework\Services\RssFeedService;
  */
 class Metadata
 {
-    protected AbstractPage $page;
+    protected HydePage $page;
 
     public array $links = [];
     public array $metadata = [];
     public array $properties = [];
     public array $generics = [];
 
-    public function __construct(AbstractPage $page)
+    public function __construct(HydePage $page)
     {
         $this->page = $page;
         $this->generate();
@@ -79,7 +79,7 @@ class Metadata
         $this->addDynamicPageMetadata($this->page);
     }
 
-    protected function addDynamicPageMetadata(AbstractPage $page): void
+    protected function addDynamicPageMetadata(HydePage $page): void
     {
         if ($page->has('canonicalUrl')) {
             $this->add(Meta::link('canonical', $page->get('canonicalUrl')));

--- a/packages/framework/src/Models/Navigation/NavItem.php
+++ b/packages/framework/src/Models/Navigation/NavItem.php
@@ -2,7 +2,7 @@
 
 namespace Hyde\Framework\Models\Navigation;
 
-use Hyde\Framework\Concerns\AbstractPage;
+use Hyde\Framework\Concerns\HydePage;
 use Hyde\Framework\Contracts\RouteContract;
 use Hyde\Framework\Hyde;
 use Illuminate\Support\Str;
@@ -91,7 +91,7 @@ class NavItem implements \Stringable
     /**
      * Check if the NavItem instance is the current page.
      */
-    public function isCurrent(?AbstractPage $current = null): bool
+    public function isCurrent(?HydePage $current = null): bool
     {
         if ($current === null) {
             $current = Hyde::currentRoute()->getSourceModel();

--- a/packages/framework/src/Models/Pages/BladePage.php
+++ b/packages/framework/src/Models/Pages/BladePage.php
@@ -2,13 +2,13 @@
 
 namespace Hyde\Framework\Models\Pages;
 
-use Hyde\Framework\Concerns\AbstractPage;
+use Hyde\Framework\Concerns\HydePage;
 use Hyde\Framework\Models\FrontMatter;
 
 /**
  * A basic wrapper for the custom Blade View compiler.
  */
-class BladePage extends AbstractPage
+class BladePage extends HydePage
 {
     /**
      * The name of the Blade View to compile. Commonly stored in _pages/{$identifier}.blade.php.

--- a/packages/framework/src/Models/Route.php
+++ b/packages/framework/src/Models/Route.php
@@ -2,7 +2,7 @@
 
 namespace Hyde\Framework\Models;
 
-use Hyde\Framework\Concerns\AbstractPage;
+use Hyde\Framework\Concerns\HydePage;
 use Hyde\Framework\Concerns\JsonSerializesArrayable;
 use Hyde\Framework\Contracts\RouteContract;
 use Hyde\Framework\Exceptions\RouteNotFoundException;
@@ -20,9 +20,9 @@ class Route implements RouteContract, \Stringable, \JsonSerializable, Arrayable
     /**
      * The source model for the route.
      *
-     * @var \Hyde\Framework\Concerns\AbstractPage
+     * @var \Hyde\Framework\Concerns\HydePage
      */
-    protected AbstractPage $sourceModel;
+    protected HydePage $sourceModel;
 
     /**
      * The unique route key for the route.
@@ -32,7 +32,7 @@ class Route implements RouteContract, \Stringable, \JsonSerializable, Arrayable
     protected string $routeKey;
 
     /** @inheritDoc */
-    public function __construct(AbstractPage $sourceModel)
+    public function __construct(HydePage $sourceModel)
     {
         $this->sourceModel = $sourceModel;
         $this->routeKey = $sourceModel->getRouteKey();
@@ -67,7 +67,7 @@ class Route implements RouteContract, \Stringable, \JsonSerializable, Arrayable
     }
 
     /** @inheritDoc */
-    public function getSourceModel(): AbstractPage
+    public function getSourceModel(): HydePage
     {
         return $this->sourceModel;
     }
@@ -117,7 +117,7 @@ class Route implements RouteContract, \Stringable, \JsonSerializable, Arrayable
     }
 
     /** @inheritDoc */
-    public static function getFromModel(AbstractPage $page): RouteContract
+    public static function getFromModel(HydePage $page): RouteContract
     {
         return $page->getRoute();
     }

--- a/packages/framework/src/Services/BuildService.php
+++ b/packages/framework/src/Services/BuildService.php
@@ -68,7 +68,7 @@ class BuildService
     }
 
     /**
-     * @return \Hyde\Framework\Foundation\RouteCollection<array-key, class-string<\Hyde\Framework\Concerns\AbstractPage>>
+     * @return \Hyde\Framework\Foundation\RouteCollection<array-key, class-string<\Hyde\Framework\Concerns\HydePage>>
      */
     protected function getDiscoveredModels(): RouteCollection
     {

--- a/packages/framework/src/Services/DiscoveryService.php
+++ b/packages/framework/src/Services/DiscoveryService.php
@@ -2,7 +2,7 @@
 
 namespace Hyde\Framework\Services;
 
-use Hyde\Framework\Concerns\AbstractPage;
+use Hyde\Framework\Concerns\HydePage;
 use Hyde\Framework\Exceptions\UnsupportedPageTypeException;
 use Hyde\Framework\Hyde;
 use Hyde\Framework\Models\File;
@@ -27,7 +27,7 @@ class DiscoveryService
     /**
      * Supply a model::class constant and get a list of all the existing source file base names.
      *
-     * @param  string<\Hyde\Framework\Concerns\AbstractPage>  $model
+     * @param  string<\Hyde\Framework\Concerns\HydePage>  $model
      * @return array
      *
      * @throws \Hyde\Framework\Exceptions\UnsupportedPageTypeException
@@ -36,7 +36,7 @@ class DiscoveryService
      */
     public static function getSourceFileListForModel(string $model): array
     {
-        if (! class_exists($model) || ! is_subclass_of($model, AbstractPage::class)) {
+        if (! class_exists($model) || ! is_subclass_of($model, HydePage::class)) {
             throw new UnsupportedPageTypeException($model);
         }
 
@@ -50,13 +50,13 @@ class DiscoveryService
 
     public static function getModelFileExtension(string $model): string
     {
-        /** @var \Hyde\Framework\Concerns\AbstractPage $model */
+        /** @var \Hyde\Framework\Concerns\HydePage $model */
         return $model::getFileExtension();
     }
 
     public static function getModelSourceDirectory(string $model): string
     {
-        /** @var \Hyde\Framework\Concerns\AbstractPage $model */
+        /** @var \Hyde\Framework\Concerns\HydePage $model */
         return $model::getSourceDirectory();
     }
 
@@ -92,7 +92,7 @@ class DiscoveryService
     /**
      * Create a filepath that can be opened in the browser from a terminal.
      *
-     * @param  string<\Hyde\Framework\Concerns\AbstractPage>  $filepath
+     * @param  string<\Hyde\Framework\Concerns\HydePage>  $filepath
      * @return string
      */
     public static function createClickableFilepath(string $filepath): string
@@ -110,7 +110,7 @@ class DiscoveryService
 
     public static function formatSlugForModel(string $model, string $filepath): string
     {
-        /** @var AbstractPage $model */
+        /** @var HydePage $model */
         $slug = str_replace(Hyde::path($model::$sourceDirectory), '', $filepath);
 
         if (str_ends_with($slug, $model::$fileExtension)) {

--- a/packages/framework/tests/Feature/AbstractPageTest.php
+++ b/packages/framework/tests/Feature/AbstractPageTest.php
@@ -3,7 +3,7 @@
 namespace Hyde\Framework\Testing\Feature;
 
 use Hyde\Framework\Concerns\AbstractMarkdownPage;
-use Hyde\Framework\Concerns\AbstractPage;
+use Hyde\Framework\Concerns\HydePage;
 use Hyde\Framework\Hyde;
 use Hyde\Framework\Models\Markdown;
 use Hyde\Framework\Models\Pages\BladePage;
@@ -14,13 +14,13 @@ use Hyde\Framework\Models\Route;
 use Hyde\Testing\TestCase;
 
 /**
- * Test the AbstractPage class.
+ * Test the HydePage class.
  *
  * Since the class is abstract, we can't test it directly,
  * so we will use the MarkdownPage class as a proxy,
  * since it's the simplest implementation.
  *
- * @covers \Hyde\Framework\Concerns\AbstractPage
+ * @covers \Hyde\Framework\Concerns\HydePage
  * @covers \Hyde\Framework\Concerns\AbstractMarkdownPage
  * @covers \Hyde\Framework\Actions\Constructors\FindsNavigationDataForPage
  * @covers \Hyde\Framework\Concerns\ConstructsPageSchemas
@@ -188,7 +188,7 @@ class AbstractPageTest extends TestCase
 
     public function test_markdown_page_implements_page_contract()
     {
-        $this->assertInstanceOf(AbstractPage::class, new MarkdownPage());
+        $this->assertInstanceOf(HydePage::class, new MarkdownPage());
     }
 
     public function test_all_page_models_extend_abstract_page()
@@ -200,10 +200,10 @@ class AbstractPageTest extends TestCase
         ];
 
         foreach ($pages as $page) {
-            $this->assertInstanceOf(AbstractPage::class, new $page());
+            $this->assertInstanceOf(HydePage::class, new $page());
         }
 
-        $this->assertInstanceOf(AbstractPage::class, new BladePage('foo'));
+        $this->assertInstanceOf(HydePage::class, new BladePage('foo'));
     }
 
     public function test_all_page_models_have_configured_source_directory()
@@ -250,12 +250,12 @@ class AbstractPageTest extends TestCase
 
     public function test_abstract_markdown_page_extends_abstract_page()
     {
-        $this->assertInstanceOf(AbstractPage::class, $this->mock(AbstractMarkdownPage::class));
+        $this->assertInstanceOf(HydePage::class, $this->mock(AbstractMarkdownPage::class));
     }
 
     public function test_abstract_markdown_page_implements_page_contract()
     {
-        $this->assertInstanceOf(AbstractPage::class, $this->mock(AbstractMarkdownPage::class));
+        $this->assertInstanceOf(HydePage::class, $this->mock(AbstractMarkdownPage::class));
     }
 
     public function test_abstract_markdown_page_has_markdown_document_property()

--- a/packages/framework/tests/Feature/HydePageTest.php
+++ b/packages/framework/tests/Feature/HydePageTest.php
@@ -25,7 +25,7 @@ use Hyde\Testing\TestCase;
  * @covers \Hyde\Framework\Actions\Constructors\FindsNavigationDataForPage
  * @covers \Hyde\Framework\Concerns\ConstructsPageSchemas
  */
-class AbstractPageTest extends TestCase
+class HydePageTest extends TestCase
 {
     protected function tearDown(): void
     {

--- a/packages/framework/tests/Feature/MetadataTest.php
+++ b/packages/framework/tests/Feature/MetadataTest.php
@@ -2,7 +2,7 @@
 
 namespace Hyde\Framework\Testing\Feature;
 
-use Hyde\Framework\Concerns\AbstractPage;
+use Hyde\Framework\Concerns\HydePage;
 use Hyde\Framework\Helpers\Meta;
 use Hyde\Framework\Models\Metadata\LinkItem;
 use Hyde\Framework\Models\Metadata\Metadata;
@@ -30,7 +30,7 @@ class MetadataTest extends TestCase
         config(['site.generate_sitemap' => false]);
     }
 
-    protected function assertPageHasMetadata(AbstractPage $page, string $metadata)
+    protected function assertPageHasMetadata(HydePage $page, string $metadata)
     {
         $this->assertStringContainsString(
             $metadata,
@@ -38,7 +38,7 @@ class MetadataTest extends TestCase
         );
     }
 
-    protected function assertPageDoesNotHaveMetadata(AbstractPage $page, string $metadata)
+    protected function assertPageDoesNotHaveMetadata(HydePage $page, string $metadata)
     {
         $this->assertStringNotContainsString(
             $metadata,

--- a/packages/framework/tests/Unit/NavItemTest.php
+++ b/packages/framework/tests/Unit/NavItemTest.php
@@ -2,7 +2,7 @@
 
 namespace Hyde\Framework\Testing\Unit;
 
-use Hyde\Framework\Concerns\AbstractPage;
+use Hyde\Framework\Concerns\HydePage;
 use Hyde\Framework\Contracts\RouteContract;
 use Hyde\Framework\Models\Navigation\NavItem;
 use Hyde\Framework\Models\Route;
@@ -19,7 +19,7 @@ class NavItemTest extends TestCase
     public function test__construct()
     {
         $route = $this->createMock(RouteContract::class);
-        $route->method('getSourceModel')->willReturn($this->createMock(AbstractPage::class));
+        $route->method('getSourceModel')->willReturn($this->createMock(HydePage::class));
         $route->method('getLink')->willReturn('/');
 
         $item = new NavItem($route, 'Test', 500, true);

--- a/packages/framework/tests/Unit/PageModelGetAllFilesHelperTest.php
+++ b/packages/framework/tests/Unit/PageModelGetAllFilesHelperTest.php
@@ -10,7 +10,7 @@ use Hyde\Framework\Models\Pages\MarkdownPost;
 use Hyde\Testing\TestCase;
 
 /**
- * @see \Hyde\Framework\Concerns\AbstractPage::files()
+ * @see \Hyde\Framework\Concerns\HydePage::files()
  */
 class PageModelGetAllFilesHelperTest extends TestCase
 {

--- a/packages/framework/tests/Unit/PageModelGetHelperTest.php
+++ b/packages/framework/tests/Unit/PageModelGetHelperTest.php
@@ -11,7 +11,7 @@ use Hyde\Testing\TestCase;
 use Illuminate\Support\Collection;
 
 /**
- * @see \Hyde\Framework\Concerns\AbstractPage::all()
+ * @see \Hyde\Framework\Concerns\HydePage::all()
  */
 class PageModelGetHelperTest extends TestCase
 {

--- a/packages/framework/tests/Unit/PageModelParseHelperTest.php
+++ b/packages/framework/tests/Unit/PageModelParseHelperTest.php
@@ -10,7 +10,7 @@ use Hyde\Framework\Models\Pages\MarkdownPost;
 use Hyde\Testing\TestCase;
 
 /**
- * @covers \Hyde\Framework\Concerns\AbstractPage::parse
+ * @covers \Hyde\Framework\Concerns\HydePage::parse
  */
 class PageModelParseHelperTest extends TestCase
 {

--- a/packages/realtime-compiler/src/Routing/PageRouter.php
+++ b/packages/realtime-compiler/src/Routing/PageRouter.php
@@ -5,7 +5,7 @@ namespace Hyde\RealtimeCompiler\Routing;
 use Desilva\Microserve\Request;
 use Desilva\Microserve\Response;
 use Hyde\Framework\Actions\StaticPageBuilder;
-use Hyde\Framework\Concerns\AbstractPage;
+use Hyde\Framework\Concerns\HydePage;
 use Hyde\Framework\Models\Route;
 use Hyde\RealtimeCompiler\Concerns\InteractsWithLaravel;
 use Hyde\RealtimeCompiler\Concerns\SendsErrorResponses;
@@ -55,7 +55,7 @@ class PageRouter
         return ltrim($path, '/');
     }
 
-    protected function getHtml(AbstractPage $page): string
+    protected function getHtml(HydePage $page): string
     {
         return file_get_contents((new StaticPageBuilder($page))->__invoke());
     }

--- a/packages/testing/src/TestCase.php
+++ b/packages/testing/src/TestCase.php
@@ -3,7 +3,7 @@
 namespace Hyde\Testing;
 
 use Hyde\Framework\Actions\ConvertsArrayToFrontMatter;
-use Hyde\Framework\Concerns\AbstractPage;
+use Hyde\Framework\Concerns\HydePage;
 use Hyde\Framework\Hyde;
 use Hyde\Framework\Models\Pages\MarkdownPage;
 use Hyde\Framework\Models\Route;
@@ -58,7 +58,7 @@ abstract class TestCase extends BaseTestCase
     }
 
     /** @internal */
-    protected function mockPage(?AbstractPage $page = null, ?string $currentPage = null)
+    protected function mockPage(?HydePage $page = null, ?string $currentPage = null)
     {
         view()->share('page', $page ?? new MarkdownPage());
         view()->share('currentPage', $currentPage ?? 'PHPUnit');


### PR DESCRIPTION
Renames the `Hyde\Framework\Concerns\AbstractPage` class to `Hyde\Framework\Concerns\HydePage`