### PR TITLE
Add cache busting

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -28,6 +28,7 @@ The most high impact change is change of sidebar front matter options, and relat
 - Added support for plain HTML pages that are copied from the _pages to the _site directory [#519](https://github.com/hydephp/develop/pull/519)
 - Added class aliases for all page types so they can be used in Blade components without the full namespace [#518](https://github.com/hydephp/develop/pull/518)
 - Added a Redirect helper to create custom static HTML redirects [#527](https://github.com/hydephp/develop/pull/527)
+- Added automatic cache busting to the Asset helper [#530](https://github.com/hydephp/develop/pull/530)
 
 ### Changed
 

--- a/packages/framework/resources/views/layouts/scripts.blade.php
+++ b/packages/framework/resources/views/layouts/scripts.blade.php
@@ -1,6 +1,6 @@
 {{-- The compiled Laravel Mix scripts --}}
 @if(Asset::hasMediaFile('app.js'))
-<script defer src="{{ Hyde::relativeLink('media/app.js') }}"></script>
+<script defer src="{{ Asset::mediaLink('app.js') }}"></script>
 @endif
 
 {{-- Alpine.js --}}

--- a/packages/framework/resources/views/layouts/styles.blade.php
+++ b/packages/framework/resources/views/layouts/styles.blade.php
@@ -5,7 +5,7 @@
 @if(config('hyde.load_app_styles_from_cdn', false))
 <link rel="stylesheet" href="{{ Asset::cdnLink('app.css') }}">
 @elseif(Asset::hasMediaFile('app.css'))
-<link rel="stylesheet" href="{{ Hyde::relativeLink('media/app.css') }}">
+<link rel="stylesheet" href="{{ Asset::mediaLink('app.css') }}">
 @endif
 
 {{-- Add any extra styles to include after the others --}}

--- a/packages/framework/src/Helpers/Asset.php
+++ b/packages/framework/src/Helpers/Asset.php
@@ -12,6 +12,7 @@ use Illuminate\Support\Facades\Facade;
  * @method static string stylePath()
  * @method static string constructCdnPath(string $file)
  * @method static string cdnLink(string $file)
+ * @method static string mediaLink(string $file)
  * @method static bool hasMediaFile(string $file)
  */
 class Asset extends Facade

--- a/packages/framework/src/Services/AssetService.php
+++ b/packages/framework/src/Services/AssetService.php
@@ -38,6 +38,11 @@ class AssetService
         return $this->constructCdnPath($file);
     }
 
+    public function mediaLink(string $file): string
+    {
+        return Hyde::relativeLink('media/'.$file);
+    }
+
     public function hasMediaFile(string $file): bool
     {
         return file_exists(Hyde::path('_media').'/'.$file);

--- a/packages/framework/src/Services/AssetService.php
+++ b/packages/framework/src/Services/AssetService.php
@@ -40,11 +40,16 @@ class AssetService
 
     public function mediaLink(string $file): string
     {
-        return Hyde::relativeLink("media/$file") . '?v=' . md5_file(Hyde::path("_media/$file"));
+        return Hyde::relativeLink("media/$file") . $this->getCacheBustKey($file);
     }
 
     public function hasMediaFile(string $file): bool
     {
         return file_exists(Hyde::path('_media').'/'.$file);
+    }
+
+    protected function getCacheBustKey(string $file): string|false
+    {
+        return '?v=' . md5_file(Hyde::path("_media/$file"));
     }
 }

--- a/packages/framework/src/Services/AssetService.php
+++ b/packages/framework/src/Services/AssetService.php
@@ -40,7 +40,7 @@ class AssetService
 
     public function mediaLink(string $file): string
     {
-        return Hyde::relativeLink("media/$file");
+        return Hyde::relativeLink("media/$file") . '?v=' . md5_file(Hyde::path("_media/$file"));
     }
 
     public function hasMediaFile(string $file): bool

--- a/packages/framework/src/Services/AssetService.php
+++ b/packages/framework/src/Services/AssetService.php
@@ -50,7 +50,7 @@ class AssetService
 
     protected function getCacheBustKey(string $file): string
     {
-        if (! config('hyde.cache_busting')) {
+        if (! config('hyde.cache_busting', true)) {
             return '';
         }
 

--- a/packages/framework/src/Services/AssetService.php
+++ b/packages/framework/src/Services/AssetService.php
@@ -50,6 +50,10 @@ class AssetService
 
     protected function getCacheBustKey(string $file): string
     {
+        if (! config('hyde.cache_busting')) {
+            return '';
+        }
+
         return '?v='.md5_file(Hyde::path("_media/$file"));
     }
 }

--- a/packages/framework/src/Services/AssetService.php
+++ b/packages/framework/src/Services/AssetService.php
@@ -48,7 +48,7 @@ class AssetService
         return file_exists(Hyde::path('_media').'/'.$file);
     }
 
-    protected function getCacheBustKey(string $file): string|false
+    protected function getCacheBustKey(string $file): string
     {
         return '?v='.md5_file(Hyde::path("_media/$file"));
     }

--- a/packages/framework/src/Services/AssetService.php
+++ b/packages/framework/src/Services/AssetService.php
@@ -40,7 +40,7 @@ class AssetService
 
     public function mediaLink(string $file): string
     {
-        return Hyde::relativeLink('media/'.$file);
+        return Hyde::relativeLink("media/$file");
     }
 
     public function hasMediaFile(string $file): bool

--- a/packages/framework/src/Services/AssetService.php
+++ b/packages/framework/src/Services/AssetService.php
@@ -40,7 +40,7 @@ class AssetService
 
     public function mediaLink(string $file): string
     {
-        return Hyde::relativeLink("media/$file") . $this->getCacheBustKey($file);
+        return Hyde::relativeLink("media/$file").$this->getCacheBustKey($file);
     }
 
     public function hasMediaFile(string $file): bool
@@ -50,6 +50,6 @@ class AssetService
 
     protected function getCacheBustKey(string $file): string|false
     {
-        return '?v=' . md5_file(Hyde::path("_media/$file"));
+        return '?v='.md5_file(Hyde::path("_media/$file"));
     }
 }

--- a/packages/framework/tests/Feature/AssetServiceTest.php
+++ b/packages/framework/tests/Feature/AssetServiceTest.php
@@ -37,10 +37,18 @@ class AssetServiceTest extends TestCase
         $this->assertStringContainsString('styles.css', $path);
     }
 
-    public function test_media_link_returns_media_path()
+    public function test_media_link_returns_media_path_with_cache_key()
     {
         $service = new AssetService();
         $this->assertIsString($path = $service->mediaLink('app.css'));
         $this->assertEquals('media/app.css?v='.md5_file(Hyde::path('_media/app.css')), $path);
+    }
+
+    public function test_media_link_returns_media_path_without_cache_key_if_cache_busting_is_disabled()
+    {
+        config(['hyde.cache_busting' => false]);
+        $service = new AssetService();
+        $this->assertIsString($path = $service->mediaLink('app.css'));
+        $this->assertEquals('media/app.css', $path);
     }
 }

