### PR TITLE
Refactor XML services

### DIFF
--- a/packages/framework/src/Facades/Features.php
+++ b/packages/framework/src/Facades/Features.php
@@ -109,9 +109,9 @@ class Features implements Arrayable, JsonSerializable
             && (app('env') !== 'testing');
     }
 
-    // ================================================
-    // Enable a given feature to be used in the config.
-    // ================================================
+    // =================================================
+    // Configure features to be used in the config file.
+    // =================================================
 
     public static function htmlPages(): string
     {
@@ -158,9 +158,10 @@ class Features implements Arrayable, JsonSerializable
         return 'torchlight';
     }
 
-    // ================================================
-    // Dynamic features.
-    // ================================================
+    // ====================================================
+    // Dynamic features that in addition to being enabled
+    // in the config file, require preconditions to be met.
+    // ====================================================
 
     /** Can a sitemap be generated? */
     public static function sitemap(): bool

--- a/packages/framework/src/Facades/Features.php
+++ b/packages/framework/src/Facades/Features.php
@@ -184,15 +184,16 @@ class Features implements Arrayable, JsonSerializable
     /**
      * Get an array representation of the features and their status.
      *
-     * @return  array<string, bool>
+     * @return array<string, bool>
+     *
      * @example ['html-pages' => true, 'markdown-pages' => false, ...]
      */
     public function toArray(): array
     {
         return collect(get_class_methods(static::class))
-            ->filter(fn(string $method): bool => str_starts_with($method, 'has'))
-            ->mapWithKeys(fn(string $method): array => [
-                Str::kebab(substr($method, 3)) => (static::{$method}())
+            ->filter(fn (string $method): bool => str_starts_with($method, 'has'))
+            ->mapWithKeys(fn (string $method): array => [
+                Str::kebab(substr($method, 3)) => (static::{$method}()),
             ])->toArray();
     }
 }

--- a/packages/framework/src/Framework/Features/BuildTasks/PostBuildTasks/GenerateRssFeed.php
+++ b/packages/framework/src/Framework/Features/BuildTasks/PostBuildTasks/GenerateRssFeed.php
@@ -15,13 +15,13 @@ class GenerateRssFeed extends BuildTask
     public function run(): void
     {
         file_put_contents(
-            Hyde::sitePath(RssFeedService::getDefaultOutputFilename()),
+            Hyde::sitePath(RssFeedService::outputFilename()),
             RssFeedService::generateFeed()
         );
     }
 
     public function then(): void
     {
-        $this->createdSiteFile('_site/'.RssFeedService::getDefaultOutputFilename())->withExecutionTime();
+        $this->createdSiteFile('_site/'.RssFeedService::outputFilename())->withExecutionTime();
     }
 }

