### PR TITLE
Normalize internal image path storage

### DIFF
--- a/packages/framework/src/Framework/Features/Blogging/Models/FeaturedImage.php
+++ b/packages/framework/src/Framework/Features/Blogging/Models/FeaturedImage.php
@@ -290,6 +290,10 @@ class FeaturedImage implements FeaturedImageSchema, Stringable
             return $path;
         }
 
+        if (str_starts_with($path, 'media/')) {
+            return '_'.$path;
+        }
+
         return '_media/'.$path;
     }
 }

--- a/packages/framework/src/Framework/Features/Blogging/Models/FeaturedImage.php
+++ b/packages/framework/src/Framework/Features/Blogging/Models/FeaturedImage.php
@@ -289,8 +289,8 @@ class FeaturedImage implements FeaturedImageSchema, Stringable
 
     protected function getLocalContentLength(): ?int
     {
-        if (file_exists($this->getPath())) {
-            return filesize($this->getPath());
+        if (file_exists(Hyde::path($this->getSourcePath()))) {
+            return filesize(Hyde::path($this->getSourcePath()));
         }
 
         return null;

--- a/packages/framework/src/Framework/Features/Blogging/Models/FeaturedImage.php
+++ b/packages/framework/src/Framework/Features/Blogging/Models/FeaturedImage.php
@@ -41,8 +41,13 @@ class FeaturedImage implements FeaturedImageSchema, Stringable
 {
     /**
      * The image's path if it's stored locally.
+     * The image must be stored in the _media directory.
+     *
+     * It no longer matters if you add the _media/ prefix or not,
+     * as it will be normalized to always begin with _media/.
      *
      * @example image.jpg.
+     * @example _media/image.jpg.
      */
     public ?string $path;
 
@@ -114,7 +119,7 @@ class FeaturedImage implements FeaturedImageSchema, Stringable
         }
 
         if (isset($this->path)) {
-            $this->path = basename($this->path);
+            $this->path = static::normalizePath($this->path);
         }
     }
 
@@ -276,5 +281,16 @@ class FeaturedImage implements FeaturedImageSchema, Stringable
         }
 
         return null;
+    }
+
+    protected static function normalizePath(string $path): string
+    {
+        $path = Hyde::pathToRelative($path);
+
+        if (str_starts_with($path, '_media/')) {
+            return $path;
+        }
+
+        return '_media/'.$path;
     }
 }

--- a/packages/framework/src/Framework/Features/Blogging/Models/FeaturedImage.php
+++ b/packages/framework/src/Framework/Features/Blogging/Models/FeaturedImage.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Hyde\Framework\Features\Blogging\Models;
 
-use Illuminate\Support\Str;
 use function array_flip;
 use function array_key_exists;
 use BadMethodCallException;
@@ -15,6 +14,7 @@ use Hyde\Hyde;
 use Hyde\Markdown\Contracts\FrontMatter\SubSchemas\FeaturedImageSchema;
 use Illuminate\Support\Facades\Http;
 use Illuminate\Support\HtmlString;
+use Illuminate\Support\Str;
 use function implode;
 use function key;
 use Stringable;
@@ -114,6 +114,7 @@ class FeaturedImage implements FeaturedImageSchema, Stringable
 
     /**
      * @var string The path to the image in the _media directory, relative to the root of the site.
+     *
      * @example "_media/image.jpg".
      */
     protected string $sourcePath;

--- a/packages/framework/src/Framework/Features/Blogging/Models/FeaturedImage.php
+++ b/packages/framework/src/Framework/Features/Blogging/Models/FeaturedImage.php
@@ -122,12 +122,6 @@ class FeaturedImage implements FeaturedImageSchema, Stringable
         }
     }
 
-    /** @inheritDoc */
-    public function __toString()
-    {
-        return $this->getLink();
-    }
-
     /** Dynamically create an image based on string or front matter array */
     public static function make(string|array $data): static
     {
@@ -143,6 +137,12 @@ class FeaturedImage implements FeaturedImageSchema, Stringable
         return str_starts_with($image, 'http')
             ? new static(['url' => $image])
             : new static(['path' => $image]);
+    }
+
+    /** @inheritDoc */
+    public function __toString()
+    {
+        return $this->getLink();
     }
 
     public function getSource(): string

--- a/packages/framework/src/Framework/Features/Blogging/Models/FeaturedImage.php
+++ b/packages/framework/src/Framework/Features/Blogging/Models/FeaturedImage.php
@@ -163,6 +163,16 @@ class FeaturedImage implements FeaturedImageSchema, Stringable
         return Hyde::image($this->getSource());
     }
 
