### PR TITLE
Method FrontMatter::get() now returns the instance instead of data array when no key is specified

### DIFF
--- a/packages/framework/src/Markdown/Models/FrontMatter.php
+++ b/packages/framework/src/Markdown/Models/FrontMatter.php
@@ -45,13 +45,14 @@ class FrontMatter implements Stringable, SerializableContract
         return $this->get($key);
     }
 
+    /** @return mixed|static */
     public function get(string $key = null, mixed $default = null): mixed
     {
         if ($key) {
             return Arr::get($this->data, $key, $default);
         }
 
-        return $this->data;
+        return $this;
     }
 
     public function set(string $key, mixed $value): static

--- a/packages/framework/tests/Unit/DocumentationPageTest.php
+++ b/packages/framework/tests/Unit/DocumentationPageTest.php
@@ -6,6 +6,7 @@ namespace Hyde\Framework\Testing\Unit;
 
 use Hyde\Framework\HydeServiceProvider;
 use Hyde\Hyde;
+use Hyde\Markdown\Models\FrontMatter;
 use Hyde\Pages\DocumentationPage;
 use Hyde\Support\Models\Route;
 use Hyde\Testing\TestCase;
@@ -171,7 +172,7 @@ class DocumentationPageTest extends TestCase
         $page = DocumentationPage::parse('foo');
         $this->assertNotNull($page->matter());
         $this->assertNotEmpty($page->matter());
-        $this->assertEquals($expected, $page->matter());
+        $this->assertEquals(new FrontMatter($expected), $page->matter());
     }
 
     public function test_page_can_be_hidden_from_sidebar_using_front_matter()

--- a/packages/framework/tests/Unit/FrontMatterModelTest.php
+++ b/packages/framework/tests/Unit/FrontMatterModelTest.php
@@ -55,16 +55,16 @@ class FrontMatterModelTest extends TestCase
         $this->assertNull($matter->foo);
     }
 
-    public function test_get_method_returns_empty_array_if_document_has_no_matter()
+    public function test_get_method_returns_self_when_no_argument_is_specified()
     {
         $matter = new FrontMatter();
-        $this->assertEquals([], $matter->get());
+        $this->assertSame($matter, $matter->get());
     }
 
-    public function test_get_method_returns_document_front_matter_array_if_no_arguments_are_specified()
+    public function test_get_method_returns_self_when_no_argument_is_specified_with_data()
     {
         $matter = new FrontMatter(['foo' => 'bar']);
-        $this->assertEquals(['foo' => 'bar'], $matter->get());
+        $this->assertSame($matter, $matter->get());
     }
 
     public function test_get_method_returns_null_if_specified_front_matter_key_does_not_exist()


### PR DESCRIPTION
Fixes https://github.com/hydephp/develop/issues/708