--- a/packages/framework/src/Framework/Features/Metadata/GlobalMetadataBag.php
+++ b/packages/framework/src/Framework/Features/Metadata/GlobalMetadataBag.php
@@ -31,7 +31,7 @@ class GlobalMetadataBag extends MetadataBag
         }
 
         if (Features::rss()) {
-            $metadataBag->add(Meta::link('alternate', Hyde::url(RssFeedService::getDefaultOutputFilename()), [
+            $metadataBag->add(Meta::link('alternate', Hyde::url(RssFeedService::outputFilename()), [
                 'type' => 'application/rss+xml', 'title' => RssFeedService::getDescription(),
             ]));
         }

--- a/packages/framework/src/Framework/Services/RssFeedService.php
+++ b/packages/framework/src/Framework/Services/RssFeedService.php
@@ -16,6 +16,7 @@ use Hyde\Hyde;
 use Hyde\Pages\MarkdownPost;
 use Hyde\Support\Helpers\XML;
 use SimpleXMLElement;
+use function throw_unless;
 
 /**
  * @see \Hyde\Framework\Testing\Feature\Services\RssFeedServiceTest
@@ -46,9 +47,9 @@ class RssFeedService
 
     public function __construct()
     {
-        if (! extension_loaded('simplexml')) {
-            throw new Exception('The ext-simplexml extension is not installed, but is required to generate RSS feeds.');
-        }
+        throw_unless(extension_loaded('simplexml'),
+            new Exception('The ext-simplexml extension is not installed, but is required to generate RSS feeds.')
+        );
 
         $this->feed = new SimpleXMLElement('<?xml version="1.0" encoding="UTF-8"?>
             <rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom" xmlns:dc="http://purl.org/dc/elements/1.1/" />');

--- a/packages/framework/src/Framework/Services/RssFeedService.php
+++ b/packages/framework/src/Framework/Services/RssFeedService.php
@@ -57,9 +57,6 @@ class RssFeedService
         $this->addInitialChannelItems();
     }
 
-    /**
-     * @throws \Exception
-     */
     public function generate(): static
     {
         /** @var \Hyde\Pages\MarkdownPost $post */

--- a/packages/framework/src/Framework/Services/RssFeedService.php
+++ b/packages/framework/src/Framework/Services/RssFeedService.php
@@ -59,10 +59,9 @@ class RssFeedService
 
     public function generate(): static
     {
-        /** @var \Hyde\Pages\MarkdownPost $post */
-        foreach (MarkdownPost::getLatestPosts() as $post) {
+        MarkdownPost::getLatestPosts()->each(function (MarkdownPost $post): void {
             $this->addItem($post);
-        }
+        });
 
         return $this;
     }

--- a/packages/framework/src/Framework/Services/RssFeedService.php
+++ b/packages/framework/src/Framework/Services/RssFeedService.php
@@ -117,7 +117,7 @@ class RssFeedService
         $this->feed->channel->addChild('lastBuildDate', date(DATE_RSS));
 
         $atomLink = $this->feed->channel->addChild('atom:link', namespace: 'http://www.w3.org/2005/Atom');
-        $atomLink->addAttribute('href', XML::escape(Site::url()) .'/'.static::outputFilename());
+        $atomLink->addAttribute('href', XML::escape(Hyde::url(static::outputFilename())));
         $atomLink->addAttribute('rel', 'self');
         $atomLink->addAttribute('type', 'application/rss+xml');
     }

--- a/packages/framework/src/Framework/Services/RssFeedService.php
+++ b/packages/framework/src/Framework/Services/RssFeedService.php
@@ -59,9 +59,8 @@ class RssFeedService
 
     public function generate(): static
     {
-        MarkdownPost::getLatestPosts()->each(function (MarkdownPost $post): void {
-            $this->addItem($post);
-        });
+        MarkdownPost::getLatestPosts()
+            ->each(fn(MarkdownPost $post) => $this->addItem($post));
 
         return $this;
     }

--- a/packages/framework/src/Framework/Services/RssFeedService.php
+++ b/packages/framework/src/Framework/Services/RssFeedService.php
@@ -112,14 +112,14 @@ class RssFeedService
         $this->feed->channel->addChild('link', static::getLink());
         $this->feed->channel->addChild('description', static::getDescription());
 
+        $this->feed->channel->addChild('language', config('site.language', 'en'));
+        $this->feed->channel->addChild('generator', 'HydePHP '.Hyde::version());
+        $this->feed->channel->addChild('lastBuildDate', date(DATE_RSS));
+
         $atomLink = $this->feed->channel->addChild('atom:link', namespace: 'http://www.w3.org/2005/Atom');
         $atomLink->addAttribute('href', static::getLink().'/'.static::outputFilename());
         $atomLink->addAttribute('rel', 'self');
         $atomLink->addAttribute('type', 'application/rss+xml');
-
-        $this->feed->channel->addChild('language', config('site.language', 'en'));
-        $this->feed->channel->addChild('generator', 'HydePHP '.Hyde::version());
-        $this->feed->channel->addChild('lastBuildDate', date(DATE_RSS));
     }
 
     protected static function getTitle(): string

--- a/packages/framework/src/Framework/Services/RssFeedService.php
+++ b/packages/framework/src/Framework/Services/RssFeedService.php
@@ -54,7 +54,7 @@ class RssFeedService
             <rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom" xmlns:dc="http://purl.org/dc/elements/1.1/" />');
         $this->feed->addChild('channel');
 
-        $this->addInitialChannelItems();
+        $this->addBaseChannelItems();
     }
 
     public function generate(): static
@@ -106,7 +106,7 @@ class RssFeedService
         }
     }
 
-    protected function addInitialChannelItems(): void
+    protected function addBaseChannelItems(): void
     {
         $this->feed->channel->addChild('title', static::getTitle());
         $this->feed->channel->addChild('link', static::getLink());

--- a/packages/framework/src/Framework/Services/RssFeedService.php
+++ b/packages/framework/src/Framework/Services/RssFeedService.php
@@ -83,7 +83,7 @@ class RssFeedService
 
         if (isset($post->image)) {
             $image = $item->addChild('enclosure');
-            $image->addAttribute('url', Hyde::image((string) $post->image, true));
+            $image->addAttribute('url', Hyde::image($post->image->getSource(), true));
             $image->addAttribute('type', $this->getImageType($post));
             $image->addAttribute('length', (string) $post->image->getContentLength());
         }

--- a/packages/framework/src/Framework/Services/RssFeedService.php
+++ b/packages/framework/src/Framework/Services/RssFeedService.php
@@ -13,6 +13,9 @@ use Hyde\Hyde;
 use Hyde\Pages\MarkdownPost;
 use Hyde\Support\Helpers\XML;
 use SimpleXMLElement;
+use function config;
+use function date;
+use function extension_loaded;
 
 /**
  * @see \Hyde\Framework\Testing\Feature\Services\RssFeedServiceTest

--- a/packages/framework/src/Framework/Services/RssFeedService.php
+++ b/packages/framework/src/Framework/Services/RssFeedService.php
@@ -119,12 +119,12 @@ class RssFeedService
         ));
     }
 
-    public static function getTitle(): string
+    protected static function getTitle(): string
     {
         return XML::escape(Site::name());
     }
 
-    public static function getLink(): string
+    protected static function getLink(): string
     {
         return XML::escape(Site::url());
     }

--- a/packages/framework/src/Framework/Services/RssFeedService.php
+++ b/packages/framework/src/Framework/Services/RssFeedService.php
@@ -121,7 +121,7 @@ class RssFeedService
 
     public static function getTitle(): string
     {
-        return XML::escape(config('site.name', 'HydePHP'));
+        return XML::escape(Site::name());
     }
 
     public static function getLink(): string

--- a/packages/framework/src/Framework/Services/RssFeedService.php
+++ b/packages/framework/src/Framework/Services/RssFeedService.php
@@ -143,6 +143,7 @@ class RssFeedService
 
     protected function getImageType(MarkdownPost $post): string
     {
+        /** @todo Add support for more types */
         return str_ends_with($post->image->getSource(), '.png') ? 'image/png' : 'image/jpeg';
     }
 }

