### PR TITLE
Fix: move NavigationDataTest from 'Model' to 'Feature'

### DIFF
--- a/packages/framework/tests/Feature/NavigationDataTest.php
+++ b/packages/framework/tests/Feature/NavigationDataTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Hyde\Framework\Testing\Models;
+namespace Hyde\Framework\Testing\Feature;
 
 use Hyde\Framework\Contracts\FrontMatter\Support\NavigationSchema;
 use Hyde\Framework\Models\Navigation\NavigationData;


### PR DESCRIPTION
This PR moves `NavigationDataTest` from `Model` directory to `Feature` and updates its namespace respectively. Closes #557 