### PR TITLE
Remove "Hyde" prefix from the console command class names

### DIFF
--- a/config/commands.php
+++ b/config/commands.php
@@ -58,7 +58,7 @@ return [
         NunoMaduro\LaravelConsoleSummary\SummaryCommand::class,
         Symfony\Component\Console\Command\DumpCompletionCommand::class,
         Symfony\Component\Console\Command\HelpCommand::class,
-        \Hyde\Console\Commands\HydeDebugCommand::class,
+        \Hyde\Console\Commands\DebugCommand::class,
     ],
 
     /*

--- a/packages/framework/src/Console/Commands/BuildRssFeedCommand.php
+++ b/packages/framework/src/Console/Commands/BuildRssFeedCommand.php
@@ -12,7 +12,7 @@ use LaravelZero\Framework\Commands\Command;
  *
  * @see \Hyde\Framework\Testing\Feature\Commands\HydeBuildRssFeedCommandTest
  */
-class HydeBuildRssFeedCommand extends Command
+class BuildRssFeedCommand extends Command
 {
     protected $signature = 'build:rss';
     protected $description = 'Generate the RSS feed';

--- a/packages/framework/src/Console/Commands/BuildSearchCommand.php
+++ b/packages/framework/src/Console/Commands/BuildSearchCommand.php
@@ -12,7 +12,7 @@ use LaravelZero\Framework\Commands\Command;
  *
  * @see \Hyde\Framework\Testing\Feature\Commands\HydeBuildSearchCommandTest
  */
-class HydeBuildSearchCommand extends Command
+class BuildSearchCommand extends Command
 {
     protected $signature = 'build:search';
     protected $description = 'Generate the docs/search.json';

--- a/packages/framework/src/Console/Commands/BuildSiteCommand.php
+++ b/packages/framework/src/Console/Commands/BuildSiteCommand.php
@@ -21,7 +21,7 @@ use LaravelZero\Framework\Commands\Command;
  *
  * @see \Hyde\Framework\Testing\Feature\StaticSiteServiceTest
  */
-class HydeBuildSiteCommand extends Command
+class BuildSiteCommand extends Command
 {
     /**
      * The signature of the command.

--- a/packages/framework/src/Console/Commands/BuildSitemapCommand.php
+++ b/packages/framework/src/Console/Commands/BuildSitemapCommand.php
@@ -12,7 +12,7 @@ use LaravelZero\Framework\Commands\Command;
  *
  * @see \Hyde\Framework\Testing\Feature\Commands\HydeBuildSitemapCommandTest
  */
-class HydeBuildSitemapCommand extends Command
+class BuildSitemapCommand extends Command
 {
     protected $signature = 'build:sitemap';
     protected $description = 'Generate the sitemap.xml';

--- a/packages/framework/src/Console/Commands/DebugCommand.php
+++ b/packages/framework/src/Console/Commands/DebugCommand.php
@@ -11,7 +11,7 @@ use LaravelZero\Framework\Commands\Command;
 /**
  * Hyde Command to print debug information.
  */
-class HydeDebugCommand extends Command
+class DebugCommand extends Command
 {
     /**
      * The signature of the command.

--- a/packages/framework/src/Console/Commands/MakePageCommand.php
+++ b/packages/framework/src/Console/Commands/MakePageCommand.php
@@ -16,7 +16,7 @@ use LaravelZero\Framework\Commands\Command;
  *
  * @see \Hyde\Framework\Testing\Feature\Commands\HydeMakePageCommandTest
  */
-class HydeMakePageCommand extends Command
+class MakePageCommand extends Command
 {
     /**
      * The name and signature of the console command.

--- a/packages/framework/src/Console/Commands/MakePostCommand.php
+++ b/packages/framework/src/Console/Commands/MakePostCommand.php
@@ -11,7 +11,7 @@ use LaravelZero\Framework\Commands\Command;
 /**
  * Hyde Command to scaffold a new Markdown Post.
  */
-class HydeMakePostCommand extends Command
+class MakePostCommand extends Command
 {
     /**
      * The signature of the command.

--- a/packages/framework/src/Console/Commands/PackageDiscoverCommand.php
+++ b/packages/framework/src/Console/Commands/PackageDiscoverCommand.php
@@ -11,7 +11,7 @@ use Illuminate\Foundation\PackageManifest;
 /**
  * @see \Hyde\Framework\Testing\Feature\Commands\HydePackageDiscoverCommandTest
  */
-class HydePackageDiscoverCommand extends BaseCommand
+class PackageDiscoverCommand extends BaseCommand
 {
     /** @var true */
     protected $hidden = true;

--- a/packages/framework/src/Console/Commands/PublishHomepageCommand.php
+++ b/packages/framework/src/Console/Commands/PublishHomepageCommand.php
@@ -15,7 +15,7 @@ use LaravelZero\Framework\Commands\Command;
  *
  * @see \Hyde\Framework\Testing\Feature\Commands\HydePublishHomepageCommandTest
  */
-class HydePublishHomepageCommand extends Command
+class PublishHomepageCommand extends Command
 {
     /** @var string */
     protected $signature = 'publish:homepage {homepage? : The name of the page to publish}

--- a/packages/framework/src/Console/Commands/PublishViewsCommand.php
+++ b/packages/framework/src/Console/Commands/PublishViewsCommand.php
@@ -11,7 +11,7 @@ use LaravelZero\Framework\Commands\Command;
 /**
  * Publish the Hyde Blade views.
  */
-class HydePublishViewsCommand extends Command
+class PublishViewsCommand extends Command
 {
     /** @var string */
     protected $signature = 'publish:views {category? : The category to publish}';

--- a/packages/framework/src/Console/Commands/RebuildStaticSiteCommand.php
+++ b/packages/framework/src/Console/Commands/RebuildStaticSiteCommand.php
@@ -16,7 +16,7 @@ use LaravelZero\Framework\Commands\Command;
  *
  * @see \Hyde\Framework\Testing\Feature\Commands\HydeRebuildStaticSiteCommandTest
  */
-class HydeRebuildStaticSiteCommand extends Command
+class RebuildStaticSiteCommand extends Command
 {
     /**
      * The signature of the command.

--- a/packages/framework/src/Console/Commands/RouteListCommand.php
+++ b/packages/framework/src/Console/Commands/RouteListCommand.php
@@ -13,7 +13,7 @@ use LaravelZero\Framework\Commands\Command;
  *
  * @see \Hyde\Framework\Testing\Feature\Commands\HydeRouteListCommandTest
  */
-class HydeRouteListCommand extends Command
+class RouteListCommand extends Command
 {
     protected $signature = 'route:list';
     protected $description = 'Display all registered routes.';

--- a/packages/framework/src/Console/Commands/ServeCommand.php
+++ b/packages/framework/src/Console/Commands/ServeCommand.php
@@ -10,7 +10,7 @@ use LaravelZero\Framework\Commands\Command;
 /**
  * Start the realtime compiler server.
  */
-class HydeServeCommand extends Command
+class ServeCommand extends Command
 {
     /**
      * The signature of the command.

--- a/packages/framework/src/Console/Commands/UpdateConfigsCommand.php
+++ b/packages/framework/src/Console/Commands/UpdateConfigsCommand.php
@@ -13,7 +13,7 @@ use LaravelZero\Framework\Commands\Command;
  *
  * @see \Hyde\Framework\Testing\Feature\Commands\HydeUpdateConfigsCommandTest
  */
-class HydeUpdateConfigsCommand extends Command
+class UpdateConfigsCommand extends Command
 {
     /** @var string */
     protected $signature = 'update:configs';

--- a/packages/framework/src/Console/Commands/ValidateCommand.php
+++ b/packages/framework/src/Console/Commands/ValidateCommand.php
@@ -10,7 +10,7 @@ use LaravelZero\Framework\Commands\Command;
 /**
  * @see \Hyde\Framework\Testing\Feature\Commands\HydeValidateCommandTest
  */
-class HydeValidateCommand extends Command
+class ValidateCommand extends Command
 {
     /** @var string */
     protected $signature = 'validate';

--- a/packages/framework/src/Framework/Actions/CreatesNewMarkdownPostFile.php
+++ b/packages/framework/src/Framework/Actions/CreatesNewMarkdownPostFile.php
@@ -15,7 +15,7 @@ use Illuminate\Support\Str;
  * using the Hyde command, and converts and formats the
  * data input by the user, and then saves the file.
  *
- * @see \Hyde\Console\Commands\HydeMakePostCommand
+ * @see \Hyde\Console\Commands\MakePostCommand
  */
 class CreatesNewMarkdownPostFile
 {

--- a/packages/framework/src/Framework/HydeServiceProvider.php
+++ b/packages/framework/src/Framework/HydeServiceProvider.php
@@ -109,23 +109,23 @@ class HydeServiceProvider extends ServiceProvider
     protected function registerHydeConsoleCommands(): void
     {
         $this->commands([
-            \Hyde\Console\Commands\HydePublishHomepageCommand::class,
-            \Hyde\Console\Commands\HydeUpdateConfigsCommand::class,
-            \Hyde\Console\Commands\HydePublishViewsCommand::class,
-            \Hyde\Console\Commands\HydeRebuildStaticSiteCommand::class,
-            \Hyde\Console\Commands\HydeBuildSiteCommand::class,
-            \Hyde\Console\Commands\HydeBuildSitemapCommand::class,
-            \Hyde\Console\Commands\HydeBuildRssFeedCommand::class,
-            \Hyde\Console\Commands\HydeBuildSearchCommand::class,
-            \Hyde\Console\Commands\HydeRouteListCommand::class,
-            \Hyde\Console\Commands\HydeMakePostCommand::class,
-            \Hyde\Console\Commands\HydeMakePageCommand::class,
-            \Hyde\Console\Commands\HydeValidateCommand::class,
+            \Hyde\Console\Commands\PublishHomepageCommand::class,
+            \Hyde\Console\Commands\UpdateConfigsCommand::class,
+            \Hyde\Console\Commands\PublishViewsCommand::class,
+            \Hyde\Console\Commands\RebuildStaticSiteCommand::class,
+            \Hyde\Console\Commands\BuildSiteCommand::class,
+            \Hyde\Console\Commands\BuildSitemapCommand::class,
+            \Hyde\Console\Commands\BuildRssFeedCommand::class,
+            \Hyde\Console\Commands\BuildSearchCommand::class,
+            \Hyde\Console\Commands\RouteListCommand::class,
+            \Hyde\Console\Commands\MakePostCommand::class,
+            \Hyde\Console\Commands\MakePageCommand::class,
+            \Hyde\Console\Commands\ValidateCommand::class,
             // Commands\HydeInstallCommand::class,
-            \Hyde\Console\Commands\HydeDebugCommand::class,
-            \Hyde\Console\Commands\HydeServeCommand::class,
+            \Hyde\Console\Commands\DebugCommand::class,
+            \Hyde\Console\Commands\ServeCommand::class,
 
-            \Hyde\Console\Commands\HydePackageDiscoverCommand::class,
+            \Hyde\Console\Commands\PackageDiscoverCommand::class,
         ]);
     }
 

--- a/packages/framework/src/Framework/Services/BuildService.php
+++ b/packages/framework/src/Framework/Services/BuildService.php
@@ -20,7 +20,7 @@ use Illuminate\Support\Facades\File;
  *
  * Handles the build loop which generates the static site.
  *
- * @see \Hyde\Console\Commands\HydeBuildSiteCommand
+ * @see \Hyde\Console\Commands\BuildSiteCommand
  * @see \Hyde\Framework\Testing\Feature\StaticSiteServiceTest
  */
 class BuildService

--- a/packages/framework/tests/Feature/Commands/HydeBuildRssFeedCommandTest.php
+++ b/packages/framework/tests/Feature/Commands/HydeBuildRssFeedCommandTest.php
@@ -8,7 +8,7 @@ use Hyde\Hyde;
 use Hyde\Testing\TestCase;
 
 /**
- * @covers \Hyde\Console\Commands\HydeBuildRssFeedCommand
+ * @covers \Hyde\Console\Commands\BuildRssFeedCommand
  * @covers \Hyde\Framework\Actions\PostBuildTasks\GenerateRssFeed
  */
 class HydeBuildRssFeedCommandTest extends TestCase

--- a/packages/framework/tests/Feature/Commands/HydeBuildSearchCommandTest.php
+++ b/packages/framework/tests/Feature/Commands/HydeBuildSearchCommandTest.php
@@ -11,7 +11,7 @@ use Hyde\Hyde;
 use Hyde\Testing\TestCase;
 
 /**
- * @covers \Hyde\Console\Commands\HydeBuildSearchCommand
+ * @covers \Hyde\Console\Commands\BuildSearchCommand
  * @covers \Hyde\Framework\Actions\PostBuildTasks\GenerateSearch
  */
 class HydeBuildSearchCommandTest extends TestCase

--- a/packages/framework/tests/Feature/Commands/HydeBuildSitemapCommandTest.php
+++ b/packages/framework/tests/Feature/Commands/HydeBuildSitemapCommandTest.php
@@ -8,7 +8,7 @@ use Hyde\Hyde;
 use Hyde\Testing\TestCase;
 
 /**
- * @covers \Hyde\Console\Commands\HydeBuildSitemapCommand
+ * @covers \Hyde\Console\Commands\BuildSitemapCommand
  * @covers \Hyde\Framework\Actions\PostBuildTasks\GenerateSitemap
  */
 class HydeBuildSitemapCommandTest extends TestCase

--- a/packages/framework/tests/Feature/Commands/HydeMakePageCommandTest.php
+++ b/packages/framework/tests/Feature/Commands/HydeMakePageCommandTest.php
@@ -10,7 +10,7 @@ use Hyde\Hyde;
 use Hyde\Testing\TestCase;
 
 /**
- * @covers \Hyde\Console\Commands\HydeMakePageCommand
+ * @covers \Hyde\Console\Commands\MakePageCommand
  */
 class HydeMakePageCommandTest extends TestCase
 {

--- a/packages/framework/tests/Feature/Commands/HydePackageDiscoverCommandTest.php
+++ b/packages/framework/tests/Feature/Commands/HydePackageDiscoverCommandTest.php
@@ -9,7 +9,7 @@ use Hyde\Testing\TestCase;
 use Illuminate\Foundation\PackageManifest;
 
 /**
- * @covers \Hyde\Console\Commands\HydePackageDiscoverCommand
+ * @covers \Hyde\Console\Commands\PackageDiscoverCommand
  */
 class HydePackageDiscoverCommandTest extends TestCase
 {

--- a/packages/framework/tests/Feature/Commands/HydePublishHomepageCommandTest.php
+++ b/packages/framework/tests/Feature/Commands/HydePublishHomepageCommandTest.php
@@ -8,7 +8,7 @@ use Hyde\Hyde;
 use Hyde\Testing\TestCase;
 
 /**
- * @covers \Hyde\Console\Commands\HydePublishHomepageCommand
+ * @covers \Hyde\Console\Commands\PublishHomepageCommand
  */
 class HydePublishHomepageCommandTest extends TestCase
 {

--- a/packages/framework/tests/Feature/Commands/HydePublishViewsCommandTest.php
+++ b/packages/framework/tests/Feature/Commands/HydePublishViewsCommandTest.php
@@ -8,7 +8,7 @@ use Hyde\Hyde;
 use Hyde\Testing\TestCase;
 
 /**
- * @covers \Hyde\Console\Commands\HydePublishViewsCommand
+ * @covers \Hyde\Console\Commands\PublishViewsCommand
  */
 class HydePublishViewsCommandTest extends TestCase
 {

--- a/packages/framework/tests/Feature/Commands/HydeRebuildStaticSiteCommandTest.php
+++ b/packages/framework/tests/Feature/Commands/HydeRebuildStaticSiteCommandTest.php
@@ -8,7 +8,7 @@ use Hyde\Hyde;
 use Hyde\Testing\TestCase;
 
 /**
- * @covers \Hyde\Console\Commands\HydeRebuildStaticSiteCommand
+ * @covers \Hyde\Console\Commands\RebuildStaticSiteCommand
  */
 class HydeRebuildStaticSiteCommandTest extends TestCase
 {

--- a/packages/framework/tests/Feature/Commands/HydeRouteListCommandTest.php
+++ b/packages/framework/tests/Feature/Commands/HydeRouteListCommandTest.php
@@ -7,7 +7,7 @@ namespace Hyde\Framework\Testing\Feature\Commands;
 use Hyde\Testing\TestCase;
 
 /**
- * @covers \Hyde\Console\Commands\HydeRouteListCommand
+ * @covers \Hyde\Console\Commands\RouteListCommand
  */
 class HydeRouteListCommandTest extends TestCase
 {

--- a/packages/framework/tests/Feature/Commands/HydeServeCommandTest.php
+++ b/packages/framework/tests/Feature/Commands/HydeServeCommandTest.php
@@ -7,7 +7,7 @@ namespace Hyde\Framework\Testing\Feature\Commands;
 use Hyde\Testing\TestCase;
 
 /**
- * @covers \Hyde\Console\Commands\HydeServeCommand
+ * @covers \Hyde\Console\Commands\ServeCommand
  */
 class HydeServeCommandTest extends TestCase
 {

--- a/packages/framework/tests/Feature/Commands/HydeUpdateConfigsCommandTest.php
+++ b/packages/framework/tests/Feature/Commands/HydeUpdateConfigsCommandTest.php
@@ -9,7 +9,7 @@ use Hyde\Testing\TestCase;
 use Illuminate\Support\Facades\File;
 
 /**
- * @covers \Hyde\Console\Commands\HydeUpdateConfigsCommand
+ * @covers \Hyde\Console\Commands\UpdateConfigsCommand
  */
 class HydeUpdateConfigsCommandTest extends TestCase
 {

--- a/packages/framework/tests/Feature/Commands/HydeValidateCommandTest.php
+++ b/packages/framework/tests/Feature/Commands/HydeValidateCommandTest.php
@@ -7,7 +7,7 @@ namespace Hyde\Framework\Testing\Feature\Commands;
 use Hyde\Testing\TestCase;
 
 /**
- * @covers \Hyde\Console\Commands\HydeValidateCommand
+ * @covers \Hyde\Console\Commands\ValidateCommand
  * @covers \Hyde\Framework\Services\ValidationService
  * @covers \Hyde\Framework\Models\Support\ValidationResult
  *

--- a/packages/framework/tests/Feature/Services/BuildTaskServiceTest.php
+++ b/packages/framework/tests/Feature/Services/BuildTaskServiceTest.php
@@ -22,7 +22,7 @@ use Illuminate\Support\Facades\File;
 class BuildTaskServiceTest extends TestCase
 {
     /**
-     * @covers \Hyde\Console\Commands\HydeBuildSiteCommand::runPostBuildActions
+     * @covers \Hyde\Console\Commands\BuildSiteCommand::runPostBuildActions
      */
     public function test_build_command_can_run_post_build_tasks()
     {

--- a/packages/framework/tests/Feature/StaticSiteServiceTest.php
+++ b/packages/framework/tests/Feature/StaticSiteServiceTest.php
@@ -10,7 +10,7 @@ use Hyde\Testing\TestCase;
 use Illuminate\Support\Facades\File;
 
 /**
- * @covers \Hyde\Console\Commands\HydeBuildSiteCommand
+ * @covers \Hyde\Console\Commands\BuildSiteCommand
  * @covers \Hyde\Framework\Services\BuildService
  */
 class StaticSiteServiceTest extends TestCase


### PR DESCRIPTION
This is HydePHP, I think it's quite clear from the context that the commands within belong to HydePHP, thus I don't think the Hyde prefix adds any extra value nor information.