### PR TITLE
Committing code to 'tag' field type.

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -1020,16 +1020,16 @@
         },
         {
             "name": "illuminate/bus",
-            "version": "v9.39.0",
+            "version": "v9.41.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/illuminate/bus.git",
-                "reference": "91f8c74ea873f552681b9f1961df808d2a37def2"
+                "reference": "a3bf4cd309afae18757ac63a616af59684fecdca"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/illuminate/bus/zipball/91f8c74ea873f552681b9f1961df808d2a37def2",
-                "reference": "91f8c74ea873f552681b9f1961df808d2a37def2",
+                "url": "https://api.github.com/repos/illuminate/bus/zipball/a3bf4cd309afae18757ac63a616af59684fecdca",
+                "reference": "a3bf4cd309afae18757ac63a616af59684fecdca",
                 "shasum": ""
             },
             "require": {
@@ -1069,11 +1069,11 @@
                 "issues": "https://github.com/laravel/framework/issues",
                 "source": "https://github.com/laravel/framework"
             },
-            "time": "2022-11-03T13:05:20+00:00"
+            "time": "2022-11-21T16:15:38+00:00"
         },
         {
             "name": "illuminate/cache",
-            "version": "v9.39.0",
+            "version": "v9.41.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/illuminate/cache.git",
@@ -1133,16 +1133,16 @@
         },
         {
             "name": "illuminate/collections",
-            "version": "v9.39.0",
+            "version": "v9.41.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/illuminate/collections.git",
-                "reference": "1729899f8e37840738d1c37bb110da5b09509990"
+                "reference": "2a65181bd78d8d00df7459dbe7e8c3ca34f0c93b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/illuminate/collections/zipball/1729899f8e37840738d1c37bb110da5b09509990",
-                "reference": "1729899f8e37840738d1c37bb110da5b09509990",
+                "url": "https://api.github.com/repos/illuminate/collections/zipball/2a65181bd78d8d00df7459dbe7e8c3ca34f0c93b",
+                "reference": "2a65181bd78d8d00df7459dbe7e8c3ca34f0c93b",
                 "shasum": ""
             },
             "require": {
@@ -1184,11 +1184,11 @@
                 "issues": "https://github.com/laravel/framework/issues",
                 "source": "https://github.com/laravel/framework"
             },
-            "time": "2022-11-07T11:40:33+00:00"
+            "time": "2022-11-16T19:49:10+00:00"
         },
         {
             "name": "illuminate/conditionable",
-            "version": "v9.39.0",
+            "version": "v9.41.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/illuminate/conditionable.git",
@@ -1234,7 +1234,7 @@
         },
         {
             "name": "illuminate/config",
-            "version": "v9.39.0",
+            "version": "v9.41.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/illuminate/config.git",
@@ -1282,16 +1282,16 @@
         },
         {
             "name": "illuminate/console",
-            "version": "v9.39.0",
+            "version": "v9.41.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/illuminate/console.git",
-                "reference": "a3627c454e0e97c3cb0b45c998f4481448706766"
+                "reference": "333eeeb4b34e1c7d27d9739c4275fb73d7c81aa1"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/illuminate/console/zipball/a3627c454e0e97c3cb0b45c998f4481448706766",
-                "reference": "a3627c454e0e97c3cb0b45c998f4481448706766",
+                "url": "https://api.github.com/repos/illuminate/console/zipball/333eeeb4b34e1c7d27d9739c4275fb73d7c81aa1",
+                "reference": "333eeeb4b34e1c7d27d9739c4275fb73d7c81aa1",
                 "shasum": ""
             },
             "require": {
@@ -1340,11 +1340,11 @@
                 "issues": "https://github.com/laravel/framework/issues",
                 "source": "https://github.com/laravel/framework"
             },
-            "time": "2022-11-07T14:46:16+00:00"
+            "time": "2022-11-09T13:57:12+00:00"
         },
         {
             "name": "illuminate/container",
-            "version": "v9.39.0",
+            "version": "v9.41.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/illuminate/container.git",
@@ -1395,7 +1395,7 @@
         },
         {
             "name": "illuminate/contracts",
-            "version": "v9.39.0",
+            "version": "v9.41.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/illuminate/contracts.git",
@@ -1443,7 +1443,7 @@
         },
         {
             "name": "illuminate/events",
-            "version": "v9.39.0",
+            "version": "v9.41.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/illuminate/events.git",
@@ -1498,16 +1498,16 @@
         },
         {
             "name": "illuminate/filesystem",
-            "version": "v9.39.0",
+            "version": "v9.41.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/illuminate/filesystem.git",
-                "reference": "05fdbbb60fa0bb17209d43ce231aa0a0bdf5465d"
+                "reference": "3e29c07c25e759a99ec09377838e3926e33d9f5f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/illuminate/filesystem/zipball/05fdbbb60fa0bb17209d43ce231aa0a0bdf5465d",
-                "reference": "05fdbbb60fa0bb17209d43ce231aa0a0bdf5465d",
+                "url": "https://api.github.com/repos/illuminate/filesystem/zipball/3e29c07c25e759a99ec09377838e3926e33d9f5f",
+                "reference": "3e29c07c25e759a99ec09377838e3926e33d9f5f",
                 "shasum": ""
             },
             "require": {
@@ -1556,20 +1556,20 @@
                 "issues": "https://github.com/laravel/framework/issues",
                 "source": "https://github.com/laravel/framework"
             },
-            "time": "2022-10-24T08:47:15+00:00"
+            "time": "2022-11-17T14:45:11+00:00"
         },
         {
             "name": "illuminate/http",
-            "version": "v9.39.0",
+            "version": "v9.41.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/illuminate/http.git",
-                "reference": "db30eb18605b9fb387e6abe4650edb09cdae37c5"
+                "reference": "8b50b823dbd927ab05f0b39004911e7f4f7263df"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/illuminate/http/zipball/db30eb18605b9fb387e6abe4650edb09cdae37c5",
-                "reference": "db30eb18605b9fb387e6abe4650edb09cdae37c5",
+                "url": "https://api.github.com/repos/illuminate/http/zipball/8b50b823dbd927ab05f0b39004911e7f4f7263df",
+                "reference": "8b50b823dbd927ab05f0b39004911e7f4f7263df",
                 "shasum": ""
             },
             "require": {
@@ -1615,20 +1615,20 @@
                 "issues": "https://github.com/laravel/framework/issues",
                 "source": "https://github.com/laravel/framework"
             },
-            "time": "2022-10-31T13:48:14+00:00"
+            "time": "2022-11-19T18:46:43+00:00"
         },
         {
             "name": "illuminate/macroable",
-            "version": "v9.39.0",
+            "version": "v9.41.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/illuminate/macroable.git",
-                "reference": "e3bfaf6401742a9c6abca61b9b10e998e5b6449a"
+                "reference": "25a2c6dac2b7541ecbadef952702e84ae15f5354"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/illuminate/macroable/zipball/e3bfaf6401742a9c6abca61b9b10e998e5b6449a",
-                "reference": "e3bfaf6401742a9c6abca61b9b10e998e5b6449a",
+                "url": "https://api.github.com/repos/illuminate/macroable/zipball/25a2c6dac2b7541ecbadef952702e84ae15f5354",
+                "reference": "25a2c6dac2b7541ecbadef952702e84ae15f5354",
                 "shasum": ""
             },
             "require": {
@@ -1661,11 +1661,11 @@
                 "issues": "https://github.com/laravel/framework/issues",
                 "source": "https://github.com/laravel/framework"
             },
-            "time": "2022-08-09T13:29:29+00:00"
+            "time": "2022-02-01T14:44:21+00:00"
         },
         {
             "name": "illuminate/pipeline",
-            "version": "v9.39.0",
+            "version": "v9.41.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/illuminate/pipeline.git",
@@ -1713,7 +1713,7 @@
         },
         {
             "name": "illuminate/session",
-            "version": "v9.39.0",
+            "version": "v9.41.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/illuminate/session.git",
@@ -1769,16 +1769,16 @@
         },
         {
             "name": "illuminate/support",
-            "version": "v9.39.0",
+            "version": "v9.41.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/illuminate/support.git",
-                "reference": "e613ecd3e9351328e64b7e748804aaf85f4a48c1"
+                "reference": "7ebea783f2f97e1c9560f679888b8c757b98f86e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/illuminate/support/zipball/e613ecd3e9351328e64b7e748804aaf85f4a48c1",
-                "reference": "e613ecd3e9351328e64b7e748804aaf85f4a48c1",
+                "url": "https://api.github.com/repos/illuminate/support/zipball/7ebea783f2f97e1c9560f679888b8c757b98f86e",
+                "reference": "7ebea783f2f97e1c9560f679888b8c757b98f86e",
                 "shasum": ""
             },
             "require": {
@@ -1835,20 +1835,20 @@
                 "issues": "https://github.com/laravel/framework/issues",
                 "source": "https://github.com/laravel/framework"
             },
