### PR TITLE
HydeRC: Use getOrFail instead of get

### DIFF
--- a/packages/realtime-compiler/src/Routing/PageRouter.php
+++ b/packages/realtime-compiler/src/Routing/PageRouter.php
@@ -28,7 +28,7 @@ class PageRouter
 
     protected function handlePageRequest(): Response
     {
-        $html = $this->getHtml(Route::get($this->normalizePath($this->request->path))->getPage());
+        $html = $this->getHtml(Route::getOrFail($this->normalizePath($this->request->path))->getPage());
 
         return (new Response(200, 'OK', [
             'body' => $html,


### PR DESCRIPTION
Uses the getOrFail method to throw a 404 when the route is not found in the realtime compiler.