### PR TITLE
Rewrite the build manifest schema

### DIFF
--- a/packages/framework/src/Actions/PostBuildTasks/GenerateBuildManifest.php
+++ b/packages/framework/src/Actions/PostBuildTasks/GenerateBuildManifest.php
@@ -41,6 +41,7 @@ class GenerateBuildManifest extends AbstractBuildTask
     protected function hashOutputPath(HydePage $page): ?string
     {
         $path = Hyde::sitePath($page->getOutputPath());
+
         return file_exists($path) ? md5_file($path) : null;
     }
 
@@ -61,7 +62,7 @@ class GenerateBuildManifest extends AbstractBuildTask
     {
         return json_encode([
             'generated' => now(),
-            'pages' => $pages
+            'pages' => $pages,
         ], JSON_PRETTY_PRINT);
     }
 }

--- a/packages/framework/src/Actions/PostBuildTasks/GenerateBuildManifest.php
+++ b/packages/framework/src/Actions/PostBuildTasks/GenerateBuildManifest.php
@@ -60,7 +60,7 @@ class GenerateBuildManifest extends AbstractBuildTask
     protected function jsonEncodeOutput(Collection $pages): string
     {
         return json_encode([
-            'date' => now(),
+            'generated' => now(),
             'pages' => $pages
         ], JSON_PRETTY_PRINT);
     }

--- a/packages/framework/src/Actions/PostBuildTasks/GenerateBuildManifest.php
+++ b/packages/framework/src/Actions/PostBuildTasks/GenerateBuildManifest.php
@@ -22,15 +22,11 @@ class GenerateBuildManifest extends AbstractBuildTask
 
     public function run(): void
     {
-        $manifest = new Collection();
-
-        $manifest->push([
-            'date' => now(),
-        ]);
+        $pages = new Collection();
 
         /** @var \Hyde\Framework\Concerns\HydePage $page */
         foreach (Hyde::pages() as $page) {
-            $manifest->push([
+            $pages->push([
                 'source_path' => $page->getSourcePath(),
                 'output_path' => $page->getOutputPath(),
                 'source_hash' => md5_file(Hyde::path($page->getSourcePath())),
@@ -41,7 +37,10 @@ class GenerateBuildManifest extends AbstractBuildTask
         file_put_contents(Hyde::path(config(
             'hyde.build_manifest_path',
             'storage/framework/cache/build-manifest.json'
-        )), $manifest->toJson());
+        )), json_encode([
+            'date' => now(),
+            'pages' => $pages
+        ]));
     }
 
     protected function hashOutputPath(string $path): ?string

--- a/packages/framework/src/Actions/PostBuildTasks/GenerateBuildManifest.php
+++ b/packages/framework/src/Actions/PostBuildTasks/GenerateBuildManifest.php
@@ -24,6 +24,10 @@ class GenerateBuildManifest extends AbstractBuildTask
     {
         $manifest = new Collection();
 
+        $manifest->push([
+            'date' => now(),
+        ]);
+
         /** @var \Hyde\Framework\Concerns\HydePage $page */
         foreach (Hyde::pages() as $page) {
             $manifest->push([

--- a/packages/framework/src/Actions/PostBuildTasks/GenerateBuildManifest.php
+++ b/packages/framework/src/Actions/PostBuildTasks/GenerateBuildManifest.php
@@ -31,7 +31,8 @@ class GenerateBuildManifest extends AbstractBuildTask
         /** @var \Hyde\Framework\Concerns\HydePage $page */
         foreach (Hyde::pages() as $page) {
             $manifest->push([
-                'page' => $page->getSourcePath(),
+                'source_path' => $page->getSourcePath(),
+                'output_path' => $page->getOutputPath(),
                 'source_hash' => md5_file(Hyde::path($page->getSourcePath())),
                 'output_hash' => $this->hashOutputPath(Hyde::sitePath($page->getOutputPath())),
             ]);

--- a/packages/framework/src/Actions/PostBuildTasks/GenerateBuildManifest.php
+++ b/packages/framework/src/Actions/PostBuildTasks/GenerateBuildManifest.php
@@ -62,6 +62,6 @@ class GenerateBuildManifest extends AbstractBuildTask
         return json_encode([
             'date' => now(),
             'pages' => $pages
-        ]);
+        ], JSON_PRETTY_PRINT);
     }
 }

--- a/packages/framework/tests/Unit/GenerateBuildManifestTest.php
+++ b/packages/framework/tests/Unit/GenerateBuildManifestTest.php
@@ -20,13 +20,22 @@ class GenerateBuildManifestTest extends TestCase
         $manifest = json_decode(file_get_contents(Hyde::path('storage/framework/cache/build-manifest.json')), true);
 
         $this->assertIsArray($manifest);
+
         $this->assertCount(2, $manifest);
+        $this->assertCount(2, $manifest['pages']);
 
-        $this->assertArrayHasKey('page', $manifest[0]);
-        $this->assertArrayHasKey('source_hash', $manifest[0]);
-        $this->assertArrayHasKey('output_hash', $manifest[0]);
+        $this->assertArrayHasKey('source_path', $manifest['pages'][0]);
+        $this->assertArrayHasKey('output_path', $manifest['pages'][0]);
+        $this->assertArrayHasKey('source_hash', $manifest['pages'][0]);
+        $this->assertArrayHasKey('output_hash', $manifest['pages'][0]);
 
-        $this->assertStringContainsString('_pages/404.blade.php', $manifest[0]['page']);
-        $this->assertStringContainsString('_pages/index.blade.php', $manifest[1]['page']);
+        $this->assertEquals('_pages/404.blade.php', $manifest['pages'][0]['source_path']);
+        $this->assertEquals('_pages/index.blade.php', $manifest['pages'][1]['source_path']);
+
+        $this->assertEquals('404.html', $manifest['pages'][0]['output_path']);
+        $this->assertEquals('index.html', $manifest['pages'][1]['output_path']);
+
+        $this->assertEquals(md5_file(Hyde::path('_pages/404.blade.php')), $manifest['pages'][0]['source_hash']);
+        $this->assertNull($manifest['pages'][0]['output_hash']);
     }
 }


### PR DESCRIPTION
## About
Adds the date the manifest was compiled, and removes the page property, replacing it with the source and output paths. Previously, the page property contained the source path. To differentiate the date from the pages, the pages are now in under the `pages` array key.

## Comparison

### Previous JSON format
```json
[
  {
    "page": "_pages/404.blade.php",
    "source_hash": "9a4e236420cd01cbb726240199d0de82",
    "output_hash": "c4ef14f1fa794d3d105b6d039b28ba06"
  },
  {
    "page": "_pages/index.blade.php",
    "source_hash": "72469ce3453f5b396402e5207493921b",
    "output_hash": "72469ce3453f5b396402e5207493921b"
  }
]
```

### New JSON format

```json
{
  "generated": "2022-10-01T13:40:09.602307Z",
  "pages": [
    {
      "source_path": "_pages/404.blade.php",
      "output_path": "404.html",
      "source_hash": "27a3012eacef5d0672e59ddcd9866985",
      "output_hash": "e8f804948dc9890a5659b53910f783ca"
    },
    {
      "source_path": "_pages/index.blade.php",
      "output_path": "index.html",
      "source_hash": "2611703286fbf5d7a39bb459736f9aa6",
      "output_hash": "2611703286fbf5d7a39bb459736f9aa6"
    }
  ]
}
```

_Output hash for the index page is the same as the default page is plain HTML. The output hash may be null in case the file does not exist, though since the manifest is generated immediately after the build, this shouldn't happen in production._