-            "time": "2022-11-02T13:45:32+00:00"
+            "time": "2022-11-21T16:30:36+00:00"
         },
         {
             "name": "illuminate/testing",
-            "version": "v9.39.0",
+            "version": "v9.41.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/illuminate/testing.git",
-                "reference": "5466e79da52edeeea960b1d87b6474003ddc79b4"
+                "reference": "a9c65d23e6353cd1f7bc85a325177ce3f6536207"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/illuminate/testing/zipball/5466e79da52edeeea960b1d87b6474003ddc79b4",
-                "reference": "5466e79da52edeeea960b1d87b6474003ddc79b4",
+                "url": "https://api.github.com/repos/illuminate/testing/zipball/a9c65d23e6353cd1f7bc85a325177ce3f6536207",
+                "reference": "a9c65d23e6353cd1f7bc85a325177ce3f6536207",
                 "shasum": ""
             },
             "require": {
@@ -1893,11 +1893,11 @@
                 "issues": "https://github.com/laravel/framework/issues",
                 "source": "https://github.com/laravel/framework"
             },
-            "time": "2022-11-03T21:24:23+00:00"
+            "time": "2022-11-16T19:59:06+00:00"
         },
         {
             "name": "illuminate/translation",
-            "version": "v9.39.0",
+            "version": "v9.41.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/illuminate/translation.git",
@@ -1949,16 +1949,16 @@
         },
         {
             "name": "illuminate/validation",
-            "version": "v9.39.0",
+            "version": "v9.41.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/illuminate/validation.git",
-                "reference": "89dba4d3a6fdb867796773c6c227554bbf0e0580"
+                "reference": "b57f8035a819bc2a805b712660e80250af4e0d74"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/illuminate/validation/zipball/89dba4d3a6fdb867796773c6c227554bbf0e0580",
-                "reference": "89dba4d3a6fdb867796773c6c227554bbf0e0580",
+                "url": "https://api.github.com/repos/illuminate/validation/zipball/b57f8035a819bc2a805b712660e80250af4e0d74",
+                "reference": "b57f8035a819bc2a805b712660e80250af4e0d74",
                 "shasum": ""
             },
             "require": {
@@ -2005,20 +2005,20 @@
                 "issues": "https://github.com/laravel/framework/issues",
                 "source": "https://github.com/laravel/framework"
             },
-            "time": "2022-10-07T19:07:25+00:00"
+            "time": "2022-11-18T19:48:58+00:00"
         },
         {
             "name": "illuminate/view",
-            "version": "v9.39.0",
+            "version": "v9.41.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/illuminate/view.git",
-                "reference": "0d8094e3f826220d26d1d509d154beb114ee7bea"
+                "reference": "951a68bbbecaa5f744bfd01e8dcdd482d0604348"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/illuminate/view/zipball/0d8094e3f826220d26d1d509d154beb114ee7bea",
-                "reference": "0d8094e3f826220d26d1d509d154beb114ee7bea",
+                "url": "https://api.github.com/repos/illuminate/view/zipball/951a68bbbecaa5f744bfd01e8dcdd482d0604348",
+                "reference": "951a68bbbecaa5f744bfd01e8dcdd482d0604348",
                 "shasum": ""
             },
             "require": {
@@ -2059,7 +2059,7 @@
                 "issues": "https://github.com/laravel/framework/issues",
                 "source": "https://github.com/laravel/framework"
             },
-            "time": "2022-11-02T15:46:09+00:00"
+            "time": "2022-11-18T19:51:25+00:00"
         },
         {
             "name": "jolicode/jolinotif",
@@ -2458,16 +2458,16 @@
         },
         {
             "name": "league/flysystem",
-            "version": "3.10.2",
+            "version": "3.10.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/thephpleague/flysystem.git",
-                "reference": "b9bd194b016114d6ff6765c09d40c7d427e4e3f6"
+                "reference": "a7790f3dd1b27af81d380e6b2afa77c16ab7e181"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/thephpleague/flysystem/zipball/b9bd194b016114d6ff6765c09d40c7d427e4e3f6",
-                "reference": "b9bd194b016114d6ff6765c09d40c7d427e4e3f6",
+                "url": "https://api.github.com/repos/thephpleague/flysystem/zipball/a7790f3dd1b27af81d380e6b2afa77c16ab7e181",
+                "reference": "a7790f3dd1b27af81d380e6b2afa77c16ab7e181",
                 "shasum": ""
             },
             "require": {
@@ -2529,7 +2529,7 @@
             ],
             "support": {
                 "issues": "https://github.com/thephpleague/flysystem/issues",
-                "source": "https://github.com/thephpleague/flysystem/tree/3.10.2"
+                "source": "https://github.com/thephpleague/flysystem/tree/3.10.4"
             },
             "funding": [
                 {
@@ -2545,7 +2545,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2022-10-25T07:01:47+00:00"
+            "time": "2022-11-26T19:48:01+00:00"
         },
         {
             "name": "league/mime-type-detection",
@@ -2605,16 +2605,16 @@
         },
         {
             "name": "nesbot/carbon",
-            "version": "2.62.1",
+            "version": "2.63.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/briannesbitt/Carbon.git",
-                "reference": "01bc4cdefe98ef58d1f9cb31bdbbddddf2a88f7a"
+                "reference": "ad35dd71a6a212b98e4b87e97389b6fa85f0e347"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/briannesbitt/Carbon/zipball/01bc4cdefe98ef58d1f9cb31bdbbddddf2a88f7a",
-                "reference": "01bc4cdefe98ef58d1f9cb31bdbbddddf2a88f7a",
+                "url": "https://api.github.com/repos/briannesbitt/Carbon/zipball/ad35dd71a6a212b98e4b87e97389b6fa85f0e347",
+                "reference": "ad35dd71a6a212b98e4b87e97389b6fa85f0e347",
                 "shasum": ""
             },
             "require": {
@@ -2703,29 +2703,29 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2022-09-02T07:48:13+00:00"
+            "time": "2022-10-30T18:34:28+00:00"
         },
         {
             "name": "nette/schema",
-            "version": "v1.2.2",
+            "version": "v1.2.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/nette/schema.git",
-                "reference": "9a39cef03a5b34c7de64f551538cbba05c2be5df"
+                "reference": "abbdbb70e0245d5f3bf77874cea1dfb0c930d06f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/nette/schema/zipball/9a39cef03a5b34c7de64f551538cbba05c2be5df",
-                "reference": "9a39cef03a5b34c7de64f551538cbba05c2be5df",
+                "url": "https://api.github.com/repos/nette/schema/zipball/abbdbb70e0245d5f3bf77874cea1dfb0c930d06f",
+                "reference": "abbdbb70e0245d5f3bf77874cea1dfb0c930d06f",
                 "shasum": ""
             },
             "require": {
                 "nette/utils": "^2.5.7 || ^3.1.5 ||  ^4.0",
-                "php": ">=7.1 <8.2"
+                "php": ">=7.1 <8.3"
             },
             "require-dev": {
                 "nette/tester": "^2.3 || ^2.4",
-                "phpstan/phpstan-nette": "^0.12",
+                "phpstan/phpstan-nette": "^1.0",
                 "tracy/tracy": "^2.7"
             },
             "type": "library",
@@ -2763,9 +2763,9 @@
             ],
             "support": {
                 "issues": "https://github.com/nette/schema/issues",
-                "source": "https://github.com/nette/schema/tree/v1.2.2"
+                "source": "https://github.com/nette/schema/tree/v1.2.3"
             },
