### PR TITLE
Add a simple session handler

### DIFF
--- a/packages/framework/src/Framework/Features/Session/Session.php
+++ b/packages/framework/src/Framework/Features/Session/Session.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Hyde\Framework\Features\Session;
+
+class Session
+{
+    //
+}

--- a/packages/framework/src/Framework/Features/Session/Session.php
+++ b/packages/framework/src/Framework/Features/Session/Session.php
@@ -9,6 +9,7 @@ namespace Hyde\Framework\Features\Session;
  * to asynchronously add warnings to be used at a later point in the request lifecycle.
  *
  * It's bound into the service container as a singleton and is not persisted.
+ *
  * @example app(Session::class)->addWarning('warning');
  */
 class Session

--- a/packages/framework/src/Framework/Features/Session/Session.php
+++ b/packages/framework/src/Framework/Features/Session/Session.php
@@ -9,6 +9,7 @@ namespace Hyde\Framework\Features\Session;
  * to asynchronously add warnings to be used at a later point in the request lifecycle.
  *
  * It's bound into the service container as a singleton and is not persisted.
+ * @example app(Session::class)->addWarning('warning');
  */
 class Session
 {

--- a/packages/framework/src/Framework/Features/Session/Session.php
+++ b/packages/framework/src/Framework/Features/Session/Session.php
@@ -4,6 +4,11 @@ declare(strict_types=1);
 
 namespace Hyde\Framework\Features\Session;
 
+/**
+ * Adds a simple session handler, arguably most useful to defer messages, for example,
+ * to asynchronously add warnings to be used at a later point in the request lifecycle.
+ * It's bound into the service container as a singleton and is not persisted.
+ */
 class Session
 {
     protected array $warnings = [];

--- a/packages/framework/src/Framework/Features/Session/Session.php
+++ b/packages/framework/src/Framework/Features/Session/Session.php
@@ -6,5 +6,15 @@ namespace Hyde\Framework\Features\Session;
 
 class Session
 {
-    //
+    protected array $warnings = [];
+
+    public function addWarning(string $warning): void
+    {
+        $this->warnings[] = $warning;
+    }
+
+    public function getWarnings(): array
+    {
+        return $this->warnings;
+    }
 }

--- a/packages/framework/src/Framework/Features/Session/Session.php
+++ b/packages/framework/src/Framework/Features/Session/Session.php
@@ -7,6 +7,7 @@ namespace Hyde\Framework\Features\Session;
 /**
  * Adds a simple session handler, arguably most useful to defer messages, for example,
  * to asynchronously add warnings to be used at a later point in the request lifecycle.
+ *
  * It's bound into the service container as a singleton and is not persisted.
  */
 class Session

--- a/packages/framework/src/Framework/Features/Session/Session.php
+++ b/packages/framework/src/Framework/Features/Session/Session.php
@@ -24,4 +24,9 @@ class Session
     {
         return $this->warnings;
     }
+
+    public function hasWarnings(): bool
+    {
+        return ! empty($this->warnings);
+    }
 }

--- a/packages/framework/src/Framework/Features/Session/SessionServiceProvider.php
+++ b/packages/framework/src/Framework/Features/Session/SessionServiceProvider.php
@@ -10,7 +10,7 @@ class SessionServiceProvider extends ServiceProvider
 {
     public function register()
     {
-        //
+        $this->app->singleton(Session::class, Session::class);
     }
 
     public function boot()

--- a/packages/framework/src/Framework/Features/Session/SessionServiceProvider.php
+++ b/packages/framework/src/Framework/Features/Session/SessionServiceProvider.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Hyde\Framework\Features\Session;
+
+use Illuminate\Support\ServiceProvider;
+
+class SessionServiceProvider extends ServiceProvider
+{
+    public function register()
+    {
+        //
+    }
+
+    public function boot()
+    {
+        //
+    }
+}

--- a/packages/framework/src/Framework/HydeServiceProvider.php
+++ b/packages/framework/src/Framework/HydeServiceProvider.php
@@ -8,6 +8,7 @@ use Hyde\Console\HydeConsoleServiceProvider;
 use Hyde\Foundation\HydeKernel;
 use Hyde\Framework\Concerns\RegistersFileLocations;
 use Hyde\Framework\Features\DataCollections\DataCollectionServiceProvider;
+use Hyde\Framework\Features\Session\SessionServiceProvider;
 use Hyde\Framework\Services\AssetService;
 use Hyde\Framework\Services\YamlConfigurationService;
 use Hyde\Framework\Views\Components\LinkComponent;
@@ -109,6 +110,7 @@ class HydeServiceProvider extends ServiceProvider
      */
     protected function registerModuleServiceProviders(): void
     {
+        $this->app->register(SessionServiceProvider::class);
         $this->app->register(HydeConsoleServiceProvider::class);
         $this->app->register(DataCollectionServiceProvider::class);
     }

--- a/packages/framework/src/Support/Models/File.php
+++ b/packages/framework/src/Support/Models/File.php
@@ -34,8 +34,8 @@ class File implements Arrayable, JsonSerializable, Stringable
     public ?string $belongsTo = null;
 
     /**
-     * @param string $path The path relative to the project root.
-     * @param class-string<\Hyde\Pages\Concerns\HydePage>|null $belongsToClass
+     * @param  string  $path  The path relative to the project root.
+     * @param  class-string<\Hyde\Pages\Concerns\HydePage>|null  $belongsToClass
      * @return \Hyde\Support\Models\File
      */
     public static function make(string $path, ?string $belongsToClass = null): static

--- a/packages/framework/tests/Framework/Feature/SessionTest.php
+++ b/packages/framework/tests/Framework/Feature/SessionTest.php
@@ -6,6 +6,7 @@ namespace Hyde\Framework\Testing\Framework\Feature;
 
 use Hyde\Framework\Features\Session\Session;
 use Hyde\Testing\TestCase;
+use function app;
 
 /**
  * @covers \Hyde\Framework\Features\Session\Session
@@ -13,5 +14,9 @@ use Hyde\Testing\TestCase;
  */
 class SessionTest extends TestCase
 {
-    //
+    public function test_session_is_bound_to_service_container_as_singleton()
+    {
+        $this->assertInstanceOf(Session::class, $this->app->make(Session::class));
+        $this->assertSame(app(Session::class), $this->app->make(Session::class));
+    }
 }

--- a/packages/framework/tests/Framework/Feature/SessionTest.php
+++ b/packages/framework/tests/Framework/Feature/SessionTest.php
@@ -22,11 +22,9 @@ class SessionTest extends TestCase
 
     public function test_session_can_add_warning()
     {
-        $session = app(Session::class);
+        app(Session::class)->addWarning('warning');
 
-        $session->addWarning('warning');
-
-        $this->assertSame(['warning'], $session->getWarnings());
+        $this->assertSame(['warning'], app(Session::class)->getWarnings());
     }
 
     public function test_session_is_not_persisted()

--- a/packages/framework/tests/Framework/Feature/SessionTest.php
+++ b/packages/framework/tests/Framework/Feature/SessionTest.php
@@ -4,9 +4,9 @@ declare(strict_types=1);
 
 namespace Hyde\Framework\Testing\Framework\Feature;
 
+use function app;
 use Hyde\Framework\Features\Session\Session;
 use Hyde\Testing\TestCase;
-use function app;
 
 /**
  * @covers \Hyde\Framework\Features\Session\Session

--- a/packages/framework/tests/Framework/Feature/SessionTest.php
+++ b/packages/framework/tests/Framework/Feature/SessionTest.php
@@ -33,4 +33,15 @@ class SessionTest extends TestCase
     {
         $this->assertSame([], app(Session::class)->getWarnings());
     }
+
+    public function test_session_can_check_if_warnings_are_present()
+    {
+        $session = app(Session::class);
+
+        $this->assertFalse($session->hasWarnings());
+
+        $session->addWarning('warning');
+
+        $this->assertTrue($session->hasWarnings());
+    }
 }

--- a/packages/framework/tests/Framework/Feature/SessionTest.php
+++ b/packages/framework/tests/Framework/Feature/SessionTest.php
@@ -28,4 +28,9 @@ class SessionTest extends TestCase
 
         $this->assertSame(['warning'], $session->getWarnings());
     }
+
+    public function test_session_is_not_persisted()
+    {
+        $this->assertSame([], app(Session::class)->getWarnings());
+    }
 }

--- a/packages/framework/tests/Framework/Feature/SessionTest.php
+++ b/packages/framework/tests/Framework/Feature/SessionTest.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Hyde\Framework\Testing\Framework\Feature;
+
+use Hyde\Framework\Features\Session\Session;
+use Hyde\Testing\TestCase;
+
+/**
+ * @covers \Hyde\Framework\Features\Session\Session
+ */
+class SessionTest extends TestCase
+{
+    //
+}

--- a/packages/framework/tests/Framework/Feature/SessionTest.php
+++ b/packages/framework/tests/Framework/Feature/SessionTest.php
@@ -9,6 +9,7 @@ use Hyde\Testing\TestCase;
 
 /**
  * @covers \Hyde\Framework\Features\Session\Session
+ * @covers \Hyde\Framework\Features\Session\SessionServiceProvider
  */
 class SessionTest extends TestCase
 {

--- a/packages/framework/tests/Framework/Feature/SessionTest.php
+++ b/packages/framework/tests/Framework/Feature/SessionTest.php
@@ -19,4 +19,13 @@ class SessionTest extends TestCase
         $this->assertInstanceOf(Session::class, $this->app->make(Session::class));
         $this->assertSame(app(Session::class), $this->app->make(Session::class));
     }
+
+    public function test_session_can_add_warning()
+    {
+        $session = app(Session::class);
+
+        $session->addWarning('warning');
+
+        $this->assertSame(['warning'], $session->getWarnings());
+    }
 }


### PR DESCRIPTION
Adds a simple session handler, arguably most useful to defer messages, for example, to asynchronously add warnings to be used at a later point in the request lifecycle.

It's bound into the service container as a singleton and is not persisted.