--- a/packages/framework/src/Framework/Services/RssFeedService.php
+++ b/packages/framework/src/Framework/Services/RssFeedService.php
@@ -40,7 +40,7 @@ class RssFeedService
     {
         return XML::escape(config(
             'hyde.rss_description',
-            static::getTitle().' RSS Feed'
+            XML::escape(Site::name()) .' RSS Feed'
         ));
     }
 
@@ -108,8 +108,8 @@ class RssFeedService
 
     protected function addBaseChannelItems(): void
     {
-        $this->feed->channel->addChild('title', static::getTitle());
-        $this->feed->channel->addChild('link', static::getLink());
+        $this->feed->channel->addChild('title', XML::escape(Site::name()));
+        $this->feed->channel->addChild('link', XML::escape(Site::url()));
         $this->feed->channel->addChild('description', static::getDescription());
 
         $this->feed->channel->addChild('language', config('site.language', 'en'));
@@ -117,19 +117,9 @@ class RssFeedService
         $this->feed->channel->addChild('lastBuildDate', date(DATE_RSS));
 
         $atomLink = $this->feed->channel->addChild('atom:link', namespace: 'http://www.w3.org/2005/Atom');
-        $atomLink->addAttribute('href', static::getLink().'/'.static::outputFilename());
+        $atomLink->addAttribute('href', XML::escape(Site::url()) .'/'.static::outputFilename());
         $atomLink->addAttribute('rel', 'self');
         $atomLink->addAttribute('type', 'application/rss+xml');
-    }
-
-    protected static function getTitle(): string
-    {
-        return XML::escape(Site::name());
-    }
-
-    protected static function getLink(): string
-    {
-        return XML::escape(Site::url());
     }
 
     protected function getImageType(MarkdownPost $post): string

--- a/packages/framework/src/Framework/Services/RssFeedService.php
+++ b/packages/framework/src/Framework/Services/RssFeedService.php
@@ -59,10 +59,10 @@ class RssFeedService
         $item->addChild('title', $post->title);
         $item->addChild('description', $post->description);
 
-        $this->addAdditionalItemData($item, $post);
+        $this->addDynamicItemData($item, $post);
     }
 
-    protected function addAdditionalItemData(SimpleXMLElement $item, MarkdownPost $post): void
+    protected function addDynamicItemData(SimpleXMLElement $item, MarkdownPost $post): void
     {
         if ($post->canonicalUrl !== null) {
             $item->addChild('link', $post->canonicalUrl);

--- a/packages/framework/src/Framework/Services/RssFeedService.php
+++ b/packages/framework/src/Framework/Services/RssFeedService.php
@@ -64,7 +64,7 @@ class RssFeedService
 
     protected function addDynamicItemData(SimpleXMLElement $item, MarkdownPost $post): void
     {
-        if ($post->canonicalUrl !== null) {
+        if (isset($post->canonicalUrl)) {
             $item->addChild('link', $post->canonicalUrl);
             $item->addChild('guid', $post->canonicalUrl);
         }

--- a/packages/framework/src/Framework/Services/RssFeedService.php
+++ b/packages/framework/src/Framework/Services/RssFeedService.php
@@ -85,7 +85,7 @@ class RssFeedService
             $image = $item->addChild('enclosure');
             $image->addAttribute('url', Hyde::image($post->image->getSource(), true));
             $image->addAttribute('type', $this->getImageType($post));
-            $image->addAttribute('length', (string) $post->image->getContentLength());
+            $image->addAttribute('length', $this->getImageLength($post));
         }
     }
 
@@ -145,5 +145,11 @@ class RssFeedService
     {
         /** @todo Add support for more types */
         return str_ends_with($post->image->getSource(), '.png') ? 'image/png' : 'image/jpeg';
+    }
+
+    protected function getImageLength(MarkdownPost $post): string
+    {
+        /** @todo We might want to add a build warning if the length is zero */
+        return (string)$post->image->getContentLength();
     }
 }

--- a/packages/framework/src/Framework/Services/RssFeedService.php
+++ b/packages/framework/src/Framework/Services/RssFeedService.php
@@ -57,10 +57,6 @@ class RssFeedService
     {
         $item = $this->feed->channel->addChild('item');
         $item->addChild('title', $post->title);
-        if ($post->canonicalUrl !== null) {
-            $item->addChild('link', $post->canonicalUrl);
-            $item->addChild('guid', $post->canonicalUrl);
-        }
         $item->addChild('description', $post->description);
 
         $this->addAdditionalItemData($item, $post);
@@ -68,6 +64,11 @@ class RssFeedService
 
     protected function addAdditionalItemData(SimpleXMLElement $item, MarkdownPost $post): void
     {
+        if ($post->canonicalUrl !== null) {
+            $item->addChild('link', $post->canonicalUrl);
+            $item->addChild('guid', $post->canonicalUrl);
+        }
+
         if (isset($post->date)) {
             $item->addChild('pubDate', $post->date->dateTimeObject->format(DATE_RSS));
         }

--- a/packages/framework/src/Framework/Services/RssFeedService.php
+++ b/packages/framework/src/Framework/Services/RssFeedService.php
@@ -96,7 +96,7 @@ class RssFeedService
         $this->feed->channel->addChild('description', static::getDescription());
 
         $atomLink = $this->feed->channel->addChild('atom:link', namespace: 'http://www.w3.org/2005/Atom');
-        $atomLink->addAttribute('href', static::getLink().'/'.static::getDefaultOutputFilename());
+        $atomLink->addAttribute('href', static::getLink().'/'.static::outputFilename());
         $atomLink->addAttribute('rel', 'self');
         $atomLink->addAttribute('type', 'application/rss+xml');
 
@@ -131,7 +131,7 @@ class RssFeedService
         ));
     }
 