-            "time": "2021-10-15T11:40:02+00:00"
+            "time": "2022-10-13T01:24:26+00:00"
         },
         {
             "name": "nette/utils",
@@ -4714,16 +4714,16 @@
         },
         {
             "name": "symfony/polyfill-ctype",
-            "version": "v1.26.0",
+            "version": "v1.27.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-ctype.git",
-                "reference": "6fd1b9a79f6e3cf65f9e679b23af304cd9e010d4"
+                "reference": "5bbc823adecdae860bb64756d639ecfec17b050a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-ctype/zipball/6fd1b9a79f6e3cf65f9e679b23af304cd9e010d4",
-                "reference": "6fd1b9a79f6e3cf65f9e679b23af304cd9e010d4",
+                "url": "https://api.github.com/repos/symfony/polyfill-ctype/zipball/5bbc823adecdae860bb64756d639ecfec17b050a",
+                "reference": "5bbc823adecdae860bb64756d639ecfec17b050a",
                 "shasum": ""
             },
             "require": {
@@ -4738,7 +4738,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "1.26-dev"
+                    "dev-main": "1.27-dev"
                 },
                 "thanks": {
                     "name": "symfony/polyfill",
@@ -4776,7 +4776,7 @@
                 "portable"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-ctype/tree/v1.26.0"
+                "source": "https://github.com/symfony/polyfill-ctype/tree/v1.27.0"
             },
             "funding": [
                 {
@@ -4792,20 +4792,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2022-05-24T11:49:31+00:00"
+            "time": "2022-11-03T14:55:06+00:00"
         },
         {
             "name": "symfony/polyfill-intl-grapheme",
-            "version": "v1.26.0",
+            "version": "v1.27.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-intl-grapheme.git",
-                "reference": "433d05519ce6990bf3530fba6957499d327395c2"
+                "reference": "511a08c03c1960e08a883f4cffcacd219b758354"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-intl-grapheme/zipball/433d05519ce6990bf3530fba6957499d327395c2",
-                "reference": "433d05519ce6990bf3530fba6957499d327395c2",
+                "url": "https://api.github.com/repos/symfony/polyfill-intl-grapheme/zipball/511a08c03c1960e08a883f4cffcacd219b758354",
+                "reference": "511a08c03c1960e08a883f4cffcacd219b758354",
                 "shasum": ""
             },
             "require": {
@@ -4817,7 +4817,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "1.26-dev"
+                    "dev-main": "1.27-dev"
                 },
                 "thanks": {
                     "name": "symfony/polyfill",
@@ -4857,7 +4857,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-intl-grapheme/tree/v1.26.0"
+                "source": "https://github.com/symfony/polyfill-intl-grapheme/tree/v1.27.0"
             },
             "funding": [
                 {
@@ -4873,20 +4873,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2022-05-24T11:49:31+00:00"
+            "time": "2022-11-03T14:55:06+00:00"
         },
         {
             "name": "symfony/polyfill-intl-idn",
-            "version": "v1.26.0",
+            "version": "v1.27.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-intl-idn.git",
-                "reference": "59a8d271f00dd0e4c2e518104cc7963f655a1aa8"
+                "reference": "639084e360537a19f9ee352433b84ce831f3d2da"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-intl-idn/zipball/59a8d271f00dd0e4c2e518104cc7963f655a1aa8",
-                "reference": "59a8d271f00dd0e4c2e518104cc7963f655a1aa8",
+                "url": "https://api.github.com/repos/symfony/polyfill-intl-idn/zipball/639084e360537a19f9ee352433b84ce831f3d2da",
+                "reference": "639084e360537a19f9ee352433b84ce831f3d2da",
                 "shasum": ""
             },
             "require": {
@@ -4900,7 +4900,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "1.26-dev"
+                    "dev-main": "1.27-dev"
                 },
                 "thanks": {
                     "name": "symfony/polyfill",
@@ -4944,7 +4944,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-intl-idn/tree/v1.26.0"
+                "source": "https://github.com/symfony/polyfill-intl-idn/tree/v1.27.0"
             },
             "funding": [
                 {
@@ -4960,20 +4960,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2022-05-24T11:49:31+00:00"
+            "time": "2022-11-03T14:55:06+00:00"
         },
         {
             "name": "symfony/polyfill-intl-normalizer",
-            "version": "v1.26.0",
+            "version": "v1.27.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-intl-normalizer.git",
-                "reference": "219aa369ceff116e673852dce47c3a41794c14bd"
+                "reference": "19bd1e4fcd5b91116f14d8533c57831ed00571b6"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-intl-normalizer/zipball/219aa369ceff116e673852dce47c3a41794c14bd",
-                "reference": "219aa369ceff116e673852dce47c3a41794c14bd",
+                "url": "https://api.github.com/repos/symfony/polyfill-intl-normalizer/zipball/19bd1e4fcd5b91116f14d8533c57831ed00571b6",
+                "reference": "19bd1e4fcd5b91116f14d8533c57831ed00571b6",
                 "shasum": ""
             },
             "require": {
@@ -4985,7 +4985,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "1.26-dev"
+                    "dev-main": "1.27-dev"
                 },
                 "thanks": {
                     "name": "symfony/polyfill",
@@ -5028,7 +5028,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-intl-normalizer/tree/v1.26.0"
+                "source": "https://github.com/symfony/polyfill-intl-normalizer/tree/v1.27.0"
             },
             "funding": [
                 {
@@ -5044,20 +5044,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2022-05-24T11:49:31+00:00"
+            "time": "2022-11-03T14:55:06+00:00"
         },
         {
             "name": "symfony/polyfill-mbstring",
-            "version": "v1.26.0",
+            "version": "v1.27.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-mbstring.git",
-                "reference": "9344f9cb97f3b19424af1a21a3b0e75b0a7d8d7e"
+                "reference": "8ad114f6b39e2c98a8b0e3bd907732c207c2b534"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-mbstring/zipball/9344f9cb97f3b19424af1a21a3b0e75b0a7d8d7e",
-                "reference": "9344f9cb97f3b19424af1a21a3b0e75b0a7d8d7e",
+                "url": "https://api.github.com/repos/symfony/polyfill-mbstring/zipball/8ad114f6b39e2c98a8b0e3bd907732c207c2b534",
+                "reference": "8ad114f6b39e2c98a8b0e3bd907732c207c2b534",
                 "shasum": ""
             },
             "require": {
@@ -5072,7 +5072,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "1.26-dev"
+                    "dev-main": "1.27-dev"
                 },
                 "thanks": {
                     "name": "symfony/polyfill",
@@ -5111,7 +5111,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-mbstring/tree/v1.26.0"
+                "source": "https://github.com/symfony/polyfill-mbstring/tree/v1.27.0"
             },
             "funding": [
                 {
@@ -5127,20 +5127,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2022-05-24T11:49:31+00:00"
+            "time": "2022-11-03T14:55:06+00:00"
         },
         {
             "name": "symfony/polyfill-php72",
-            "version": "v1.26.0",
+            "version": "v1.27.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-php72.git",
-                "reference": "bf44a9fd41feaac72b074de600314a93e2ae78e2"
+                "reference": "869329b1e9894268a8a61dabb69153029b7a8c97"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-php72/zipball/bf44a9fd41feaac72b074de600314a93e2ae78e2",
-                "reference": "bf44a9fd41feaac72b074de600314a93e2ae78e2",
+                "url": "https://api.github.com/repos/symfony/polyfill-php72/zipball/869329b1e9894268a8a61dabb69153029b7a8c97",
+                "reference": "869329b1e9894268a8a61dabb69153029b7a8c97",
                 "shasum": ""
             },
             "require": {
@@ -5149,7 +5149,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "1.26-dev"
+                    "dev-main": "1.27-dev"
                 },
                 "thanks": {
                     "name": "symfony/polyfill",
@@ -5187,7 +5187,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-php72/tree/v1.26.0"
+                "source": "https://github.com/symfony/polyfill-php72/tree/v1.27.0"
             },
             "funding": [
                 {
@@ -5203,20 +5203,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2022-05-24T11:49:31+00:00"
+            "time": "2022-11-03T14:55:06+00:00"
         },
         {
             "name": "symfony/polyfill-php80",
-            "version": "v1.26.0",
+            "version": "v1.27.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-php80.git",
-                "reference": "cfa0ae98841b9e461207c13ab093d76b0fa7bace"
+                "reference": "7a6ff3f1959bb01aefccb463a0f2cd3d3d2fd936"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-php80/zipball/cfa0ae98841b9e461207c13ab093d76b0fa7bace",
-                "reference": "cfa0ae98841b9e461207c13ab093d76b0fa7bace",
+                "url": "https://api.github.com/repos/symfony/polyfill-php80/zipball/7a6ff3f1959bb01aefccb463a0f2cd3d3d2fd936",
+                "reference": "7a6ff3f1959bb01aefccb463a0f2cd3d3d2fd936",
                 "shasum": ""
             },
             "require": {
@@ -5225,7 +5225,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "1.26-dev"
+                    "dev-main": "1.27-dev"
                 },
                 "thanks": {
                     "name": "symfony/polyfill",
@@ -5270,7 +5270,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-php80/tree/v1.26.0"
+                "source": "https://github.com/symfony/polyfill-php80/tree/v1.27.0"
             },
             "funding": [
                 {
@@ -5286,20 +5286,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2022-05-10T07:21:04+00:00"
+            "time": "2022-11-03T14:55:06+00:00"
         },
         {
             "name": "symfony/polyfill-php81",
-            "version": "v1.26.0",
+            "version": "v1.27.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-php81.git",
-                "reference": "13f6d1271c663dc5ae9fb843a8f16521db7687a1"
+                "reference": "707403074c8ea6e2edaf8794b0157a0bfa52157a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-php81/zipball/13f6d1271c663dc5ae9fb843a8f16521db7687a1",
-                "reference": "13f6d1271c663dc5ae9fb843a8f16521db7687a1",
+                "url": "https://api.github.com/repos/symfony/polyfill-php81/zipball/707403074c8ea6e2edaf8794b0157a0bfa52157a",
+                "reference": "707403074c8ea6e2edaf8794b0157a0bfa52157a",
                 "shasum": ""
             },
             "require": {
@@ -5308,7 +5308,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "1.26-dev"
+                    "dev-main": "1.27-dev"
                 },
                 "thanks": {
                     "name": "symfony/polyfill",
@@ -5349,7 +5349,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-php81/tree/v1.26.0"
+                "source": "https://github.com/symfony/polyfill-php81/tree/v1.27.0"
             },
             "funding": [
                 {
@@ -5365,7 +5365,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2022-05-24T11:49:31+00:00"
+            "time": "2022-11-03T14:55:06+00:00"
         },
         {
             "name": "symfony/process",
@@ -6655,16 +6655,16 @@
         },
         {
             "name": "composer/pcre",
-            "version": "3.0.2",
+            "version": "3.1.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/composer/pcre.git",
-                "reference": "4482b6409ca6bfc2af043a5711cd21ac3e7a8dfb"
+                "reference": "4bff79ddd77851fe3cdd11616ed3f92841ba5bd2"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/composer/pcre/zipball/4482b6409ca6bfc2af043a5711cd21ac3e7a8dfb",
-                "reference": "4482b6409ca6bfc2af043a5711cd21ac3e7a8dfb",
+                "url": "https://api.github.com/repos/composer/pcre/zipball/4bff79ddd77851fe3cdd11616ed3f92841ba5bd2",
+                "reference": "4bff79ddd77851fe3cdd11616ed3f92841ba5bd2",
                 "shasum": ""
             },
             "require": {
@@ -6706,7 +6706,7 @@
             ],
             "support": {
                 "issues": "https://github.com/composer/pcre/issues",
-                "source": "https://github.com/composer/pcre/tree/3.0.2"
+                "source": "https://github.com/composer/pcre/tree/3.1.0"
             },
             "funding": [
                 {
@@ -6722,7 +6722,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2022-11-03T20:24:16+00:00"
+            "time": "2022-11-17T09:50:14+00:00"
         },
         {
             "name": "composer/semver",
@@ -7390,16 +7390,16 @@
         },
         {
             "name": "laravel/tinker",
-            "version": "v2.7.2",
+            "version": "v2.7.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/laravel/tinker.git",
-                "reference": "dff39b661e827dae6e092412f976658df82dbac5"
+                "reference": "5062061b4924af3392225dd482ca7b4d85d8b8ef"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/laravel/tinker/zipball/dff39b661e827dae6e092412f976658df82dbac5",
-                "reference": "dff39b661e827dae6e092412f976658df82dbac5",
+                "url": "https://api.github.com/repos/laravel/tinker/zipball/5062061b4924af3392225dd482ca7b4d85d8b8ef",
+                "reference": "5062061b4924af3392225dd482ca7b4d85d8b8ef",
                 "shasum": ""
             },
             "require": {
@@ -7452,9 +7452,9 @@
             ],
             "support": {
                 "issues": "https://github.com/laravel/tinker/issues",
-                "source": "https://github.com/laravel/tinker/tree/v2.7.2"
+                "source": "https://github.com/laravel/tinker/tree/v2.7.3"
             },
-            "time": "2022-03-23T12:38:24+00:00"
+            "time": "2022-11-09T15:11:38+00:00"
         },
         {
             "name": "mockery/mockery",
@@ -7640,16 +7640,16 @@
         },
         {
             "name": "nikic/php-parser",
-            "version": "v4.15.1",
+            "version": "v4.15.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/nikic/PHP-Parser.git",
-                "reference": "0ef6c55a3f47f89d7a374e6f835197a0b5fcf900"
+                "reference": "f59bbe44bf7d96f24f3e2b4ddc21cd52c1d2adbc"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/nikic/PHP-Parser/zipball/0ef6c55a3f47f89d7a374e6f835197a0b5fcf900",
-                "reference": "0ef6c55a3f47f89d7a374e6f835197a0b5fcf900",
+                "url": "https://api.github.com/repos/nikic/PHP-Parser/zipball/f59bbe44bf7d96f24f3e2b4ddc21cd52c1d2adbc",
+                "reference": "f59bbe44bf7d96f24f3e2b4ddc21cd52c1d2adbc",
                 "shasum": ""
             },
             "require": {
@@ -7690,9 +7690,9 @@
             ],
             "support": {
                 "issues": "https://github.com/nikic/PHP-Parser/issues",
-                "source": "https://github.com/nikic/PHP-Parser/tree/v4.15.1"
+                "source": "https://github.com/nikic/PHP-Parser/tree/v4.15.2"
             },
-            "time": "2022-09-04T07:30:47+00:00"
+            "time": "2022-11-12T15:38:23+00:00"
         },
         {
             "name": "openlss/lib-array2xml",
@@ -7749,30 +7749,30 @@
         },
         {
             "name": "pestphp/pest",
-            "version": "v1.22.1",
+            "version": "v1.22.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/pestphp/pest.git",
-                "reference": "af6240b4eed8b049ac43c91184141ee337305df7"
+                "reference": "339414e34842f9463f33641b00559d4bf227e478"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/pestphp/pest/zipball/af6240b4eed8b049ac43c91184141ee337305df7",
-                "reference": "af6240b4eed8b049ac43c91184141ee337305df7",
+                "url": "https://api.github.com/repos/pestphp/pest/zipball/339414e34842f9463f33641b00559d4bf227e478",
+                "reference": "339414e34842f9463f33641b00559d4bf227e478",
                 "shasum": ""
             },
             "require": {
-                "nunomaduro/collision": "^5.10.0|^6.0",
-                "pestphp/pest-plugin": "^1.0.0",
+                "nunomaduro/collision": "^5.11.0|^6.3.0",
+                "pestphp/pest-plugin": "^1.1.0",
                 "php": "^7.3 || ^8.0",
-                "phpunit/phpunit": "^9.5.5"
+                "phpunit/phpunit": "^9.5.26"
             },
             "require-dev": {
-                "illuminate/console": "^8.47.0",
-                "illuminate/support": "^8.47.0",
-                "laravel/dusk": "^6.15.0",
-                "pestphp/pest-dev-tools": "dev-master",
-                "pestphp/pest-plugin-parallel": "^1.0"
+                "illuminate/console": "^8.83.26",
+                "illuminate/support": "^8.83.26",
+                "laravel/dusk": "^6.25.2",
+                "pestphp/pest-dev-tools": "^1.0.0",
+                "pestphp/pest-plugin-parallel": "^1.2"
             },
             "bin": [
                 "bin/pest"
@@ -7826,7 +7826,7 @@
             ],
             "support": {
                 "issues": "https://github.com/pestphp/pest/issues",
-                "source": "https://github.com/pestphp/pest/tree/v1.22.1"
+                "source": "https://github.com/pestphp/pest/tree/v1.22.2"
             },
             "funding": [
                 {
@@ -7842,10 +7842,6 @@
                     "type": "github"
                 },
                 {
-                    "url": "https://github.com/octoper",
-                    "type": "github"
-                },
-                {
                     "url": "https://github.com/olivernybroe",
                     "type": "github"
                 },
@@ -7858,7 +7854,7 @@
                     "type": "patreon"
                 }
             ],
-            "time": "2022-08-29T10:42:13+00:00"
+            "time": "2022-11-09T21:10:57+00:00"
         },
         {
             "name": "pestphp/pest-plugin",
@@ -8332,16 +8328,16 @@
         },
         {
             "name": "phpstan/phpstan",
-            "version": "1.9.1",
+            "version": "1.9.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpstan/phpstan.git",
-                "reference": "a59c8b5bfd4a236f27efc8b5ce72c313c2b54b5f"
+                "reference": "d6fdf01c53978b6429f1393ba4afeca39cc68afa"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/a59c8b5bfd4a236f27efc8b5ce72c313c2b54b5f",
-                "reference": "a59c8b5bfd4a236f27efc8b5ce72c313c2b54b5f",
+                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/d6fdf01c53978b6429f1393ba4afeca39cc68afa",
+                "reference": "d6fdf01c53978b6429f1393ba4afeca39cc68afa",
                 "shasum": ""
             },
             "require": {
@@ -8371,7 +8367,7 @@
             ],
             "support": {
                 "issues": "https://github.com/phpstan/phpstan/issues",
-                "source": "https://github.com/phpstan/phpstan/tree/1.9.1"
+                "source": "https://github.com/phpstan/phpstan/tree/1.9.2"
             },
             "funding": [
                 {
@@ -8387,20 +8383,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2022-11-04T13:35:59+00:00"
+            "time": "2022-11-10T09:56:11+00:00"
         },
         {
             "name": "phpunit/php-code-coverage",
-            "version": "9.2.18",
+            "version": "9.2.19",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-code-coverage.git",
-                "reference": "12fddc491826940cf9b7e88ad9664cf51f0f6d0a"
+                "reference": "c77b56b63e3d2031bd8997fcec43c1925ae46559"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/12fddc491826940cf9b7e88ad9664cf51f0f6d0a",
-                "reference": "12fddc491826940cf9b7e88ad9664cf51f0f6d0a",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/c77b56b63e3d2031bd8997fcec43c1925ae46559",
+                "reference": "c77b56b63e3d2031bd8997fcec43c1925ae46559",
                 "shasum": ""
             },
             "require": {
@@ -8456,7 +8452,7 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/php-code-coverage/issues",
-                "source": "https://github.com/sebastianbergmann/php-code-coverage/tree/9.2.18"
+                "source": "https://github.com/sebastianbergmann/php-code-coverage/tree/9.2.19"
             },
             "funding": [
                 {
@@ -8464,7 +8460,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2022-10-27T13:35:33+00:00"
+            "time": "2022-11-18T07:47:47+00:00"
         },
         {
             "name": "phpunit/php-file-iterator",
@@ -8887,16 +8883,16 @@
         },
         {
             "name": "rector/rector",
-            "version": "0.14.7",
+            "version": "0.14.8",
             "source": {
                 "type": "git",
                 "url": "https://github.com/rectorphp/rector.git",
-                "reference": "3553aaba0e820083fc6d7f0dc78d8d789226a398"
+                "reference": "46ee9a173a2b2645ca92a75ffc17460139fa226e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/rectorphp/rector/zipball/3553aaba0e820083fc6d7f0dc78d8d789226a398",
-                "reference": "3553aaba0e820083fc6d7f0dc78d8d789226a398",
+                "url": "https://api.github.com/repos/rectorphp/rector/zipball/46ee9a173a2b2645ca92a75ffc17460139fa226e",
+                "reference": "46ee9a173a2b2645ca92a75ffc17460139fa226e",
                 "shasum": ""
             },
             "require": {
@@ -8932,7 +8928,7 @@
             "description": "Instant Upgrade and Automated Refactoring of any PHP code",
             "support": {
                 "issues": "https://github.com/rectorphp/rector/issues",
-                "source": "https://github.com/rectorphp/rector/tree/0.14.7"
+                "source": "https://github.com/rectorphp/rector/tree/0.14.8"
             },
             "funding": [
                 {
@@ -8940,7 +8936,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2022-11-04T08:48:40+00:00"
+            "time": "2022-11-14T14:09:49+00:00"
         },
         {
             "name": "sebastian/cli-parser",

--- a/packages/framework/src/Console/Commands/MakePublicationCommand.php
+++ b/packages/framework/src/Console/Commands/MakePublicationCommand.php
@@ -57,7 +57,7 @@ class MakePublicationCommand extends ValidatingCommand implements CommandHandleI
         return Command::SUCCESS;
     }
 
-    protected function captureFieldInput(PublicationFieldType $field, Collection $mediaFiles): string|array
+    protected function captureFieldInput(PublicationFieldType $field, PublicationType $pubType): string|array
     {
         if ($field->type === 'text') {
             $lines = [];
@@ -70,7 +70,7 @@ class MakePublicationCommand extends ValidatingCommand implements CommandHandleI
                 $lines[] = $line;
             } while (true);
 
-            return implode("\n", $lines);
+            return $lines;
         }
 
         if ($field->type === 'array') {
@@ -81,7 +81,7 @@ class MakePublicationCommand extends ValidatingCommand implements CommandHandleI
                 if ($line === '') {
                     break;
                 }
-                $lines[] = $line;
+                $lines[] = trim($line);
             } while (true);
 
             return $lines;
@@ -89,15 +89,34 @@ class MakePublicationCommand extends ValidatingCommand implements CommandHandleI
 
         if ($field->type === 'image') {
             $this->output->writeln($field->name.' (end with an empty line)');
-            $offset = 0;
-            foreach ($mediaFiles as $index => $file) {
-                $offset = $index + 1;
-                $this->output->writeln("  $offset: $file");
-            }
-            $selected = $this->askWithValidation($field->name, $field->name, ['required', 'integer', "between:1,$offset"]);
+            do {
+                $offset     = 0;
+                $mediaFiles = PublicationService::getMediaForPubType($pubType);
+                foreach ($mediaFiles as $index => $file) {
+                    $offset = $index + 1;
+                    $this->output->writeln("  $offset: $file");
+                }
+                $selected = (int)$this->askWithValidation($field->name, $field->name, ['required', 'integer', "between:1,$offset"]);
+            } while ($selected == 0);
             $file = $mediaFiles->{$selected - 1};
 
             return '_media/'.Str::of($file)->after('media/')->toString();
+        }
+
+        if ($field->type === 'tag') {
+            $this->output->writeln($field->name.' (enter 0 to reload tag definitions)');
+            do {
+                $offset = 0;
+                $tagsForGroup = PublicationService::getAllTags()->{$field->tagGroup};
+                foreach ($tagsForGroup as $index=>$value) {
+                    $offset = $index + 1;
+                    $this->output->writeln("  $offset: $value");
+                }
+                $selected = (int)$this->askWithValidation($field->name, $field->name, ['required', 'integer', "between:0,$offset"]);
+            }
+            while ($selected == 0);
+
+            return $tagsForGroup->{$selected - 1};
         }
 
         // Fields which are not of type array, text or image
@@ -151,10 +170,8 @@ class MakePublicationCommand extends ValidatingCommand implements CommandHandleI
     {
         $this->output->writeln("\n<bg=magenta;fg=white>Now please enter the field data:</>");
 
-        $mediaFiles = PublicationService::getMediaForPubType($pubType);
-
-        return Collection::make($pubType->fields)->mapWithKeys(function ($field) use ($mediaFiles) {
-            return [$field['name'] => $this->captureFieldInput(PublicationFieldType::fromArray($field), $mediaFiles)];
+        return Collection::make($pubType->fields)->mapWithKeys(function ($field) use ($pubType) {
+            return [$field['name'] => $this->captureFieldInput(PublicationFieldType::fromArray($field), $pubType)];
         });
     }
 

--- a/packages/framework/src/Console/Commands/MakePublicationCommand.php
+++ b/packages/framework/src/Console/Commands/MakePublicationCommand.php
@@ -90,13 +90,13 @@ class MakePublicationCommand extends ValidatingCommand implements CommandHandleI
         if ($field->type === 'image') {
             $this->output->writeln($field->name.' (end with an empty line)');
             do {
-                $offset     = 0;
+                $offset = 0;
                 $mediaFiles = PublicationService::getMediaForPubType($pubType);
                 foreach ($mediaFiles as $index => $file) {
                     $offset = $index + 1;
                     $this->output->writeln("  $offset: $file");
                 }
-                $selected = (int)$this->askWithValidation($field->name, $field->name, ['required', 'integer', "between:1,$offset"]);
+                $selected = (int) $this->askWithValidation($field->name, $field->name, ['required', 'integer', "between:1,$offset"]);
             } while ($selected == 0);
             $file = $mediaFiles->{$selected - 1};
 
@@ -112,9 +112,8 @@ class MakePublicationCommand extends ValidatingCommand implements CommandHandleI
                     $offset = $index + 1;
                     $this->output->writeln("  $offset: $value");
                 }
-                $selected = (int)$this->askWithValidation($field->name, $field->name, ['required', 'integer', "between:0,$offset"]);
-            }
-            while ($selected == 0);
+                $selected = (int) $this->askWithValidation($field->name, $field->name, ['required', 'integer', "between:0,$offset"]);
+            } while ($selected == 0);
 
             return $tagsForGroup->{$selected - 1};
         }

--- a/packages/framework/src/Console/Commands/MakePublicationTagCommand.php
+++ b/packages/framework/src/Console/Commands/MakePublicationTagCommand.php
@@ -1,0 +1,58 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Hyde\Console\Commands;
+
+use Hyde\Console\Commands\Interfaces\CommandHandleInterface;
+use Hyde\Console\Concerns\ValidatingCommand;
+use Hyde\Framework\Features\Publications\PublicationService;
+use Hyde\Hyde;
+use Illuminate\Support\Str;
+use LaravelZero\Framework\Commands\Command;
+use function Safe\json_decode;
+use function Safe\json_encode;
+use function Safe\file_put_contents;
+
+/**
+ * Hyde Command to create a new publication type.
+ *
+ * @see \Hyde\Framework\Testing\Feature\Commands\MakePublicationTypeCommandTest
+ */
+class MakePublicationTagCommand extends ValidatingCommand implements CommandHandleInterface
+{
+    /** @var string */
+    protected $signature = 'make:publicationTag';
+
+    /** @var string */
+    protected $description = 'Create a new publication type tag definition';
+
+    public function handle(): int
+    {
+        $this->title('Creating a new Publication Type Tag!');
+
+        $filename = Hyde::pathToRelative('tags.json');
+        $tags     = PublicationService::getAllTags();
+        $tagName  = $this->askWithValidation('name', 'Tag name', ['required', 'string']);
+        if (isset($tags[$tagName])) {
+            $this->output->error("Tag [$tagName] already exists");
+            return Command::FAILURE;
+        }
+
+        $lines = [];
+        $this->output->writeln('<bg=magenta;fg=white>Enter the tag values (end with an empty line):</>');
+        do {
+            $line = Str::replace("\n", '', fgets(STDIN));
+            if ($line === '') {
+                break;
+            }
+            $lines[] = trim($line);
+        } while (true);
+        $tags[$tagName] = $lines;
+
+        $this->output->writeln(sprintf('Saving tag data to [%s]', $filename));
+        file_put_contents($filename, json_encode($tags, JSON_PRETTY_PRINT));
+
+        return Command::SUCCESS;
+    }
+}

--- a/packages/framework/src/Console/Commands/MakePublicationTagCommand.php
+++ b/packages/framework/src/Console/Commands/MakePublicationTagCommand.php
@@ -10,9 +10,8 @@ use Hyde\Framework\Features\Publications\PublicationService;
 use Hyde\Hyde;
 use Illuminate\Support\Str;
 use LaravelZero\Framework\Commands\Command;
-use function Safe\json_decode;
-use function Safe\json_encode;
 use function Safe\file_put_contents;
+use function Safe\json_encode;
 
 /**
  * Hyde Command to create a new publication type.
@@ -32,10 +31,11 @@ class MakePublicationTagCommand extends ValidatingCommand implements CommandHand
         $this->title('Creating a new Publication Type Tag!');
 
         $filename = Hyde::pathToRelative('tags.json');
-        $tags     = PublicationService::getAllTags();
-        $tagName  = $this->askWithValidation('name', 'Tag name', ['required', 'string']);
+        $tags = PublicationService::getAllTags();
+        $tagName = $this->askWithValidation('name', 'Tag name', ['required', 'string']);
         if (isset($tags[$tagName])) {
             $this->output->error("Tag [$tagName] already exists");
+
             return Command::FAILURE;
         }
 

--- a/packages/framework/src/Console/Commands/MakePublicationTagCommand.php
+++ b/packages/framework/src/Console/Commands/MakePublicationTagCommand.php
@@ -42,7 +42,7 @@ class MakePublicationTagCommand extends ValidatingCommand implements CommandHand
         $lines = [];
         $this->output->writeln('<bg=magenta;fg=white>Enter the tag values (end with an empty line):</>');
         do {
-            $line = Str::replace("\n", '', fgets(STDIN));
+            $line = Str::replace(["\n", "\r"], '', fgets(STDIN));
             if ($line === '') {
                 break;
             }

--- a/packages/framework/src/Console/Commands/MakePublicationTypeCommand.php
+++ b/packages/framework/src/Console/Commands/MakePublicationTypeCommand.php
@@ -85,7 +85,7 @@ class MakePublicationTypeCommand extends ValidatingCommand implements CommandHan
                 $this->line("  $offset: $v->name");
             }
         }
-        $selected       = (int) $this->askWithValidation('selected', "Canonical field (1-$offset)", ['required', 'integer', "between:1,$offset"], 1);
+        $selected = (int) $this->askWithValidation('selected', "Canonical field (1-$offset)", ['required', 'integer', "between:1,$offset"], 1);
         $canonicalField = $fieldNames[$selected - 1];
 
         try {
@@ -114,7 +114,7 @@ class MakePublicationTypeCommand extends ValidatingCommand implements CommandHan
             $field = Collection::create();
             do {
                 $field->name = trim($this->askWithValidation('name', 'Field name', ['required']));
-                $duplicate   = $fields->where('name', $field->name)->count();
+                $duplicate = $fields->where('name', $field->name)->count();
                 if ($duplicate) {
                     $this->error("Field name [$field->name] already exists!");
                 }
@@ -135,14 +135,14 @@ class MakePublicationTypeCommand extends ValidatingCommand implements CommandHan
 
             if ($type < 10) {
                 do {
-                    $field->min   = trim($this->askWithValidation('min', 'Min value (for strings, this refers to string length)', ['required', 'string'], 0));
-                    $field->max   = trim($this->askWithValidation('max', 'Max value (for strings, this refers to string length)', ['required', 'string'], 0));
+                    $field->min = trim($this->askWithValidation('min', 'Min value (for strings, this refers to string length)', ['required', 'string'], 0));
+                    $field->max = trim($this->askWithValidation('max', 'Max value (for strings, this refers to string length)', ['required', 'string'], 0));
                     $lengthsValid = true;
                     if ($field->max < $field->min) {
                         $lengthsValid = false;
                         $this->output->warning('Field length [max] must be [>=] than [min]');
                     }
-                } while (!$lengthsValid);
+                } while (! $lengthsValid);
             } else {
                 $allTags = PublicationService::getAllTags();
                 $offset = 1;
@@ -151,10 +151,10 @@ class MakePublicationTypeCommand extends ValidatingCommand implements CommandHan
                     $offset++;
                 }
                 $offset--; // The above loop overcounts by 1
-                $selected        = $this->askWithValidation('tagGroup', 'Tag Group', ['required', 'integer', "between:1,$offset"], 0);
+                $selected = $this->askWithValidation('tagGroup', 'Tag Group', ['required', 'integer', "between:1,$offset"], 0);
                 $field->tagGroup = $allTags->keys()->{$selected - 1};
-                $field->min      = 0;
-                $field->max      = 0;
+                $field->min = 0;
+                $field->max = 0;
             }
             $addAnother = $this->askWithValidation('addAnother', '<bg=magenta;fg=white>Add another field (y/n)</>', ['required', 'string', 'in:y,n'], 'y');
 

--- a/packages/framework/src/Console/Commands/MakePublicationTypeCommand.php
+++ b/packages/framework/src/Console/Commands/MakePublicationTypeCommand.php
@@ -135,11 +135,6 @@ class MakePublicationTypeCommand extends ValidatingCommand implements CommandHan
 
             if ($type < 10) {
                 do {
-                    // TODO This should only be done for types that can have length restrictions right?
-                    // ANSWER: No, it can also be a value restriction
-                    // - (int: 0 - 2022)
-                    // - (float: 0 - 360)
-                    // - (datetime: 2022-01-01 - 2022-12-31)
                     $field->min   = trim($this->askWithValidation('min', 'Min value (for strings, this refers to string length)', ['required', 'string'], 0));
                     $field->max   = trim($this->askWithValidation('max', 'Max value (for strings, this refers to string length)', ['required', 'string'], 0));
                     $lengthsValid = true;

--- a/packages/framework/src/Console/Concerns/ValidatingCommand.php
+++ b/packages/framework/src/Console/Concerns/ValidatingCommand.php
@@ -64,7 +64,12 @@ class ValidatingCommand extends Command
         mixed $default = null,
         int $retryCount = 0
     ): mixed {
-        $answer = $this->ask(ucfirst($question), $default);
+        if ($retryCount >= self::MAX_RETRIES) {
+            // Prevent infinite loops that may happen, for example when testing. The retry count is high enough to not affect normal usage.
+            throw new RuntimeException(sprintf("Too many validation errors trying to validate '$name' with rules: [%s]", implode(', ', $rules)));
+        }
+
+        $answer = trim($this->ask(ucfirst($question), $default));
         $validator = Validator::make([$name => $answer], [$name => $rules]);
 
         if ($validator->passes()) {
@@ -75,14 +80,7 @@ class ValidatingCommand extends Command
             $this->error($this->translate($name, $error));
         }
 
-        $retryCount++;
-
-        if ($retryCount >= self::MAX_RETRIES) {
-            // Prevent infinite loops that may happen, for example when testing. The retry count is high enough to not affect normal usage.
-            throw new RuntimeException(sprintf("Too many validation errors trying to validate '$name' with rules: [%s]", implode(', ', $rules)));
-        }
-
-        return $this->askWithValidation($name, $question, $rules, $default, $retryCount);
+        return $this->askWithValidation($name, $question, $rules, $default, $retryCount+1);
     }
 
     /**

--- a/packages/framework/src/Console/Concerns/ValidatingCommand.php
+++ b/packages/framework/src/Console/Concerns/ValidatingCommand.php
@@ -80,7 +80,7 @@ class ValidatingCommand extends Command
             $this->error($this->translate($name, $error));
         }
 
-        return $this->askWithValidation($name, $question, $rules, $default, $retryCount+1);
+        return $this->askWithValidation($name, $question, $rules, $default, $retryCount + 1);
     }
 
     /**

--- a/packages/framework/src/Console/Concerns/ValidatingCommand.php
+++ b/packages/framework/src/Console/Concerns/ValidatingCommand.php
@@ -63,7 +63,7 @@ class ValidatingCommand extends Command
         array $rules = [],
         mixed $default = null,
         int $retryCount = 0
-    ): mixed {
+    ): string {
         if ($retryCount >= self::MAX_RETRIES) {
             // Prevent infinite loops that may happen, for example when testing. The retry count is high enough to not affect normal usage.
             throw new RuntimeException(sprintf("Too many validation errors trying to validate '$name' with rules: [%s]", implode(', ', $rules)));

--- a/packages/framework/src/Console/Concerns/ValidatingCommand.php
+++ b/packages/framework/src/Console/Concerns/ValidatingCommand.php
@@ -69,7 +69,7 @@ class ValidatingCommand extends Command
             throw new RuntimeException(sprintf("Too many validation errors trying to validate '$name' with rules: [%s]", implode(', ', $rules)));
         }
 
-        $answer = trim($this->ask(ucfirst($question), $default));
+        $answer = trim((string) $this->ask(ucfirst($question), $default));
         $validator = Validator::make([$name => $answer], [$name => $rules]);
 
         if ($validator->passes()) {

--- a/packages/framework/src/Console/HydeConsoleServiceProvider.php
+++ b/packages/framework/src/Console/HydeConsoleServiceProvider.php
@@ -26,6 +26,7 @@ class HydeConsoleServiceProvider extends ServiceProvider
 
                 Commands\MakePageCommand::class,
                 Commands\MakePostCommand::class,
+                Commands\MakePublicationTagCommand::class,
                 Commands\MakePublicationTypeCommand::class,
                 Commands\MakePublicationCommand::class,
 

--- a/packages/framework/src/Framework/Features/Publications/Models/PublicationFieldType.php
+++ b/packages/framework/src/Framework/Features/Publications/Models/PublicationFieldType.php
@@ -29,8 +29,8 @@ class PublicationFieldType implements SerializableContract
     ];
 
     public readonly string $type;
-    public readonly string $max; // FIXME: should not be null, default = 0?
-    public readonly string $min; // FIXME: should not be null, default = 0?
+    public readonly string $max;
+    public readonly string $min;
     public readonly string $name;
     public readonly ?string $tagGroup;
 

--- a/packages/framework/src/Framework/Features/Publications/Models/PublicationFieldType.php
+++ b/packages/framework/src/Framework/Features/Publications/Models/PublicationFieldType.php
@@ -43,8 +43,8 @@ class PublicationFieldType implements SerializableContract
     {
         $this->type = strtolower($type);
         $this->name = Str::kebab($name);
-        $this->min = (string)$min; // FIXME: should always be string, loose comparison will also work on numeric datatypes
-        $this->max = (string)$max; // FIXME: should always be string, loose comparison will also work on numeric datatypes
+        $this->min = (string)$min;
+        $this->max = (string)$max;
         $this->tagGroup = $tagGroup;
 
         if (! in_array(strtolower($type), self::TYPES)) {

--- a/packages/framework/src/Framework/Features/Publications/Models/PublicationFieldType.php
+++ b/packages/framework/src/Framework/Features/Publications/Models/PublicationFieldType.php
@@ -17,7 +17,7 @@ class PublicationFieldType implements SerializableContract
 {
     use Serializable;
 
-    public final const TYPES = ['string', 'boolean', 'integer', 'float', 'datetime', 'url', 'array', 'text', 'image'];
+    public final const TYPES = ['string', 'boolean', 'integer', 'float', 'datetime', 'url', 'array', 'text', 'image', 'tag'];
     public final const DEFAULT_RULES = [
         'string'   => ['required', 'string', 'between'],
         'boolean'  => ['required', 'boolean'],
@@ -29,27 +29,29 @@ class PublicationFieldType implements SerializableContract
     ];
 
     public readonly string $type;
-    public readonly ?int $max;
-    public readonly ?int $min;
+    public readonly string $max; // FIXME: needs to be string (dates, etc), should not be null, default = 0?
+    public readonly string $min; // FIXME: needs to be string (dates, etc), should not be null, default = 0?
     public readonly string $name;
+    public readonly ?string $tagGroup;
 
     public static function fromArray(array $array): static
     {
         return new static(...$array);
     }
 
-    public function __construct(string $type, string $name, int|string|null $min, int|string|null $max)
+    public function __construct(string $type, string $name, int|string|null $min, int|string|null $max, ?string $tagGroup=null)
     {
         $this->type = strtolower($type);
         $this->name = Str::kebab($name);
-        $this->min = $this->parseInt($min);
-        $this->max = $this->parseInt($max);
+        $this->min = (string)$min; // FIXME: should always be string, loose comparison will also work on numeric datatypes
+        $this->max = (string)$max; // FIXME: should always be string, loose comparison will also work on numeric datatypes
+        $this->tagGroup = $tagGroup;
 
         if (! in_array(strtolower($type), self::TYPES)) {
             throw new InvalidArgumentException(sprintf("The type '$type' is not a valid type. Valid types are: %s.", implode(', ', self::TYPES)));
         }
 
-        if (($min !== null) && ($max !== null) && $max < $min) {
+        if ($max < $min) {
             throw new InvalidArgumentException("The 'max' value cannot be less than the 'min' value.");
         }
     }

--- a/packages/framework/src/Framework/Features/Publications/Models/PublicationFieldType.php
+++ b/packages/framework/src/Framework/Features/Publications/Models/PublicationFieldType.php
@@ -39,12 +39,12 @@ class PublicationFieldType implements SerializableContract
         return new static(...$array);
     }
 
-    public function __construct(string $type, string $name, int|string|null $min, int|string|null $max, ?string $tagGroup=null)
+    public function __construct(string $type, string $name, int|string|null $min, int|string|null $max, ?string $tagGroup = null)
     {
         $this->type = strtolower($type);
         $this->name = Str::kebab($name);
-        $this->min = (string)$min;
-        $this->max = (string)$max;
+        $this->min = (string) $min;
+        $this->max = (string) $max;
         $this->tagGroup = $tagGroup;
 
         if (! in_array(strtolower($type), self::TYPES)) {

--- a/packages/framework/src/Framework/Features/Publications/Models/PublicationFieldType.php
+++ b/packages/framework/src/Framework/Features/Publications/Models/PublicationFieldType.php
@@ -29,8 +29,8 @@ class PublicationFieldType implements SerializableContract
     ];
 
     public readonly string $type;
-    public readonly string $max; // FIXME: needs to be string (dates, etc), should not be null, default = 0?
-    public readonly string $min; // FIXME: needs to be string (dates, etc), should not be null, default = 0?
+    public readonly string $max; // FIXME: should not be null, default = 0?
+    public readonly string $min; // FIXME: should not be null, default = 0?
     public readonly string $name;
     public readonly ?string $tagGroup;
 

--- a/packages/framework/src/Framework/Features/Publications/PublicationService.php
+++ b/packages/framework/src/Framework/Features/Publications/PublicationService.php
@@ -12,10 +12,10 @@ use Hyde\Hyde;
 use Hyde\Pages\PublicationPage;
 use Illuminate\Support\Str;
 use Rgasch\Collection\Collection;
-use Spatie\YamlFrontMatter\YamlFrontMatter;
 use function Safe\file_get_contents;
 use function Safe\glob;
 use function Safe\json_decode;
+use Spatie\YamlFrontMatter\YamlFrontMatter;
 
 /**
  * @see \Hyde\Framework\Testing\Feature\Services\PublicationServiceTest
@@ -26,13 +26,14 @@ class PublicationService
      * Get all available/tags.
      *
      * @return \Rgasch\Collection\Collection
+     *
      * @throws \Safe\Exceptions\FilesystemException
      * @throws \Safe\Exceptions\JsonException
      */
     public static function getAllTags(): Collection
     {
         $filename = Hyde::pathToRelative('tags.json');
-        if (!file_exists($filename)) {
+        if (! file_exists($filename)) {
             return Collection::create();
         }
 
@@ -78,9 +79,10 @@ class PublicationService
     /**
      * Get all values for a given tag name.
      *
-     * @param string $tagName
-     * @param \Hyde\Framework\Features\Publications\Models\PublicationType $publicationType
+     * @param  string  $tagName
+     * @param  \Hyde\Framework\Features\Publications\Models\PublicationType  $publicationType
      * @return \Rgasch\Collection\Collection|null
+     *
      * @throws \Safe\Exceptions\FilesystemException
      * @throws \Safe\Exceptions\JsonException
      */

--- a/packages/framework/tests/Feature/Commands/MakePublicationTypeCommandTest.php
+++ b/packages/framework/tests/Feature/Commands/MakePublicationTypeCommandTest.php
@@ -19,7 +19,7 @@ class MakePublicationTypeCommandTest extends TestCase
         $this->artisan('make:publicationType')
             ->expectsQuestion('Publication type name', 'Test Publication')
             ->expectsQuestion('Field name', 'Title')
-            ->expectsQuestion('Field type (1-9)', 1)
+            ->expectsQuestion('Field type (1-10)', 1)
             ->expectsQuestion('Min value (for strings, this refers to string length)', 'default')
             ->expectsQuestion('Max value (for strings, this refers to string length)', 'default')
             ->expectsQuestion('Add another field (y/n)', 'n')

--- a/packages/framework/tests/Feature/Commands/MakePublicationTypeCommandTest.php
+++ b/packages/framework/tests/Feature/Commands/MakePublicationTypeCommandTest.php
@@ -22,7 +22,7 @@ class MakePublicationTypeCommandTest extends TestCase
             ->expectsQuestion('Field type (1-10)', 1)
             ->expectsQuestion('Min value (for strings, this refers to string length)', 'default')
             ->expectsQuestion('Max value (for strings, this refers to string length)', 'default')
-            ->expectsQuestion('Add another field (y/n)', 'n')
+            ->expectsQuestion('<bg=magenta;fg=white>Add another field (y/n)</>', 'n')
             ->expectsQuestion('Sort field (0-1)', 0)
             ->expectsQuestion('Sort field (1-2)', 1)
             ->expectsQuestion('Enter the pageSize (0 for no limit)', 10)

--- a/packages/framework/tests/Feature/PublicationFieldTypeTest.php
+++ b/packages/framework/tests/Feature/PublicationFieldTypeTest.php
@@ -20,8 +20,8 @@ class PublicationFieldTypeTest extends TestCase
 
         $this->assertSame('string', $field->type);
         $this->assertSame('test', $field->name);
-        $this->assertSame(1, $field->min);
-        $this->assertSame(10, $field->max);
+        $this->assertSame('1', $field->min);
+        $this->assertSame('10', $field->max);
     }
 
     public function test_from_array_method()
@@ -29,16 +29,16 @@ class PublicationFieldTypeTest extends TestCase
         $field = PublicationFieldType::fromArray([
             'type' => 'string',
             'name' => 'test',
-            'min'  => 1,
-            'max'  => 10,
+            'min'  => '1',
+            'max'  => '10',
         ]);
 
         $this->assertInstanceOf(PublicationFieldType::class, $field);
 
         $this->assertSame('string', $field->type);
         $this->assertSame('test', $field->name);
-        $this->assertSame(1, $field->min);
-        $this->assertSame(10, $field->max);
+        $this->assertSame('1', $field->min);
+        $this->assertSame('10', $field->max);
     }
 
     public function test_can_get_field_as_array()
@@ -46,21 +46,21 @@ class PublicationFieldTypeTest extends TestCase
         $this->assertSame([
             'type' => 'string',
             'name' => 'test',
-            'min'  => 1,
-            'max'  => 10,
+            'min'  => '1',
+            'max'  => '10',
         ], $this->makeField()->toArray());
     }
 
     public function test_can_encode_field_as_json()
     {
-        $this->assertSame('{"type":"string","name":"test","min":1,"max":10}', json_encode($this->makeField()));
+        $this->assertSame('{"type":"string","name":"test","min":"1","max":"10"}', json_encode($this->makeField()));
     }
 
-    public function test_range_values_can_be_null()
+    public function test_null_range_values_are_cast_to_empty_string()
     {
         $field = new PublicationFieldType('string', 'test', null, null);
-        $this->assertNull($field->min);
-        $this->assertNull($field->max);
+        $this->assertSame('', $field->min);
+        $this->assertSame('', $field->max);
     }
 
     public function test_max_value_cannot_be_less_than_min_value()
@@ -68,14 +68,14 @@ class PublicationFieldTypeTest extends TestCase
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage("The 'max' value cannot be less than the 'min' value.");
 
-        new PublicationFieldType('string', 'test', 10, 1);
+        new PublicationFieldType('string', 'test', '10', '1');
     }
 
     public function test_integers_can_be_added_as_strings()
     {
-        $field = new PublicationFieldType('string', 'test', 1, '10');
-        $this->assertSame(1, $field->min);
-        $this->assertSame(10, $field->max);
+        $field = new PublicationFieldType('string', 'test', '1', '10');
+        $this->assertSame('1', $field->min);
+        $this->assertSame('10', $field->max);
     }
 
     public function test_type_must_be_valid()
@@ -83,18 +83,18 @@ class PublicationFieldTypeTest extends TestCase
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage("The type 'invalid' is not a valid type. Valid types are: string, boolean, integer, float, datetime, url, array, text, image, tag.");
 
-        new PublicationFieldType('invalid', 'test', 1, 10);
+        new PublicationFieldType('invalid', 'test', '1', '10');
     }
 
     public function test_type_input_is_case_insensitive()
     {
-        $field = new PublicationFieldType('STRING', 'test', 1, 10);
+        $field = new PublicationFieldType('STRING', 'test', '1', '10');
         $this->assertSame('string', $field->type);
     }
 
     public function test_name_gets_stored_as_kebab_case()
     {
-        $field = new PublicationFieldType('string', 'Test Field', 1, 10);
+        $field = new PublicationFieldType('string', 'Test Field', '1', '10');
         $this->assertSame('test-field', $field->name);
     }
 
@@ -110,6 +110,6 @@ class PublicationFieldTypeTest extends TestCase
 
     protected function makeField(): PublicationFieldType
     {
-        return new PublicationFieldType('string', 'test', 1, 10);
+        return new PublicationFieldType('string', 'test', 1, '10');
     }
 }

--- a/packages/framework/tests/Feature/PublicationFieldTypeTest.php
+++ b/packages/framework/tests/Feature/PublicationFieldTypeTest.php
@@ -81,7 +81,7 @@ class PublicationFieldTypeTest extends TestCase
     public function test_type_must_be_valid()
     {
         $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage("The type 'invalid' is not a valid type. Valid types are: string, boolean, integer, float, datetime, url, array, text, image.");
+        $this->expectExceptionMessage("The type 'invalid' is not a valid type. Valid types are: string, boolean, integer, float, datetime, url, array, text, image, tag.");
 
         new PublicationFieldType('invalid', 'test', 1, 10);
     }
@@ -105,7 +105,7 @@ class PublicationFieldTypeTest extends TestCase
 
     public function test_types_constant()
     {
-        $this->assertSame(['string', 'boolean', 'integer', 'float', 'datetime', 'url', 'array', 'text', 'image'], PublicationFieldType::TYPES);
+        $this->assertSame(['string', 'boolean', 'integer', 'float', 'datetime', 'url', 'array', 'text', 'image', 'tag'], PublicationFieldType::TYPES);
     }
 
     protected function makeField(): PublicationFieldType


### PR DESCRIPTION
Mainly it includes the new tag feature, but also some other minor improvements such as: 

1) Use trim() on input where appropriate
2) Changed min/max types to string, this makes sense because it could be a datetime or A-Z or something like that
3) Simplified the logic for MAX_RETRIES on the validation  checker for input, I think this version reads nicer than the original one (sidenote: this method doesn't really need to be recursive, it could also be done in a do...while loop)
4) Some other minor things


Please look for the string FIXME in the code, I used this to mark some things which I think you should review just to make sure. It should not be anything to fix, but just to review.


The new command is called makePublicationTag ... I called it "tag" because this is the most obvious use case, but it's basically the action of chosing an item from a list, doesn't have to be tag
This command creates (or adds to) a file called tags.json ... the fact that we now have another file in the root directory IMHO strengthens the case for the argument that all content files should be under a content directory


Also, fom the above paragraph you will deduce that tags are global. Yes they are ... initially I had a version which did both global and per-publication tags but the code got messy and there are some edge cases which appear which you deal with this configuration ... so the global version is much simpler (code wise) so this is what I opted for. I think this is OK because for most applications, you wont have like 50 tags, probably more like 5-10 max so this is OK
Give it a try and let me know what you think


Oh yes, I also added a check to make sure you can't add the same filename twice when defining a publication type