### PR TITLE
Handle console commands in new HydeConsoleServiceProvider

### DIFF
--- a/packages/framework/src/Console/HydeConsoleServiceProvider.php
+++ b/packages/framework/src/Console/HydeConsoleServiceProvider.php
@@ -17,23 +17,24 @@ class HydeConsoleServiceProvider extends ServiceProvider
     public function register(): void
     {
         $this->commands([
-            Commands\PublishHomepageCommand::class,
-            Commands\UpdateConfigsCommand::class,
-            Commands\PublishViewsCommand::class,
-            Commands\RebuildStaticSiteCommand::class,
-            Commands\BuildSiteCommand::class,
-            Commands\BuildSitemapCommand::class,
             Commands\BuildRssFeedCommand::class,
             Commands\BuildSearchCommand::class,
-            Commands\RouteListCommand::class,
-            Commands\MakePostCommand::class,
-            Commands\MakePageCommand::class,
-            Commands\ValidateCommand::class,
-            Commands\DebugCommand::class,
-            Commands\ServeCommand::class,
+            Commands\BuildSiteCommand::class,
+            Commands\BuildSitemapCommand::class,
+            Commands\RebuildStaticSiteCommand::class,
 
+            Commands\MakePageCommand::class,
+            Commands\MakePostCommand::class,
+
+            Commands\PublishHomepageCommand::class,
+            Commands\PublishViewsCommand::class,
+            Commands\UpdateConfigsCommand::class,
             Commands\PackageDiscoverCommand::class,
+
+            Commands\RouteListCommand::class,
+            Commands\ValidateCommand::class,
+            Commands\ServeCommand::class,
+            Commands\DebugCommand::class,
         ]);
     }
-
 }

--- a/packages/framework/src/Console/HydeConsoleServiceProvider.php
+++ b/packages/framework/src/Console/HydeConsoleServiceProvider.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Hyde\Console;
 
 use Illuminate\Support\ServiceProvider;

--- a/packages/framework/src/Console/HydeConsoleServiceProvider.php
+++ b/packages/framework/src/Console/HydeConsoleServiceProvider.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Hyde\Console;
 
 use Illuminate\Support\ServiceProvider;
