### PR TITLE
Breaking unification of URL-related methods and variables

### DIFF
--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -18,7 +18,7 @@
       <entry_point TYPE="phpMethod" FQNAME="\Hyde\Framework\HydeKernel __construct" />
       <entry_point TYPE="phpMethod" FQNAME="\Hyde\Framework\HydeKernel currentRoute" />
       <entry_point TYPE="phpMethod" FQNAME="\Hyde\Framework\HydeKernel features" />
-      <entry_point TYPE="phpMethod" FQNAME="\Hyde\Framework\HydeKernel formatHtmlPath" />
+      <entry_point TYPE="phpMethod" FQNAME="\Hyde\Framework\HydeKernel formatLink" />
       <entry_point TYPE="phpMethod" FQNAME="\Hyde\Framework\HydeKernel getBladePagePath" />
       <entry_point TYPE="phpMethod" FQNAME="\Hyde\Framework\HydeKernel getDocumentationPagePath" />
       <entry_point TYPE="phpMethod" FQNAME="\Hyde\Framework\HydeKernel getMarkdownPagePath" />
@@ -51,7 +51,7 @@
     <pattern value="\Hyde\Framework\HydeKernel" member="__construct" />
     <pattern value="\Hyde\Framework\HydeKernel" member="currentRoute" />
     <pattern value="\Hyde\Framework\HydeKernel" member="features" />
-    <pattern value="\Hyde\Framework\HydeKernel" member="formatHtmlPath" />
+    <pattern value="\Hyde\Framework\HydeKernel" member="formatLink" />
     <pattern value="\Hyde\Framework\HydeKernel" member="getBladePagePath" />
     <pattern value="\Hyde\Framework\HydeKernel" member="getDocumentationPagePath" />
     <pattern value="\Hyde\Framework\HydeKernel" member="getMarkdownPagePath" />

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -70,6 +70,7 @@ This change also bubbles to the HydePage accessors, though that will only affect
 - Renamed command class HydeBuildStaticSiteCommand to HydeBuildSiteCommand
 - Renamed legacy class FileCacheService to ViewDiffService
 - Renamed method `Hyde::getSiteOutputPath()` to `Hyde::sitePath()`
+- Renamed method `Hyde::formatHtmlPath()` to `Hyde::formatLink()`
 
 #### Namespace changes
 - Moved class StaticPageBuilder to Actions namespace

--- a/packages/framework/resources/views/components/article-excerpt.blade.php
+++ b/packages/framework/resources/views/components/article-excerpt.blade.php
@@ -9,7 +9,7 @@
     @endif
 
     <header>
-        <a href="posts/{{ Hyde::formatHtmlPath($post->identifier . '.html') }}" class="block w-fit">
+        <a href="posts/{{ Hyde::formatLink($post->identifier . '.html') }}" class="block w-fit">
             <h2 class="text-2xl font-bold text-gray-700 hover:text-gray-900 dark:text-gray-200 dark:hover:text-white transition-colors duration-75">
                 {{ $post->get('title') ?? $post->title }}
             </h2>
@@ -42,7 +42,7 @@
     @endisset
 
     <footer>
-        <a href="posts/{{ Hyde::formatHtmlPath($post->identifier . '.html') }}"
+        <a href="posts/{{ Hyde::formatLink($post->identifier . '.html') }}"
            class="text-indigo-500 hover:underline font-medium">
             Read post</a>
     </footer>

--- a/packages/framework/src/Concerns/HydePage.php
+++ b/packages/framework/src/Concerns/HydePage.php
@@ -192,7 +192,7 @@ abstract class HydePage implements CompilableContract, PageSchema
     /**
      * Format the page instance to a URL path (relative to site root) with support for pretty URLs if enabled.
      */
-    public function getUriPath(): string
+    public function getLink(): string
     {
         return Hyde::formatLink($this->getOutputPath());
     }

--- a/packages/framework/src/Concerns/HydePage.php
+++ b/packages/framework/src/Concerns/HydePage.php
@@ -194,7 +194,7 @@ abstract class HydePage implements CompilableContract, PageSchema
      */
     public function getUriPath(): string
     {
-        return Hyde::formatHtmlPath($this->getOutputPath());
+        return Hyde::formatLink($this->getOutputPath());
     }
 
     // Section: Getters

