### PR TITLE
Internal: Update testing helpers

### DIFF
--- a/packages/framework/tests/Feature/StaticSiteServiceTest.php
+++ b/packages/framework/tests/Feature/StaticSiteServiceTest.php
@@ -60,15 +60,11 @@ class StaticSiteServiceTest extends TestCase
 
     public function test_build_command_transfers_media_asset_files_recursively()
     {
-        $path = Hyde::path('_media/foo/img.png');
-        @mkdir(dirname($path), recursive: true);
-        file_put_contents($path, 'foo');
+        $this->directory('_media/foo');
+
+        file_put_contents(Hyde::path('_media/foo/img.png'), 'foo');
         $this->artisan('build')->assertSuccessful();
         $this->assertFileEquals(Hyde::path('_media/foo/img.png'), Hyde::path('_site/media/foo/img.png'));
-        unlink(Hyde::path('_media/foo/img.png'));
-        rmdir(Hyde::path('_media/foo'));
-        unlink(Hyde::path('_site/media/foo/img.png'));
-        rmdir(Hyde::path('_site/media/foo'));
     }
 
     public function test_all_page_types_can_be_compiled()

--- a/packages/testing/src/TestCase.php
+++ b/packages/testing/src/TestCase.php
@@ -50,7 +50,11 @@ abstract class TestCase extends BaseTestCase
         if (sizeof($this->fileMemory) > 0) {
             foreach ($this->fileMemory as $file) {
                 if (Filesystem::isDirectory($file)) {
-                    Filesystem::deleteDirectory($file);
+                    $dontDelete = ['_site', '_media', '_pages', '_posts', '_docs', 'app', 'config', 'storage', 'vendor', 'node_modules'];
+
+                    if (! in_array($file, $dontDelete)) {
+                        Filesystem::deleteDirectory($file);
+                    }
                 } else {
                     Filesystem::unlink($file);
                 }

--- a/packages/testing/src/TestCase.php
+++ b/packages/testing/src/TestCase.php
@@ -47,20 +47,7 @@ abstract class TestCase extends BaseTestCase
      */
     protected function tearDown(): void
     {
-        if (sizeof($this->fileMemory) > 0) {
-            foreach ($this->fileMemory as $file) {
-                if (Filesystem::isDirectory($file)) {
-                    $dontDelete = ['_site', '_media', '_pages', '_posts', '_docs', 'app', 'config', 'storage', 'vendor', 'node_modules'];
-
-                    if (! in_array($file, $dontDelete)) {
-                        Filesystem::deleteDirectory($file);
-                    }
-                } else {
-                    Filesystem::unlink($file);
-                }
-            }
-            $this->fileMemory = [];
-        }
+        $this->cleanUpFilesystem();
 
         if (method_exists(\Illuminate\View\Component::class, 'flushCache')) {
             /** Until https://github.com/laravel/framework/pull/44648 makes its way into Laravel Zero, we need to clear the cache ourselves */
@@ -133,5 +120,23 @@ abstract class TestCase extends BaseTestCase
             strip_newlines($expected, true),
             strip_newlines($actual, true),
         );
+    }
+
+    protected function cleanUpFilesystem(): void
+    {
+        if (sizeof($this->fileMemory) > 0) {
+            foreach ($this->fileMemory as $file) {
+                if (Filesystem::isDirectory($file)) {
+                    $dontDelete = ['_site', '_media', '_pages', '_posts', '_docs', 'app', 'config', 'storage', 'vendor', 'node_modules'];
+
+                    if (!in_array($file, $dontDelete)) {
+                        Filesystem::deleteDirectory($file);
+                    }
+                } else {
+                    Filesystem::unlink($file);
+                }
+            }
+            $this->fileMemory = [];
+        }
     }
 }

--- a/packages/testing/src/TestCase.php
+++ b/packages/testing/src/TestCase.php
@@ -3,6 +3,7 @@
 namespace Hyde\Testing;
 
 use Hyde\Facades\Features;
+use Hyde\Facades\Filesystem;
 use Hyde\Framework\Actions\ConvertsArrayToFrontMatter;
 use Hyde\Hyde;
 use Hyde\Pages\Concerns\HydePage;
@@ -47,7 +48,13 @@ abstract class TestCase extends BaseTestCase
     protected function tearDown(): void
     {
         if (sizeof($this->fileMemory) > 0) {
-            Hyde::unlink($this->fileMemory);
+            foreach ($this->fileMemory as $file) {
+                if (Filesystem::isDirectory($file)) {
+                    Filesystem::deleteDirectory($file);
+                } else {
+                    Filesystem::unlink($file);
+                }
+            }
             $this->fileMemory = [];
         }
 
@@ -93,6 +100,17 @@ abstract class TestCase extends BaseTestCase
         } else {
             Hyde::touch($path);
         }
+
+        $this->fileMemory[] = $path;
+    }
+
+    /**
+     * Create a temporary directory in the project directory.
+     * The TestCase will automatically remove the entire directory when the test is completed.
+     */
+    protected function directory(string $path): void
+    {
+        Filesystem::makeDirectory($path, recursive: true, force: true);
 
         $this->fileMemory[] = $path;
     }

