### PR TITLE
Allow navigation group to be set with category key

### DIFF
--- a/packages/framework/src/Framework/Factories/NavigationDataFactory.php
+++ b/packages/framework/src/Framework/Factories/NavigationDataFactory.php
@@ -139,7 +139,7 @@ class NavigationDataFactory extends Concerns\PageDataFactory implements Navigati
             // then we can use that as the category name.
             ? Str::before($this->identifier, '/')
             // Otherwise, we look in the front matter.
-            : $this->matter('navigation.group', 'other');
+            : $this->findGroupFromMatter();
     }
 
     protected function searchForLabelInConfig(): ?string
@@ -159,5 +159,10 @@ class NavigationDataFactory extends Concerns\PageDataFactory implements Navigati
     protected function isInstanceOf(string $class): bool
     {
         return is_a($this->pageClass, $class, true);
+    }
+
+    protected function findGroupFromMatter(): mixed
+    {
+        return $this->matter('navigation.group', 'other');
     }
 }

--- a/packages/framework/src/Framework/Factories/NavigationDataFactory.php
+++ b/packages/framework/src/Framework/Factories/NavigationDataFactory.php
@@ -163,6 +163,8 @@ class NavigationDataFactory extends Concerns\PageDataFactory implements Navigati
 
     protected function findGroupFromMatter(): mixed
     {
-        return $this->matter('navigation.group', 'other');
+        return $this->matter('navigation.group')
+            ?? $this->matter('navigation.category')
+            ?? 'other';
     }
 }


### PR DESCRIPTION
Makes so that the following yield the same result, where previously the latter would do nothing.

```markdown
---
navigation:
  group: Example
---
```

```markdown
---
navigation:
  category: Example
---
```

This saves you having to try to remember which front matter key works, as now both does!