--- a/packages/framework/src/Foundation/Concerns/ForwardsHyperlinks.php
+++ b/packages/framework/src/Foundation/Concerns/ForwardsHyperlinks.php
@@ -9,7 +9,7 @@ namespace Hyde\Framework\Foundation\Concerns;
  */
 trait ForwardsHyperlinks
 {
-    public function formatHtmlPath(string $destination): string
+    public function formatLink(string $destination): string
     {
         return $this->hyperlinks->formatLink($destination);
     }

--- a/packages/framework/src/Foundation/Concerns/ForwardsHyperlinks.php
+++ b/packages/framework/src/Foundation/Concerns/ForwardsHyperlinks.php
@@ -11,7 +11,7 @@ trait ForwardsHyperlinks
 {
     public function formatHtmlPath(string $destination): string
     {
-        return $this->hyperlinks->formatHtmlPath($destination);
+        return $this->hyperlinks->formatLink($destination);
     }
 
     public function relativeLink(string $destination): string

--- a/packages/framework/src/Foundation/Hyperlinks.php
+++ b/packages/framework/src/Foundation/Hyperlinks.php
@@ -23,7 +23,7 @@ class Hyperlinks
     }
 
     /**
-     * Format a link to an HTML file, allowing for pretty URLs, if enabled.
+     * Format a web link to an HTML file, allowing for pretty URLs, if enabled.
      *
      * @see \Hyde\Framework\Testing\Unit\Foundation\HyperlinkformatLinkTest
      */

--- a/packages/framework/src/Foundation/Hyperlinks.php
+++ b/packages/framework/src/Foundation/Hyperlinks.php
@@ -27,7 +27,7 @@ class Hyperlinks
      *
      * @see \Hyde\Framework\Testing\Unit\Foundation\HyperlinkFormatHtmlPathTest
      */
-    public function formatHtmlPath(string $destination): string
+    public function formatLink(string $destination): string
     {
         if (config('site.pretty_urls', false) === true) {
             if (str_ends_with($destination, '.html')) {
@@ -64,7 +64,7 @@ class Hyperlinks
         if ($nestCount > 0) {
             $route .= str_repeat('../', $nestCount);
         }
-        $route .= $this->formatHtmlPath($destination);
+        $route .= $this->formatLink($destination);
 
         return str_replace('//', '/', $route);
     }
@@ -108,7 +108,7 @@ class Hyperlinks
      */
     public function url(string $path = '', ?string $default = null): string
     {
-        $path = $this->formatHtmlPath(trim($path, '/'));
+        $path = $this->formatLink(trim($path, '/'));
 
         if ($this->hasSiteUrl()) {
             return rtrim(rtrim(config('site.url'), '/')."/$path", '/');

--- a/packages/framework/src/Foundation/Hyperlinks.php
+++ b/packages/framework/src/Foundation/Hyperlinks.php
@@ -25,7 +25,7 @@ class Hyperlinks
     /**
      * Format a link to an HTML file, allowing for pretty URLs, if enabled.
      *
-     * @see \Hyde\Framework\Testing\Unit\Foundation\HyperlinkFormatHtmlPathTest
+     * @see \Hyde\Framework\Testing\Unit\Foundation\HyperlinkformatLinkTest
      */
     public function formatLink(string $destination): string
     {

--- a/packages/framework/src/Foundation/Hyperlinks.php
+++ b/packages/framework/src/Foundation/Hyperlinks.php
@@ -34,6 +34,7 @@ class Hyperlinks
                 if ($destination === 'index.html') {
                     return '/';
                 }
+
                 if ($destination === DocumentationPage::outputDirectory().'/index.html') {
                     return DocumentationPage::outputDirectory().'/';
                 }

--- a/packages/framework/src/Hyde.php
+++ b/packages/framework/src/Hyde.php
@@ -27,7 +27,7 @@ use Illuminate\Support\Facades\Facade;
  * @method static string getMarkdownPostPath(string $path = '')
  * @method static string getDocumentationPagePath(string $path = '')
  * @method static string sitePath(string $path = '')
- * @method static string formatHtmlPath(string $destination)
+ * @method static string formatLink(string $destination)
  * @method static string relativeLink(string $destination)
  * @method static string image(string $name, bool $preferQualifiedUrl = false)
  * @method static string url(string $path = '', null|string $default = null)

--- a/packages/framework/src/Models/Route.php
+++ b/packages/framework/src/Models/Route.php
@@ -49,7 +49,7 @@ class Route implements \Stringable, \JsonSerializable, Arrayable
         $this->routeKey = $page->getRouteKey();
         $this->sourcePath = $page->getSourcePath();
         $this->outputPath = $page->getOutputPath();
-        $this->uriPath = $page->getUriPath();
+        $this->uriPath = $page->getLink();
     }
 
     /**

--- a/packages/framework/src/Models/Route.php
+++ b/packages/framework/src/Models/Route.php
@@ -13,7 +13,7 @@ use Illuminate\Contracts\Support\Arrayable;
  * The Route class bridges the gaps between Hyde pages and their respective compiled static webpages
  * by providing helper methods and information allowing you to easily access and interact with the
  * various paths associated with a page, both source and compiled file paths as well as the URL.
- * 
+ *
  * @see \Hyde\Framework\Testing\Feature\RouteTest
  */
 class Route implements \Stringable, \JsonSerializable, Arrayable

--- a/packages/framework/src/Services/BuildService.php
+++ b/packages/framework/src/Services/BuildService.php
@@ -17,7 +17,6 @@ use Illuminate\Support\Facades\File;
  * Handles the build loop which generates the static site.
  *
  * @see \Hyde\Framework\Commands\HydeBuildSiteCommand
- *
  * @see \Hyde\Framework\Testing\Feature\StaticSiteServiceTest
  */
 class BuildService

--- a/packages/framework/tests/Feature/HydeKernelTest.php
+++ b/packages/framework/tests/Feature/HydeKernelTest.php
@@ -90,12 +90,12 @@ class HydeKernelTest extends TestCase
     public function test_format_html_path_helper_formats_path_according_to_config_rules()
     {
         Config::set('site.pretty_urls', false);
-        $this->assertEquals('foo.html', Hyde::formatHtmlPath('foo.html'));
-        $this->assertEquals('index.html', Hyde::formatHtmlPath('index.html'));
+        $this->assertEquals('foo.html', Hyde::formatLink('foo.html'));
+        $this->assertEquals('index.html', Hyde::formatLink('index.html'));
 
         Config::set('site.pretty_urls', true);
-        $this->assertEquals('foo', Hyde::formatHtmlPath('foo.html'));
-        $this->assertEquals('/', Hyde::formatHtmlPath('index.html'));
+        $this->assertEquals('foo', Hyde::formatLink('foo.html'));
+        $this->assertEquals('/', Hyde::formatLink('index.html'));
     }
 
     public function test_relative_link_helper_returns_relative_link_to_destination()

--- a/packages/framework/tests/Feature/HydePageTest.php
+++ b/packages/framework/tests/Feature/HydePageTest.php
@@ -813,7 +813,7 @@ class HydePageTest extends TestCase
     public function testGetUriPathUsesHyperlinksHelper()
     {
         $this->assertSame(
-            Hyde::formatHtmlPath((new HandlesPageFilesystemTestClass('hello-world'))->getOutputPath()),
+            Hyde::formatLink((new HandlesPageFilesystemTestClass('hello-world'))->getOutputPath()),
             (new HandlesPageFilesystemTestClass('hello-world'))->getUriPath()
         );
     }

--- a/packages/framework/tests/Feature/HydePageTest.php
+++ b/packages/framework/tests/Feature/HydePageTest.php
@@ -89,7 +89,7 @@ class HydePageTest extends TestCase
     {
         $this->assertSame(
             'output/hello-world.html',
-            (new HandlesPageFilesystemTestClass('hello-world'))->getUriPath()
+            (new HandlesPageFilesystemTestClass('hello-world'))->getLink()
         );
     }
 
@@ -806,7 +806,7 @@ class HydePageTest extends TestCase
     {
         config(['site.pretty_urls' => true]);
         $this->assertEquals('output/hello-world',
-            (new HandlesPageFilesystemTestClass('hello-world'))->getUriPath()
+            (new HandlesPageFilesystemTestClass('hello-world'))->getLink()
         );
     }
 
@@ -814,7 +814,7 @@ class HydePageTest extends TestCase
     {
         $this->assertSame(
             Hyde::formatLink((new HandlesPageFilesystemTestClass('hello-world'))->getOutputPath()),
-            (new HandlesPageFilesystemTestClass('hello-world'))->getUriPath()
+            (new HandlesPageFilesystemTestClass('hello-world'))->getLink()
         );
     }
 

--- a/packages/framework/tests/Feature/HydePageTest.php
+++ b/packages/framework/tests/Feature/HydePageTest.php
@@ -85,7 +85,7 @@ class HydePageTest extends TestCase
         );
     }
 
-    public function testGetUriPath()
+    public function testGetLink()
     {
         $this->assertSame(
             'output/hello-world.html',
@@ -802,7 +802,7 @@ class HydePageTest extends TestCase
         $this->assertEquals('baz', $page->get('foo.bar'));
     }
 
-    public function testGetUriPathWithPrettyUrls()
+    public function testGetLinkWithPrettyUrls()
     {
         config(['site.pretty_urls' => true]);
         $this->assertEquals('output/hello-world',
@@ -810,7 +810,7 @@ class HydePageTest extends TestCase
         );
     }
 
-    public function testGetUriPathUsesHyperlinksHelper()
+    public function testGetLinkUsesHyperlinksHelper()
     {
         $this->assertSame(
             Hyde::formatLink((new HandlesPageFilesystemTestClass('hello-world'))->getOutputPath()),

--- a/packages/framework/tests/Unit/Foundation/HyperlinkFormatHtmlPathTest.php
+++ b/packages/framework/tests/Unit/Foundation/HyperlinkFormatHtmlPathTest.php
@@ -6,7 +6,7 @@ use Hyde\Framework\Hyde;
 use Hyde\Testing\TestCase;
 
 /**
- * @covers \Hyde\Framework\Foundation\Hyperlinks::formatHtmlPath
+ * @covers \Hyde\Framework\Foundation\Hyperlinks::formatLink
  */
 class HyperlinkFormatHtmlPathTest extends TestCase
 {

--- a/packages/framework/tests/Unit/Foundation/HyperlinkFormatHtmlPathTest.php
+++ b/packages/framework/tests/Unit/Foundation/HyperlinkFormatHtmlPathTest.php
@@ -8,7 +8,7 @@ use Hyde\Testing\TestCase;
 /**
  * @covers \Hyde\Framework\Foundation\Hyperlinks::formatLink
  */
-class HyperlinkFormatHtmlPathTest extends TestCase
+class HyperlinkformatLinkTest extends TestCase
 {
     public function test_helper_returns_string_as_is_if_pretty_urls_is_not_true()
     {

--- a/packages/framework/tests/Unit/Foundation/HyperlinkFormatHtmlPathTest.php
+++ b/packages/framework/tests/Unit/Foundation/HyperlinkFormatHtmlPathTest.php
@@ -14,80 +14,80 @@ class HyperlinkFormatHtmlPathTest extends TestCase
     {
         config(['site.pretty_urls' => false]);
 
-        $this->assertEquals('foo/bar.html', Hyde::formatHtmlPath('foo/bar.html'));
+        $this->assertEquals('foo/bar.html', Hyde::formatLink('foo/bar.html'));
     }
 
     public function test_helper_returns_pretty_url_if_pretty_urls_is_true()
     {
         config(['site.pretty_urls' => true]);
 
-        $this->assertEquals('foo/bar', Hyde::formatHtmlPath('foo/bar.html'));
+        $this->assertEquals('foo/bar', Hyde::formatLink('foo/bar.html'));
     }
 
     public function test_non_pretty_urls_is_default_value_when_config_is_not_set()
     {
         config(['site.pretty_urls' => null]);
 
-        $this->assertEquals('foo/bar.html', Hyde::formatHtmlPath('foo/bar.html'));
+        $this->assertEquals('foo/bar.html', Hyde::formatLink('foo/bar.html'));
     }
 
     public function test_helper_respects_absolute_urls()
     {
         config(['site.pretty_urls' => false]);
-        $this->assertEquals('/foo/bar.html', Hyde::formatHtmlPath('/foo/bar.html'));
+        $this->assertEquals('/foo/bar.html', Hyde::formatLink('/foo/bar.html'));
     }
 
     public function test_helper_respects_pretty_absolute_urls()
     {
         config(['site.pretty_urls' => true]);
-        $this->assertEquals('/foo/bar', Hyde::formatHtmlPath('/foo/bar.html'));
+        $this->assertEquals('/foo/bar', Hyde::formatLink('/foo/bar.html'));
     }
 
     public function test_helper_respects_relative_urls()
     {
         config(['site.pretty_urls' => false]);
-        $this->assertEquals('../foo/bar.html', Hyde::formatHtmlPath('../foo/bar.html'));
+        $this->assertEquals('../foo/bar.html', Hyde::formatLink('../foo/bar.html'));
     }
 
     public function test_helper_respects_pretty_relative_urls()
     {
         config(['site.pretty_urls' => true]);
-        $this->assertEquals('../foo/bar', Hyde::formatHtmlPath('../foo/bar.html'));
+        $this->assertEquals('../foo/bar', Hyde::formatLink('../foo/bar.html'));
     }
 
     public function test_non_html_links_are_not_modified()
     {
         config(['site.pretty_urls' => true]);
-        $this->assertEquals('/foo/bar.jpg', Hyde::formatHtmlPath('/foo/bar.jpg'));
+        $this->assertEquals('/foo/bar.jpg', Hyde::formatLink('/foo/bar.jpg'));
     }
 
     public function test_helper_respects_absolute_urls_with_pretty_urls_enabled()
     {
         config(['site.pretty_urls' => true]);
-        $this->assertEquals('/foo/bar.jpg', Hyde::formatHtmlPath('/foo/bar.jpg'));
+        $this->assertEquals('/foo/bar.jpg', Hyde::formatLink('/foo/bar.jpg'));
     }
 
     public function test_helper_rewrites_index_when_using_pretty_urls()
     {
         config(['site.pretty_urls' => true]);
-        $this->assertEquals('/', Hyde::formatHtmlPath('index.html'));
+        $this->assertEquals('/', Hyde::formatLink('index.html'));
     }
 
     public function test_helper_does_not_rewrite_index_when_not_using_pretty_urls()
     {
         config(['site.pretty_urls' => false]);
-        $this->assertEquals('index.html', Hyde::formatHtmlPath('index.html'));
+        $this->assertEquals('index.html', Hyde::formatLink('index.html'));
     }
 
     public function test_helper_rewrites_documentation_page_index_when_using_pretty_urls()
     {
         config(['site.pretty_urls' => true]);
-        $this->assertEquals('docs/', Hyde::formatHtmlPath('docs/index.html'));
+        $this->assertEquals('docs/', Hyde::formatLink('docs/index.html'));
     }
 
     public function test_helper_does_not_rewrite_documentation_page_index_when_not_using_pretty_urls()
     {
         config(['site.pretty_urls' => false]);
-        $this->assertEquals('docs/index.html', Hyde::formatHtmlPath('docs/index.html'));
+        $this->assertEquals('docs/index.html', Hyde::formatLink('docs/index.html'));
     }
 }

--- a/projects/shelf/single-file-dashboard/dashboard.php
+++ b/projects/shelf/single-file-dashboard/dashboard.php
@@ -295,7 +295,7 @@ try {
                                              Blade
                                           </th>
                                           <td>
-                                             <a title="View with realtime compiler" href="<?= Hyde::formatHtmlPath($page->slug.'.html') ?>"><?= $page->view ?></a>
+                                             <a title="View with realtime compiler" href="<?= Hyde::formatLink($page->slug.'.html') ?>"><?= $page->view ?></a>
                                           </td>
                                           <td>
                                              <a title="Open in CMS file manager" href="?page=file-viewer&type=bladepage&file=<?= urlencode($page->view) ?>"><?= BladePage::$sourceDirectory.'/'.$page->view.BladePage::$fileExtension ?></a>
@@ -311,7 +311,7 @@ try {
                                              Markdown
                                           </th>
                                           <td>
-                                             <a title="View with realtime compiler" href="<?= Hyde::formatHtmlPath($page->slug.'.html') ?>"><?= $page->title ?></a>
+                                             <a title="View with realtime compiler" href="<?= Hyde::formatLink($page->slug.'.html') ?>"><?= $page->title ?></a>
                                           </td>
                                           <td>
                                              <a title="Open in CMS file manager" href="?page=file-viewer&type=markdownpage&file=<?= urlencode($page->slug) ?>"><?= MarkdownPage::$sourceDirectory.'/'.$page->slug.MarkdownPage::$fileExtension ?></a>
@@ -403,7 +403,7 @@ try {
                                  <pre ><code id="filecontents" class="language-<?= $editor->type === BladePage::class ? 'html' : 'markdown' ?>"><?= e($editor->getContents()) ?></code></pre>
                               </div>
                               <div class="tab-pane fade" id="pills-compiled" role="tabpanel" aria-labelledby="pills-compiled-tab">
-                                 <iframe loading="lazy" width="100%" height="100%" style="min-height: 600px;" src="<?= Hyde::formatHtmlPath($editor->filename.'.html') ?>" frameborder="0">
+                                 <iframe loading="lazy" width="100%" height="100%" style="min-height: 600px;" src="<?= Hyde::formatLink($editor->filename.'.html') ?>" frameborder="0">
                                  Loading...
                               </iframe>
                            </div>

--- a/projects/templates/dashboard.blade.php
+++ b/projects/templates/dashboard.blade.php
@@ -244,7 +244,7 @@
                     @foreach (BladePage::all() as $page)
                         <tr>
                             <td>
-                                <a href="{{ Hyde::formatHtmlPath($page->slug . '.html') }}">
+                                <a href="{{ Hyde::formatLink($page->slug . '.html') }}">
                                     {{ Hyde::makeTitle($page->view) }}
                                 </a>
                             </td>
@@ -273,7 +273,7 @@
                     @foreach (MarkdownPage::all() as $page)
                         <tr>
                             <td>
-                                <a href="{{ Hyde::formatHtmlPath($page->slug . '.html') }}">
+                                <a href="{{ Hyde::formatLink($page->slug . '.html') }}">
                                     {{ $page->title }}
                                 </a>
                             </td>
@@ -302,7 +302,7 @@
                     @foreach (DocumentationPage::all() as $page)
                         <tr>
                             <td>
-                                <a href="{{ DocumentationPage::$outputDirectory .'/'. Hyde::formatHtmlPath($page->slug . '.html') }}">
+                                <a href="{{ DocumentationPage::$outputDirectory .'/'. Hyde::formatLink($page->slug . '.html') }}">
                                     {{ $page->title }}
                                 </a>
                             </td>
@@ -331,7 +331,7 @@
                     @foreach (MarkdownPost::all() as $post)
                         <tr>
                             <td>
-                                <a href="posts/{{ Hyde::formatHtmlPath($post->slug . '.html') }}">
+                                <a href="posts/{{ Hyde::formatLink($post->slug . '.html') }}">
                                     {{ $post->title }}
                                 </a>
                             </td>


### PR DESCRIPTION
## About

Before v1 I want to make sure we are using consistent naming. To aid in this, I'm drafting a schema spec/glossary relating to paths here.

### Changes

- Renaming methods and variables using the term `URI` with `URL`

--- 

# Glossary

## Path types

### Absolute path

An absolute path is a path that starts from the root of the filesystem. For example, `/home/user/my-hyde-project/_pages/example.md` is an absolute path. These should only be used as the last step of a filesystem operation, for example just before writing, reading, or creating a file.

### Relative path

Hyde prefers relative paths. These are paths that are relative to the project root (or a subdirectory therein). For example, `_pages/example.md` is a relative path. These should be used as much as possible, as they are more portable and easier to work with.

## Path sources

Now that the path types are defined, let's set up some examples for the rest of this document.

### Project roots

The project root is simply the directory that contains all the project files.

Our project root is `/home/user/my-hyde-project`. Almost all paths used will be relative to this directory. For example, if we are talking about `_pages/example.md`, we are really talking about `/home/user/my-hyde-project/_pages/example.md`.


## Directories

### Project directory

The project directory is the directory that contains all the project files. This is the same as the project root.

### Source directories

Source directories are directories that contain source files. The directory (and in cases of `_pages/` also the file extension) lets Hyde know what type of page to parse the source file as. For example, if you put a Markdown file in the `_posts` directory, Hyde will know to parse it as a `MarkdownPage` object and use the Blade templates for post, and that the page should be output to the `_site/posts` directory.

The source directories are:

* _media
* _pages
* _posts
* _docs

### (Site) Output directory

The output directory is the directory that Hyde will output the generated site to. By default, this is the `_site` directory.

### Nested directories

Nested directories are directories that are nested within the their relative scope. Simply put, a nested directory in Hyde is a source directory that contains a subdirectory. For example, if you have a directory inside the _pages directory, that's a nested directory. This term can also apply to output directories, but it's not as common.


## URL components

HydePHP follows the [MDN description of URLs](https://developer.mozilla.org/en-US/docs/Learn/Common_questions/What_is_a_URL) which can be visualized using their graphic (CC-BY-SA):
![URL components](https://developer.mozilla.org/en-US/docs/Learn/Common_questions/What_is_a_URL/mdn-url-all.png)


### Paths VS links

When we talk about paths, we are talking about the actual file paths on the filesystem. When we talk about links, we are talking about the URL that the user will see in their browser.

### Just links

When we talk about just links, we are talking about the URL path that the user will see in their browser. Unless it's specified wether a link is relative or absolute, it's assumed to be relative to the index page of the site and will not contain a leading slash nor path traversal directives,

### Relative links

When links are relative, they are always relative to the page that is currently being visited. If there is no information about the page being visited, they are relative to the root of the site. The relative information is denoted by a set of path traversal directives (`../`) and are automatically generated by Hyde when resolving links.

### Absolute links

Absolute links (or root-relative links) are links that start from the root of the site. For example, `/about` is an absolute link. These are generally discouraged in Hyde, as they are not portable and can cause issues when moving the site to a different domain or subdirectory. They also break local browsing when not using a web server, and are thus not used for links in Hyde generated HTML (but can of course be specified by the user).

### Qualified links

Qualified (URI/URL) links are absolute links that include the project's configured base URL. When a base URL is available, it is used for links where such a type is preferred, such as canonical meta tags, and RSS feeds, and the sitemap.

### Pretty links/URLs

Pretty links are links that do not include the file extension. For example, `about` is a pretty link, while `about.html` is not. Pretty links are disabled by default, but can be enabled in the project configuration. When enabled, some pages may also be rewritten, for example `index.html` will be rewritten to `/`.

## Path components and terminologies

Now that we have the basics out of the way, let's get into the specifics AKA the more interesting stuff.


### Identifiers

The identifier is the part between the source directory and the file extension It may also be known as a 'slug', or previously 'basename'.

For example, the identifier of a source file stored as '_pages/about/contact.md' would be 'about/contact', and 'pages/about.md' would simply be 'about'.

An identifier never contains the file extension, and is always relative to the source directory (which is thus also not included).

### Route keys

The route key is the URI path relative to the site root. Route keys are very important in Hyde as they map the correlation between a source file and the eventual HTTP endpoint that will resolve to the static HTML file.

For example, if the compiled page will be saved to _site/docs/index.html,
then the route key will be 'docs/index'. Route keys are used to
identify pages, similar to how named routes work in Laravel.

Route keys are always relative to the site root, and never contain the file extension (as they always refer to HTML pages).

### Variable naming conventions

* `$sourcePath` - Generally a local file path for the page source file relative to the project root.
* `$outputPath` - Generally an output file path relative to the _site output directory.

* `$filename` - The full name of a file (without path information). In other words, it's a slug with a file extension.
Example: `hello-world.md`
* `$filepath` - The full file path (almost always relative to the root of the Hyde project installation). Includes the file extension.
Example: `_posts/hello-world.md`

### Visualizing the anatomy of a file name

Text in [brackets] show data that is implied by the context, but are not a part of the value itself.

#### Identifier (Slug)
[_posts/]**hello-world**[.md]

#### File Name
[_posts/]**hello-world.md**

#### File Path
**_posts/hello-world.md**

#### Route Key
**posts/hello-world**

#### Output Path
[_site/]**posts/hello-world.html**
