### PR TITLE
Refactor shared view data handling

### DIFF
--- a/packages/framework/resources/views/pages/documentation-search.blade.php
+++ b/packages/framework/resources/views/pages/documentation-search.blade.php
@@ -1,8 +1,6 @@
 @php
 // Emulate a page object
-$page = Hyde\Framework\Models\Pages\DocumentationPage::make('search', ['title' => 'Search']);
-$currentPage = $page->getRouteKey();
-$currentRoute = $page->getRoute();
+Hyde::shareViewData(Hyde\Framework\Models\Pages\DocumentationPage::make('search', ['title' => 'Search']));
 $markdown = '';
 @endphp
 

--- a/packages/framework/src/Actions/StaticPageBuilder.php
+++ b/packages/framework/src/Actions/StaticPageBuilder.php
@@ -38,7 +38,7 @@ class StaticPageBuilder
      */
     public function __invoke(): string
     {
-        $this->shareViewData();
+        Hyde::shareViewData();
 
         $this->needsDirectory(Hyde::sitePath());
         $this->needsDirectory(dirname(Hyde::sitePath($this->page->getOutputPath())));
@@ -59,12 +59,5 @@ class StaticPageBuilder
         file_put_contents($path, $contents);
 
         return $path;
-    }
-
-    protected function shareViewData(): void
-    {
-        view()->share('page', $this->page);
-        view()->share('currentPage', $this->page->getRouteKey());
-        view()->share('currentRoute', $this->page->getRoute());
     }
 }

--- a/packages/framework/src/Actions/StaticPageBuilder.php
+++ b/packages/framework/src/Actions/StaticPageBuilder.php
@@ -38,9 +38,7 @@ class StaticPageBuilder
      */
     public function __invoke(): string
     {
-        view()->share('page', $this->page);
-        view()->share('currentPage', $this->page->getRouteKey());
-        view()->share('currentRoute', $this->page->getRoute());
+        $this->shareViewData();
 
         $this->needsDirectory(Hyde::sitePath());
         $this->needsDirectory(dirname(Hyde::sitePath($this->page->getOutputPath())));
@@ -61,5 +59,12 @@ class StaticPageBuilder
         file_put_contents($path, $contents);
 
         return $path;
+    }
+
+    protected function shareViewData(): void
+    {
+        view()->share('page', $this->page);
+        view()->share('currentPage', $this->page->getRouteKey());
+        view()->share('currentRoute', $this->page->getRoute());
     }
 }

