### PR TITLE
Breaking: Rename Features::blogPosts to Features::markdownPost to match the page type name 

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -13,6 +13,8 @@ In general, these changes should only affect those who have written custom code 
 
 #### What you can expect to break
 
+This update **requires the configuration file to be updated**.
+
 The most high impact change is change of sidebar front matter options, and related areas. Please try updating your site in a test environment first, to see if you need to update any of your front matter.
 
 ### Added
@@ -33,6 +35,8 @@ The most high impact change is change of sidebar front matter options, and relat
 
 **A very large number the changes in this update are breaking**, as such, not all are marked as breaking. The really major changes that require especially close attention are here listed, please scroll down to see the rest as well as the concrete changes of this high level overview.
 
+- Rename `Features::blogPosts` to `Features::markdownPosts` - This means you must update your hyde.php config, otherwise blog posts might not be generated
+- Rename `Features::hasBlogPosts` to `Features::hasMarkdownPosts`
 - Renamed base class AbstractPage to HydePage
 - Renamed base class AbstractMarkdownPage to BaseMarkdownPage
 - Renamed several HydePage methods to be more consistent

--- a/config/hyde.php
+++ b/config/hyde.php
@@ -54,7 +54,7 @@ return [
     'features' => [
         // Page Modules
         Features::htmlPages(),
-        Features::blogPosts(),
+        Features::markdownPosts(),
         Features::bladePages(),
         Features::markdownPages(),
         Features::documentationPages(),

--- a/packages/framework/config/hyde.php
+++ b/packages/framework/config/hyde.php
@@ -54,7 +54,7 @@ return [
     'features' => [
         // Page Modules
         Features::htmlPages(),
-        Features::blogPosts(),
+        Features::markdownPosts(),
         Features::bladePages(),
         Features::markdownPages(),
         Features::documentationPages(),

--- a/packages/framework/src/Foundation/FileCollection.php
+++ b/packages/framework/src/Foundation/FileCollection.php
@@ -58,7 +58,7 @@ final class FileCollection extends BaseFoundationCollection
             $this->discoverFilesFor(MarkdownPage::class);
         }
 
-        if (Features::hasBlogPosts()) {
+        if (Features::hasMarkdownPosts()) {
             $this->discoverFilesFor(MarkdownPost::class);
         }
 

--- a/packages/framework/src/Foundation/PageCollection.php
+++ b/packages/framework/src/Foundation/PageCollection.php
@@ -45,7 +45,7 @@ final class PageCollection extends BaseFoundationCollection
             $this->discoverPagesFor(MarkdownPage::class);
         }
 
-        if (Features::hasBlogPosts()) {
+        if (Features::hasMarkdownPosts()) {
             $this->discoverPagesFor(MarkdownPost::class);
         }
 

--- a/packages/framework/src/Helpers/Features.php
+++ b/packages/framework/src/Helpers/Features.php
@@ -50,11 +50,6 @@ class Features implements Arrayable, \JsonSerializable
     // Determine if a given feature is enabled.
     // ================================================
 
-    public static function hasMarkdownPosts(): bool
-    {
-        return static::enabled(static::markdownPosts());
-    }
-
     public static function hasHtmlPages(): bool
     {
         return static::enabled(static::htmlPages());
@@ -68,6 +63,11 @@ class Features implements Arrayable, \JsonSerializable
     public static function hasMarkdownPages(): bool
     {
         return static::enabled(static::markdownPages());
+    }
+
+    public static function hasMarkdownPosts(): bool
+    {
+        return static::enabled(static::markdownPosts());
     }
 
     public static function hasDocumentationPages(): bool
@@ -107,11 +107,6 @@ class Features implements Arrayable, \JsonSerializable
     // Enable a given feature to be used in the config.
     // ================================================
 
-    public static function markdownPosts(): string
-    {
-        return 'markdown-posts';
-    }
-
     public static function htmlPages(): string
     {
         return 'html-pages';
@@ -125,6 +120,11 @@ class Features implements Arrayable, \JsonSerializable
     public static function markdownPages(): string
     {
         return 'markdown-pages';
+    }
+
+    public static function markdownPosts(): string
+    {
+        return 'markdown-posts';
     }
 
     public static function documentationPages(): string

--- a/packages/framework/src/Helpers/Features.php
+++ b/packages/framework/src/Helpers/Features.php
@@ -31,7 +31,7 @@ class Features implements Arrayable, \JsonSerializable
         return in_array($feature, config('hyde.features', [
             // Page Modules
             static::htmlPages(),
-            static::blogPosts(),
+            static::markdownPosts(),
             static::bladePages(),
             static::markdownPages(),
             static::documentationPages(),
@@ -52,7 +52,7 @@ class Features implements Arrayable, \JsonSerializable
 
     public static function hasBlogPosts(): bool
     {
-        return static::enabled(static::blogPosts());
+        return static::enabled(static::markdownPosts());
     }
 
     public static function hasHtmlPages(): bool
@@ -107,9 +107,9 @@ class Features implements Arrayable, \JsonSerializable
     // Enable a given feature to be used in the config.
     // ================================================
 
-    public static function blogPosts(): string
+    public static function markdownPosts(): string
     {
-        return 'blog-posts';
+        return 'markdown-posts';
     }
 
     public static function htmlPages(): string

--- a/packages/framework/src/Helpers/Features.php
+++ b/packages/framework/src/Helpers/Features.php
@@ -50,7 +50,7 @@ class Features implements Arrayable, \JsonSerializable
     // Determine if a given feature is enabled.
     // ================================================
 
-    public static function hasBlogPosts(): bool
+    public static function hasMarkdownPosts(): bool
     {
         return static::enabled(static::markdownPosts());
     }
@@ -168,7 +168,7 @@ class Features implements Arrayable, \JsonSerializable
     public static function rss(): bool
     {
         return Hyde::hasSiteUrl()
-            && static::hasBlogPosts()
+            && static::hasMarkdownPosts()
             && config('hyde.generate_rss_feed', true)
             && extension_loaded('simplexml')
             && count(DiscoveryService::getMarkdownPostFiles()) > 0;

--- a/packages/framework/tests/Unit/HydeHelperFacadeTest.php
+++ b/packages/framework/tests/Unit/HydeHelperFacadeTest.php
@@ -22,7 +22,7 @@ class HydeHelperFacadeTest extends TestCase
     public function test_features_facade_can_be_used_to_call_static_methods_on_features_class()
     {
         $this->assertTrue(
-            Hyde::features()->hasBlogPosts()
+            Hyde::features()->hasMarkdownPosts()
         );
     }
 

--- a/packages/framework/tests/Unit/HydeHelperFacadeTest.php
+++ b/packages/framework/tests/Unit/HydeHelperFacadeTest.php
@@ -29,7 +29,7 @@ class HydeHelperFacadeTest extends TestCase
     public function test_hyde_has_feature_shorthand_calls_static_method_on_features_class()
     {
         $this->assertTrue(
-            Hyde::hasFeature('blog-posts')
+            Hyde::hasFeature('markdown-posts')
         );
     }
 }


### PR DESCRIPTION
This means you must update your hyde.php config, otherwise blog posts might not be generated.