+    public function getPath(): ?string
+    {
+        return $this->path ?? null;
+    }
+
+    public function getSourcePath(): ?string
+    {
+        return $this->sourcePath ?? null;
+    }
+
     public function getContentLength(): int
     {
         return (str_starts_with($this->getSource(), 'http')
@@ -261,16 +271,6 @@ class FeaturedImage implements FeaturedImageSchema, Stringable
         return isset($this->attributionUrl)
             ? $this->getAuthorLink()
             : $this->getAuthorSpan();
-    }
-
-    public function getPath(): ?string
-    {
-        return $this->path ?? null;
-    }
-
-    public function getSourcePath(): ?string
-    {
-        return $this->sourcePath ?? null;
     }
 
     protected function getContentLengthFromRemote(): ?int

--- a/packages/framework/src/Framework/Features/Blogging/Models/FeaturedImage.php
+++ b/packages/framework/src/Framework/Features/Blogging/Models/FeaturedImage.php
@@ -289,7 +289,7 @@ class FeaturedImage implements FeaturedImageSchema, Stringable
 
     protected function getLocalContentLength(): ?int
     {
-        if (file_exists(Hyde::path($this->getSourcePath()))) {
+        if (isset($this->sourcePath) && file_exists(Hyde::path($this->getSourcePath()))) {
             return filesize(Hyde::path($this->getSourcePath()));
         }
 

--- a/packages/framework/src/Framework/Features/Blogging/Models/FeaturedImage.php
+++ b/packages/framework/src/Framework/Features/Blogging/Models/FeaturedImage.php
@@ -263,7 +263,7 @@ class FeaturedImage implements FeaturedImageSchema, Stringable
             : $this->getAuthorSpan();
     }
 
-    protected function getPath(): ?string
+    public function getPath(): ?string
     {
         return $this->path ?? null;
     }

--- a/packages/framework/src/Framework/Features/Blogging/Models/FeaturedImage.php
+++ b/packages/framework/src/Framework/Features/Blogging/Models/FeaturedImage.php
@@ -7,7 +7,6 @@ namespace Hyde\Framework\Features\Blogging\Models;
 use function array_flip;
 use function array_key_exists;
 use BadMethodCallException;
-use function basename;
 use function config;
 use function e;
 use function file_exists;

--- a/packages/framework/tests/Feature/FeaturedImageModelTest.php
+++ b/packages/framework/tests/Feature/FeaturedImageModelTest.php
@@ -42,16 +42,28 @@ class FeaturedImageModelTest extends TestCase
         $this->assertEquals('bar', $image->title);
     }
 
-    public function test_image_path_is_normalized_to_always_begin_with_media_prefix()
+    public function test_image_path_is_normalized_to_never_begin_with_media_prefix()
     {
         $image = FeaturedImage::make('foo');
-        $this->assertSame('_media/foo', $image->path);
+        $this->assertSame('foo', $image->path);
 
         $image = FeaturedImage::make('_media/foo');
-        $this->assertSame('_media/foo', $image->path);
+        $this->assertSame('foo', $image->path);
 
         $image = FeaturedImage::make('_media/foo');
-        $this->assertSame('_media/foo', $image->path);
+        $this->assertSame('foo', $image->path);
+    }
+
+    public function test_image_source_path_is_normalized_to_always_begin_with_media_prefix()
+    {
+        $image = FeaturedImage::make('foo');
+        $this->assertSame('_media/foo', $image->getSourcePath());
+
+        $image = FeaturedImage::make('_media/foo');
+        $this->assertSame('_media/foo', $image->getSourcePath());
+
+        $image = FeaturedImage::make('_media/foo');
+        $this->assertSame('_media/foo', $image->getSourcePath());
     }
 
     public function test_from_source_automatically_assigns_proper_property_depending_on_if_the_string_is_remote()

--- a/packages/framework/tests/Feature/FeaturedImageModelTest.php
+++ b/packages/framework/tests/Feature/FeaturedImageModelTest.php
@@ -419,15 +419,14 @@ class FeaturedImageModelTest extends TestCase
 
     public function test_it_can_find_the_content_length_for_a_local_image_stored_in_the_media_directory()
     {
-        $image = new FeaturedImage();
-        $image->path = '_media/image.jpg';
-        file_put_contents($image->path, '16bytelongstring');
+        $image = new FeaturedImage(['path' => 'image.jpg']);
+        file_put_contents($image->getSourcePath(), '16bytelongstring');
 
         $this->assertEquals(
             16, $image->getContentLength()
         );
 
-        unlink($image->path);
+        unlink($image->getSourcePath());
     }
 
     public function test_it_can_find_the_content_length_for_a_remote_image()

--- a/packages/framework/tests/Feature/FeaturedImageModelTest.php
+++ b/packages/framework/tests/Feature/FeaturedImageModelTest.php
@@ -45,10 +45,10 @@ class FeaturedImageModelTest extends TestCase
     public function test_image_path_is_normalized_to_always_begin_with_media_prefix()
     {
         $image = FeaturedImage::make('foo');
-        $this->assertEquals('_media/foo', $image->path);
+        $this->assertSame('_media/foo', $image->path);
 
         $image = FeaturedImage::make('_media/foo');
-        $this->assertEquals('_media/foo', $image->path);
+        $this->assertSame('_media/foo', $image->path);
     }
 
     public function test_from_source_automatically_assigns_proper_property_depending_on_if_the_string_is_remote()

--- a/packages/framework/tests/Feature/FeaturedImageModelTest.php
+++ b/packages/framework/tests/Feature/FeaturedImageModelTest.php
@@ -28,7 +28,7 @@ class FeaturedImageModelTest extends TestCase
     {
         $image = FeaturedImage::make('foo');
         $this->assertInstanceOf(FeaturedImage::class, $image);
-        $this->assertEquals('_media/foo', $image->path);
+        $this->assertEquals('foo', $image->path);
     }
 
     public function test_make_can_create_an_image_based_on_array()
@@ -38,7 +38,7 @@ class FeaturedImageModelTest extends TestCase
             'title' => 'bar',
         ]);
         $this->assertInstanceOf(FeaturedImage::class, $image);