--- a/packages/testing/src/TestCase.php
+++ b/packages/testing/src/TestCase.php
@@ -92,7 +92,7 @@ abstract class TestCase extends BaseTestCase
             Hyde::touch($path);
         }
 
-        $this->fileMemory[] = $path;
+        $this->cleanUpWhenDone($path);
     }
 
     /**
@@ -103,7 +103,7 @@ abstract class TestCase extends BaseTestCase
     {
         Filesystem::makeDirectory($path, recursive: true, force: true);
 
-        $this->fileMemory[] = $path;
+        $this->cleanUpWhenDone($path);
     }
 
     /**
@@ -138,5 +138,13 @@ abstract class TestCase extends BaseTestCase
             }
             $this->fileMemory = [];
         }
+    }
+
+    /**
+     * Mark a path to be deleted when the test is completed.
+     */
+    protected function cleanUpWhenDone(string $path): void
+    {
+        $this->fileMemory[] = $path;
     }
 }

--- a/packages/testing/src/TestCase.php
+++ b/packages/testing/src/TestCase.php
@@ -129,7 +129,7 @@ abstract class TestCase extends BaseTestCase
                 if (Filesystem::isDirectory($file)) {
                     $dontDelete = ['_site', '_media', '_pages', '_posts', '_docs', 'app', 'config', 'storage', 'vendor', 'node_modules'];
 
-                    if (!in_array($file, $dontDelete)) {
+                    if (! in_array($file, $dontDelete)) {
                         Filesystem::deleteDirectory($file);
                     }
                 } else {

--- a/packages/testing/src/TestCase.php
+++ b/packages/testing/src/TestCase.php
@@ -61,6 +61,14 @@ abstract class TestCase extends BaseTestCase
         parent::tearDown();
     }
 
+    protected function assertEqualsIgnoringLineEndingType(string $expected, string $actual): void
+    {
+        $this->assertEquals(
+            strip_newlines($expected, true),
+            strip_newlines($actual, true),
+        );
+    }
+
     /** @internal */
     protected function mockRoute(?Route $route = null)
     {
@@ -112,14 +120,6 @@ abstract class TestCase extends BaseTestCase
     protected function markdown(string $path, string $contents = '', array $matter = []): void
     {
         $this->file($path, (new ConvertsArrayToFrontMatter())->execute($matter).$contents);
-    }
-
-    protected function assertEqualsIgnoringLineEndingType(string $expected, string $actual): void
-    {
-        $this->assertEquals(
-            strip_newlines($expected, true),
-            strip_newlines($actual, true),
-        );
     }
 
     protected function cleanUpFilesystem(): void

--- a/packages/testing/src/helpers.php
+++ b/packages/testing/src/helpers.php
@@ -39,6 +39,15 @@ if (! function_exists('deleteDirectory')) {
     }
 }
 
+if (! function_exists('makeDirectory')) {
+    function makeDirectory(string $directory): void
+    {
+        if (file_exists($directory)) {
+            File::makeDirectory($directory);
+        }
+    }
+}
+
 if (! function_exists('unlinkUnlessDefault')) {
     function unlinkUnlessDefault(string $filepath): void
     {


### PR DESCRIPTION
Adds a new testing helper to create temporary directories.

Here's an example of a test refactored to use this:

Before:
```php
{
    $path = Hyde::path('_media/foo/img.png');
    @mkdir(dirname($path), recursive: true);
    file_put_contents($path, 'foo');
    $this->artisan('build')->assertSuccessful();
    $this->assertFileEquals(Hyde::path('_media/foo/img.png'), Hyde::path('_site/media/foo/img.png'));
    unlink(Hyde::path('_media/foo/img.png'));
    rmdir(Hyde::path('_media/foo'));
    unlink(Hyde::path('_site/media/foo/img.png'));
    rmdir(Hyde::path('_site/media/foo'));
}
```

After:
```php
{
    $this->directory('_media/foo');
    $this->cleanUpWhenDone('_site/media/foo');
    file_put_contents(Hyde::path('_media/foo/img.png'), 'foo');
    $this->artisan('build')->assertSuccessful();
    $this->assertFileEquals(Hyde::path('_media/foo/img.png'), Hyde::path('_site/media/foo/img.png'));
}
```