### PR TITLE
Change most Route helpers to return null instead of throwing exceptions

### DIFF
--- a/packages/framework/src/Models/Support/Route.php
+++ b/packages/framework/src/Models/Support/Route.php
@@ -195,16 +195,14 @@ class Route implements Stringable, JsonSerializable, Arrayable
     /**
      * Get a route from the route index for the specified source file path.
      *
-     * @param  string  $sourceFilePath  Example: _posts/foo.md
-     * @return \Hyde\Framework\Models\Support\Route
-     *
-     * @throws \Hyde\Framework\Exceptions\RouteNotFoundException
+     * @param string $sourceFilePath Example: _posts/foo.md
+     * @return \Hyde\Framework\Models\Support\Route|null
      */
-    public static function getFromSource(string $sourceFilePath): static
+    public static function getFromSource(string $sourceFilePath): ?static
     {
         return Hyde::routes()->first(function (Route $route) use ($sourceFilePath) {
             return $route->getSourcePath() === $sourceFilePath;
-        }) ?? throw new RouteNotFoundException($sourceFilePath);
+        });
     }
 
     /**

--- a/packages/framework/src/Models/Support/Route.php
+++ b/packages/framework/src/Models/Support/Route.php
@@ -18,6 +18,9 @@ use Stringable;
  * by providing helper methods and information allowing you to easily access and interact with the
  * various paths associated with a page, both source and compiled file paths as well as the URL.
  *
+ * If you visualize a web of this class's properties, you should be able to see how this
+ * class links them all together, and what powerful information you can gain from it.
+ *
  * @see \Hyde\Framework\Testing\Feature\RouteTest
  */
 class Route implements Stringable, JsonSerializable, Arrayable

--- a/packages/framework/src/Models/Support/Route.php
+++ b/packages/framework/src/Models/Support/Route.php
@@ -187,7 +187,7 @@ class Route implements Stringable, JsonSerializable, Arrayable
     /**
      * Get a route from the route index for the specified route key.
      *
-     * @param string $routeKey Example: posts/foo, posts.foo
+     * @param  string  $routeKey  Example: posts/foo, posts.foo
      * @return \Hyde\Framework\Models\Support\Route|null
      */
     public static function getFromKey(string $routeKey): ?static
@@ -198,7 +198,7 @@ class Route implements Stringable, JsonSerializable, Arrayable
     /**
      * Get a route from the route index for the specified source file path.
      *
-     * @param string $sourceFilePath Example: _posts/foo.md
+     * @param  string  $sourceFilePath  Example: _posts/foo.md
      * @return \Hyde\Framework\Models\Support\Route|null
      */
     public static function getFromSource(string $sourceFilePath): ?static

--- a/packages/framework/src/Models/Support/Route.php
+++ b/packages/framework/src/Models/Support/Route.php
@@ -178,8 +178,7 @@ class Route implements Stringable, JsonSerializable, Arrayable
      */
     public static function get(string $routeKey): static
     {
-        return static::getFromKey($routeKey)
-            ?? throw new RouteNotFoundException($routeKey);
+        return static::getFromKey($routeKey) ?? throw new RouteNotFoundException($routeKey);
     }
 
     /**

--- a/packages/framework/src/Models/Support/Route.php
+++ b/packages/framework/src/Models/Support/Route.php
@@ -237,7 +237,7 @@ class Route implements Stringable, JsonSerializable, Arrayable
     /**
      * Get the home route, usually the index page route.
      */
-    public static function home(): Route
+    public static function home(): ?Route
     {
         return static::getFromKey('index');
     }

