### PR TITLE
Add 'getExtension' method to the File class

### DIFF
--- a/packages/framework/src/Models/Support/File.php
+++ b/packages/framework/src/Models/Support/File.php
@@ -131,6 +131,11 @@ class File implements Arrayable, \JsonSerializable, \Stringable
         return 'text/plain';
     }
 
+    public function getExtension(): string
+    {
+        return pathinfo($this->path, PATHINFO_EXTENSION);
+    }
+
     /** @inheritDoc */
     public function toArray(): array
     {

--- a/packages/framework/tests/Feature/FileTest.php
+++ b/packages/framework/tests/Feature/FileTest.php
@@ -87,6 +87,15 @@ class FileTest extends TestCase
         $this->assertSame(7, File::make('foo.txt')->getContentLength());
     }
 
+    public function test_get_extension_returns_extension_of_file()
+    {
+        $this->file('foo.txt', 'foo');
+        $this->assertSame('txt', File::make('foo.txt')->getExtension());
+
+        $this->file('foo.png', 'foo');
+        $this->assertSame('png', File::make('foo.png')->getExtension());
+    }
+
     public function test_get_mime_type_returns_mime_type_of_file_using_lookup_table()
     {
         $lookup = [


### PR DESCRIPTION
This PR adds `getExtension(): string` method to the [File.php](https://github.com/hydephp/develop/blob/master/packages/framework/src/Models/Support/File.php) class that by using `pathinfo()` method under the hood returns extension of a file as a result.
To confirm that everything works as expected I've attached a simple test in `FileTest.php` file that check few potential use cases.
This should close issue #556 