### PR TITLE
Add a serializable contract

### DIFF
--- a/packages/framework/src/Facades/Features.php
+++ b/packages/framework/src/Facades/Features.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Hyde\Facades;
 
+use Hyde\Support\Contracts\SerializableContract;
 use function count;
 use Hyde\Framework\Concerns\Internal\MockableFeatures;
 use Hyde\Framework\Services\DiscoveryService;
@@ -24,7 +25,7 @@ use function str_starts_with;
  * Based entirely on Laravel Jetstream (License MIT)
  * @see https://jetstream.laravel.com/
  */
-class Features implements Arrayable, JsonSerializable
+class Features implements SerializableContract
 {
     use Serializable;
     use MockableFeatures;

--- a/packages/framework/src/Facades/Features.php
+++ b/packages/framework/src/Facades/Features.php
@@ -8,7 +8,7 @@ use function count;
 use Hyde\Framework\Concerns\Internal\MockableFeatures;
 use Hyde\Framework\Services\DiscoveryService;
 use Hyde\Hyde;
-use Hyde\Support\Concerns\JsonSerializesArrayable;
+use Hyde\Support\Concerns\Serializable;
 use Illuminate\Contracts\Support\Arrayable;
 use Illuminate\Support\Str;
 use JsonSerializable;
@@ -26,7 +26,7 @@ use function str_starts_with;
  */
 class Features implements Arrayable, JsonSerializable
 {
-    use JsonSerializesArrayable;
+    use Serializable;
     use MockableFeatures;
 
     /**

--- a/packages/framework/src/Foundation/HydeKernel.php
+++ b/packages/framework/src/Foundation/HydeKernel.php
@@ -6,6 +6,7 @@ namespace Hyde\Foundation;
 
 use Hyde\Facades\Features;
 use Hyde\Support\Concerns\Serializable;
+use Hyde\Support\Contracts\SerializableContract;
 use Illuminate\Contracts\Support\Arrayable;
 use Illuminate\Support\Traits\Macroable;
 use JsonSerializable;
@@ -31,7 +32,7 @@ use JsonSerializable;
  *
  * The Kernel instance is constructed in bootstrap.php, and is available globally as $hyde.
  */
-class HydeKernel implements Arrayable, JsonSerializable
+class HydeKernel implements SerializableContract
 {
     use Concerns\HandlesFoundationCollections;
     use Concerns\ImplementsStringHelpers;

--- a/packages/framework/src/Foundation/HydeKernel.php
+++ b/packages/framework/src/Foundation/HydeKernel.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace Hyde\Foundation;
 
 use Hyde\Facades\Features;
-use Hyde\Support\Concerns\JsonSerializesArrayable;
+use Hyde\Support\Concerns\Serializable;
 use Illuminate\Contracts\Support\Arrayable;
 use Illuminate\Support\Traits\Macroable;
 use JsonSerializable;
@@ -40,7 +40,7 @@ class HydeKernel implements Arrayable, JsonSerializable
     use Concerns\ManagesHydeKernel;
     use Concerns\ManagesViewData;
 
-    use JsonSerializesArrayable;
+    use Serializable;
     use Macroable;
 
     protected static HydeKernel $instance;

--- a/packages/framework/src/Framework/Factories/Concerns/CoreDataObject.php
+++ b/packages/framework/src/Framework/Factories/Concerns/CoreDataObject.php
@@ -6,7 +6,7 @@ namespace Hyde\Framework\Factories\Concerns;
 
 use Hyde\Markdown\Models\FrontMatter;
 use Hyde\Markdown\Models\Markdown;
-use Hyde\Support\Concerns\JsonSerializesArrayable;
+use Hyde\Support\Concerns\Serializable;
 use Illuminate\Contracts\Support\Arrayable;
 use JsonSerializable;
 
@@ -23,7 +23,7 @@ use JsonSerializable;
  */
 final class CoreDataObject implements Arrayable, JsonSerializable
 {
-    use JsonSerializesArrayable;
+    use Serializable;
 
     public function __construct(
         public readonly FrontMatter $matter,

--- a/packages/framework/src/Framework/Factories/Concerns/CoreDataObject.php
+++ b/packages/framework/src/Framework/Factories/Concerns/CoreDataObject.php
@@ -7,6 +7,7 @@ namespace Hyde\Framework\Factories\Concerns;
 use Hyde\Markdown\Models\FrontMatter;
 use Hyde\Markdown\Models\Markdown;
 use Hyde\Support\Concerns\Serializable;
+use Hyde\Support\Contracts\SerializableContract;
 use Illuminate\Contracts\Support\Arrayable;
 use JsonSerializable;
 
@@ -21,7 +22,7 @@ use JsonSerializable;
  * that the latter's state is unpredictable due to the nature of the construction process continuously
  * mutating the page object. This class on the other hand is immutable, making it highly predictable.
  */
-final class CoreDataObject implements Arrayable, JsonSerializable
+final class CoreDataObject implements SerializableContract
 {
     use Serializable;
 

--- a/packages/framework/src/Framework/Features/Navigation/NavigationData.php
+++ b/packages/framework/src/Framework/Features/Navigation/NavigationData.php
@@ -7,6 +7,7 @@ namespace Hyde\Framework\Features\Navigation;
 use ArrayObject;
 use Hyde\Markdown\Contracts\FrontMatter\SubSchemas\NavigationSchema;
 use Hyde\Support\Concerns\Serializable;
+use Hyde\Support\Contracts\SerializableContract;
 use Illuminate\Contracts\Support\Arrayable;
 use JsonSerializable;
 
@@ -14,7 +15,7 @@ use JsonSerializable;
  * Object implementation for the NavigationSchema. It extends the ArrayObject class so
  * that its data can be accessed using dot notation in the page's front matter data.
  */
-final class NavigationData extends ArrayObject implements NavigationSchema, Arrayable, JsonSerializable
+final class NavigationData extends ArrayObject implements NavigationSchema, SerializableContract
 {
     use Serializable;
 

--- a/packages/framework/src/Framework/Features/Navigation/NavigationData.php
+++ b/packages/framework/src/Framework/Features/Navigation/NavigationData.php
@@ -6,7 +6,7 @@ namespace Hyde\Framework\Features\Navigation;
 
 use ArrayObject;
 use Hyde\Markdown\Contracts\FrontMatter\SubSchemas\NavigationSchema;
-use Hyde\Support\Concerns\JsonSerializesArrayable;
+use Hyde\Support\Concerns\Serializable;
 use Illuminate\Contracts\Support\Arrayable;
 use JsonSerializable;
 
@@ -16,7 +16,7 @@ use JsonSerializable;
  */
 final class NavigationData extends ArrayObject implements NavigationSchema, Arrayable, JsonSerializable
 {
-    use JsonSerializesArrayable;
+    use Serializable;
 
     public ?string $label = null;
     public ?string $group = null;

--- a/packages/framework/src/Markdown/Models/FrontMatter.php
+++ b/packages/framework/src/Markdown/Models/FrontMatter.php
@@ -7,9 +7,7 @@ namespace Hyde\Markdown\Models;
 use Hyde\Framework\Actions\ConvertsArrayToFrontMatter;
 use Hyde\Support\Concerns\Serializable;
 use Hyde\Support\Contracts\SerializableContract;
-use Illuminate\Contracts\Support\Arrayable;
 use Illuminate\Support\Arr;
-use JsonSerializable;
 use Stringable;
 
 /**

--- a/packages/framework/src/Markdown/Models/FrontMatter.php
+++ b/packages/framework/src/Markdown/Models/FrontMatter.php
@@ -6,6 +6,7 @@ namespace Hyde\Markdown\Models;
 
 use Hyde\Framework\Actions\ConvertsArrayToFrontMatter;
 use Hyde\Support\Concerns\Serializable;
+use Hyde\Support\Contracts\SerializableContract;
 use Illuminate\Contracts\Support\Arrayable;
 use Illuminate\Support\Arr;
 use JsonSerializable;
@@ -25,7 +26,7 @@ use Stringable;
  * @see \Hyde\Framework\Testing\Unit\FrontMatterModelTest
  * @phpstan-consistent-constructor
  */
-class FrontMatter implements Arrayable, Stringable, JsonSerializable
+class FrontMatter implements Stringable, SerializableContract
 {
     use Serializable;
 

--- a/packages/framework/src/Markdown/Models/FrontMatter.php
+++ b/packages/framework/src/Markdown/Models/FrontMatter.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace Hyde\Markdown\Models;
 
 use Hyde\Framework\Actions\ConvertsArrayToFrontMatter;
-use Hyde\Support\Concerns\JsonSerializesArrayable;
+use Hyde\Support\Concerns\Serializable;
 use Illuminate\Contracts\Support\Arrayable;
 use Illuminate\Support\Arr;
 use JsonSerializable;
@@ -27,7 +27,7 @@ use Stringable;
  */
 class FrontMatter implements Arrayable, Stringable, JsonSerializable
 {
-    use JsonSerializesArrayable;
+    use Serializable;
 
     public array $data;
 

--- a/packages/framework/src/Support/Concerns/Serializable.php
+++ b/packages/framework/src/Support/Concerns/Serializable.php
@@ -9,7 +9,7 @@ namespace Hyde\Support\Concerns;
  *
  * @see \JsonSerializable
  * @see \Illuminate\Contracts\Support\Arrayable
- * @see \Hyde\Framework\Testing\Unit\JsonSerializesArrayableTest
+ * @see \Hyde\Framework\Testing\Unit\Serializable
  */
 trait Serializable
 {

--- a/packages/framework/src/Support/Concerns/Serializable.php
+++ b/packages/framework/src/Support/Concerns/Serializable.php
@@ -11,7 +11,7 @@ namespace Hyde\Support\Concerns;
  * @see \Illuminate\Contracts\Support\Arrayable
  * @see \Hyde\Framework\Testing\Unit\JsonSerializesArrayableTest
  */
-trait JsonSerializesArrayable
+trait Serializable
 {
     /** @inheritDoc */
     public function jsonSerialize(): array

--- a/packages/framework/src/Support/Concerns/Serializable.php
+++ b/packages/framework/src/Support/Concerns/Serializable.php
@@ -8,7 +8,7 @@ namespace Hyde\Support\Concerns;
  * Automatically serializes an Arrayable interface when JSON is requested.
  *
  * @see \Hyde\Support\Contracts\SerializableContract
- * @see \Hyde\Framework\Testing\Unit\Serializable
+ * @see \Hyde\Framework\Testing\Unit\SerializableTest
  */
 trait Serializable
 {

--- a/packages/framework/src/Support/Concerns/Serializable.php
+++ b/packages/framework/src/Support/Concerns/Serializable.php
@@ -7,8 +7,7 @@ namespace Hyde\Support\Concerns;
 /**
  * Automatically serializes an Arrayable interface when JSON is requested.
  *
- * @see \JsonSerializable
- * @see \Illuminate\Contracts\Support\Arrayable
+ * @see \Hyde\Support\Contracts\SerializableContract
  * @see \Hyde\Framework\Testing\Unit\Serializable
  */
 trait Serializable

--- a/packages/framework/src/Support/Concerns/Serializable.php
+++ b/packages/framework/src/Support/Concerns/Serializable.php
@@ -13,11 +13,11 @@ namespace Hyde\Support\Concerns;
 trait Serializable
 {
     /** @inheritDoc */
+    abstract public function toArray(): array;
+
+    /** @inheritDoc */
     public function jsonSerialize(): array
     {
         return $this->toArray();
     }
-
-    /** @inheritDoc */
-    abstract public function toArray(): array;
 }

--- a/packages/framework/src/Support/Concerns/Serializable.php
+++ b/packages/framework/src/Support/Concerns/Serializable.php
@@ -20,4 +20,10 @@ trait Serializable
     {
         return $this->toArray();
     }
+
+    /** @inheritDoc */
+    public function toJson($options = 0): string
+    {
+        return json_encode($this->jsonSerialize(), $options);
+    }
 }

--- a/packages/framework/src/Support/Contracts/SerializableContract.php
+++ b/packages/framework/src/Support/Contracts/SerializableContract.php
@@ -4,7 +4,11 @@ declare(strict_types=1);
 
 namespace Hyde\Support\Contracts;
 
-interface SerializableContract
+use Illuminate\Contracts\Support\Arrayable;
+use Illuminate\Contracts\Support\Jsonable;
+use JsonSerializable;
+
+interface SerializableContract extends Arrayable, Jsonable, JsonSerializable
 {
     //
 }

--- a/packages/framework/src/Support/Contracts/SerializableContract.php
+++ b/packages/framework/src/Support/Contracts/SerializableContract.php
@@ -10,12 +10,27 @@ use JsonSerializable;
 
 interface SerializableContract extends Arrayable, Jsonable, JsonSerializable
 {
-    /** @inheritDoc */
+    /**
+     * Get the instance as an array.
+     *
+     * @return array<TKey, TValue>
+     */
     public function toArray(): array;
 
-    /** @inheritDoc */
+    /**
+     * Convert the object to its JSON representation.
+     *
+     * @param  int  $options
+     * @return string
+     */
     public function toJson($options = 0): string;
 
-    /** @inheritDoc */
+    /**
+     * Specify data which should be serialized to JSON
+     * @link https://php.net/manual/en/jsonserializable.jsonserialize.php
+     * @return mixed data which can be serialized by <b>json_encode</b>,
+     * which is a value of any type other than a resource.
+     * @since 5.4
+     */
     public function jsonSerialize(): mixed;
 }

--- a/packages/framework/src/Support/Contracts/SerializableContract.php
+++ b/packages/framework/src/Support/Contracts/SerializableContract.php
@@ -33,9 +33,6 @@ interface SerializableContract extends Arrayable, Jsonable, JsonSerializable
 
     /**
      * Specify data which should be serialized to JSON.
-     *
-     * @return mixed data which can be serialized by <b>json_encode</b>,
-     * which is a value of any type other than a resource.
      */
-    public function jsonSerialize(): mixed;
+    public function jsonSerialize(): array;
 }

--- a/packages/framework/src/Support/Contracts/SerializableContract.php
+++ b/packages/framework/src/Support/Contracts/SerializableContract.php
@@ -9,6 +9,8 @@ use Illuminate\Contracts\Support\Jsonable;
 use JsonSerializable;
 
 /**
+ * Specifies that a class can be serialized to an array and/or JSON.
+ *
  * @template TKey of array-key
  * @template TValue
  */

--- a/packages/framework/src/Support/Contracts/SerializableContract.php
+++ b/packages/framework/src/Support/Contracts/SerializableContract.php
@@ -10,9 +10,12 @@ use JsonSerializable;
 
 interface SerializableContract extends Arrayable, Jsonable, JsonSerializable
 {
+    /** @inheritDoc */
     public function toArray(): array;
 
+    /** @inheritDoc */
     public function toJson($options = 0): string;
 
+    /** @inheritDoc */
     public function jsonSerialize(): mixed;
 }

--- a/packages/framework/src/Support/Contracts/SerializableContract.php
+++ b/packages/framework/src/Support/Contracts/SerializableContract.php
@@ -22,7 +22,7 @@ interface SerializableContract extends Arrayable, Jsonable, JsonSerializable
     public function toArray(): array;
 
     /**
-     * Convert the object to its JSON representation.
+     * Convert the instance to its JSON representation.
      *
      * @param  int  $options
      * @return string
@@ -30,11 +30,10 @@ interface SerializableContract extends Arrayable, Jsonable, JsonSerializable
     public function toJson($options = 0): string;
 
     /**
-     * Specify data which should be serialized to JSON
-     * @link https://php.net/manual/en/jsonserializable.jsonserialize.php
+     * Specify data which should be serialized to JSON.
+     *
      * @return mixed data which can be serialized by <b>json_encode</b>,
      * which is a value of any type other than a resource.
-     * @since 5.4
      */
     public function jsonSerialize(): mixed;
 }

--- a/packages/framework/src/Support/Contracts/SerializableContract.php
+++ b/packages/framework/src/Support/Contracts/SerializableContract.php
@@ -33,6 +33,8 @@ interface SerializableContract extends Arrayable, Jsonable, JsonSerializable
 
     /**
      * Specify data which should be serialized to JSON.
+     *
+     * @return array<TKey, TValue>
      */
     public function jsonSerialize(): array;
 }

--- a/packages/framework/src/Support/Contracts/SerializableContract.php
+++ b/packages/framework/src/Support/Contracts/SerializableContract.php
@@ -10,5 +10,9 @@ use JsonSerializable;
 
 interface SerializableContract extends Arrayable, Jsonable, JsonSerializable
 {
-    //
+    public function toArray(): array;
+
+    public function toJson($options = 0): string;
+
+    public function jsonSerialize(): mixed;
 }

--- a/packages/framework/src/Support/Contracts/SerializableContract.php
+++ b/packages/framework/src/Support/Contracts/SerializableContract.php
@@ -8,6 +8,10 @@ use Illuminate\Contracts\Support\Arrayable;
 use Illuminate\Contracts\Support\Jsonable;
 use JsonSerializable;
 
+/**
+ * @template TKey of array-key
+ * @template TValue
+ */
 interface SerializableContract extends Arrayable, Jsonable, JsonSerializable
 {
     /**

--- a/packages/framework/src/Support/Contracts/SerializableContract.php
+++ b/packages/framework/src/Support/Contracts/SerializableContract.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Hyde\Support\Contracts;
+
+interface SerializableContract
+{
+    //
+}

--- a/packages/framework/src/Support/Contracts/SerializableContract.php
+++ b/packages/framework/src/Support/Contracts/SerializableContract.php
@@ -14,8 +14,15 @@ use JsonSerializable;
  * @template TKey of array-key
  * @template TValue
  */
-interface SerializableContract extends Arrayable, Jsonable, JsonSerializable
+interface SerializableContract extends JsonSerializable, Arrayable, Jsonable
 {
+    /**
+     * Specify data which should be serialized to JSON.
+     *
+     * @return array<TKey, TValue>
+     */
+    public function jsonSerialize(): array;
+
     /**
      * Get the instance as an array.
      *
@@ -30,11 +37,4 @@ interface SerializableContract extends Arrayable, Jsonable, JsonSerializable
      * @return string
      */
     public function toJson($options = 0): string;
-
-    /**
-     * Specify data which should be serialized to JSON.
-     *
-     * @return array<TKey, TValue>
-     */
-    public function jsonSerialize(): array;
 }

--- a/packages/framework/src/Support/Models/File.php
+++ b/packages/framework/src/Support/Models/File.php
@@ -6,6 +6,7 @@ namespace Hyde\Support\Models;
 
 use Hyde\Hyde;
 use Hyde\Support\Concerns\Serializable;
+use Hyde\Support\Contracts\SerializableContract;
 use Illuminate\Contracts\Support\Arrayable;
 use JsonSerializable;
 use Stringable;
@@ -15,7 +16,7 @@ use Stringable;
  *
  * @see \Hyde\Framework\Testing\Feature\FileTest
  */
-class File implements Arrayable, JsonSerializable, Stringable
+class File implements SerializableContract, Stringable
 {
     use Serializable;
 

--- a/packages/framework/src/Support/Models/File.php
+++ b/packages/framework/src/Support/Models/File.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace Hyde\Support\Models;
 
 use Hyde\Hyde;
-use Hyde\Support\Concerns\JsonSerializesArrayable;
+use Hyde\Support\Concerns\Serializable;
 use Illuminate\Contracts\Support\Arrayable;
 use JsonSerializable;
 use Stringable;
@@ -17,7 +17,7 @@ use Stringable;
  */
 class File implements Arrayable, JsonSerializable, Stringable
 {
-    use JsonSerializesArrayable;
+    use Serializable;
 
     /**
      * @var string The path relative to the project root.

--- a/packages/framework/src/Support/Models/Route.php
+++ b/packages/framework/src/Support/Models/Route.php
@@ -10,6 +10,7 @@ use Hyde\Framework\Exceptions\RouteNotFoundException;
 use Hyde\Hyde;
 use Hyde\Pages\Concerns\HydePage;
 use Hyde\Support\Concerns\Serializable;
+use Hyde\Support\Contracts\SerializableContract;
 use Illuminate\Contracts\Support\Arrayable;
 use JsonSerializable;
 use function str_replace;
@@ -25,7 +26,7 @@ use Stringable;
  *
  * @see \Hyde\Framework\Testing\Feature\RouteTest
  */
-class Route implements Stringable, JsonSerializable, Arrayable
+class Route implements Stringable, SerializableContract
 {
     use Serializable;
 

--- a/packages/framework/src/Support/Models/Route.php
+++ b/packages/framework/src/Support/Models/Route.php
@@ -9,7 +9,7 @@ use Hyde\Foundation\RouteCollection;
 use Hyde\Framework\Exceptions\RouteNotFoundException;
 use Hyde\Hyde;
 use Hyde\Pages\Concerns\HydePage;
-use Hyde\Support\Concerns\JsonSerializesArrayable;
+use Hyde\Support\Concerns\Serializable;
 use Illuminate\Contracts\Support\Arrayable;
 use JsonSerializable;
 use function str_replace;
@@ -27,7 +27,7 @@ use Stringable;
  */
 class Route implements Stringable, JsonSerializable, Arrayable
 {
-    use JsonSerializesArrayable;
+    use Serializable;
 
     protected HydePage $page;
 

--- a/packages/framework/src/Support/Models/Route.php
+++ b/packages/framework/src/Support/Models/Route.php
@@ -11,8 +11,6 @@ use Hyde\Hyde;
 use Hyde\Pages\Concerns\HydePage;
 use Hyde\Support\Concerns\Serializable;
 use Hyde\Support\Contracts\SerializableContract;
-use Illuminate\Contracts\Support\Arrayable;
-use JsonSerializable;
 use function str_replace;
 use Stringable;
 

--- a/packages/framework/tests/Unit/JsonSerializesArrayableTest.php
+++ b/packages/framework/tests/Unit/JsonSerializesArrayableTest.php
@@ -4,11 +4,11 @@ declare(strict_types=1);
 
 namespace Hyde\Framework\Testing\Unit;
 
-use Hyde\Support\Concerns\JsonSerializesArrayable;
+use Hyde\Support\Concerns\Serializable;
 use Hyde\Testing\TestCase;
 
 /**
- * @covers \Hyde\Support\Concerns\JsonSerializesArrayable
+ * @covers \Hyde\Support\Concerns\Serializable
  */
 class JsonSerializesArrayableTest extends TestCase
 {
@@ -16,7 +16,7 @@ class JsonSerializesArrayableTest extends TestCase
     {
         $class = new class implements \JsonSerializable
         {
-            use JsonSerializesArrayable;
+            use Serializable;
 
             public function toArray(): array
             {

--- a/packages/framework/tests/Unit/SerializableContractTest.php
+++ b/packages/framework/tests/Unit/SerializableContractTest.php
@@ -6,16 +6,50 @@ namespace Hyde\Framework\Testing\Unit;
 
 use Hyde\Support\Contracts\SerializableContract;
 use Hyde\Testing\TestCase;
+use Illuminate\Contracts\Support\Arrayable;
+use Illuminate\Contracts\Support\Jsonable;
+use JsonSerializable;
 
 /**
  * @see \Hyde\Support\Contracts\SerializableContract
  */
 class SerializableContractTest extends TestCase
 {
-    //
+    public function testInterface()
+    {
+        $this->assertInstanceOf(SerializableContract::class, new SerializableContractTestClass());
+    }
+
+    public function testInterfaceExtendsArrayable()
+    {
+        $this->assertInstanceOf(Arrayable::class, new SerializableContractTestClass());
+    }
+
+    public function testInterfaceExtendsJsonable()
+    {
+        $this->assertInstanceOf(Jsonable::class, new SerializableContractTestClass());
+    }
+
+    public function testInterfaceExtendsJsonSerializable()
+    {
+        $this->assertInstanceOf(JsonSerializable::class, new SerializableContractTestClass());
+    }
 }
 
 class SerializableContractTestClass implements SerializableContract
 {
-    //
+    public function toArray()
+    {
+        return [];
+    }
+
+    public function toJson($options = 0)
+    {
+        return '';
+    }
+
+    public function jsonSerialize()
+    {
+        return [];
+    }
 }

--- a/packages/framework/tests/Unit/SerializableContractTest.php
+++ b/packages/framework/tests/Unit/SerializableContractTest.php
@@ -20,6 +20,11 @@ class SerializableContractTest extends TestCase
         $this->assertInstanceOf(SerializableContract::class, new SerializableContractTestClass());
     }
 
+    public function testInterfaceExtendsJsonSerializable()
+    {
+        $this->assertInstanceOf(JsonSerializable::class, new SerializableContractTestClass());
+    }
+
     public function testInterfaceExtendsArrayable()
     {
         $this->assertInstanceOf(Arrayable::class, new SerializableContractTestClass());
@@ -29,15 +34,15 @@ class SerializableContractTest extends TestCase
     {
         $this->assertInstanceOf(Jsonable::class, new SerializableContractTestClass());
     }
-
-    public function testInterfaceExtendsJsonSerializable()
-    {
-        $this->assertInstanceOf(JsonSerializable::class, new SerializableContractTestClass());
-    }
 }
 
 class SerializableContractTestClass implements SerializableContract
 {
+    public function jsonSerialize(): array
+    {
+        return [];
+    }
+
     public function toArray(): array
     {
         return [];
@@ -46,10 +51,5 @@ class SerializableContractTestClass implements SerializableContract
     public function toJson($options = 0): string
     {
         return '';
-    }
-
-    public function jsonSerialize(): array
-    {
-        return [];
     }
 }

--- a/packages/framework/tests/Unit/SerializableContractTest.php
+++ b/packages/framework/tests/Unit/SerializableContractTest.php
@@ -38,17 +38,17 @@ class SerializableContractTest extends TestCase
 
 class SerializableContractTestClass implements SerializableContract
 {
-    public function toArray()
+    public function toArray(): array
     {
         return [];
     }
 
-    public function toJson($options = 0)
+    public function toJson($options = 0): string
     {
         return '';
     }
 
-    public function jsonSerialize()
+    public function jsonSerialize(): mixed
     {
         return [];
     }

--- a/packages/framework/tests/Unit/SerializableContractTest.php
+++ b/packages/framework/tests/Unit/SerializableContractTest.php
@@ -14,3 +14,8 @@ class SerializableContractTest extends TestCase
 {
     //
 }
+
+class SerializableContractTestClass implements SerializableContract
+{
+    //
+}

--- a/packages/framework/tests/Unit/SerializableContractTest.php
+++ b/packages/framework/tests/Unit/SerializableContractTest.php
@@ -48,7 +48,7 @@ class SerializableContractTestClass implements SerializableContract
         return '';
     }
 
-    public function jsonSerialize(): mixed
+    public function jsonSerialize(): array
     {
         return [];
     }

--- a/packages/framework/tests/Unit/SerializableContractTest.php
+++ b/packages/framework/tests/Unit/SerializableContractTest.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Hyde\Framework\Testing\Unit;
+
+use Hyde\Support\Contracts\SerializableContract;
+use Hyde\Testing\TestCase;
+
+/**
+ * @see \Hyde\Support\Contracts\SerializableContract
+ */
+class SerializableContractTest extends TestCase
+{
+    //
+}

--- a/packages/framework/tests/Unit/SerializableTest.php
+++ b/packages/framework/tests/Unit/SerializableTest.php
@@ -6,6 +6,7 @@ namespace Hyde\Framework\Testing\Unit;
 
 use Hyde\Support\Concerns\Serializable;
 use Hyde\Testing\TestCase;
+use JsonSerializable;
 
 /**
  * @covers \Hyde\Support\Concerns\Serializable
@@ -14,7 +15,7 @@ class SerializableTest extends TestCase
 {
     public function test_json_serialize()
     {
-        $class = new class implements \JsonSerializable
+        $class = new class implements JsonSerializable
         {
             use Serializable;
 
@@ -37,7 +38,7 @@ class SerializableTest extends TestCase
 
     public function test_to_json()
     {
-        $class = new class implements \JsonSerializable
+        $class = new class implements JsonSerializable
         {
             use Serializable;
 

--- a/packages/framework/tests/Unit/SerializableTest.php
+++ b/packages/framework/tests/Unit/SerializableTest.php
@@ -38,7 +38,7 @@ class SerializableTest extends TestCase
 
     public function test_to_json()
     {
-        $class = new class implements JsonSerializable
+        $class = new class
         {
             use Serializable;
 

--- a/packages/framework/tests/Unit/SerializableTest.php
+++ b/packages/framework/tests/Unit/SerializableTest.php
@@ -25,13 +25,8 @@ class SerializableTest extends TestCase
             }
         };
 
-        $this->assertSame([
-            'foo' => 'bar',
-        ], $class->toArray());
-
-        $this->assertSame([
-            'foo' => 'bar',
-        ], $class->jsonSerialize());
+        $this->assertSame(['foo' => 'bar'], $class->toArray());
+        $this->assertSame(['foo' => 'bar'], $class->jsonSerialize());
 
         $this->assertSame('{"foo":"bar"}', json_encode($class));
     }

--- a/packages/framework/tests/Unit/SerializableTest.php
+++ b/packages/framework/tests/Unit/SerializableTest.php
@@ -25,15 +25,15 @@ class SerializableTest extends TestCase
             }
         };
 
-        $this->assertEquals([
+        $this->assertSame([
             'foo' => 'bar',
         ], $class->toArray());
 
-        $this->assertEquals([
+        $this->assertSame([
             'foo' => 'bar',
         ], $class->jsonSerialize());
 
-        $this->assertEquals('{"foo":"bar"}', json_encode($class));
+        $this->assertSame('{"foo":"bar"}', json_encode($class));
     }
 
     public function test_to_json()
@@ -48,6 +48,6 @@ class SerializableTest extends TestCase
             }
         };
 
-        $this->assertEquals('{"foo":"bar"}', $class->toJson());
+        $this->assertSame('{"foo":"bar"}', $class->toJson());
     }
 }

--- a/packages/framework/tests/Unit/SerializableTest.php
+++ b/packages/framework/tests/Unit/SerializableTest.php
@@ -10,7 +10,7 @@ use Hyde\Testing\TestCase;
 /**
  * @covers \Hyde\Support\Concerns\Serializable
  */
-class JsonSerializesArrayableTest extends TestCase
+class SerializableTest extends TestCase
 {
     public function test_json_serialize()
     {

--- a/packages/framework/tests/Unit/SerializableTest.php
+++ b/packages/framework/tests/Unit/SerializableTest.php
@@ -34,4 +34,19 @@ class SerializableTest extends TestCase
 
         $this->assertEquals('{"foo":"bar"}', json_encode($class));
     }
+
+    public function test_to_json()
+    {
+        $class = new class implements \JsonSerializable
+        {
+            use Serializable;
+
+            public function toArray(): array
+            {
+                return ['foo' => 'bar'];
+            }
+        };
+
+        $this->assertEquals('{"foo":"bar"}', $class->toJson());
+    }
 }


### PR DESCRIPTION
Now we have a lot of classes that implements JsonSerializable and Arrayable. For further compatability we could also add Jsonable. To make the code shorter and instantly clear this PR merges these interfaces into a `SerializableContract` and updates the former usages to use the new one. It also updates the trait used for automatically serializing arrayables.