--- a/packages/framework/tests/Feature/AssetServiceTest.php
+++ b/packages/framework/tests/Feature/AssetServiceTest.php
@@ -2,6 +2,7 @@
 
 namespace Hyde\Framework\Testing\Feature;
 
+use Hyde\Framework\Hyde;
 use Hyde\Framework\Services\AssetService;
 use Hyde\Testing\TestCase;
 
@@ -39,7 +40,7 @@ class AssetServiceTest extends TestCase
     public function test_media_link_returns_media_path()
     {
         $service = new AssetService();
-        $this->assertIsString($path = $service->mediaLink('styles.css'));
-        $this->assertEquals('media/styles.css', $path);
+        $this->assertIsString($path = $service->mediaLink('app.css'));
+        $this->assertEquals('media/app.css?v='.md5_file(Hyde::path('_media/app.css')), $path);
     }
 }

--- a/packages/framework/tests/Feature/AssetServiceTest.php
+++ b/packages/framework/tests/Feature/AssetServiceTest.php
@@ -35,4 +35,11 @@ class AssetServiceTest extends TestCase
         $this->assertIsString($path = $service->constructCdnPath('styles.css'));
         $this->assertStringContainsString('styles.css', $path);
     }
+
+    public function test_media_link_returns_media_path()
+    {
+        $service = new AssetService();
+        $this->assertIsString($path = $service->mediaLink('styles.css'));
+        $this->assertEquals('media/styles.css', $path);
+    }
 }

--- a/packages/framework/tests/Feature/MetadataViewTest.php
+++ b/packages/framework/tests/Feature/MetadataViewTest.php
@@ -21,6 +21,7 @@ class MetadataViewTest extends TestCase
         parent::setUp();
 
         config(['site.url' => 'http://localhost']);
+        config(['hyde.cache_busting' => false]);
     }
 
     protected function build(?string $page = null): void

--- a/packages/framework/tests/Unit/RelativeLinksAcrossPagesRetainsIntegrityTest.php
+++ b/packages/framework/tests/Unit/RelativeLinksAcrossPagesRetainsIntegrityTest.php
@@ -15,6 +15,8 @@ class RelativeLinksAcrossPagesRetainsIntegrityTest extends TestCase
     {
         parent::setUp();
 
+        config(['hyde.cache_busting' => false]);
+
         $this->needsDirectory('_pages/nested');
         $this->file('_pages/root.md');
         $this->file('_pages/root1.md');

--- a/packages/framework/tests/Unit/Views/ScriptsComponentViewTest.php
+++ b/packages/framework/tests/Unit/Views/ScriptsComponentViewTest.php
@@ -15,6 +15,7 @@ class ScriptsComponentViewTest extends TestCase
 
     protected function renderTestView(): string
     {
+        config(['hyde.cache_busting' => false]);
         view()->share('currentPage', $this->mockCurrentPage ?? '');
 
         return Blade::render(file_get_contents(

--- a/packages/framework/tests/Unit/Views/StylesComponentViewTest.php
+++ b/packages/framework/tests/Unit/Views/StylesComponentViewTest.php
@@ -16,6 +16,7 @@ class StylesComponentViewTest extends TestCase
 
     protected function renderTestView(): string
     {
+        config(['hyde.cache_busting' => false]);
         view()->share('currentPage', $this->mockCurrentPage ?? '');
 
         return Blade::render(file_get_contents(


### PR DESCRIPTION
Adds a new `Asset::mediaLink()`helper method which (besides adding visual consistency in Blade views) automatically appends `?v= + md5()` of the file, allowing for easy cache busting. This can be disabled by setting `hyde.cache_busting` to false.