### PR TITLE
Remove RealtimeCompiler support for the legacy bootstrap file

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -136,6 +136,7 @@ This change also bubbles to the HydePage accessors, though that will only affect
 - Removed method `Route::getOutputFilePath()` (use new `Route::getOutputPath()` instead)
 - Removed unused $default parameter from Hyde::url method
 - Using absolute paths for site output directories is no longer supported (use build tasks to move files around after build if needed)
+- RealtimeCompiler: Removed support for the legacy bootstrapping file removed in Hyde v0.40
 
 ### Fixed
 - Fixed validation bug in the rebuild command

--- a/packages/realtime-compiler/src/Concerns/InteractsWithLaravel.php
+++ b/packages/realtime-compiler/src/Concerns/InteractsWithLaravel.php
@@ -16,14 +16,7 @@ trait InteractsWithLaravel
 
     protected function createApplication(): void
     {
-        // The core bootstrapping file was moved in hyde/framework v0.35.x.
-        // The old file was removed in hyde/framework v0.40.x
-
-        // To preserve backwards compatibility, we will continue to load
-        // the old bootstrap file for several minor versions.
-
-        // Temporarily add compatability for old bootstrap file location making the transition easier
-        $this->laravel = require_once file_exists(BASE_PATH.'/app/bootstrap.php') ? BASE_PATH.'/app/bootstrap.php' : BASE_PATH.'/bootstrap/app.php';
+        $this->laravel = require_once BASE_PATH.'/app/bootstrap.php';
     }
 
     protected function bootApplication(): void

--- a/packages/realtime-compiler/src/Routing/Router.php
+++ b/packages/realtime-compiler/src/Routing/Router.php
@@ -64,7 +64,7 @@ class Router
         $extension = pathinfo($request->path)['extension'] ?? null;
 
         // If the extension is not set (pretty url), or is .html,
-        //we assume it's a web page which we need to compile.
+        // we assume it's a web page which we need to compile.
         if ($extension === null || $extension === 'html') {
             return false;
         }


### PR DESCRIPTION
Removed support for the legacy bootstrapping file removed in Hyde v0.40