### PR TITLE
Breaking: Rename method 'get' to 'data' in InteractsWithFrontMatter

### DIFF
--- a/packages/framework/resources/views/components/article-excerpt.blade.php
+++ b/packages/framework/resources/views/components/article-excerpt.blade.php
@@ -11,7 +11,7 @@
     <header>
         <a href="posts/{{ Hyde::formatLink($post->identifier . '.html') }}" class="block w-fit">
             <h2 class="text-2xl font-bold text-gray-700 hover:text-gray-900 dark:text-gray-200 dark:hover:text-white transition-colors duration-75">
-                {{ $post->get('title') ?? $post->title }}
+                {{ $post->data('title') ?? $post->title }}
             </h2>
         </a>
     </header>
@@ -33,10 +33,10 @@
         @endisset
     </footer>
 
-    @if($post->get('description') !== null)
+    @if($post->data('description') !== null)
         <section role="doc-abstract" aria-label="Excerpt">
             <p class="leading-relaxed my-1">
-                {{ $post->get('description') }}
+                {{ $post->data('description') }}
             </p>
         </section>
     @endisset

--- a/packages/framework/src/Framework/Concerns/InteractsWithFrontMatter.php
+++ b/packages/framework/src/Framework/Concerns/InteractsWithFrontMatter.php
@@ -21,7 +21,7 @@ trait InteractsWithFrontMatter
      */
     public function get(string $key = null, mixed $default = null): mixed
     {
-        return $this->extracted($key, $default);
+        return $this->matter($key, $default);
     }
 
     /**
@@ -31,7 +31,7 @@ trait InteractsWithFrontMatter
      */
     public function matter(string $key = null, mixed $default = null): mixed
     {
-        return $this->matter->get($key, $default);
+        return $this->extracted($key, $default);
     }
 
     /**

--- a/packages/framework/src/Framework/Concerns/InteractsWithFrontMatter.php
+++ b/packages/framework/src/Framework/Concerns/InteractsWithFrontMatter.php
@@ -21,7 +21,7 @@ trait InteractsWithFrontMatter
      */
     public function get(string $key = null, mixed $default = null): mixed
     {
-        return $this->matter($key, $default);
+        return $this->extracted($key, $default);
     }
 
     /**
@@ -31,7 +31,7 @@ trait InteractsWithFrontMatter
      */
     public function matter(string $key = null, mixed $default = null): mixed
     {
-        return $this->extracted($key, $default);
+        return $this->matter->get($key, $default);
     }
 
     /**

--- a/packages/framework/src/Framework/Concerns/InteractsWithFrontMatter.php
+++ b/packages/framework/src/Framework/Concerns/InteractsWithFrontMatter.php
@@ -21,10 +21,7 @@ trait InteractsWithFrontMatter
      */
     public function get(string $key = null, mixed $default = null): mixed
     {
-        return Arr::get(array_filter(array_merge(
-            $this->matter->toArray(),
-            (array) $this,
-        )), $key, $default);
+        return $this->extracted($key, $default);
     }
 
     /**
@@ -43,5 +40,13 @@ trait InteractsWithFrontMatter
     public function has(string $key): bool
     {
         return ! blank($this->get($key));
+    }
+
+    protected function extracted(?string $key, mixed $default): mixed
+    {
+        return Arr::get(array_filter(array_merge(
+            $this->matter->toArray(),
+            (array)$this,
+        )), $key, $default);
     }
 }

--- a/packages/framework/src/Framework/Concerns/InteractsWithFrontMatter.php
+++ b/packages/framework/src/Framework/Concerns/InteractsWithFrontMatter.php
@@ -19,7 +19,7 @@ trait InteractsWithFrontMatter
      *
      * @return \Hyde\Markdown\Models\FrontMatter|mixed
      */
