### PR TITLE
Change CSS identifier class 'sidebar-category' to 'sidebar-group'

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -53,6 +53,9 @@ This change also bubbles to the HydePage accessors, though that will only affect
 - Refactored how navigation and sidebar data are handled, unifying the API, see below for more details
 - The algorithm for finding the navigation and sidebar orders has been updated, this may affect the order of your pages, and may require you to re-tweak any custom priorities.
 - The navigation link to documentation index page now has default priority 500 instead of 100
+- Changed Blade component identifier class 'sidebar-category' to 'sidebar-group'
+- Changed Blade component identifier class 'sidebar-category-heading' to 'sidebar-group-heading'
+- Changed Blade component identifier class 'sidebar-category-list' to 'sidebar-group-list'
 - internal: Move responsibility for filtering documentation pages to the navigation menus (this means that documentation pages that are not 'index' are no longer regarded as hidden)
 - internal: The HydePage::$navigation property is now a NavigationData object instead of an array, however the object extends ArrayObject, so it should be mostly compatible with existing code
 

--- a/packages/framework/resources/views/components/docs/grouped-sidebar-navigation.blade.php
+++ b/packages/framework/resources/views/components/docs/grouped-sidebar-navigation.blade.php
@@ -1,8 +1,8 @@
 <ul id="sidebar-navigation" role="list">
 	@foreach ($sidebar->getGroups() as $group)
-	<li class="sidebar-category mb-4 mt-4 first:mt-0" role="listitem">
-		<h4 class="sidebar-category-heading text-base font-semibold mb-2 -ml-1">{{ Hyde::makeTitle($group) }}</h4>
-		<ul class="sidebar-category-list ml-4" role="list">
+	<li class="sidebar-group mb-4 mt-4 first:mt-0" role="listitem">
+		<h4 class="sidebar-group-heading text-base font-semibold mb-2 -ml-1">{{ Hyde::makeTitle($group) }}</h4>
+		<ul class="sidebar-group-list ml-4" role="list">
 			@foreach ($sidebar->getItemsInGroup($group) as $item)
 				<x-hyde::docs.grouped-sidebar-item :item="$item" :active="$item->route->getRouteKey() === $currentRoute->getRouteKey()" />
 			@endforeach

--- a/tests/Browser/HighLevelViewTest.php
+++ b/tests/Browser/HighLevelViewTest.php
@@ -176,10 +176,10 @@ date: 2022-01-01 12:00
                 ->assertSee('Page1')
                 ->assertSee('Page2')
                 ->assertSee('Page3')
-                ->assertAttributeContains('#sidebar-navigation > li', 'class', 'sidebar-category')
-                ->assertSeeIn('#sidebar-navigation > li:nth-child(1) > h4.sidebar-category-heading', 'Group 1')
+                ->assertAttributeContains('#sidebar-navigation > li', 'class', 'sidebar-group')
+                ->assertSeeIn('#sidebar-navigation > li:nth-child(1) > h4.sidebar-group-heading', 'Group 1')
                 ->assertAriaAttribute('#sidebar-navigation > li:nth-child(1) > ul > li.sidebar-navigation-item.active > a', 'current', 'true')
-                ->assertSeeIn('#sidebar-navigation > li:nth-child(2) > h4.sidebar-category-heading', 'Other')
+                ->assertSeeIn('#sidebar-navigation > li:nth-child(2) > h4.sidebar-group-heading', 'Other')
                 ->screenshot('docs/with_grouped_sidebar_pages')
                 ->storeSourceAsHtml('docs/with_grouped_sidebar_pages');
         });


### PR DESCRIPTION
These classes are internally only used for Dusk testing, but adds a semantic CSS hook that should be renamed according to https://github.com/hydephp/develop/pull/498

- Changed Blade component identifier class 'sidebar-category' to 'sidebar-group'
- Changed Blade component identifier class 'sidebar-category-heading' to 'sidebar-group-heading'
- Changed Blade component identifier class 'sidebar-category-list' to 'sidebar-group-list'