-    public static function getDefaultOutputFilename(): string
+    public static function outputFilename(): string
     {
         return config('hyde.rss_filename', 'feed.xml');
     }

--- a/packages/framework/src/Framework/Services/RssFeedService.php
+++ b/packages/framework/src/Framework/Services/RssFeedService.php
@@ -117,11 +117,6 @@ class RssFeedService
         $atomLink->addAttribute('rel', 'self');
         $atomLink->addAttribute('type', 'application/rss+xml');
 
-        $this->addAdditionalChannelData();
-    }
-
-    protected function addAdditionalChannelData(): void
-    {
         $this->feed->channel->addChild('language', config('site.language', 'en'));
         $this->feed->channel->addChild('generator', 'HydePHP '.Hyde::version());
         $this->feed->channel->addChild('lastBuildDate', date(DATE_RSS));

--- a/packages/framework/src/Framework/Services/RssFeedService.php
+++ b/packages/framework/src/Framework/Services/RssFeedService.php
@@ -23,6 +23,24 @@ class RssFeedService
 {
     public SimpleXMLElement $feed;
 
+    public static function generateFeed(): string
+    {
+        return (new static)->generate()->getXML();
+    }
+
+    public static function outputFilename(): string
+    {
+        return config('hyde.rss_filename', 'feed.xml');
+    }
+
+    public static function getDescription(): string
+    {
+        return XML::escape(config(
+            'hyde.rss_description',
+            static::getTitle().' RSS Feed'
+        ));
+    }
+
     public function __construct()
     {
         if (! extension_loaded('simplexml') || config('testing.mock_disabled_extensions', false) === true) {
@@ -111,14 +129,6 @@ class RssFeedService
         $this->feed->channel->addChild('lastBuildDate', date(DATE_RSS));
     }
 
-    public static function getDescription(): string
-    {
-        return XML::escape(config(
-            'hyde.rss_description',
-            static::getTitle().' RSS Feed'
-        ));
-    }
-
     protected static function getTitle(): string
     {
         return XML::escape(Site::name());
@@ -127,16 +137,6 @@ class RssFeedService
     protected static function getLink(): string
     {
         return XML::escape(Site::url());
-    }
-
-    public static function outputFilename(): string
-    {
-        return config('hyde.rss_filename', 'feed.xml');
-    }
-
-    public static function generateFeed(): string
-    {
-        return (new static)->generate()->getXML();
     }
 
     protected function getImageType(MarkdownPost $post): string

--- a/packages/framework/src/Framework/Services/RssFeedService.php
+++ b/packages/framework/src/Framework/Services/RssFeedService.php
@@ -84,7 +84,7 @@ class RssFeedService
         if (isset($post->image)) {
             $image = $item->addChild('enclosure');
             $image->addAttribute('url', Hyde::image((string) $post->image, true));
-            $image->addAttribute('type', str_ends_with($post->image->getSource(), '.png') ? 'image/png' : 'image/jpeg');
+            $image->addAttribute('type', $this->getImageType($post));
             $image->addAttribute('length', (string) $post->image->getContentLength());
         }
     }
@@ -139,5 +139,10 @@ class RssFeedService
     public static function generateFeed(): string
     {
         return (new static)->generate()->getXML();
+    }
+
+    protected function getImageType(MarkdownPost $post): string
+    {
+        return str_ends_with($post->image->getSource(), '.png') ? 'image/png' : 'image/jpeg';
     }
 }

--- a/packages/framework/src/Framework/Services/RssFeedService.php
+++ b/packages/framework/src/Framework/Services/RssFeedService.php
@@ -8,6 +8,7 @@ declare(strict_types=1);
 namespace Hyde\Framework\Services;
 
 use Exception;
+use Hyde\Facades\Site;
 use Hyde\Hyde;
 use Hyde\Pages\MarkdownPost;
 use Hyde\Support\Helpers\XML;
@@ -125,10 +126,7 @@ class RssFeedService
 
     public static function getLink(): string
     {
-        return XML::escape(rtrim(
-            config('site.url') ?? 'http://localhost',
-            '/'
-        ));
+        return XML::escape(Site::url());
     }
 
     public static function outputFilename(): string

--- a/packages/framework/src/Framework/Services/RssFeedService.php
+++ b/packages/framework/src/Framework/Services/RssFeedService.php
@@ -46,7 +46,7 @@ class RssFeedService
 
     public function __construct()
     {
-        if (! extension_loaded('simplexml') || config('testing.mock_disabled_extensions', false) === true) {
+        if (! extension_loaded('simplexml')) {
             throw new Exception('The ext-simplexml extension is not installed, but is required to generate RSS feeds.');
         }
 

--- a/packages/framework/src/Framework/Services/RssFeedService.php
+++ b/packages/framework/src/Framework/Services/RssFeedService.php
@@ -10,6 +10,7 @@ namespace Hyde\Framework\Services;
 use Exception;
 use Hyde\Hyde;
 use Hyde\Pages\MarkdownPost;
+use Hyde\Support\Helpers\XML;
 use SimpleXMLElement;
 
 /**
@@ -108,36 +109,25 @@ class RssFeedService
         $this->feed->channel->addChild('lastBuildDate', date(DATE_RSS));
     }
 
-    protected static function xmlEscape(string $string): string
-    {
-        return htmlspecialchars($string, ENT_XML1 | ENT_COMPAT, 'UTF-8');
-    }
-
     public static function getDescription(): string
     {
-        return static::xmlEscape(
-            config(
-                'hyde.rss_description',
-                static::getTitle().' RSS Feed'
-            )
-        );
+        return XML::escape(config(
+            'hyde.rss_description',
+            static::getTitle() . ' RSS Feed'
+        ));
     }
 
     public static function getTitle(): string
     {
-        return static::xmlEscape(
-            config('site.name', 'HydePHP')
-        );
+        return XML::escape(config('site.name', 'HydePHP'));
     }
 
     public static function getLink(): string
     {
-        return static::xmlEscape(
-            rtrim(
-                config('site.url') ?? 'http://localhost',
-                '/'
-            )
-        );
+        return XML::escape(rtrim(
+            config('site.url') ?? 'http://localhost',
+            '/'
+        ));
     }
 
     public static function getDefaultOutputFilename(): string

--- a/packages/framework/src/Framework/Services/RssFeedService.php
+++ b/packages/framework/src/Framework/Services/RssFeedService.php
@@ -7,15 +7,15 @@ declare(strict_types=1);
 
 namespace Hyde\Framework\Services;
 
+use function config;
+use function date;
 use Exception;
+use function extension_loaded;
 use Hyde\Facades\Site;
 use Hyde\Hyde;
 use Hyde\Pages\MarkdownPost;
 use Hyde\Support\Helpers\XML;
 use SimpleXMLElement;
-use function config;
-use function date;
-use function extension_loaded;
 
 /**
  * @see \Hyde\Framework\Testing\Feature\Services\RssFeedServiceTest
@@ -40,7 +40,7 @@ class RssFeedService
     {
         return XML::escape(config(
             'hyde.rss_description',
-            XML::escape(Site::name()) .' RSS Feed'
+            XML::escape(Site::name()).' RSS Feed'
         ));
     }
 
@@ -60,7 +60,7 @@ class RssFeedService
     public function generate(): static
     {
         MarkdownPost::getLatestPosts()
-            ->each(fn(MarkdownPost $post) => $this->addItem($post));
+            ->each(fn (MarkdownPost $post) => $this->addItem($post));
 
         return $this;
     }

--- a/packages/framework/src/Framework/Services/SitemapService.php
+++ b/packages/framework/src/Framework/Services/SitemapService.php
@@ -99,7 +99,7 @@ class SitemapService
 
     protected function checkIfXMLIsSupported(): void
     {
-        if (!extension_loaded('simplexml') || config('testing.mock_disabled_extensions', false) === true) {
+        if (!extension_loaded('simplexml')) {
             throw new Exception('The ext-simplexml extension is not installed, but is required to generate RSS feeds.');
         }
     }

--- a/packages/framework/src/Framework/Services/SitemapService.php
+++ b/packages/framework/src/Framework/Services/SitemapService.php
@@ -2,8 +2,6 @@
 
 declare(strict_types=1);
 
-/** @noinspection PhpComposerExtensionStubsInspection */
-
 namespace Hyde\Framework\Services;
 
 use Exception;

--- a/packages/framework/src/Framework/Services/SitemapService.php
+++ b/packages/framework/src/Framework/Services/SitemapService.php
@@ -21,7 +21,7 @@ use SimpleXMLElement;
 class SitemapService
 {
     public SimpleXMLElement $xmlElement;
-    protected float $time_start;
+    protected float $timeStart;
 
     public function __construct()
     {
@@ -29,7 +29,7 @@ class SitemapService
             throw new Exception('The ext-simplexml extension is not installed, but is required to generate RSS feeds.');
         }
 
-        $this->time_start = microtime(true);
+        $this->timeStart = microtime(true);
 
         $this->xmlElement = new SimpleXMLElement('<?xml version="1.0" encoding="UTF-8"?><urlset xmlns="https://www.sitemaps.org/schemas/sitemap/0.9"></urlset>');
         $this->xmlElement->addAttribute('generator', 'HydePHP '.Hyde::version());
@@ -46,7 +46,7 @@ class SitemapService
 
     public function getXML(): string
     {
-        $this->xmlElement->addAttribute('processing_time_ms', (string) round((microtime(true) - $this->time_start) * 1000, 2));
+        $this->xmlElement->addAttribute('processing_time_ms', (string) round((microtime(true) - $this->timeStart) * 1000, 2));
 
         return (string) $this->xmlElement->asXML();
     }

--- a/packages/framework/src/Framework/Services/SitemapService.php
+++ b/packages/framework/src/Framework/Services/SitemapService.php
@@ -7,6 +7,8 @@ declare(strict_types=1);
 namespace Hyde\Framework\Services;
 
 use Exception;
+use function config;
+use function date;
 use function extension_loaded;
 use Hyde\Hyde;
 use Hyde\Pages\BladePage;
@@ -16,6 +18,10 @@ use Hyde\Pages\MarkdownPost;
 use Hyde\Support\Helpers\XML;
 use Hyde\Support\Models\Route;
 use SimpleXMLElement;
+use function filemtime;
+use function in_array;
+use function microtime;
+use function round;
 use function throw_unless;
 
 /**

--- a/packages/framework/src/Framework/Services/SitemapService.php
+++ b/packages/framework/src/Framework/Services/SitemapService.php
@@ -12,6 +12,8 @@ use Hyde\Pages\MarkdownPage;
 use Hyde\Pages\MarkdownPost;
 use Hyde\Support\Models\Route;
 use SimpleXMLElement;
+use function extension_loaded;
+use function throw_unless;
 
 /**
  * @see \Hyde\Framework\Testing\Feature\Services\SitemapServiceTest
@@ -25,7 +27,7 @@ class SitemapService
 
     public function __construct()
     {
-        $this->checkIfXMLIsSupported();
+        throw_unless(extension_loaded('simplexml'), new Exception('The ext-simplexml extension is not installed, but is required to generate RSS feeds.'));
 
         $this->timeStart = microtime(true);
 
@@ -95,11 +97,5 @@ class SitemapService
     public static function generateSitemap(): string
     {
         return (new static)->generate()->getXML();
-    }
-
-    /** @codeCoverageIgnore  */
-    protected function checkIfXMLIsSupported(): void
-    {
-        throw_unless(extension_loaded('simplexml'), new Exception('The ext-simplexml extension is not installed, but is required to generate RSS feeds.'));
     }
 }

--- a/packages/framework/src/Framework/Services/SitemapService.php
+++ b/packages/framework/src/Framework/Services/SitemapService.php
@@ -69,7 +69,9 @@ class SitemapService
         $urlItem->addChild('changefreq', 'daily');
 
         if (config('hyde.sitemap.dynamic_priority', true)) {
-            $urlItem->addChild('priority', $this->getPriority($route->getPageClass(), $route->getPage()->getIdentifier()));
+            $urlItem->addChild('priority', $this->getPriority(
+                $route->getPageClass(), $route->getPage()->getIdentifier()
+            ));
         }
     }
 

--- a/packages/framework/src/Framework/Services/SitemapService.php
+++ b/packages/framework/src/Framework/Services/SitemapService.php
@@ -42,7 +42,7 @@ class SitemapService
     public function __construct()
     {
         throw_unless(extension_loaded('simplexml'),
-            new Exception('The ext-simplexml extension is not installed, but is required to generate RSS feeds.')
+            new Exception('The ext-simplexml extension is not installed, but is required to generate sitemaps.')
         );
 
         $this->timeStart = microtime(true);

--- a/packages/framework/src/Framework/Services/SitemapService.php
+++ b/packages/framework/src/Framework/Services/SitemapService.php
@@ -63,8 +63,8 @@ class SitemapService
     {
         $urlItem = $this->xmlElement->addChild('url');
 
-        $urlItem->addChild('loc', htmlentities(Hyde::url($route->getOutputPath())));
-        $urlItem->addChild('lastmod', htmlentities($this->getLastModDate($route->getSourcePath())));
+        $urlItem->addChild('loc', htmlspecialchars(Hyde::url($route->getOutputPath())));
+        $urlItem->addChild('lastmod', htmlspecialchars($this->getLastModDate($route->getSourcePath())));
         $urlItem->addChild('changefreq', 'daily');
 
         if (config('hyde.sitemap.dynamic_priority', true)) {

--- a/packages/framework/src/Framework/Services/SitemapService.php
+++ b/packages/framework/src/Framework/Services/SitemapService.php
@@ -97,6 +97,7 @@ class SitemapService
         return (new static)->generate()->getXML();
     }
 
+    /** @codeCoverageIgnore  */
     protected function checkIfXMLIsSupported(): void
     {
         if (!extension_loaded('simplexml')) {

--- a/packages/framework/src/Framework/Services/SitemapService.php
+++ b/packages/framework/src/Framework/Services/SitemapService.php
@@ -62,9 +62,11 @@ class SitemapService
     public function addRoute(Route $route): void
     {
         $urlItem = $this->xmlElement->addChild('url');
+
         $urlItem->addChild('loc', htmlentities(Hyde::url($route->getOutputPath())));
         $urlItem->addChild('lastmod', htmlentities($this->getLastModDate($route->getSourcePath())));
         $urlItem->addChild('changefreq', 'daily');
+
         if (config('hyde.sitemap.dynamic_priority', true)) {
             $urlItem->addChild('priority', $this->getPriority($route->getPageClass(), $route->getPage()->getIdentifier()));
         }

--- a/packages/framework/src/Framework/Services/SitemapService.php
+++ b/packages/framework/src/Framework/Services/SitemapService.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Hyde\Framework\Services;
 
 use Exception;
+use function extension_loaded;
 use Hyde\Hyde;
 use Hyde\Pages\BladePage;
 use Hyde\Pages\DocumentationPage;
@@ -13,7 +14,6 @@ use Hyde\Pages\MarkdownPost;
 use Hyde\Support\Helpers\XML;
 use Hyde\Support\Models\Route;
 use SimpleXMLElement;
-use function extension_loaded;
 use function throw_unless;
 
 /**

--- a/packages/framework/src/Framework/Services/SitemapService.php
+++ b/packages/framework/src/Framework/Services/SitemapService.php
@@ -1,5 +1,7 @@
 <?php
 
+/** @noinspection PhpComposerExtensionStubsInspection */
+
 declare(strict_types=1);
 
 namespace Hyde\Framework\Services;
@@ -20,7 +22,6 @@ use function throw_unless;
  * @see \Hyde\Framework\Testing\Feature\Services\SitemapServiceTest
  * @see https://www.sitemaps.org/protocol.html
  * @phpstan-consistent-constructor
- * @noinspection PhpComposerExtensionStubsInspection
  */
 class SitemapService
 {

--- a/packages/framework/src/Framework/Services/SitemapService.php
+++ b/packages/framework/src/Framework/Services/SitemapService.php
@@ -27,7 +27,9 @@ class SitemapService
 
     public function __construct()
     {
-        throw_unless(extension_loaded('simplexml'), new Exception('The ext-simplexml extension is not installed, but is required to generate RSS feeds.'));
+        throw_unless(extension_loaded('simplexml'),
+            new Exception('The ext-simplexml extension is not installed, but is required to generate RSS feeds.')
+        );
 
         $this->timeStart = microtime(true);
 
@@ -37,7 +39,7 @@ class SitemapService
 
     public function generate(): static
     {
-        \Hyde\Facades\Route::all()->each(function ($route) {
+        Route::all()->each(function ($route) {
             $this->addRoute($route);
         });
 
@@ -64,9 +66,7 @@ class SitemapService
 
     protected function getLastModDate(string $file): string
     {
-        return date('c', filemtime(
-            $file
-        ));
+        return date('c', filemtime($file));
     }
 
     protected function getPriority(string $pageClass, string $slug): string

--- a/packages/framework/src/Framework/Services/SitemapService.php
+++ b/packages/framework/src/Framework/Services/SitemapService.php
@@ -25,9 +25,7 @@ class SitemapService
 
     public function __construct()
     {
-        if (! extension_loaded('simplexml') || config('testing.mock_disabled_extensions', false) === true) {
-            throw new Exception('The ext-simplexml extension is not installed, but is required to generate RSS feeds.');
-        }
+        $this->checkIfXMLIsSupported();
 
         $this->timeStart = microtime(true);
 
@@ -97,5 +95,12 @@ class SitemapService
     public static function generateSitemap(): string
     {
         return (new static)->generate()->getXML();
+    }
+
+    protected function checkIfXMLIsSupported(): void
+    {
+        if (!extension_loaded('simplexml') || config('testing.mock_disabled_extensions', false) === true) {
+            throw new Exception('The ext-simplexml extension is not installed, but is required to generate RSS feeds.');
+        }
     }
 }

--- a/packages/framework/src/Framework/Services/SitemapService.php
+++ b/packages/framework/src/Framework/Services/SitemapService.php
@@ -26,6 +26,11 @@ class SitemapService
     public SimpleXMLElement $xmlElement;
     protected float $timeStart;
 
+    public static function generateSitemap(): string
+    {
+        return (new static)->generate()->getXML();
+    }
+
     public function __construct()
     {
         throw_unless(extension_loaded('simplexml'),
@@ -98,10 +103,5 @@ class SitemapService
     protected function getFormattedProcessingTime(): string
     {
         return (string) round((microtime(true) - $this->timeStart) * 1000, 2);
-    }
-
-    public static function generateSitemap(): string
-    {
-        return (new static)->generate()->getXML();
     }
 }

--- a/packages/framework/src/Framework/Services/SitemapService.php
+++ b/packages/framework/src/Framework/Services/SitemapService.php
@@ -6,10 +6,11 @@ declare(strict_types=1);
 
 namespace Hyde\Framework\Services;
 
-use Exception;
 use function config;
 use function date;
+use Exception;
 use function extension_loaded;
+use function filemtime;
 use Hyde\Hyde;
 use Hyde\Pages\BladePage;
 use Hyde\Pages\DocumentationPage;
@@ -17,11 +18,10 @@ use Hyde\Pages\MarkdownPage;
 use Hyde\Pages\MarkdownPost;
 use Hyde\Support\Helpers\XML;
 use Hyde\Support\Models\Route;
-use SimpleXMLElement;
-use function filemtime;
 use function in_array;
 use function microtime;
 use function round;
+use SimpleXMLElement;
 use function throw_unless;
 
 /**

--- a/packages/framework/src/Framework/Services/SitemapService.php
+++ b/packages/framework/src/Framework/Services/SitemapService.php
@@ -10,6 +10,7 @@ use Hyde\Pages\BladePage;
 use Hyde\Pages\DocumentationPage;
 use Hyde\Pages\MarkdownPage;
 use Hyde\Pages\MarkdownPost;
+use Hyde\Support\Helpers\XML;
 use Hyde\Support\Models\Route;
 use SimpleXMLElement;
 use function extension_loaded;
@@ -63,8 +64,8 @@ class SitemapService
     {
         $urlItem = $this->xmlElement->addChild('url');
 
-        $urlItem->addChild('loc', htmlspecialchars(Hyde::url($route->getOutputPath())));
-        $urlItem->addChild('lastmod', htmlspecialchars($this->getLastModDate($route->getSourcePath())));
+        $urlItem->addChild('loc', XML::escape(Hyde::url($route->getOutputPath())));
+        $urlItem->addChild('lastmod', XML::escape($this->getLastModDate($route->getSourcePath())));
         $urlItem->addChild('changefreq', 'daily');
 
         if (config('hyde.sitemap.dynamic_priority', true)) {

--- a/packages/framework/src/Framework/Services/SitemapService.php
+++ b/packages/framework/src/Framework/Services/SitemapService.php
@@ -40,7 +40,7 @@ class SitemapService
 
     public function generate(): static
     {
-        Route::all()->each(function ($route) {
+        Route::all()->each(function (Route $route): void {
             $this->addRoute($route);
         });
 

--- a/packages/framework/src/Framework/Services/SitemapService.php
+++ b/packages/framework/src/Framework/Services/SitemapService.php
@@ -19,6 +19,7 @@ use function throw_unless;
  * @see \Hyde\Framework\Testing\Feature\Services\SitemapServiceTest
  * @see https://www.sitemaps.org/protocol.html
  * @phpstan-consistent-constructor
+ * @noinspection PhpComposerExtensionStubsInspection
  */
 class SitemapService
 {

--- a/packages/framework/src/Framework/Services/SitemapService.php
+++ b/packages/framework/src/Framework/Services/SitemapService.php
@@ -100,8 +100,6 @@ class SitemapService
     /** @codeCoverageIgnore  */
     protected function checkIfXMLIsSupported(): void
     {
-        if (!extension_loaded('simplexml')) {
-            throw new Exception('The ext-simplexml extension is not installed, but is required to generate RSS feeds.');
-        }
+        throw_unless(extension_loaded('simplexml'), new Exception('The ext-simplexml extension is not installed, but is required to generate RSS feeds.'));
     }
 }

--- a/packages/framework/src/Framework/Services/SitemapService.php
+++ b/packages/framework/src/Framework/Services/SitemapService.php
@@ -49,7 +49,7 @@ class SitemapService
 
     public function getXML(): string
     {
-        $this->xmlElement->addAttribute('processing_time_ms', (string) round((microtime(true) - $this->timeStart) * 1000, 2));
+        $this->xmlElement->addAttribute('processing_time_ms', $this->getFormattedProcessingTime());
 
         return (string) $this->xmlElement->asXML();
     }
@@ -93,6 +93,11 @@ class SitemapService
         }
 
         return (string) $priority;
+    }
+
+    protected function getFormattedProcessingTime(): string
+    {
+        return (string) round((microtime(true) - $this->timeStart) * 1000, 2);
     }
 
     public static function generateSitemap(): string

--- a/packages/framework/src/Support/Helpers/XML.php
+++ b/packages/framework/src/Support/Helpers/XML.php
@@ -4,7 +4,12 @@ declare(strict_types=1);
 
 namespace Hyde\Support\Helpers;
 
+use function htmlspecialchars;
+
 class XML
 {
-    //
+    public static function escape(string $string): string
+    {
+        return htmlspecialchars($string, ENT_XML1 | ENT_COMPAT, 'UTF-8');
+    }
 }

--- a/packages/framework/src/Support/Helpers/XML.php
+++ b/packages/framework/src/Support/Helpers/XML.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Hyde\Support\Helpers;
+
+class XML
+{
+    //
+}

--- a/packages/framework/src/Support/Helpers/XML.php
+++ b/packages/framework/src/Support/Helpers/XML.php
@@ -6,6 +6,9 @@ namespace Hyde\Support\Helpers;
 
 use function htmlspecialchars;
 
+/**
+ * @internal This class is currently experimental and may change without notice.
+ */
 class XML
 {
     public static function escape(string $string): string

--- a/packages/framework/tests/Feature/BuildOutputDirectoryCanBeChangedTest.php
+++ b/packages/framework/tests/Feature/BuildOutputDirectoryCanBeChangedTest.php
@@ -15,6 +15,7 @@ use Illuminate\Support\Facades\File;
  * Class BuildOutputDirectoryCanBeChangedTest.
  *
  * @todo add test for the Rebuild Service
+ * @todo this unit test should be moved to the unit test suite
  */
 class BuildOutputDirectoryCanBeChangedTest extends TestCase
 {

--- a/packages/framework/tests/Feature/Services/RssFeedServiceTest.php
+++ b/packages/framework/tests/Feature/Services/RssFeedServiceTest.php
@@ -20,15 +20,6 @@ class RssFeedServiceTest extends TestCase
         $this->assertInstanceOf('SimpleXMLElement', $service->feed);
     }
 
-    public function test_constructor_throws_exception_when_missing_simplexml_extension()
-    {
-        config(['testing.mock_disabled_extensions' => true]);
-
-        $this->expectException(\Exception::class);
-        $this->expectExceptionMessage('The ext-simplexml extension is not installed, but is required to generate RSS feeds.');
-        new RssFeedService();
-    }
-
     public function test_xml_root_element_is_set_to_rss_2_0()
     {
         $service = new RssFeedService();

--- a/packages/framework/tests/Feature/Services/SitemapServiceTest.php
+++ b/packages/framework/tests/Feature/Services/SitemapServiceTest.php
@@ -30,15 +30,6 @@ class SitemapServiceTest extends TestCase
         $this->assertInstanceOf('SimpleXMLElement', $service->xmlElement);
     }
 
-    public function test_constructor_throws_exception_when_missing_simplexml_extension()
-    {
-        config(['testing.mock_disabled_extensions' => true]);
-
-        $this->expectException(\Exception::class);
-        $this->expectExceptionMessage('The ext-simplexml extension is not installed, but is required to generate RSS feeds.');
-        new SitemapService();
-    }
-
     public function test_generate_adds_default_pages_to_xml()
     {
         $service = new SitemapService();


### PR DESCRIPTION
Refactors [RssFeedService.php](https://github.com/hydephp/develop/blob/master/packages/framework/src/Framework/Services/RssFeedService.php) and [SitemapService.php](https://github.com/hydephp/develop/blob/master/packages/framework/src/Framework/Services/SitemapService.php)

Contains one breaking API change:
- Renames RssFeedService method getDefaultOutputFilename to outputFilename, as the word default implies it can be changed, but we have no such logic.
