### PR TITLE
Update the RealtimeCompiler package

### DIFF
--- a/packages/hyde/composer.json
+++ b/packages/hyde/composer.json
@@ -29,7 +29,7 @@
         "laravel-zero/framework": "^9.1"
     },
     "require-dev": {
-        "hyde/realtime-compiler": "^2.6"
+        "hyde/realtime-compiler": "^2.7"
     },
     "autoload": {
         "psr-4": {

--- a/packages/realtime-compiler/README.md
+++ b/packages/realtime-compiler/README.md
@@ -20,38 +20,3 @@ See the [Security Policy](https://github.com/hydephp/realtime-compiler/security/
 | < 1.0   | :x:                | Alpha  |
 
 *1.x LTS receives security fixes only
-
-## v2.0 Release Notes
-
-### Preface
-
-This release completely rewrites the Hyde Realtime Compiler.
-
-The application server is now powered by the lightweight [Microserve](https://github.com/caendesilva/microserve)
-HTTP server API, providing a robust and fast way to route and handle requests without any extra dependencies.
-
-In addition, the source files are no longer compiled by calling the HydeCLI in a separate process,
-instead, the server compiles source files directly through the Hyde Framework code without any
-intermediary process.
-
-This gives the huge benefit of being able to catch errors and exceptions directly,
-without having to search for them in the console output like in v1.x.
-
-### Internal Changes
-
-- HTTP logic is handled by [Microserve](https://github.com/caendesilva/microserve), through the new [HttpKernel](https://github.com/hydephp/realtime-compiler/blob/master/src/Http/HttpKernel.php).
-- Requests are sent to the Router to be processed by the appropriate handler.
-- Web pages are compiled through the [Hyde Framework](https://github.com/hydephp/framework), instead of calling the HydeCLI.
-- Static assets are proxied directly without booting the entire framework.
-- Exceptions are handled by [Whoops](https://github.com/filp/whoops), through the ExceptionHandler.
-- The server.php is moved to the `bin` directory.
-
-### API Changes
-
-The way the server works for the end-user has not been changed much.
-Most people will not even notice anything but the new features.
-
-The only real change is that applications will need to point to the
-new `server.php` file which is now located in the `bin` directory.
-
-The debug/console output has been removed.

--- a/packages/realtime-compiler/composer.json
+++ b/packages/realtime-compiler/composer.json
@@ -20,6 +20,6 @@
         "hyde/framework": "*"
     },
     "suggest": {
-        "hyde/framework": "This package requires Hyde Framework version v0.48.0-beta or higher."
+        "hyde/framework": "This package requires Hyde Framework version v0.64.0-beta or higher."
     }
 }

--- a/packages/realtime-compiler/composer.json
+++ b/packages/realtime-compiler/composer.json
@@ -17,9 +17,6 @@
     "bin": ["bin/server.php"],
     "require": {
         "desilva/microserve": "^1.0",
-        "hyde/framework": "*"
-    },
-    "suggest": {
-        "hyde/framework": "This package requires Hyde Framework version v0.64.0-beta or higher."
+        "hyde/framework": "^v0.64"
     }
 }


### PR DESCRIPTION
Fixes #515:

> Needs a minor version bump as well as updating the minimum framework version as the package uses the HydePage class from the upcoming framework release.