### PR TITLE
Change version method to return the new version constant instead of using Composer

### DIFF
--- a/packages/framework/src/HydeKernel.php
+++ b/packages/framework/src/HydeKernel.php
@@ -2,7 +2,6 @@
 
 namespace Hyde\Framework;
 
-use Composer\InstalledVersions;
 use Hyde\Framework\Concerns\JsonSerializesArrayable;
 use Hyde\Framework\Foundation\FileCollection;
 use Hyde\Framework\Foundation\Filesystem;
@@ -70,7 +69,7 @@ class HydeKernel implements Arrayable, \JsonSerializable
 
     public static function version(): string
     {
-        return InstalledVersions::getPrettyVersion('hyde/framework') ?: 'unreleased';
+        return self::VERSION;
     }
 
     public function features(): Features

--- a/packages/framework/tests/Feature/HydeKernelTest.php
+++ b/packages/framework/tests/Feature/HydeKernelTest.php
@@ -240,4 +240,9 @@ class HydeKernelTest extends TestCase
             HydeKernel::VERSION, InstalledVersions::getPrettyVersion('hyde/framework')
             ) >= 0);
     }
+
+    public function test_version_method_returns_version_constant()
+    {
+        $this->assertSame(HydeKernel::VERSION, Hyde::version());
+    }
 }

--- a/packages/framework/tests/Feature/MetadataViewTest.php
+++ b/packages/framework/tests/Feature/MetadataViewTest.php
@@ -3,6 +3,7 @@
 namespace Hyde\Framework\Testing\Feature;
 
 use Hyde\Framework\Hyde;
+use Hyde\Framework\HydeKernel;
 use Hyde\Testing\TestCase;
 
 /**
@@ -75,7 +76,7 @@ class MetadataViewTest extends TestCase
             '<meta name="viewport" content="width=device-width, initial-scale=1">',
             '<meta id="meta-color-scheme" name="color-scheme" content="light">',
             '<link rel="sitemap" href="http://localhost/sitemap.xml" type="application/xml" title="Sitemap">',
-            '<meta name="generator" content="HydePHP dev-master">',
+            '<meta name="generator" content="HydePHP '.HydeKernel::VERSION.'">',
             '<meta property="og:site_name" content="HydePHP">',
         ];
     }


### PR DESCRIPTION
If you want to get the "real" installed version, you can still use the following (which was the old behaviour)

```php
Composer\InstalledVersions::getPrettyVersion('hyde/framework')
```