--- a/packages/framework/src/Models/Support/Route.php
+++ b/packages/framework/src/Models/Support/Route.php
@@ -228,6 +228,8 @@ class Route implements Stringable, JsonSerializable, Arrayable
 
     /**
      * Get the current route for the page being rendered.
+     *
+     * @throws \Hyde\Framework\Exceptions\RouteNotFoundException
      */
     public static function current(): Route
     {

--- a/packages/framework/src/Models/Support/Route.php
+++ b/packages/framework/src/Models/Support/Route.php
@@ -184,15 +184,12 @@ class Route implements Stringable, JsonSerializable, Arrayable
     /**
      * Get a route from the route index for the specified route key.
      *
-     * @param  string  $routeKey  Example: posts/foo, posts.foo
-     * @return \Hyde\Framework\Models\Support\Route
-     *
-     * @throws \Hyde\Framework\Exceptions\RouteNotFoundException
+     * @param string $routeKey Example: posts/foo, posts.foo
+     * @return \Hyde\Framework\Models\Support\Route|null
      */
-    public static function getFromKey(string $routeKey): static
+    public static function getFromKey(string $routeKey): ?static
     {
-        return Hyde::routes()->get(str_replace('.', '/', $routeKey))
-            ?? throw new RouteNotFoundException($routeKey);
+        return Hyde::routes()->get(str_replace('.', '/', $routeKey));
     }
 
     /**

--- a/packages/framework/src/Models/Support/Route.php
+++ b/packages/framework/src/Models/Support/Route.php
@@ -177,7 +177,8 @@ class Route implements Stringable, JsonSerializable, Arrayable
      */
     public static function get(string $routeKey): static
     {
-        return static::getFromKey($routeKey);
+        return static::getFromKey($routeKey)
+            ?? throw new RouteNotFoundException($routeKey);
     }
 
     /**

--- a/packages/framework/src/Models/Support/Route.php
+++ b/packages/framework/src/Models/Support/Route.php
@@ -228,12 +228,10 @@ class Route implements Stringable, JsonSerializable, Arrayable
 
     /**
      * Get the current route for the page being rendered.
-     *
-     * @throws \Hyde\Framework\Exceptions\RouteNotFoundException
      */
-    public static function current(): Route
+    public static function current(): ?Route
     {
-        return Hyde::currentRoute() ?? throw new RouteNotFoundException('current');
+        return Hyde::currentRoute();
     }
 
     /**

--- a/packages/framework/src/Models/Support/Route.php
+++ b/packages/framework/src/Models/Support/Route.php
@@ -169,9 +169,7 @@ class Route implements Stringable, JsonSerializable, Arrayable
     }
 
     /**
-     * Get a route from the route index for the specified route key.
-     *
-     * Alias for static::getFromKey().
+     * Get a route from the route index for the specified route key or fail.
      *
      * @param  string  $routeKey  Example: posts/foo.md
      * @return \Hyde\Framework\Models\Support\Route

--- a/packages/framework/tests/Feature/RouteTest.php
+++ b/packages/framework/tests/Feature/RouteTest.php
@@ -209,11 +209,14 @@ class RouteTest extends TestCase
         $route = new Route(new MarkdownPage(identifier: 'foo'));
         view()->share('currentRoute', $route);
         $this->assertEquals($route, Route::current());
+
+        $this->assertSame(Hyde::currentRoute(), Route::current());
     }
 
     public function test_current_returns_null_if_route_is_not_found()
     {
         $this->assertNull(Route::current());
+        $this->assertSame(Hyde::currentRoute(), Route::current());
     }
 
     public function test_home_helper_returns_index_route()

--- a/packages/framework/tests/Feature/RouteTest.php
+++ b/packages/framework/tests/Feature/RouteTest.php
@@ -93,8 +93,7 @@ class RouteTest extends TestCase
 
     public function test_get_from_source_returns_null_if_route_is_not_found()
     {
-        $this->expectException(RouteNotFoundException::class);
-        Route::getFromSource('not-found');
+        $this->assertNull(Route::getFromSource('not-found'));
     }
 
     public function test_get_from_source_can_find_blade_pages()

--- a/packages/framework/tests/Feature/RouteTest.php
+++ b/packages/framework/tests/Feature/RouteTest.php
@@ -211,10 +211,9 @@ class RouteTest extends TestCase
         $this->assertEquals($route, Route::current());
     }
 
-    public function test_current_throws_exception_if_route_is_not_found()
+    public function test_current_returns_null_if_route_is_not_found()
     {
-        $this->expectException(RouteNotFoundException::class);
-        Route::current();
+        $this->assertNull(Route::current());
     }
 
     public function test_home_helper_returns_index_route()


### PR DESCRIPTION
Refactors the Route helper, so that only the `Route::get()` helper throws an exception if the route is not found, the others now return null.