### PR TITLE
Add a route:list command

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -22,6 +22,7 @@ The most high impact change is change of sidebar front matter options, and relat
 - Added a NavigationData object to HydePage.php
 - Added a Route::is() method to determine if a given route or route key matches the instance it's called on
 - Added a Site model [#506](https://github.com/hydephp/develop/pull/506)
+- Added a route:list command [#516](https://github.com/hydephp/develop/pull/516)
 
 ### Changed
 

--- a/docs/getting-started/console-commands.md
+++ b/docs/getting-started/console-commands.md
@@ -236,6 +236,12 @@ you can use this command to republish the configuration files.
 You should be sure to have backups, or version control such as Git, before running this command.</p>
 </blockquote>
 
+### List the available pages/routes
+```bash
+php hyde route:list
+```
+
+Display a list of all the discovered pages, their route keys, and their source and output paths.
 
 ### Run validation tests to optimize your site
 ```bash

--- a/packages/framework/src/Commands/HydeRouteListCommand.php
+++ b/packages/framework/src/Commands/HydeRouteListCommand.php
@@ -3,6 +3,7 @@
 namespace Hyde\Framework\Commands;
 
 use Hyde\Framework\Hyde;
+use Hyde\Framework\Services\DiscoveryService;
 use LaravelZero\Framework\Commands\Command;
 
 /**
@@ -50,6 +51,7 @@ class HydeRouteListCommand extends Command
 
     protected function formatSourcePath(string $path): string
     {
-        return $path;
+        $link = DiscoveryService::createClickableFilepath(Hyde::path($path));
+        return "<href=$link>$path</>";
     }
 }

--- a/packages/framework/src/Commands/HydeRouteListCommand.php
+++ b/packages/framework/src/Commands/HydeRouteListCommand.php
@@ -46,7 +46,7 @@ class HydeRouteListCommand extends Command
         return str_replace('Hyde\\Framework\\Models\\Pages\\', '', $class);
     }
 
-    protected function formatSourcePath(string $path)
+    protected function formatSourcePath(string $path): string
     {
         return $path;
     }

--- a/packages/framework/src/Commands/HydeRouteListCommand.php
+++ b/packages/framework/src/Commands/HydeRouteListCommand.php
@@ -57,10 +57,10 @@ class HydeRouteListCommand extends Command
     protected function formatOutputPath(string $path): string
     {
         if (! file_exists(Hyde::sitePath($path))) {
-            return $path;
+            return "_site/$path";
         }
 
-        return $this->clickablePathLink(DiscoveryService::createClickableFilepath(Hyde::sitePath($path)), $path);
+        return $this->clickablePathLink(DiscoveryService::createClickableFilepath(Hyde::sitePath($path)), "_site/$path");
     }
 
     protected function clickablePathLink(string $link, string $path): string

--- a/packages/framework/src/Commands/HydeRouteListCommand.php
+++ b/packages/framework/src/Commands/HydeRouteListCommand.php
@@ -57,6 +57,10 @@ class HydeRouteListCommand extends Command
 
     protected function formatOutputPath(string $path): string
     {
+        if (! file_exists(Hyde::sitePath($path))) {
+            return $path;
+        }
+
         $link = DiscoveryService::createClickableFilepath(Hyde::sitePath($path));
         return "<href=$link>$path</>";
     }

--- a/packages/framework/src/Commands/HydeRouteListCommand.php
+++ b/packages/framework/src/Commands/HydeRouteListCommand.php
@@ -53,7 +53,7 @@ class HydeRouteListCommand extends Command
     {
         $link = DiscoveryService::createClickableFilepath(Hyde::path($path));
 
-        return "<href=$link>$path</>";
+        return $this->clickablePathLink($link, $path);
     }
 
     protected function formatOutputPath(string $path): string
@@ -64,6 +64,11 @@ class HydeRouteListCommand extends Command
 
         $link = DiscoveryService::createClickableFilepath(Hyde::sitePath($path));
 
+        return $this->clickablePathLink($link, $path);
+    }
+
+    protected function clickablePathLink(string $link, string $path): string
+    {
         return "<href=$link>$path</>";
     }
 }

--- a/packages/framework/src/Commands/HydeRouteListCommand.php
+++ b/packages/framework/src/Commands/HydeRouteListCommand.php
@@ -17,10 +17,10 @@ class HydeRouteListCommand extends Command
     public function handle(): int
     {
         $this->table([
-            'Route Key',
+            'Page Type',
             'Source File',
             'Output File',
-            'Page Type',
+            'Route Key',
         ], $this->getRoutes());
 
         return 0;
@@ -32,10 +32,10 @@ class HydeRouteListCommand extends Command
         /** @var \Hyde\Framework\Models\Route $route */
         foreach (Hyde::routes() as $route) {
             $routes[] = [
-                $route->getRouteKey(),
+                $this->formatPageType($route->getPageType()),
                 $route->getSourcePath(),
                 $route->getOutputPath(),
-                $this->formatPageType($route->getPageType()),
+                $route->getRouteKey(),
             ];
         }
         return $routes;

--- a/packages/framework/src/Commands/HydeRouteListCommand.php
+++ b/packages/framework/src/Commands/HydeRouteListCommand.php
@@ -16,7 +16,12 @@ class HydeRouteListCommand extends Command
 
     public function handle(): int
     {
-        $this->table(['Route Key', 'Source File', 'Output File', 'Page Type'], $this->getRoutes());
+        $this->table([
+            'Route Key',
+            'Source File',
+            'Output File',
+            'Page Type',
+        ], $this->getRoutes());
 
         return 0;
     }

--- a/packages/framework/src/Commands/HydeRouteListCommand.php
+++ b/packages/framework/src/Commands/HydeRouteListCommand.php
@@ -30,9 +30,14 @@ class HydeRouteListCommand extends Command
                 $route->getRouteKey(),
                 $route->getSourcePath(),
                 $route->getOutputPath(),
-                $route->getPageType(),
+                $this->formatPageType($route->getPageType()),
             ];
         }
         return $routes;
+    }
+
+    protected function formatPageType(string $class): string
+    {
+        return str_replace('Hyde\\Framework\\Models\\Pages\\', '', $class);
     }
 }

--- a/packages/framework/src/Commands/HydeRouteListCommand.php
+++ b/packages/framework/src/Commands/HydeRouteListCommand.php
@@ -33,7 +33,7 @@ class HydeRouteListCommand extends Command
         foreach (Hyde::routes() as $route) {
             $routes[] = [
                 $this->formatPageType($route->getPageType()),
-                $route->getSourcePath(),
+                $this->formatSourcePath($route->getSourcePath()),
                 $route->getOutputPath(),
                 $route->getRouteKey(),
             ];
@@ -44,5 +44,10 @@ class HydeRouteListCommand extends Command
     protected function formatPageType(string $class): string
     {
         return str_replace('Hyde\\Framework\\Models\\Pages\\', '', $class);
+    }
+
+    protected function formatSourcePath(string $path)
+    {
+        return $path;
     }
 }

--- a/packages/framework/src/Commands/HydeRouteListCommand.php
+++ b/packages/framework/src/Commands/HydeRouteListCommand.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Hyde\Framework\Commands;
+
+use LaravelZero\Framework\Commands\Command;
+/**
+ * Hyde command to display the list of site routes.
+ *
+ * @see \Hyde\Framework\Testing\Feature\Commands\HydeRouteListCommandTest
+ */
+class HydeRouteListCommand extends Command
+{
+    protected $signature = 'route:list';
+    protected $description = 'Display all registered routes.';
+
+    public function handle(): int
+    {
+        //
+
+        return 0;
+    }
+}

--- a/packages/framework/src/Commands/HydeRouteListCommand.php
+++ b/packages/framework/src/Commands/HydeRouteListCommand.php
@@ -51,9 +51,7 @@ class HydeRouteListCommand extends Command
 
     protected function formatSourcePath(string $path): string
     {
-        $link = DiscoveryService::createClickableFilepath(Hyde::path($path));
-
-        return $this->clickablePathLink($link, $path);
+        return $this->clickablePathLink(DiscoveryService::createClickableFilepath(Hyde::path($path)), $path);
     }
 
     protected function formatOutputPath(string $path): string
@@ -62,9 +60,7 @@ class HydeRouteListCommand extends Command
             return $path;
         }
 
-        $link = DiscoveryService::createClickableFilepath(Hyde::sitePath($path));
-
-        return $this->clickablePathLink($link, $path);
+        return $this->clickablePathLink(DiscoveryService::createClickableFilepath(Hyde::sitePath($path)), $path);
     }
 
     protected function clickablePathLink(string $link, string $path): string

--- a/packages/framework/src/Commands/HydeRouteListCommand.php
+++ b/packages/framework/src/Commands/HydeRouteListCommand.php
@@ -36,7 +36,7 @@ class HydeRouteListCommand extends Command
             $routes[] = [
                 $this->formatPageType($route->getPageType()),
                 $this->formatSourcePath($route->getSourcePath()),
-                $route->getOutputPath(),
+                $this->formatOutputPath($route->getOutputPath()),
                 $route->getRouteKey(),
             ];
         }
@@ -52,6 +52,12 @@ class HydeRouteListCommand extends Command
     protected function formatSourcePath(string $path): string
     {
         $link = DiscoveryService::createClickableFilepath(Hyde::path($path));
+        return "<href=$link>$path</>";
+    }
+
+    protected function formatOutputPath(string $path): string
+    {
+        $link = DiscoveryService::createClickableFilepath(Hyde::sitePath($path));
         return "<href=$link>$path</>";
     }
 }

--- a/packages/framework/src/Commands/HydeRouteListCommand.php
+++ b/packages/framework/src/Commands/HydeRouteListCommand.php
@@ -2,6 +2,7 @@
 
 namespace Hyde\Framework\Commands;
 
+use Hyde\Framework\Hyde;
 use LaravelZero\Framework\Commands\Command;
 /**
  * Hyde command to display the list of site routes.
@@ -15,8 +16,23 @@ class HydeRouteListCommand extends Command
 
     public function handle(): int
     {
-        //
+        $this->table(['Route Key', 'Source File', 'Output File', 'Page Type'], $this->getRoutes());
 
         return 0;
+    }
+
+    protected function getRoutes(): array
+    {
+        $routes = [];
+        /** @var \Hyde\Framework\Models\Route $route */
+        foreach (Hyde::routes() as $route) {
+            $routes[] = [
+                $route->getRouteKey(),
+                $route->getSourcePath(),
+                $route->getOutputPath(),
+                $route->getPageType(),
+            ];
+        }
+        return $routes;
     }
 }

--- a/packages/framework/src/HydeServiceProvider.php
+++ b/packages/framework/src/HydeServiceProvider.php
@@ -108,6 +108,7 @@ class HydeServiceProvider extends ServiceProvider
             Commands\HydeBuildSitemapCommand::class,
             Commands\HydeBuildRssFeedCommand::class,
             Commands\HydeBuildSearchCommand::class,
+            Commands\HydeRouteListCommand::class,
             Commands\HydeMakePostCommand::class,
             Commands\HydeMakePageCommand::class,
             Commands\HydeValidateCommand::class,

--- a/packages/framework/tests/Feature/Commands/HydeRouteListCommandTest.php
+++ b/packages/framework/tests/Feature/Commands/HydeRouteListCommandTest.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace Hyde\Framework\Testing\Feature\Commands;
+
+class HydeRouteListCommandTest
+{
+    //
+}

--- a/packages/framework/tests/Feature/Commands/HydeRouteListCommandTest.php
+++ b/packages/framework/tests/Feature/Commands/HydeRouteListCommandTest.php
@@ -16,13 +16,13 @@ class HydeRouteListCommandTest extends TestCase
                 [
                     'BladePage',
                     '_pages/404.blade.php',
-                    '404.html',
+                    '_site/404.html',
                     '404',
                 ],
                 [
                     'BladePage',
                     '_pages/index.blade.php',
-                    'index.html',
+                    '_site/index.html',
                     'index',
                 ],
             ])->assertExitCode(0);

--- a/packages/framework/tests/Feature/Commands/HydeRouteListCommandTest.php
+++ b/packages/framework/tests/Feature/Commands/HydeRouteListCommandTest.php
@@ -27,4 +27,11 @@ class HydeRouteListCommandTest extends TestCase
                 ],
             ])->assertExitCode(0);
     }
+
+    public function testClickableLinks()
+    {
+        $this->file('_site/index.html');
+        $this->artisan('route:list')
+            ->assertExitCode(0);
+    }
 }

--- a/packages/framework/tests/Feature/Commands/HydeRouteListCommandTest.php
+++ b/packages/framework/tests/Feature/Commands/HydeRouteListCommandTest.php
@@ -12,18 +12,18 @@ class HydeRouteListCommandTest extends TestCase
     public function testRouteListCommand()
     {
         $this->artisan('route:list')
-            ->expectsTable(['Route Key', 'Source File', 'Output File', 'Page Type'], [
+            ->expectsTable(['Page Type', 'Source File', 'Output File', 'Route Key'], [
                 [
-                    '404',
+                    'BladePage',
                     '_pages/404.blade.php',
                     '404.html',
-                    'BladePage',
+                    '404',
                 ],
                 [
-                    'index',
+                    'BladePage',
                     '_pages/index.blade.php',
                     'index.html',
-                    'BladePage',
+                    'index',
                 ]
             ])->assertExitCode(0);
     }

--- a/packages/framework/tests/Feature/Commands/HydeRouteListCommandTest.php
+++ b/packages/framework/tests/Feature/Commands/HydeRouteListCommandTest.php
@@ -9,5 +9,22 @@ use Hyde\Testing\TestCase;
  */
 class HydeRouteListCommandTest extends TestCase
 {
-    //
+    public function testRouteListCommand()
+    {
+        $this->artisan('route:list')
+            ->expectsTable(['Route Key', 'Source File', 'Output File', 'Page Type'], [
+                [
+                    '404',
+                    '_pages/404.blade.php',
+                    '404.html',
+                    'BladePage',
+                ],
+                [
+                    'index',
+                    '_pages/index.blade.php',
+                    'index.html',
+                    'BladePage',
+                ]
+            ])->assertExitCode(0);
+    }
 }

--- a/packages/framework/tests/Feature/Commands/HydeRouteListCommandTest.php
+++ b/packages/framework/tests/Feature/Commands/HydeRouteListCommandTest.php
@@ -2,7 +2,12 @@
 
 namespace Hyde\Framework\Testing\Feature\Commands;
 
-class HydeRouteListCommandTest
+use Hyde\Testing\TestCase;
+
+/**
+ * @covers \Hyde\Framework\Commands\HydeRouteListCommand
+ */
+class HydeRouteListCommandTest extends TestCase
 {
     //
 }


### PR DESCRIPTION
Adds a `route:list` command

```
$ php hyde route:list

+-----------+------------------------+------------------+-----------+
| Page Type | Source File            | Output File      | Route Key |
+-----------+------------------------+------------------+-----------+
| BladePage | _pages/404.blade.php   | _site/404.html   | 404       |
| BladePage | _pages/index.blade.php | _site/index.html | index     |
+-----------+------------------------+------------------+-----------+
```