### PR TITLE
Remove unused $default parameter to Hyde::url method

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -128,6 +128,7 @@ This change also bubbles to the HydePage accessors, though that will only affect
 - Removed method `AbstractPage::getCurrentPagePath()` (merged into `getRouteKey()` in the same class)
 - Removed method `Route::getSourceFilePath()` (use new `Route::getSourcePath()` instead)
 - Removed method `Route::getOutputFilePath()` (use new `Route::getOutputPath()` instead)
+- Removed unused $default parameter from Hyde::url method
 - Using absolute paths for site output directories is no longer supported (use build tasks to move files around after build if needed)
 
 ### Fixed

--- a/packages/framework/src/Foundation/Hyperlinks.php
+++ b/packages/framework/src/Foundation/Hyperlinks.php
@@ -102,21 +102,16 @@ class Hyperlinks
      * Return a qualified URL to the supplied path if a base URL is set.
      *
      * @param  string  $path  optional relative path suffix. Omit to return base url.
-     * @param  string|null  $default  optional default value to return if no site url is set.
      * @return string
      *
      * @throws BaseUrlNotSetException If no site URL is set and no default is provided
      */
-    public function url(string $path = '', ?string $default = null): string
+    public function url(string $path = ''): string
     {
         $path = $this->formatLink(trim($path, '/'));
 
         if ($this->hasSiteUrl()) {
             return rtrim(rtrim(config('site.url'), '/')."/$path", '/');
-        }
-
-        if ($default !== null) {
-            return "$default/$path";
         }
 
         throw new BaseUrlNotSetException();

--- a/packages/framework/src/Hyde.php
+++ b/packages/framework/src/Hyde.php
@@ -31,7 +31,7 @@ use Illuminate\Support\Facades\Facade;
  * @method static string formatLink(string $destination)
  * @method static string relativeLink(string $destination)
  * @method static string image(string $name, bool $preferQualifiedUrl = false)
- * @method static string url(string $path = '', null|string $default = null)
+ * @method static string url(string $path = '')
  * @method static string makeTitle(string $slug)
  * @method static string currentPage()
  * @method static string getBasePath()

--- a/packages/framework/tests/Unit/Foundation/HyperlinksUrlPathHelpersTest.php
+++ b/packages/framework/tests/Unit/Foundation/HyperlinksUrlPathHelpersTest.php
@@ -81,18 +81,6 @@ class HyperlinksUrlPathHelpersTest extends TestCase
         $this->class->url();
     }
 
-    public function test_qualified_url_uses_default_parameter_when_no_site_url_is_set()
-    {
-        config(['site.url' => null]);
-        $this->assertEquals('bar/foo', $this->class->url('foo', 'bar'));
-    }
-
-    public function test_qualified_url_does_not_use_default_parameter_when_site_url_is_set()
-    {
-        config(['site.url' => 'https://example.com']);
-        $this->assertEquals('https://example.com/foo', $this->class->url('foo', 'bar'));
-    }
-
     public function test_helper_returns_expected_string_when_site_url_is_set()
     {
         config(['site.url' => 'https://example.com']);


### PR DESCRIPTION
This parameter is only used in a single test, and never in actual code
