### PR TITLE
Change schema.org identifiers to use https

### DIFF
--- a/.idea/inspectionProfiles/Project_Default.xml
+++ b/.idea/inspectionProfiles/Project_Default.xml
@@ -28,7 +28,7 @@
           <option value="http://cxf.apache.org/schemas/" />
           <option value="http://primefaces.org/ui" />
           <option value="http://tiles.apache.org/" />
-          <option value="http://schema.org" />
+          <option value="https://schema.org" />
           <option value="http://purl.org" />
         </list>
       </option>

--- a/packages/framework/resources/views/components/article-excerpt.blade.php
+++ b/packages/framework/resources/views/components/article-excerpt.blade.php
@@ -2,7 +2,7 @@
     /** @var \Hyde\Pages\MarkdownPost $post */
 @endphp
 
-<article class="mt-4 mb-8" itemscope itemtype="http://schema.org/Article">
+<article class="mt-4 mb-8" itemscope itemtype="https://schema.org/Article">
     <meta itemprop="identifier" content="{{ $post->identifier }}">
     @if(Hyde::hasSiteUrl())
         <meta itemprop="url" content="{{ Hyde::url('posts/' . $post->identifier) }}">
@@ -24,7 +24,7 @@
 		</span>
         @endisset
         @isset($post->author)
-            <span itemprop="author" itemscope itemtype="http://schema.org/Person">
+            <span itemprop="author" itemscope itemtype="https://schema.org/Person">
 			<span class="opacity-75">by</span>
 			<span itemprop="name">
 				{{ $post->author->name ?? $post->author->username }}

--- a/packages/framework/resources/views/components/docs/documentation-article.blade.php
+++ b/packages/framework/resources/views/components/docs/documentation-article.blade.php
@@ -3,7 +3,7 @@
     'document',
 ])
 
