### PR TITLE
Clean up and normalize console command classes

### DIFF
--- a/packages/framework/src/Console/Commands/BuildRssFeedCommand.php
+++ b/packages/framework/src/Console/Commands/BuildRssFeedCommand.php
@@ -14,7 +14,10 @@ use LaravelZero\Framework\Commands\Command;
  */
 class BuildRssFeedCommand extends Command
 {
+    /** @var string */
     protected $signature = 'build:rss';
+
+    /** @var string */
     protected $description = 'Generate the RSS feed';
 
     public function handle(): int

--- a/packages/framework/src/Console/Commands/BuildRssFeedCommand.php
+++ b/packages/framework/src/Console/Commands/BuildRssFeedCommand.php
@@ -10,7 +10,7 @@ use LaravelZero\Framework\Commands\Command;
 /**
  * Hyde command to run the build process for the RSS feed.
  *
- * @see \Hyde\Framework\Testing\Feature\Commands\HydeBuildRssFeedCommandTest
+ * @see \Hyde\Framework\Testing\Feature\Commands\BuildRssFeedCommandTest
  */
 class BuildRssFeedCommand extends Command
 {

--- a/packages/framework/src/Console/Commands/BuildSearchCommand.php
+++ b/packages/framework/src/Console/Commands/BuildSearchCommand.php
@@ -14,7 +14,10 @@ use LaravelZero\Framework\Commands\Command;
  */
 class BuildSearchCommand extends Command
 {
+    /** @var string */
     protected $signature = 'build:search';
+
+    /** @var string */
     protected $description = 'Generate the docs/search.json';
 
     public function handle(): int

--- a/packages/framework/src/Console/Commands/BuildSearchCommand.php
+++ b/packages/framework/src/Console/Commands/BuildSearchCommand.php
@@ -10,7 +10,7 @@ use LaravelZero\Framework\Commands\Command;
 /**
  * Hyde command to run the build process for the documentation search index.
  *
- * @see \Hyde\Framework\Testing\Feature\Commands\HydeBuildSearchCommandTest
+ * @see \Hyde\Framework\Testing\Feature\Commands\BuildSearchCommandTest
  */
 class BuildSearchCommand extends Command
 {

--- a/packages/framework/src/Console/Commands/BuildSiteCommand.php
+++ b/packages/framework/src/Console/Commands/BuildSiteCommand.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Hyde\Console\Commands;
 
-use Exception;
 use Hyde\Framework\Actions\PostBuildTasks\GenerateRssFeed;
 use Hyde\Framework\Actions\PostBuildTasks\GenerateSearch;
 use Hyde\Framework\Actions\PostBuildTasks\GenerateSitemap;

--- a/packages/framework/src/Console/Commands/BuildSiteCommand.php
+++ b/packages/framework/src/Console/Commands/BuildSiteCommand.php
@@ -36,13 +36,6 @@ class BuildSiteCommand extends Command
 
     protected BuildService $service;
 
-    /**
-     * Execute the console command.
-     *
-     * @return int
-     *
-     * @throws Exception
-     */
     public function handle(): int
     {
         $time_start = microtime(true);
@@ -84,11 +77,6 @@ class BuildSiteCommand extends Command
         }
     }
 
-    /**
-     * Run any post-build actions.
-     *
-     * @return void
-     */
     public function runPostBuildActions(): void
     {
         $service = new BuildTaskService($this->output);

--- a/packages/framework/src/Console/Commands/BuildSiteCommand.php
+++ b/packages/framework/src/Console/Commands/BuildSiteCommand.php
@@ -59,7 +59,6 @@ class BuildSiteCommand extends Command
         return 0;
     }
 
-    /** @internal */
     protected function runPreBuildActions(): void
     {
         if ($this->option('no-api')) {
@@ -104,7 +103,6 @@ class BuildSiteCommand extends Command
         $service->runPostBuildTasks();
     }
 
-    /** @internal */
     protected function printFinishMessage(float $time_start): void
     {
         $execution_time = (microtime(true) - $time_start);
@@ -121,7 +119,6 @@ class BuildSiteCommand extends Command
         );
     }
 
-    /* @internal */
     protected function runNodeCommand(string $command, string $message, ?string $actionMessage = null): void
     {
         $this->info($message.' This may take a second.');

--- a/packages/framework/src/Console/Commands/BuildSiteCommand.php
+++ b/packages/framework/src/Console/Commands/BuildSiteCommand.php
@@ -23,11 +23,7 @@ use LaravelZero\Framework\Commands\Command;
  */
 class BuildSiteCommand extends Command
 {
-    /**
-     * The signature of the command.
-     *
-     * @var string
-     */
+    /** @var string */
     protected $signature = 'build 
         {--run-dev : Run the NPM dev script after build}
         {--run-prod : Run the NPM prod script after build}
@@ -35,11 +31,7 @@ class BuildSiteCommand extends Command
         {--pretty-urls : Should links in output use pretty URLs?}
         {--no-api : Disable API calls, for example, Torchlight}';
 
-    /**
-     * The description of the command.
-     *
-     * @var string
-     */
+    /** @var string */
     protected $description = 'Build the static site';
 
     protected BuildService $service;

--- a/packages/framework/src/Console/Commands/BuildSitemapCommand.php
+++ b/packages/framework/src/Console/Commands/BuildSitemapCommand.php
@@ -10,7 +10,7 @@ use LaravelZero\Framework\Commands\Command;
 /**
  * Hyde command to run the build process for the sitemap.
  *
- * @see \Hyde\Framework\Testing\Feature\Commands\HydeBuildSitemapCommandTest
+ * @see \Hyde\Framework\Testing\Feature\Commands\BuildSitemapCommandTest
  */
 class BuildSitemapCommand extends Command
 {

--- a/packages/framework/src/Console/Commands/DebugCommand.php
+++ b/packages/framework/src/Console/Commands/DebugCommand.php
@@ -28,11 +28,6 @@ class DebugCommand extends Command
         }
     }
 
-    /**
-     * Execute the console command.
-     *
-     * @return int
-     */
     public function handle(): int
     {
         $this->info('HydePHP Debug Screen');

--- a/packages/framework/src/Console/Commands/DebugCommand.php
+++ b/packages/framework/src/Console/Commands/DebugCommand.php
@@ -13,18 +13,10 @@ use LaravelZero\Framework\Commands\Command;
  */
 class DebugCommand extends Command
 {
-    /**
-     * The signature of the command.
-     *
-     * @var string
-     */
+    /** @var string */
     protected $signature = 'debug';
 
-    /**
-     * The description of the command.
-     *
-     * @var string
-     */
+    /** @var string */
     protected $description = 'Print debug info';
 
     public function __construct()

--- a/packages/framework/src/Console/Commands/MakePageCommand.php
+++ b/packages/framework/src/Console/Commands/MakePageCommand.php
@@ -14,7 +14,7 @@ use LaravelZero\Framework\Commands\Command;
 /**
  * Hyde Command to scaffold a new Markdown or Blade page file.
  *
- * @see \Hyde\Framework\Testing\Feature\Commands\HydeMakePageCommandTest
+ * @see \Hyde\Framework\Testing\Feature\Commands\MakePageCommandTest
  */
 class MakePageCommand extends Command
 {

--- a/packages/framework/src/Console/Commands/MakePageCommand.php
+++ b/packages/framework/src/Console/Commands/MakePageCommand.php
@@ -18,11 +18,7 @@ use LaravelZero\Framework\Commands\Command;
  */
 class MakePageCommand extends Command
 {
-    /**
-     * The name and signature of the console command.
-     *
-     * @var string
-     */
+    /** @var string */
     protected $signature = 'make:page 
 		{title? : The name of the page file to create. Will be used to generate the slug}
 		{--type=markdown : The type of page to create (markdown, blade, or docs)}
@@ -30,11 +26,7 @@ class MakePageCommand extends Command
         {--docs : Create a Documentation page}
 		{--force : Overwrite any existing files}';
 
-    /**
-     * The console command description.
-     *
-     * @var string
-     */
+    /** @var string */
     protected $description = 'Scaffold a new Markdown, Blade, or documentation page file';
 
     /**
@@ -57,9 +49,6 @@ class MakePageCommand extends Command
      */
     public bool $force;
 
-    /**
-     * Execute the console command.
-     */
     public function handle(): int
     {
         $this->title('Creating a new page!');
@@ -81,13 +70,6 @@ class MakePageCommand extends Command
         return 0;
     }
 
-    /**
-     * Validate the options passed to the command.
-     *
-     * @return void
-     *
-     * @throws UnsupportedPageTypeException if the page type is invalid.
-     */
     protected function validateOptions(): void
     {
         $type = $this->getSelectedType();
@@ -112,11 +94,6 @@ class MakePageCommand extends Command
         throw new UnsupportedPageTypeException("Invalid page type: $type");
     }
 
-    /**
-     * Get the selected page type.
-     *
-     * @return string
-     */
     protected function getSelectedType(): string
     {
         $type = 'markdown';

--- a/packages/framework/src/Console/Commands/MakePostCommand.php
+++ b/packages/framework/src/Console/Commands/MakePostCommand.php
@@ -21,11 +21,6 @@ class MakePostCommand extends Command
     /** @var string */
     protected $description = 'Scaffold a new Markdown blog post file';
 
-    /**
-     * Execute the console command.
-     *
-     * @return int
-     */
     public function handle(): int
     {
         $this->title('Creating a new post!');

--- a/packages/framework/src/Console/Commands/MakePostCommand.php
+++ b/packages/framework/src/Console/Commands/MakePostCommand.php
@@ -13,20 +13,12 @@ use LaravelZero\Framework\Commands\Command;
  */
 class MakePostCommand extends Command
 {
-    /**
-     * The signature of the command.
-     *
-     * @var string
-     */
+    /** @var string */
     protected $signature = 'make:post
                             {title? : The title for the Post. Will be used to generate the slug}
                             {--force : Should the generated file overwrite existing posts with the same slug?}';
 
-    /**
-     * The description of the command.
-     *
-     * @var string
-     */
+    /** @var string */
     protected $description = 'Scaffold a new Markdown blog post file';
 
     /**

--- a/packages/framework/src/Console/Commands/PackageDiscoverCommand.php
+++ b/packages/framework/src/Console/Commands/PackageDiscoverCommand.php
@@ -9,7 +9,7 @@ use Illuminate\Foundation\Console\PackageDiscoverCommand as BaseCommand;
 use Illuminate\Foundation\PackageManifest;
 
 /**
- * @see \Hyde\Framework\Testing\Feature\Commands\HydePackageDiscoverCommandTest
+ * @see \Hyde\Framework\Testing\Feature\Commands\PackageDiscoverCommandTest
  */
 class PackageDiscoverCommand extends BaseCommand
 {

--- a/packages/framework/src/Console/Commands/PackageDiscoverCommand.php
+++ b/packages/framework/src/Console/Commands/PackageDiscoverCommand.php
@@ -16,7 +16,7 @@ class PackageDiscoverCommand extends BaseCommand
     /** @var true */
     protected $hidden = true;
 
-    public function handle(PackageManifest $manifest)
+    public function handle(PackageManifest $manifest): void
     {
         $manifest->manifestPath = Hyde::path('storage/framework/cache/packages.php');
         parent::handle($manifest);

--- a/packages/framework/src/Console/Commands/PublishHomepageCommand.php
+++ b/packages/framework/src/Console/Commands/PublishHomepageCommand.php
@@ -13,7 +13,7 @@ use LaravelZero\Framework\Commands\Command;
 /**
  * Publish one of the default homepages.
  *
- * @see \Hyde\Framework\Testing\Feature\Commands\HydePublishHomepageCommandTest
+ * @see \Hyde\Framework\Testing\Feature\Commands\PublishHomepageCommandTest
  */
 class PublishHomepageCommand extends Command
 {

--- a/packages/framework/src/Console/Commands/RebuildStaticSiteCommand.php
+++ b/packages/framework/src/Console/Commands/RebuildStaticSiteCommand.php
@@ -32,11 +32,6 @@ class RebuildStaticSiteCommand extends Command
      */
     public string $path;
 
-    /**
-     * Execute the console command.
-     *
-     * @return int
-     */
     public function handle(): int
     {
         $time_start = microtime(true);

--- a/packages/framework/src/Console/Commands/RebuildStaticSiteCommand.php
+++ b/packages/framework/src/Console/Commands/RebuildStaticSiteCommand.php
@@ -14,7 +14,7 @@ use LaravelZero\Framework\Commands\Command;
 /**
  * Hyde Command to build a single static site file.
  *
- * @see \Hyde\Framework\Testing\Feature\Commands\HydeRebuildStaticSiteCommandTest
+ * @see \Hyde\Framework\Testing\Feature\Commands\RebuildStaticSiteCommandTest
  */
 class RebuildStaticSiteCommand extends Command
 {

--- a/packages/framework/src/Console/Commands/RebuildStaticSiteCommand.php
+++ b/packages/framework/src/Console/Commands/RebuildStaticSiteCommand.php
@@ -18,19 +18,11 @@ use LaravelZero\Framework\Commands\Command;
  */
 class RebuildStaticSiteCommand extends Command
 {
-    /**
-     * The signature of the command.
-     *
-     * @var string
-     */
+    /** @var string */
     protected $signature = 'rebuild
         {path : The relative file path (example: _posts/hello-world.md)}';
 
-    /**
-     * The description of the command.
-     *
-     * @var string
-     */
+    /** @var string */
     protected $description = 'Run the static site builder for a single file';
 
     /**

--- a/packages/framework/src/Console/Commands/RouteListCommand.php
+++ b/packages/framework/src/Console/Commands/RouteListCommand.php
@@ -15,7 +15,10 @@ use LaravelZero\Framework\Commands\Command;
  */
 class RouteListCommand extends Command
 {
+    /** @var string */
     protected $signature = 'route:list';
+
+    /** @var string */
     protected $description = 'Display all registered routes.';
 
     public function handle(): int

--- a/packages/framework/src/Console/Commands/RouteListCommand.php
+++ b/packages/framework/src/Console/Commands/RouteListCommand.php
@@ -11,7 +11,7 @@ use LaravelZero\Framework\Commands\Command;
 /**
  * Hyde command to display the list of site routes.
  *
- * @see \Hyde\Framework\Testing\Feature\Commands\HydeRouteListCommandTest
+ * @see \Hyde\Framework\Testing\Feature\Commands\RouteListCommandTest
  */
 class RouteListCommand extends Command
 {

--- a/packages/framework/src/Console/Commands/ServeCommand.php
+++ b/packages/framework/src/Console/Commands/ServeCommand.php
@@ -12,18 +12,10 @@ use LaravelZero\Framework\Commands\Command;
  */
 class ServeCommand extends Command
 {
-    /**
-     * The signature of the command.
-     *
-     * @var string
-     */
+    /** @var string */
     protected $signature = 'serve {--port=8080} {--host=localhost}';
 
-    /**
-     * The description of the command.
-     *
-     * @var string
-     */
+    /** @var string */
     protected $description = 'Start the experimental realtime compiler.';
 
     /**

--- a/packages/framework/src/Console/Commands/ServeCommand.php
+++ b/packages/framework/src/Console/Commands/ServeCommand.php
@@ -18,11 +18,6 @@ class ServeCommand extends Command
     /** @var string */
     protected $description = 'Start the experimental realtime compiler.';
 
-    /**
-     * Execute the console command.
-     *
-     * @return int
-     */
     public function handle(): int
     {
         $this->line('<info>Starting the HydeRC server...</info> Press Ctrl+C to stop');

--- a/packages/framework/src/Console/Commands/UpdateConfigsCommand.php
+++ b/packages/framework/src/Console/Commands/UpdateConfigsCommand.php
@@ -11,7 +11,7 @@ use LaravelZero\Framework\Commands\Command;
 /**
  * Publish the Hyde Config Files.
  *
- * @see \Hyde\Framework\Testing\Feature\Commands\HydeUpdateConfigsCommandTest
+ * @see \Hyde\Framework\Testing\Feature\Commands\UpdateConfigsCommandTest
  */
 class UpdateConfigsCommand extends Command
 {

--- a/packages/framework/src/Console/Commands/ValidateCommand.php
+++ b/packages/framework/src/Console/Commands/ValidateCommand.php
@@ -8,7 +8,7 @@ use Hyde\Framework\Services\ValidationService;
 use LaravelZero\Framework\Commands\Command;
 
 /**
- * @see \Hyde\Framework\Testing\Feature\Commands\HydeValidateCommandTest
+ * @see \Hyde\Framework\Testing\Feature\Commands\ValidateCommandTest
  */
 class ValidateCommand extends Command
 {

--- a/packages/framework/src/Framework/Concerns/AbstractBuildTask.php
+++ b/packages/framework/src/Framework/Concerns/AbstractBuildTask.php
@@ -20,6 +20,10 @@ abstract class AbstractBuildTask implements BuildTaskContract
     protected static string $description = 'Generic build task';
 
     protected float $timeStart;
+
+    /**
+     * @todo Consider setting default value to 0
+     */
     protected ?int $exitCode = null;
 
     public function __construct(?OutputStyle $output = null)

--- a/packages/framework/src/Framework/Models/Support/ValidationResult.php
+++ b/packages/framework/src/Framework/Models/Support/ValidationResult.php
@@ -6,7 +6,7 @@ namespace Hyde\Framework\Models\Support;
 
 /**
  * @see \Hyde\Framework\Testing\Feature\Services\ValidationServiceTest
- * @see \Hyde\Framework\Testing\Feature\Commands\HydeValidateCommandTest
+ * @see \Hyde\Framework\Testing\Feature\Commands\ValidateCommandTest
  */
 class ValidationResult
 {

--- a/packages/framework/src/Framework/Services/ValidationService.php
+++ b/packages/framework/src/Framework/Services/ValidationService.php
@@ -10,7 +10,7 @@ use Hyde\Hyde;
 
 /**
  * @see \Hyde\Framework\Testing\Feature\Services\ValidationServiceTest
- * @see \Hyde\Framework\Testing\Feature\Commands\HydeValidateCommandTest
+ * @see \Hyde\Framework\Testing\Feature\Commands\ValidateCommandTest
  */
 class ValidationService
 {

--- a/packages/framework/tests/Feature/Commands/BuildRssFeedCommandTest.php
+++ b/packages/framework/tests/Feature/Commands/BuildRssFeedCommandTest.php
@@ -11,7 +11,7 @@ use Hyde\Testing\TestCase;
  * @covers \Hyde\Console\Commands\BuildRssFeedCommand
  * @covers \Hyde\Framework\Actions\PostBuildTasks\GenerateRssFeed
  */
-class HydeBuildRssFeedCommandTest extends TestCase
+class BuildRssFeedCommandTest extends TestCase
 {
     public function test_rss_feed_is_generated_when_conditions_are_met()
     {

--- a/packages/framework/tests/Feature/Commands/BuildSearchCommandTest.php
+++ b/packages/framework/tests/Feature/Commands/BuildSearchCommandTest.php
@@ -14,7 +14,7 @@ use Hyde\Testing\TestCase;
  * @covers \Hyde\Console\Commands\BuildSearchCommand
  * @covers \Hyde\Framework\Actions\PostBuildTasks\GenerateSearch
  */
-class HydeBuildSearchCommandTest extends TestCase
+class BuildSearchCommandTest extends TestCase
 {
     protected function setUp(): void
     {

--- a/packages/framework/tests/Feature/Commands/BuildSitemapCommandTest.php
+++ b/packages/framework/tests/Feature/Commands/BuildSitemapCommandTest.php
@@ -11,7 +11,7 @@ use Hyde\Testing\TestCase;
  * @covers \Hyde\Console\Commands\BuildSitemapCommand
  * @covers \Hyde\Framework\Actions\PostBuildTasks\GenerateSitemap
  */
-class HydeBuildSitemapCommandTest extends TestCase
+class BuildSitemapCommandTest extends TestCase
 {
     public function test_sitemap_is_generated_when_conditions_are_met()
     {

--- a/packages/framework/tests/Feature/Commands/DebugCommandTest.php
+++ b/packages/framework/tests/Feature/Commands/DebugCommandTest.php
@@ -6,6 +6,9 @@ namespace Hyde\Framework\Testing\Feature\Commands;
 
 use Hyde\Testing\TestCase;
 
+/**
+ * @covers \Hyde\Console\Commands\DebugCommand
+ */
 class DebugCommandTest extends TestCase
 {
     public function test_debug_command_can_run()

--- a/packages/framework/tests/Feature/Commands/MakePageCommandTest.php
+++ b/packages/framework/tests/Feature/Commands/MakePageCommandTest.php
@@ -12,7 +12,7 @@ use Hyde\Testing\TestCase;
 /**
  * @covers \Hyde\Console\Commands\MakePageCommand
  */
-class HydeMakePageCommandTest extends TestCase
+class MakePageCommandTest extends TestCase
 {
     protected string $markdownPath;
     protected string $bladePath;

--- a/packages/framework/tests/Feature/Commands/PackageDiscoverCommandTest.php
+++ b/packages/framework/tests/Feature/Commands/PackageDiscoverCommandTest.php
@@ -11,7 +11,7 @@ use Illuminate\Foundation\PackageManifest;
 /**
  * @covers \Hyde\Console\Commands\PackageDiscoverCommand
  */
-class HydePackageDiscoverCommandTest extends TestCase
+class PackageDiscoverCommandTest extends TestCase
 {
     public function test_package_discover_command_can_run()
     {

--- a/packages/framework/tests/Feature/Commands/PublishHomepageCommandTest.php
+++ b/packages/framework/tests/Feature/Commands/PublishHomepageCommandTest.php
@@ -10,7 +10,7 @@ use Hyde\Testing\TestCase;
 /**
  * @covers \Hyde\Console\Commands\PublishHomepageCommand
  */
-class HydePublishHomepageCommandTest extends TestCase
+class PublishHomepageCommandTest extends TestCase
 {
     protected string $file;
 

--- a/packages/framework/tests/Feature/Commands/PublishViewsCommandTest.php
+++ b/packages/framework/tests/Feature/Commands/PublishViewsCommandTest.php
@@ -10,7 +10,7 @@ use Hyde\Testing\TestCase;
 /**
  * @covers \Hyde\Console\Commands\PublishViewsCommand
  */
-class HydePublishViewsCommandTest extends TestCase
+class PublishViewsCommandTest extends TestCase
 {
     protected function setUp(): void
     {

--- a/packages/framework/tests/Feature/Commands/RebuildStaticSiteCommandTest.php
+++ b/packages/framework/tests/Feature/Commands/RebuildStaticSiteCommandTest.php
@@ -10,7 +10,7 @@ use Hyde\Testing\TestCase;
 /**
  * @covers \Hyde\Console\Commands\RebuildStaticSiteCommand
  */
-class HydeRebuildStaticSiteCommandTest extends TestCase
+class RebuildStaticSiteCommandTest extends TestCase
 {
     public function test_handle_is_successful_with_valid_path()
     {

--- a/packages/framework/tests/Feature/Commands/RouteListCommandTest.php
+++ b/packages/framework/tests/Feature/Commands/RouteListCommandTest.php
@@ -9,7 +9,7 @@ use Hyde\Testing\TestCase;
 /**
  * @covers \Hyde\Console\Commands\RouteListCommand
  */
-class HydeRouteListCommandTest extends TestCase
+class RouteListCommandTest extends TestCase
 {
     public function testRouteListCommand()
     {

--- a/packages/framework/tests/Feature/Commands/ServeCommandTest.php
+++ b/packages/framework/tests/Feature/Commands/ServeCommandTest.php
@@ -9,7 +9,7 @@ use Hyde\Testing\TestCase;
 /**
  * @covers \Hyde\Console\Commands\ServeCommand
  */
-class HydeServeCommandTest extends TestCase
+class ServeCommandTest extends TestCase
 {
     public function test_hyde_serve_command()
     {

--- a/packages/framework/tests/Feature/Commands/UpdateConfigsCommandTest.php
+++ b/packages/framework/tests/Feature/Commands/UpdateConfigsCommandTest.php
@@ -11,7 +11,7 @@ use Illuminate\Support\Facades\File;
 /**
  * @covers \Hyde\Console\Commands\UpdateConfigsCommand
  */
-class HydeUpdateConfigsCommandTest extends TestCase
+class UpdateConfigsCommandTest extends TestCase
 {
     /** Setup */
     public function setUp(): void

--- a/packages/framework/tests/Feature/Commands/ValidateCommandTest.php
+++ b/packages/framework/tests/Feature/Commands/ValidateCommandTest.php
@@ -13,7 +13,7 @@ use Hyde\Testing\TestCase;
  *
  * @see \Hyde\Framework\Testing\Feature\Services\ValidationServiceTest
  */
-class HydeValidateCommandTest extends TestCase
+class ValidateCommandTest extends TestCase
 {
     public function test_validate_command_can_run()
     {

--- a/packages/framework/tests/Feature/Services/ValidationServiceTest.php
+++ b/packages/framework/tests/Feature/Services/ValidationServiceTest.php
@@ -15,7 +15,7 @@ use Hyde\Testing\TestCase;
  * @covers \Hyde\Framework\Services\ValidationService
  * @covers \Hyde\Framework\Models\Support\ValidationResult
  *
- * @see \Hyde\Framework\Testing\Feature\Commands\HydeValidateCommandTest
+ * @see \Hyde\Framework\Testing\Feature\Commands\ValidateCommandTest
  */
 class ValidationServiceTest extends TestCase
 {

--- a/packages/framework/tests/Feature/StaticSiteBuilderPostModuleTest.php
+++ b/packages/framework/tests/Feature/StaticSiteBuilderPostModuleTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Hyde\Framework\Testing\Feature\Commands;
+namespace Hyde\Framework\Testing\Feature;
 
 use Hyde\Framework\Actions\StaticPageBuilder;
 use Hyde\Framework\Models\Pages\MarkdownPost;

--- a/packages/framework/tests/Unit/MarkdownPostParserTest.php
+++ b/packages/framework/tests/Unit/MarkdownPostParserTest.php
@@ -11,7 +11,7 @@ use Hyde\Hyde;
 use Hyde\Testing\TestCase;
 
 /**
- * @see \Hyde\Framework\Testing\Feature\Commands\StaticSiteBuilderPostModuleTest for the compiler test.
+ * @see \Hyde\Framework\Testing\Feature\StaticSiteBuilderPostModuleTest for the compiler test.
  */
 class MarkdownPostParserTest extends TestCase
 {


### PR DESCRIPTION
Cleans up the console commands to make them more consistent.

- Renames the tests to match https://github.com/hydephp/develop/pull/597.
- Removes unnecessary PHPDocs.
- Also adds a bunch of missing types.