### PR TITLE
Add a Hyde::markdown() helper

### DIFF
--- a/packages/framework/src/Foundation/Concerns/ImplementsStringHelpers.php
+++ b/packages/framework/src/Foundation/Concerns/ImplementsStringHelpers.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Hyde\Foundation\Concerns;
 
+use Hyde\Markdown\Models\Markdown;
+use Illuminate\Support\HtmlString;
 use Illuminate\Support\Str;
 
 /**
@@ -22,5 +24,10 @@ trait ImplementsStringHelpers
             $alwaysLowercase,
             Str::headline($slug)
         ));
+    }
+
+    public function markdown(string $text): HtmlString
+    {
+        return new HtmlString(Markdown::render($text));
     }
 }

--- a/packages/framework/src/Hyde.php
+++ b/packages/framework/src/Hyde.php
@@ -12,6 +12,7 @@ use Hyde\Foundation\RouteCollection;
 use Hyde\Pages\Concerns\HydePage;
 use Hyde\Support\Models\Route;
 use Illuminate\Support\Facades\Facade;
+use Illuminate\Support\HtmlString;
 
 /**
  * General facade for Hyde services.
@@ -36,6 +37,7 @@ use Illuminate\Support\Facades\Facade;
  * @method static string image(string $name, bool $preferQualifiedUrl = false)
  * @method static string url(string $path = '')
  * @method static string makeTitle(string $slug)
+ * @method static HtmlString markdown(string $text)
  * @method static string currentPage()
  * @method static string getBasePath()
  * @method static string getSourceRoot()

--- a/packages/framework/tests/Feature/HydeKernelTest.php
+++ b/packages/framework/tests/Feature/HydeKernelTest.php
@@ -16,6 +16,7 @@ use Hyde\Support\Models\Route;
 use Hyde\Testing\TestCase;
 use Illuminate\Support\Facades\Config;
 use Illuminate\Support\Facades\View;
+use Illuminate\Support\HtmlString;
 
 /**
  * This test class runs high-level tests on the HydeKernel class,
@@ -88,6 +89,11 @@ class HydeKernelTest extends TestCase
     public function test_make_title_helper_returns_title_from_page_slug()
     {
         $this->assertEquals('Foo Bar', Hyde::makeTitle('foo-bar'));
+    }
+
+    public function test_markdown_helper_converts_markdown_to_html()
+    {
+        $this->assertEquals(new HtmlString("<p>foo</p>\n"), Hyde::markdown('foo'));
     }
 
     public function test_format_html_path_helper_formats_path_according_to_config_rules()


### PR DESCRIPTION
Adds a helper to the Hyde facade to quickly convert Markdown to HTML.