-<article id="document" itemscope itemtype="http://schema.org/Article" @class([
+<article id="document" itemscope itemtype="https://schema.org/Article" @class([
         'mx-auto lg:ml-8 prose dark:prose-invert max-w-3xl p-12 md:px-16 max-w-[1000px] min-h-[calc(100vh_-_4rem)]',
         'torchlight-enabled' => $document->hasTorchlight()])>
     @yield('content')

--- a/packages/framework/resources/views/components/post/article.blade.php
+++ b/packages/framework/resources/views/components/post/article.blade.php
@@ -1,5 +1,5 @@
 <article aria-label="Article" id="{{ Hyde::url("posts/$page->identifier", '') }}" itemscope
-         itemtype="http://schema.org/Article"
+         itemtype="https://schema.org/Article"
         @class(['post-article mx-auto prose dark:prose-invert', 'torchlight-enabled' => Hyde\Facades\Features::hasTorchlight()])>
     <meta itemprop="identifier" content="{{ $page->identifier }}">
     @if(Hyde::hasSiteUrl())

--- a/packages/framework/resources/views/components/post/author.blade.php
+++ b/packages/framework/resources/views/components/post/author.blade.php
@@ -1,5 +1,5 @@
 by author
-<address itemprop="author" itemscope itemtype="http://schema.org/Person" aria-label="The post author" style="display: inline;"> 
+<address itemprop="author" itemscope itemtype="https://schema.org/Person" aria-label="The post author" style="display: inline;"> 
 	@if($page->author->website)
 	<a href="{{ $page->author->website }}" rel="author" itemprop="url" aria-label="The author's website">
 	@endif

--- a/packages/framework/resources/views/components/post/image.blade.php
+++ b/packages/framework/resources/views/components/post/image.blade.php
@@ -3,13 +3,13 @@
     /** @var \Hyde\Framework\Features\Blogging\Models\FeaturedImage $image  */
     $image = $page->image;
 @endphp
-<figure aria-label="Cover image" itemprop="image" itemscope itemtype="http://schema.org/ImageObject" role="doc-cover">
+<figure aria-label="Cover image" itemprop="image" itemscope itemtype="https://schema.org/ImageObject" role="doc-cover">
     <img src="{{ $image->getSource() }}" alt="{{ $image->getAltText() ?? '' }}" title="{{ $image->getTitleText() ?? '' }}"
          itemprop="image" class="mb-0">
     <figcaption aria-label="Image caption" itemprop="caption">
         @if($image->hasAuthorName())
             <span>Image by</span>
-            <span itemprop="creator" itemscope="" itemtype="http://schema.org/Person">
+            <span itemprop="creator" itemscope="" itemtype="https://schema.org/Person">
                 @if($image->hasAuthorUrl())
                     <a href="{{ $image->getAuthorUrl() }}" rel="author noopener nofollow" itemprop="url">
                         <span itemprop="name">{{ $image->getAuthorName() }}</span>.

--- a/packages/framework/tests/Feature/StaticSiteBuilderPostModuleTest.php
+++ b/packages/framework/tests/Feature/StaticSiteBuilderPostModuleTest.php
@@ -105,8 +105,8 @@ class StaticSiteBuilderPostModuleTest extends TestCase
     public function test_post_contains_expected_itemprops()
     {
         $this->inspectHtml([
-            'itemtype="http://schema.org/Article"',
-            'itemtype="http://schema.org/Person"',
+            'itemtype="https://schema.org/Article"',
+            'itemtype="https://schema.org/Person"',
             'itemprop="identifier"',
             'itemprop="headline"',
             'itemprop="dateCreated datePublished"',

--- a/packages/framework/tests/Unit/Views/ArticleExcerptViewTest.php
+++ b/packages/framework/tests/Unit/Views/ArticleExcerptViewTest.php
@@ -24,7 +24,7 @@ class ArticleExcerptViewTest extends TestCase
     public function test_component_can_be_rendered()
     {
         $view = $this->renderTestView(MarkdownPost::make());
-        $this->assertStringContainsString('http://schema.org/Article', $view);
+        $this->assertStringContainsString('https://schema.org/Article', $view);
     }
 
     public function test_component_renders_post_data()

--- a/packages/framework/tests/Unit/Views/FeaturedImageViewTest.php
+++ b/packages/framework/tests/Unit/Views/FeaturedImageViewTest.php
@@ -50,7 +50,7 @@ class FeaturedImageViewTest extends TestCase
     {
         $string = $this->renderComponent(['image.author' => 'John Doe']);
         $this->assertStringContainsString('itemprop="creator"', $string);
-        $this->assertStringContainsString('itemtype="http://schema.org/Person"', $string);
+        $this->assertStringContainsString('itemtype="https://schema.org/Person"', $string);
         $this->assertStringContainsString('<span itemprop="name">John Doe</span>', $string);
     }
 
@@ -62,7 +62,7 @@ class FeaturedImageViewTest extends TestCase
         ]);
         $this->assertStringContainsString('itemprop="creator"', $string);
         $this->assertStringContainsString('itemprop="url"', $string);
-        $this->assertStringContainsString('itemtype="http://schema.org/Person"', $string);
+        $this->assertStringContainsString('itemtype="https://schema.org/Person"', $string);
         $this->assertStringContainsString('<span itemprop="name">John Doe</span>', $string);
         $this->assertStringContainsString('<a href="https://example.com/"', $string);
     }


### PR DESCRIPTION
Changes itemtypes to use the https version of schema identifiers. See https://schema.org/docs/faq.html#19

> Q: Should we write 'https://schema.org' or 'http://schema.org' in our markup?
> 
> There is a general trend towards using 'https' more widely, and you can already write 'https://schema.org' in your structured data. We have migrated the schema.org site itself towards using https: as the default version of the site and our preferred form in examples. However 'http://schema.org' -based URLs in structured data markup will remain widely understood for the foreseeable future and there should be no urgency about migrating existing data. This is a lengthy way of saying that both 'https://schema.org' and 'http://schema.org' are fine.