### PR TITLE
Remove unreachable conditional result

### DIFF
--- a/packages/framework/src/Models/Image.php
+++ b/packages/framework/src/Models/Image.php
@@ -141,10 +141,6 @@ class Image implements \Stringable
 
     public function getLink(): string
     {
-        if (! $this->getSource()) {
-            return '';
-        }
-
         return Hyde::image($this->getSource());
     }
 


### PR DESCRIPTION
Since the check never returns a falsely value, but instead throws an exception, this condition can never be reached.