-    public function get(string $key = null, mixed $default = null): mixed
+    public function data(string $key = null, mixed $default = null): mixed
     {
         return Arr::get(array_filter(array_merge(
             $this->matter->toArray(),
@@ -42,6 +42,6 @@ trait InteractsWithFrontMatter
      */
     public function has(string $key): bool
     {
-        return ! blank($this->get($key));
+        return ! blank($this->data($key));
     }
 }

--- a/packages/framework/src/Framework/Concerns/InteractsWithFrontMatter.php
+++ b/packages/framework/src/Framework/Concerns/InteractsWithFrontMatter.php
@@ -21,7 +21,10 @@ trait InteractsWithFrontMatter
      */
     public function get(string $key = null, mixed $default = null): mixed
     {
-        return $this->extracted($key, $default);
+        return Arr::get(array_filter(array_merge(
+            $this->matter->toArray(),
+            (array) $this,
+        )), $key, $default);
     }
 
     /**
@@ -40,13 +43,5 @@ trait InteractsWithFrontMatter
     public function has(string $key): bool
     {
         return ! blank($this->get($key));
-    }
-
-    protected function extracted(?string $key, mixed $default): mixed
-    {
-        return Arr::get(array_filter(array_merge(
-            $this->matter->toArray(),
-            (array)$this,
-        )), $key, $default);
     }
 }

--- a/packages/framework/src/Framework/Features/Metadata/PageMetadataBag.php
+++ b/packages/framework/src/Framework/Features/Metadata/PageMetadataBag.php
@@ -27,7 +27,7 @@ class PageMetadataBag extends MetadataBag
     protected function addDynamicPageMetadata(HydePage $page): void
     {
         if ($page->has('canonicalUrl')) {
-            $this->add(Meta::link('canonical', $page->get('canonicalUrl')));
+            $this->add(Meta::link('canonical', $page->data('canonicalUrl')));
         }
 
         if ($page->has('title')) {
@@ -48,7 +48,7 @@ class PageMetadataBag extends MetadataBag
         $this->addPostMetadataIfExists($page, 'canonicalUrl', 'url');
 
         if ($page->has('canonicalUrl')) {
-            $this->add(Meta::property('url', $page->get('canonicalUrl')));
+            $this->add(Meta::property('url', $page->data('canonicalUrl')));
         }
 
         if ($page->has('date')) {
@@ -56,7 +56,7 @@ class PageMetadataBag extends MetadataBag
         }
 
         if ($page->has('image')) {
-            $this->add(Meta::property('image', $this->resolveImageLink((string) $page->get('image'))));
+            $this->add(Meta::property('image', $this->resolveImageLink((string) $page->data('image'))));
         }
 
         $this->add(Meta::property('type', 'article'));
@@ -65,7 +65,7 @@ class PageMetadataBag extends MetadataBag
     protected function addPostMetadataIfExists(MarkdownPost $page, string $property, ?string $name = null): void
     {
         if ($page->has($property)) {
-            $this->add(Meta::name($name ?? $property, (string) $page->get($property)));
+            $this->add(Meta::name($name ?? $property, (string) $page->data($property)));
         }
     }
 

--- a/packages/framework/src/Framework/Features/Navigation/DocumentationSidebar.php
+++ b/packages/framework/src/Framework/Features/Navigation/DocumentationSidebar.php
@@ -20,7 +20,7 @@ class DocumentationSidebar extends NavigationMenu
     {
         Router::getRoutes(DocumentationPage::class)->each(function (Route $route) {
             $this->items->push(tap(NavItem::fromRoute($route)->setPriority($this->getPriorityForRoute($route)), function (NavItem $item) {
-                $item->label = $item->route->getPage()->get('navigation.label');
+                $item->label = $item->route->getPage()->data('navigation.label');
             }));
         });
 
@@ -48,7 +48,7 @@ class DocumentationSidebar extends NavigationMenu
 
     protected function getPriorityForRoute(Route $route): int
     {
-        return $route->getPage()->get('navigation.priority');
+        return $route->getPage()->data('navigation.priority');
     }
 
     protected function filterDocumentationPage(NavItem $item): bool

--- a/packages/framework/src/Framework/Features/Navigation/NavItem.php
+++ b/packages/framework/src/Framework/Features/Navigation/NavItem.php
@@ -124,7 +124,7 @@ class NavItem implements Stringable
 
     public function getGroup(): ?string
     {
-        return $this->normalizeGroupKey($this->route->getPage()->get('navigation.group'));
+        return $this->normalizeGroupKey($this->route->getPage()->data('navigation.group'));
     }
 
     protected function normalizeGroupKey(?string $group): ?string

--- a/packages/framework/tests/Feature/HydePageTest.php
+++ b/packages/framework/tests/Feature/HydePageTest.php
@@ -886,19 +886,19 @@ class HydePageTest extends TestCase
     public function test_get_method_can_access_data_from_page()
     {
         $page = MarkdownPage::make('foo', ['foo' => 'bar']);
-        $this->assertEquals('bar', $page->get('foo'));
+        $this->assertEquals('bar', $page->data('foo'));
     }
 
     public function test_get_method_can_access_nested_data_from_page()
     {
         $page = MarkdownPage::make('foo', ['foo' => ['bar' => 'baz']]);
-        $this->assertEquals('baz', $page->get('foo')['bar']);
+        $this->assertEquals('baz', $page->data('foo')['bar']);
     }
 
     public function test_get_method_can_access_nested_data_from_page_with_dot_notation()
     {
         $page = MarkdownPage::make('foo', ['foo' => ['bar' => 'baz']]);
-        $this->assertEquals('baz', $page->get('foo.bar'));
+        $this->assertEquals('baz', $page->data('foo.bar'));
     }
 
     public function testGetLinkWithPrettyUrls()

--- a/packages/framework/tests/Feature/HydePageTest.php
+++ b/packages/framework/tests/Feature/HydePageTest.php
@@ -30,6 +30,7 @@ use Hyde\Testing\TestCase;
  * @covers \Hyde\Framework\Factories\FeaturedImageFactory
  * @covers \Hyde\Framework\Factories\HydePageDataFactory
  * @covers \Hyde\Framework\Factories\BlogPostDataFactory
+ * @covers \Hyde\Framework\Concerns\InteractsWithFrontMatter
  */
 class HydePageTest extends TestCase
 {

--- a/packages/framework/tests/Feature/SourceFileParserTest.php
+++ b/packages/framework/tests/Feature/SourceFileParserTest.php
@@ -85,13 +85,13 @@ class SourceFileParserTest extends TestCase
     {
         $this->file('_pages/foo.blade.php', "@php(\$foo = 'bar')\n");
         $page = BladePage::parse('foo');
-        $this->assertEquals('bar', $page->get('foo'));
+        $this->assertEquals('bar', $page->data('foo'));
     }
 
     public function test_blade_page_matter_is_used_for_the_page_title()
     {
         $this->file('_pages/foo.blade.php', "@php(\$title = 'Foo Bar')\n");
         $page = BladePage::parse('foo');
-        $this->assertEquals('Foo Bar', $page->get('title'));
+        $this->assertEquals('Foo Bar', $page->data('title'));
     }
 }

--- a/packages/framework/tests/Unit/MarkdownPostParserTest.php
+++ b/packages/framework/tests/Unit/MarkdownPostParserTest.php
@@ -54,8 +54,8 @@ This is a post stub used in the automated tests
     public function test_parsed_markdown_post_contains_valid_front_matter()
     {
         $post = MarkdownPost::parse('test-post');
-        $this->assertEquals('My New Post', $post->get('title'));
-        $this->assertEquals('Mr. Hyde', $post->get('author'));
-        $this->assertEquals('blog', $post->get('category'));
+        $this->assertEquals('My New Post', $post->data('title'));
+        $this->assertEquals('Mr. Hyde', $post->data('author'));
+        $this->assertEquals('blog', $post->data('category'));
     }
 }


### PR DESCRIPTION
Part one of fixing https://github.com/hydephp/develop/issues/709

This is a breaking change as this trait is used by the HydePage class, and therefore affects all page models.