--- a/packages/framework/src/Actions/StaticPageBuilder.php
+++ b/packages/framework/src/Actions/StaticPageBuilder.php
@@ -38,7 +38,7 @@ class StaticPageBuilder
      */
     public function __invoke(): string
     {
-        Hyde::shareViewData();
+        Hyde::shareViewData($this->page);
 
         $this->needsDirectory(Hyde::sitePath());
         $this->needsDirectory(dirname(Hyde::sitePath($this->page->getOutputPath())));

--- a/packages/framework/src/Foundation/Concerns/ManagesViewData.php
+++ b/packages/framework/src/Foundation/Concerns/ManagesViewData.php
@@ -21,7 +21,6 @@ trait ManagesViewData
     public function shareViewData(HydePage $page): void
     {
         View::share('page', $page);
-        View::share('currentPage', $page->getRouteKey());
         View::share('currentRoute', $page->getRoute());
     }
 

--- a/packages/framework/src/Foundation/Concerns/ManagesViewData.php
+++ b/packages/framework/src/Foundation/Concerns/ManagesViewData.php
@@ -31,7 +31,7 @@ trait ManagesViewData
      */
     public function currentPage(): ?string
     {
-        return View::shared('currentPage');
+        return View::shared('page')?->getRouteKey();
     }
 
     /**

--- a/packages/framework/src/Foundation/Concerns/ManagesViewData.php
+++ b/packages/framework/src/Foundation/Concerns/ManagesViewData.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Hyde\Framework\Foundation\Concerns;
+
+/**
+ * @internal Single-use trait for the HydeKernel class.
+ *
+ * @see \Hyde\Framework\HydeKernel
+ */
+trait ManagesViewData
+{
+    //
+}

--- a/packages/framework/src/Foundation/Concerns/ManagesViewData.php
+++ b/packages/framework/src/Foundation/Concerns/ManagesViewData.php
@@ -2,6 +2,7 @@
 
 namespace Hyde\Framework\Foundation\Concerns;
 
+use Hyde\Framework\Concerns\HydePage;
 use Hyde\Framework\Models\Route;
 use Illuminate\Support\Facades\View;
 
@@ -12,6 +13,13 @@ use Illuminate\Support\Facades\View;
  */
 trait ManagesViewData
 {
+    public function shareViewData(HydePage $page): void
+    {
+        view()->share('page', $page);
+        view()->share('currentPage', $page->getRouteKey());
+        view()->share('currentRoute', $page->getRoute());
+    }
+
     public function currentPage(): ?string
     {
         return View::shared('currentPage');

--- a/packages/framework/src/Foundation/Concerns/ManagesViewData.php
+++ b/packages/framework/src/Foundation/Concerns/ManagesViewData.php
@@ -21,6 +21,7 @@ trait ManagesViewData
     public function shareViewData(HydePage $page): void
     {
         View::share('page', $page);
+        View::share('currentPage', $page->getRouteKey());
         View::share('currentRoute', $page->getRoute());
     }
 

--- a/packages/framework/src/Foundation/Concerns/ManagesViewData.php
+++ b/packages/framework/src/Foundation/Concerns/ManagesViewData.php
@@ -13,6 +13,11 @@ use Illuminate\Support\Facades\View;
  */
 trait ManagesViewData
 {
+    /**
+     * Share data for the page being rendered.
+     *
+     * @param \Hyde\Framework\Concerns\HydePage $page
+     */
     public function shareViewData(HydePage $page): void
     {
         View::share('page', $page);
@@ -20,11 +25,21 @@ trait ManagesViewData
         View::share('currentRoute', $page->getRoute());
     }
 
+    /**
+     * Get the route key for the page being rendered.
+     *
+     * @return string|null
+     */
     public function currentPage(): ?string
     {
         return View::shared('currentPage');
     }
 
+    /**
+     * Get the route for the page being rendered.
+     *
+     * @return \Hyde\Framework\Models\Route|null
+     */
     public function currentRoute(): ?Route
     {
         return View::shared('currentRoute');

--- a/packages/framework/src/Foundation/Concerns/ManagesViewData.php
+++ b/packages/framework/src/Foundation/Concerns/ManagesViewData.php
@@ -2,6 +2,9 @@
 
 namespace Hyde\Framework\Foundation\Concerns;
 
+use Hyde\Framework\Models\Route;
+use Illuminate\Support\Facades\View;
+
 /**
  * @internal Single-use trait for the HydeKernel class.
  *
@@ -9,5 +12,13 @@ namespace Hyde\Framework\Foundation\Concerns;
  */
 trait ManagesViewData
 {
-    //
+    public function currentPage(): ?string
+    {
+        return View::shared('currentPage');
+    }
+
+    public function currentRoute(): ?Route
+    {
+        return View::shared('currentRoute');
+    }
 }

--- a/packages/framework/src/Foundation/Concerns/ManagesViewData.php
+++ b/packages/framework/src/Foundation/Concerns/ManagesViewData.php
@@ -31,7 +31,7 @@ trait ManagesViewData
      */
     public function currentPage(): ?string
     {
-        return View::shared('page')?->getRouteKey();
+        return View::shared('currentPage');
     }
 
     /**

--- a/packages/framework/src/Foundation/Concerns/ManagesViewData.php
+++ b/packages/framework/src/Foundation/Concerns/ManagesViewData.php
@@ -15,9 +15,9 @@ trait ManagesViewData
 {
     public function shareViewData(HydePage $page): void
     {
-        view()->share('page', $page);
-        view()->share('currentPage', $page->getRouteKey());
-        view()->share('currentRoute', $page->getRoute());
+        View::share('page', $page);
+        View::share('currentPage', $page->getRouteKey());
+        View::share('currentRoute', $page->getRoute());
     }
 
     public function currentPage(): ?string

--- a/packages/framework/src/Hyde.php
+++ b/packages/framework/src/Hyde.php
@@ -2,6 +2,7 @@
 
 namespace Hyde\Framework;
 
+use Hyde\Framework\Concerns\HydePage;
 use Hyde\Framework\Foundation\FileCollection;
 use Hyde\Framework\Foundation\PageCollection;
 use Hyde\Framework\Foundation\RouteCollection;
@@ -47,6 +48,7 @@ use Illuminate\Support\Facades\Facade;
  * @method static bool unlink(array|string $path)
  * @method static void setInstance(HydeKernel $instance)
  * @method static void setBasePath(string $basePath)
+ * @method static void shareViewData(HydePage $page)
  * @method static array toArray()
  * @method static void boot()
  */

--- a/packages/framework/src/HydeKernel.php
+++ b/packages/framework/src/HydeKernel.php
@@ -43,6 +43,7 @@ class HydeKernel implements Arrayable, \JsonSerializable
     use Foundation\Concerns\ForwardsHyperlinks;
     use Foundation\Concerns\ForwardsFilesystem;
     use Foundation\Concerns\ManagesHydeKernel;
+    use Foundation\Concerns\ManagesViewData;
 
     use JsonSerializesArrayable;
     use Macroable;

--- a/packages/framework/src/HydeKernel.php
+++ b/packages/framework/src/HydeKernel.php
@@ -10,9 +10,7 @@ use Hyde\Framework\Foundation\Hyperlinks;
 use Hyde\Framework\Foundation\PageCollection;
 use Hyde\Framework\Foundation\RouteCollection;
 use Hyde\Framework\Helpers\Features;
-use Hyde\Framework\Models\Route;
 use Illuminate\Contracts\Support\Arrayable;
-use Illuminate\Support\Facades\View;
 use Illuminate\Support\Traits\Macroable;
 
 /**
@@ -81,16 +79,6 @@ class HydeKernel implements Arrayable, \JsonSerializable
     public function hasFeature(string $feature): bool
     {
         return Features::enabled($feature);
-    }
-
-    public function currentPage(): ?string
-    {
-        return View::shared('currentPage');
-    }
-
-    public function currentRoute(): ?Route
-    {
-        return View::shared('currentRoute');
     }
 
     /**

--- a/packages/framework/src/HydeKernel.php
+++ b/packages/framework/src/HydeKernel.php
@@ -82,9 +82,9 @@ class HydeKernel implements Arrayable, \JsonSerializable
         return Features::enabled($feature);
     }
 
-    public function currentPage(): string
+    public function currentPage(): ?string
     {
-        return View::shared('currentPage', '');
+        return View::shared('currentPage');
     }
 
     public function currentRoute(): ?Route


### PR DESCRIPTION
Moves responsibility for sharing the current page data to the view from the static page builder to the Hyde kernel