-        $this->assertEquals('_media/foo', $image->path);
+        $this->assertEquals('foo', $image->path);
         $this->assertEquals('bar', $image->title);
     }
 
@@ -62,7 +62,7 @@ class FeaturedImageModelTest extends TestCase
 
         $image = FeaturedImage::fromSource('image.jpg');
         $this->assertInstanceOf(FeaturedImage::class, $image);
-        $this->assertEquals('_media/image.jpg', $image->path);
+        $this->assertEquals('image.jpg', $image->path);
     }
 
     public function test_array_data_can_be_used_to_initialize_properties_in_constructor()
@@ -76,7 +76,7 @@ class FeaturedImageModelTest extends TestCase
 
         $image = new FeaturedImage($data);
 
-        $this->assertEquals('_media/'.$data['path'], $image->path);
+        $this->assertEquals($data['path'], $image->path);
         $this->assertEquals($data['url'], $image->url);
         $this->assertEquals($data['description'], $image->description);
         $this->assertEquals($data['title'], $image->title);
@@ -342,15 +342,15 @@ class FeaturedImageModelTest extends TestCase
 
     public function test_local_path_is_normalized_to_the_media_directory()
     {
-        $this->assertEquals('_media/image.jpg', (new FeaturedImage([
+        $this->assertEquals('image.jpg', (new FeaturedImage([
             'path' => 'image.jpg',
         ]))->path);
 
-        $this->assertEquals('_media/image.jpg', (new FeaturedImage([
+        $this->assertEquals('image.jpg', (new FeaturedImage([
             'path' => '_media/image.jpg',
         ]))->path);
 
-        $this->assertEquals('_media/image.jpg', (new FeaturedImage([
+        $this->assertEquals('image.jpg', (new FeaturedImage([
             'path' => 'media/image.jpg',
         ]))->path);
     }

--- a/packages/framework/tests/Feature/FeaturedImageModelTest.php
+++ b/packages/framework/tests/Feature/FeaturedImageModelTest.php
@@ -28,7 +28,7 @@ class FeaturedImageModelTest extends TestCase
     {
         $image = FeaturedImage::make('foo');
         $this->assertInstanceOf(FeaturedImage::class, $image);
-        $this->assertEquals('foo', $image->path);
+        $this->assertEquals('_media/foo', $image->path);
     }
 
     public function test_make_can_create_an_image_based_on_array()
@@ -38,7 +38,7 @@ class FeaturedImageModelTest extends TestCase
             'title' => 'bar',
         ]);
         $this->assertInstanceOf(FeaturedImage::class, $image);
-        $this->assertEquals('foo', $image->path);
+        $this->assertEquals('_media/foo', $image->path);
         $this->assertEquals('bar', $image->title);
     }
 
@@ -59,7 +59,7 @@ class FeaturedImageModelTest extends TestCase
 
         $image = FeaturedImage::fromSource('image.jpg');
         $this->assertInstanceOf(FeaturedImage::class, $image);
-        $this->assertEquals('image.jpg', $image->path);
+        $this->assertEquals('_media/image.jpg', $image->path);
     }
 
     public function test_array_data_can_be_used_to_initialize_properties_in_constructor()
@@ -73,7 +73,7 @@ class FeaturedImageModelTest extends TestCase
 
         $image = new FeaturedImage($data);
 
-        $this->assertEquals($data['path'], $image->path);
+        $this->assertEquals('_media/'.$data['path'], $image->path);
         $this->assertEquals($data['url'], $image->url);
         $this->assertEquals($data['description'], $image->description);
         $this->assertEquals($data['title'], $image->title);
@@ -339,15 +339,15 @@ class FeaturedImageModelTest extends TestCase
 
     public function test_local_path_is_normalized_to_the_media_directory()
     {
-        $this->assertEquals('image.jpg', (new FeaturedImage([
+        $this->assertEquals('_media/image.jpg', (new FeaturedImage([
             'path' => 'image.jpg',
         ]))->path);
 
-        $this->assertEquals('image.jpg', (new FeaturedImage([
+        $this->assertEquals('_media/image.jpg', (new FeaturedImage([
             'path' => '_media/image.jpg',
         ]))->path);
 
-        $this->assertEquals('image.jpg', (new FeaturedImage([
+        $this->assertEquals('_media/image.jpg', (new FeaturedImage([
             'path' => 'media/image.jpg',
         ]))->path);
     }

--- a/packages/framework/tests/Feature/FeaturedImageModelTest.php
+++ b/packages/framework/tests/Feature/FeaturedImageModelTest.php
@@ -42,6 +42,15 @@ class FeaturedImageModelTest extends TestCase
         $this->assertEquals('bar', $image->title);
     }
 
+    public function test_image_path_is_normalized_to_always_begin_with_media_prefix()
+    {
+        $image = FeaturedImage::make('foo');
+        $this->assertEquals('_media/foo', $image->path);
+
+        $image = FeaturedImage::make('_media/foo');
+        $this->assertEquals('_media/foo', $image->path);
+    }
+
     public function test_from_source_automatically_assigns_proper_property_depending_on_if_the_string_is_remote()
     {
         $image = FeaturedImage::fromSource('https://example.com/image.jpg');

--- a/packages/framework/tests/Feature/FeaturedImageModelTest.php
+++ b/packages/framework/tests/Feature/FeaturedImageModelTest.php
@@ -49,6 +49,9 @@ class FeaturedImageModelTest extends TestCase
 
         $image = FeaturedImage::make('_media/foo');
         $this->assertSame('_media/foo', $image->path);
+
+        $image = FeaturedImage::make('_media/foo');
+        $this->assertSame('_media/foo', $image->path);
     }
 
     public function test_from_source_automatically_assigns_proper_property_depending_on_if_the_string_is_remote()

--- a/packages/framework/tests/Feature/MarkdownPostTest.php
+++ b/packages/framework/tests/Feature/MarkdownPostTest.php
@@ -88,7 +88,7 @@ class MarkdownPostTest extends TestCase
         $page = MarkdownPost::make(matter: ['image' => 'foo.png']);
         $image = $page->image;
         $this->assertInstanceOf(FeaturedImage::class, $image);
-        $this->assertEquals('_media/foo.png', $image->path);
+        $this->assertEquals('foo.png', $image->path);
     }
 
     public function test_featured_image_can_be_constructed_returns_image_object_with_remote_path_when_matter_is_string()
@@ -104,7 +104,7 @@ class MarkdownPostTest extends TestCase
         $page = MarkdownPost::make(matter: ['image' => ['path' => 'foo.png', 'title' => 'bar']]);
         $image = $page->image;
         $this->assertInstanceOf(FeaturedImage::class, $image);
-        $this->assertEquals('_media/foo.png', $image->path);
+        $this->assertEquals('foo.png', $image->path);
         $this->assertEquals('bar', $image->title);
     }
 }

--- a/packages/framework/tests/Feature/MarkdownPostTest.php
+++ b/packages/framework/tests/Feature/MarkdownPostTest.php
@@ -88,7 +88,7 @@ class MarkdownPostTest extends TestCase
         $page = MarkdownPost::make(matter: ['image' => 'foo.png']);
         $image = $page->image;
         $this->assertInstanceOf(FeaturedImage::class, $image);
-        $this->assertEquals('foo.png', $image->path);
+        $this->assertEquals('_media/foo.png', $image->path);
     }
 
     public function test_featured_image_can_be_constructed_returns_image_object_with_remote_path_when_matter_is_string()
@@ -104,7 +104,7 @@ class MarkdownPostTest extends TestCase
         $page = MarkdownPost::make(matter: ['image' => ['path' => 'foo.png', 'title' => 'bar']]);
         $image = $page->image;
         $this->assertInstanceOf(FeaturedImage::class, $image);
-        $this->assertEquals('foo.png', $image->path);
+        $this->assertEquals('_media/foo.png', $image->path);
         $this->assertEquals('bar', $image->title);
     }
 }


### PR DESCRIPTION
Leads to a more explicit, consistant, and predictable behaviour. It also makes usage more forgiving as front matter can use both _media/ or just the filename as it will be normalized.