+use Hyde\Console\Commands;
 
 class HydeConsoleServiceProvider extends ServiceProvider
 {
@@ -24,22 +25,22 @@ class HydeConsoleServiceProvider extends ServiceProvider
     protected function registerHydeConsoleCommands(): void
     {
         $this->commands([
-            \Hyde\Console\Commands\PublishHomepageCommand::class,
-            \Hyde\Console\Commands\UpdateConfigsCommand::class,
-            \Hyde\Console\Commands\PublishViewsCommand::class,
-            \Hyde\Console\Commands\RebuildStaticSiteCommand::class,
-            \Hyde\Console\Commands\BuildSiteCommand::class,
-            \Hyde\Console\Commands\BuildSitemapCommand::class,
-            \Hyde\Console\Commands\BuildRssFeedCommand::class,
-            \Hyde\Console\Commands\BuildSearchCommand::class,
-            \Hyde\Console\Commands\RouteListCommand::class,
-            \Hyde\Console\Commands\MakePostCommand::class,
-            \Hyde\Console\Commands\MakePageCommand::class,
-            \Hyde\Console\Commands\ValidateCommand::class,
-            \Hyde\Console\Commands\DebugCommand::class,
-            \Hyde\Console\Commands\ServeCommand::class,
+            Commands\PublishHomepageCommand::class,
+            Commands\UpdateConfigsCommand::class,
+            Commands\PublishViewsCommand::class,
+            Commands\RebuildStaticSiteCommand::class,
+            Commands\BuildSiteCommand::class,
+            Commands\BuildSitemapCommand::class,
+            Commands\BuildRssFeedCommand::class,
+            Commands\BuildSearchCommand::class,
+            Commands\RouteListCommand::class,
+            Commands\MakePostCommand::class,
+            Commands\MakePageCommand::class,
+            Commands\ValidateCommand::class,
+            Commands\DebugCommand::class,
+            Commands\ServeCommand::class,
 
-            \Hyde\Console\Commands\PackageDiscoverCommand::class,
+            Commands\PackageDiscoverCommand::class,
         ]);
     }
 

--- a/packages/framework/src/Console/HydeConsoleServiceProvider.php
+++ b/packages/framework/src/Console/HydeConsoleServiceProvider.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Hyde\Console;
+
+use Illuminate\Support\ServiceProvider;
+
+class HydeConsoleServiceProvider extends ServiceProvider
+{
+    //
+}

--- a/packages/framework/src/Console/HydeConsoleServiceProvider.php
+++ b/packages/framework/src/Console/HydeConsoleServiceProvider.php
@@ -16,14 +16,6 @@ class HydeConsoleServiceProvider extends ServiceProvider
      */
     public function register(): void
     {
-        $this->registerHydeConsoleCommands();
-    }
-
-    /**
-     * Register the HydeCLI console commands.
-     */
-    protected function registerHydeConsoleCommands(): void
-    {
         $this->commands([
             Commands\PublishHomepageCommand::class,
             Commands\UpdateConfigsCommand::class,

--- a/packages/framework/src/Console/HydeConsoleServiceProvider.php
+++ b/packages/framework/src/Console/HydeConsoleServiceProvider.php
@@ -10,8 +10,6 @@ class HydeConsoleServiceProvider extends ServiceProvider
 {
     /**
      * Register any console services.
-     *
-     * @return void
      */
     public function register(): void
     {

--- a/packages/framework/src/Console/HydeConsoleServiceProvider.php
+++ b/packages/framework/src/Console/HydeConsoleServiceProvider.php
@@ -8,5 +8,39 @@ use Illuminate\Support\ServiceProvider;
 
 class HydeConsoleServiceProvider extends ServiceProvider
 {
-    //
+    /**
+     * Register any console services.
+     *
+     * @return void
+     */
+    public function register(): void
+    {
+        $this->registerHydeConsoleCommands();
+    }
+
+    /**
+     * Register the HydeCLI console commands.
+     */
+    protected function registerHydeConsoleCommands(): void
+    {
+        $this->commands([
+            \Hyde\Console\Commands\PublishHomepageCommand::class,
+            \Hyde\Console\Commands\UpdateConfigsCommand::class,
+            \Hyde\Console\Commands\PublishViewsCommand::class,
+            \Hyde\Console\Commands\RebuildStaticSiteCommand::class,
+            \Hyde\Console\Commands\BuildSiteCommand::class,
+            \Hyde\Console\Commands\BuildSitemapCommand::class,
+            \Hyde\Console\Commands\BuildRssFeedCommand::class,
+            \Hyde\Console\Commands\BuildSearchCommand::class,
+            \Hyde\Console\Commands\RouteListCommand::class,
+            \Hyde\Console\Commands\MakePostCommand::class,
+            \Hyde\Console\Commands\MakePageCommand::class,
+            \Hyde\Console\Commands\ValidateCommand::class,
+            \Hyde\Console\Commands\DebugCommand::class,
+            \Hyde\Console\Commands\ServeCommand::class,
+
+            \Hyde\Console\Commands\PackageDiscoverCommand::class,
+        ]);
+    }
+
 }

--- a/packages/framework/src/Console/HydeConsoleServiceProvider.php
+++ b/packages/framework/src/Console/HydeConsoleServiceProvider.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Hyde\Console;
 
 use Illuminate\Support\ServiceProvider;
-use Hyde\Console\Commands;
 
 class HydeConsoleServiceProvider extends ServiceProvider
 {

--- a/packages/framework/src/Console/HydeConsoleServiceProvider.php
+++ b/packages/framework/src/Console/HydeConsoleServiceProvider.php
@@ -6,6 +6,9 @@ namespace Hyde\Console;
 
 use Illuminate\Support\ServiceProvider;
 
+/**
+ * Register the HydeCLI console commands.
+ */
 class HydeConsoleServiceProvider extends ServiceProvider
 {
     /**

--- a/packages/framework/src/Framework/HydeServiceProvider.php
+++ b/packages/framework/src/Framework/HydeServiceProvider.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Hyde\Framework;
 
+use Hyde\Console\HydeConsoleServiceProvider;
 use Hyde\DataCollections\DataCollectionServiceProvider;
 use Hyde\Foundation\HydeKernel;
 use Hyde\Framework\Actions\MarkdownConverter;
@@ -134,6 +135,7 @@ class HydeServiceProvider extends ServiceProvider
      */
     protected function registerModuleServiceProviders(): void
     {
+        $this->app->register(HydeConsoleServiceProvider::class);
         $this->app->register(DataCollectionServiceProvider::class);
     }
 }

--- a/packages/framework/src/Framework/HydeServiceProvider.php
+++ b/packages/framework/src/Framework/HydeServiceProvider.php
@@ -121,7 +121,6 @@ class HydeServiceProvider extends ServiceProvider
             \Hyde\Console\Commands\MakePostCommand::class,
             \Hyde\Console\Commands\MakePageCommand::class,
             \Hyde\Console\Commands\ValidateCommand::class,
-            // Commands\HydeInstallCommand::class,
             \Hyde\Console\Commands\DebugCommand::class,
             \Hyde\Console\Commands\ServeCommand::class,
 

--- a/packages/framework/src/Framework/HydeServiceProvider.php
+++ b/packages/framework/src/Framework/HydeServiceProvider.php
@@ -60,7 +60,6 @@ class HydeServiceProvider extends ServiceProvider
 
         $this->discoverBladeViewsIn(BladePage::sourceDirectory());
 
-        $this->registerHydeConsoleCommands();
         $this->registerModuleServiceProviders();
     }
 
@@ -103,31 +102,6 @@ class HydeServiceProvider extends ServiceProvider
         if (YamlConfigurationService::hasFile()) {
             YamlConfigurationService::boot();
         }
-    }
-
-    /**
-     * Register the HydeCLI console commands.
-     */
-    protected function registerHydeConsoleCommands(): void
-    {
-        $this->commands([
-            \Hyde\Console\Commands\PublishHomepageCommand::class,
-            \Hyde\Console\Commands\UpdateConfigsCommand::class,
-            \Hyde\Console\Commands\PublishViewsCommand::class,
-            \Hyde\Console\Commands\RebuildStaticSiteCommand::class,
-            \Hyde\Console\Commands\BuildSiteCommand::class,
-            \Hyde\Console\Commands\BuildSitemapCommand::class,
-            \Hyde\Console\Commands\BuildRssFeedCommand::class,
-            \Hyde\Console\Commands\BuildSearchCommand::class,
-            \Hyde\Console\Commands\RouteListCommand::class,
-            \Hyde\Console\Commands\MakePostCommand::class,
-            \Hyde\Console\Commands\MakePageCommand::class,
-            \Hyde\Console\Commands\ValidateCommand::class,
-            \Hyde\Console\Commands\DebugCommand::class,
-            \Hyde\Console\Commands\ServeCommand::class,
-
-            \Hyde\Console\Commands\PackageDiscoverCommand::class,
-        ]);
     }
 
     /**

--- a/packages/framework/src/Framework/HydeServiceProvider.php
+++ b/packages/framework/src/Framework/HydeServiceProvider.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Hyde\Framework;
 
+use Hyde\DataCollections\DataCollectionServiceProvider;
 use Hyde\Foundation\HydeKernel;
 use Hyde\Framework\Actions\MarkdownConverter;
 use Hyde\Framework\Concerns\RegistersFileLocations;
@@ -133,6 +134,6 @@ class HydeServiceProvider extends ServiceProvider
      */
     protected function registerModuleServiceProviders(): void
     {
-        $this->app->register(\Hyde\DataCollections\DataCollectionServiceProvider::class);
+        $this->app->register(DataCollectionServiceProvider::class);
     }
 }


### PR DESCRIPTION
The HydeServiceProvider class is really long, hoping to start to refactor it to extract its responsibilities to the new domains added by the experimental refactor branch.