### PR TITLE
Make BladePage $view argument optional

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -69,6 +69,7 @@ This change also bubbles to the HydePage accessors, though that will only affect
 - Changed the Route::toArray schema 
 - Split the page metadata handling so that global metadata is now handled by the Site model (meta.blade.php must be updated if you have published it)
 - The MetadataBag class now implements Htmlable, so you can use it directly in Blade templates without calling `render()`
+- BladePage $view constructor argument is now optional
 - internal: Move responsibility for filtering documentation pages to the navigation menus (this means that documentation pages that are not 'index' are no longer regarded as hidden)
 - internal: The HydePage::$navigation property is now a NavigationData object instead of an array, however the object extends ArrayObject, so it should be mostly compatible with existing code
 

--- a/packages/framework/src/Models/Pages/BladePage.php
+++ b/packages/framework/src/Models/Pages/BladePage.php
@@ -21,7 +21,7 @@ class BladePage extends HydePage
      * @param  string  $view
      * @param  \Hyde\Framework\Models\FrontMatter|array  $matter
      */
-    public function __construct(string $view, FrontMatter|array $matter = [])
+    public function __construct(string $view = '', FrontMatter|array $matter = [])
     {
         parent::__construct($view, $matter);
         $this->view = $view;


### PR DESCRIPTION
Makes the BladePage $view argument optional to match the base HydePage class. This was originally made required as Blade pages need a concrete view to compile, so pages still won't be able to be compiled without a view, so this PR will just defer that error if a developer tries that.