### PR TITLE
Create render helper to canonicalize the schema for data passed to renders

### DIFF
--- a/packages/framework/src/Facades/Render.php
+++ b/packages/framework/src/Facades/Render.php
@@ -10,6 +10,7 @@ use Illuminate\Support\Facades\Facade;
  * Manages data for the current page being rendered/compiled.
  *
  * @see \Hyde\Support\Models\Render
+ * @mixin \Hyde\Support\Models\Render
  */
 class Render extends Facade
 {

--- a/packages/framework/src/Facades/Render.php
+++ b/packages/framework/src/Facades/Render.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Hyde\Facades;
+
+class Render
+{
+    //
+}

--- a/packages/framework/src/Facades/Render.php
+++ b/packages/framework/src/Facades/Render.php
@@ -4,6 +4,11 @@ declare(strict_types=1);
 
 namespace Hyde\Facades;
 
+/**
+ * Manages data for the current page being rendered/compiled.
+ *
+ * @see \Hyde\Support\Models\Render
+ */
 class Render
 {
     //

--- a/packages/framework/src/Facades/Render.php
+++ b/packages/framework/src/Facades/Render.php
@@ -4,12 +4,22 @@ declare(strict_types=1);
 
 namespace Hyde\Facades;
 
+use Hyde\Pages\Concerns\HydePage;
+use Hyde\Support\Models\Route;
 use Illuminate\Support\Facades\Facade;
 
 /**
  * Manages data for the current page being rendered/compiled.
  *
  * @see \Hyde\Support\Models\Render
+ *
+ * @method static void setPage(HydePage $page)
+ * @method static HydePage getPage()
+ * @method static Route getCurrentRoute()
+ * @method static string getCurrentPage()
+ * @method static void share(string $key, mixed $value)
+ * @method static mixed shared(string $key, mixed $default = null)
+ * @method static bool has(string $key)
  */
 class Render extends Facade
 {

--- a/packages/framework/src/Facades/Render.php
+++ b/packages/framework/src/Facades/Render.php
@@ -4,22 +4,12 @@ declare(strict_types=1);
 
 namespace Hyde\Facades;
 
-use Hyde\Pages\Concerns\HydePage;
-use Hyde\Support\Models\Route;
 use Illuminate\Support\Facades\Facade;
 
 /**
  * Manages data for the current page being rendered/compiled.
  *
  * @see \Hyde\Support\Models\Render
- *
- * @method static void setPage(HydePage $page)
- * @method static HydePage getPage()
- * @method static Route getCurrentRoute()
- * @method static string getCurrentPage()
- * @method static void share(string $key, mixed $value)
- * @method static mixed shared(string $key, mixed $default = null)
- * @method static bool has(string $key)
  */
 class Render extends Facade
 {

--- a/packages/framework/src/Facades/Render.php
+++ b/packages/framework/src/Facades/Render.php
@@ -4,12 +4,17 @@ declare(strict_types=1);
 
 namespace Hyde\Facades;
 
+use Illuminate\Support\Facades\Facade;
+
 /**
  * Manages data for the current page being rendered/compiled.
  *
  * @see \Hyde\Support\Models\Render
  */
-class Render
+class Render extends Facade
 {
-    //
+    protected static function getFacadeAccessor(): string
+    {
+        return \Hyde\Support\Models\Render::class;
+    }
 }

--- a/packages/framework/src/Foundation/Concerns/ManagesViewData.php
+++ b/packages/framework/src/Foundation/Concerns/ManagesViewData.php
@@ -21,7 +21,6 @@ trait ManagesViewData
     public function shareViewData(HydePage $page): void
     {
         Render::setPage($page);
-        Render::shareToView();
     }
 
     /**

--- a/packages/framework/src/Foundation/Concerns/ManagesViewData.php
+++ b/packages/framework/src/Foundation/Concerns/ManagesViewData.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Hyde\Foundation\Concerns;
 
 use Hyde\Pages\Concerns\HydePage;
+use Hyde\Support\Facades\Render;
 use Hyde\Support\Models\Route;
 use Illuminate\Support\Facades\View;
 
@@ -20,9 +21,8 @@ trait ManagesViewData
      */
     public function shareViewData(HydePage $page): void
     {
-        View::share('page', $page);
-        View::share('currentPage', $page->getRouteKey());
-        View::share('currentRoute', $page->getRoute());
+        Render::setPage($page);
+        Render::shareToView();
     }
 
     /**
@@ -30,7 +30,7 @@ trait ManagesViewData
      */
     public function currentPage(): ?string
     {
-        return View::shared('currentPage');
+        return Render::getCurrentPage();
     }
 
     /**
@@ -38,6 +38,6 @@ trait ManagesViewData
      */
     public function currentRoute(): ?Route
     {
-        return View::shared('currentRoute');
+        return Render::getCurrentRoute();
     }
 }

--- a/packages/framework/src/Foundation/Concerns/ManagesViewData.php
+++ b/packages/framework/src/Foundation/Concerns/ManagesViewData.php
@@ -11,9 +11,6 @@ use Illuminate\Support\Facades\View;
 /**
  * @internal Single-use trait for the HydeKernel class.
  *
- * @todo Consider if this logic is better suited for a "Render" class solely for handling data related to the current render.
- *       This could then also have a proper schema for the defined data so it can be type-hinted.
- *
  * @see \Hyde\Foundation\HydeKernel
  */
 trait ManagesViewData

--- a/packages/framework/src/Support/Facades/Render.php
+++ b/packages/framework/src/Support/Facades/Render.php
@@ -10,7 +10,6 @@ use Illuminate\Support\Facades\Facade;
  * Manages data for the current page being rendered/compiled.
  *
  * @see \Hyde\Support\Models\Render
- * @mixin \Hyde\Support\Models\Render
  */
 class Render extends Facade
 {

--- a/packages/framework/src/Support/Facades/Render.php
+++ b/packages/framework/src/Support/Facades/Render.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Hyde\Facades;
+namespace Hyde\Support\Facades;
 
 use Illuminate\Support\Facades\Facade;
 

--- a/packages/framework/src/Support/Facades/Render.php
+++ b/packages/framework/src/Support/Facades/Render.php
@@ -4,12 +4,22 @@ declare(strict_types=1);
 
 namespace Hyde\Support\Facades;
 
+use Hyde\Pages\Concerns\HydePage;
+use Hyde\Support\Models\Route;
 use Illuminate\Support\Facades\Facade;
 
 /**
  * Manages data for the current page being rendered/compiled.
  *
  * @see \Hyde\Support\Models\Render
+ *
+ * @method static void setPage(HydePage $page)
+ * @method static HydePage getPage()
+ * @method static Route getCurrentRoute()
+ * @method static string getCurrentPage()
+ * @method static void share(string $key, mixed $value)
+ * @method static mixed shared(string $key, mixed $default = null)
+ * @method static bool has(string $key)
  */
 class Render extends Facade
 {

--- a/packages/framework/src/Support/Facades/Render.php
+++ b/packages/framework/src/Support/Facades/Render.php
@@ -14,12 +14,12 @@ use Illuminate\Support\Facades\Facade;
  * @see \Hyde\Support\Models\Render
  *
  * @method static void setPage(HydePage $page)
- * @method static HydePage getPage()
- * @method static Route getCurrentRoute()
- * @method static string getCurrentPage()
+ * @method static HydePage|null getPage()
+ * @method static Route|null getCurrentRoute()
+ * @method static string|null getCurrentPage()
  * @method static void share(string $key, mixed $value)
- * @method static mixed shared(string $key, mixed $default = null)
- * @method static bool has(string $key)
+ * @method static void shareToView()
+ * @method static void clearData()
  */
 class Render extends Facade
 {

--- a/packages/framework/src/Support/Models/Render.php
+++ b/packages/framework/src/Support/Models/Render.php
@@ -73,6 +73,7 @@ class Render implements Arrayable
     public function toArray(): array
     {
         return [
+            'render' => $this,
             'page' => $this->getPage(),
             'currentRoute' => $this->getCurrentRoute(),
             'currentPage' => $this->getCurrentPage(),

--- a/packages/framework/src/Support/Models/Render.php
+++ b/packages/framework/src/Support/Models/Render.php
@@ -30,6 +30,8 @@ class Render implements Arrayable
         $this->page = $page;
         $this->currentRoute = $page->getRoute();
         $this->currentPage = $page->getRouteKey();
+
+        $this->shareToView();
     }
 
     public function getPage(): ?HydePage

--- a/packages/framework/src/Support/Models/Render.php
+++ b/packages/framework/src/Support/Models/Render.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Hyde\Support\Models;
+
+class Render
+{
+    //
+}

--- a/packages/framework/src/Support/Models/Render.php
+++ b/packages/framework/src/Support/Models/Render.php
@@ -51,6 +51,13 @@ class Render implements Arrayable
         View::share($this->toArray());
     }
 
+    public function share(string $key, mixed $value): void
+    {
+        if (property_exists($this, $key)) {
+            $this->{$key} = $value;
+        }
+    }
+
     public function clearData(): void
     {
         unset($this->page, $this->currentRoute, $this->currentPage);

--- a/packages/framework/src/Support/Models/Render.php
+++ b/packages/framework/src/Support/Models/Render.php
@@ -14,6 +14,7 @@ use Hyde\Pages\Concerns\HydePage;
  * @see \Hyde\Framework\Testing\Feature\RenderHelperTest
  *
  * @todo Refactor into singleton and add facade
+ * @todo Refactor to actually utilize this class
  */
 class Render
 {

--- a/packages/framework/src/Support/Models/Render.php
+++ b/packages/framework/src/Support/Models/Render.php
@@ -65,8 +65,8 @@ class Render
 
     public static function shareToView(): void
     {
-        View::share('page', static::$page);
-        View::share('currentRoute', static::$currentRoute);
-        View::share('currentPage', static::$currentPage);
+        View::share('page', static::getPage());
+        View::share('currentRoute', static::getCurrentRoute());
+        View::share('currentPage', static::getCurrentPage());
     }
 }

--- a/packages/framework/src/Support/Models/Render.php
+++ b/packages/framework/src/Support/Models/Render.php
@@ -4,6 +4,9 @@ declare(strict_types=1);
 
 namespace Hyde\Support\Models;
 
+/**
+ * @see \Hyde\Framework\Testing\Feature\RenderHelperTest
+ */
 class Render
 {
     //

--- a/packages/framework/src/Support/Models/Render.php
+++ b/packages/framework/src/Support/Models/Render.php
@@ -66,8 +66,6 @@ class Render implements Arrayable
     {
         unset($this->page, $this->currentRoute, $this->currentPage);
         View::share(['page' => null, 'currentRoute' => null, 'currentPage' => null]);
-
-        // TODO: Can be used when fallback is removed: View::share($this->toArray());
     }
 
     public function toArray(): array

--- a/packages/framework/src/Support/Models/Render.php
+++ b/packages/framework/src/Support/Models/Render.php
@@ -12,6 +12,8 @@ use Hyde\Pages\Concerns\HydePage;
  * All public data here will be available in the Blade views through @see ManagesViewData::shareViewData().
  *
  * @see \Hyde\Framework\Testing\Feature\RenderHelperTest
+ *
+ * @todo Refactor into singleton and add facade
  */
 class Render
 {

--- a/packages/framework/src/Support/Models/Render.php
+++ b/packages/framework/src/Support/Models/Render.php
@@ -15,7 +15,6 @@ use Illuminate\Support\Facades\View;
  * @see \Hyde\Support\Facades\Render
  * @see \Hyde\Framework\Testing\Feature\RenderHelperTest
  *
- * @todo Refactor into singleton and add facade
  * @todo Refactor to actually utilize this class
  */
 class Render

--- a/packages/framework/src/Support/Models/Render.php
+++ b/packages/framework/src/Support/Models/Render.php
@@ -7,6 +7,7 @@ namespace Hyde\Support\Models;
 use Hyde\Pages\Concerns\HydePage;
 use Illuminate\Contracts\Support\Arrayable;
 use Illuminate\Support\Facades\View;
+use InvalidArgumentException;
 
 /**
  * Contains data for the current page being rendered/compiled.
@@ -55,6 +56,8 @@ class Render implements Arrayable
     {
         if (property_exists($this, $key)) {
             $this->{$key} = $value;
+        } else {
+            throw new InvalidArgumentException("Property '$key' does not exist on " . self::class);
         }
     }
 

--- a/packages/framework/src/Support/Models/Render.php
+++ b/packages/framework/src/Support/Models/Render.php
@@ -74,7 +74,7 @@ class Render implements Arrayable
         $shared = View::shared($property);
 
         if ($shared !== null) {
-            trigger_error('Setting page rendering data via the view facade is deprecated. Use the Render model/facade instead.', E_USER_DEPRECATED);
+            trigger_error('Setting page rendering data via the view facade is deprecated. Use the Render model/facade instead.', E_USER_ERROR);
         }
 
         return $shared;

--- a/packages/framework/src/Support/Models/Render.php
+++ b/packages/framework/src/Support/Models/Render.php
@@ -18,4 +18,43 @@ class Render
     protected static HydePage $page;
     protected static Route $currentRoute;
     protected static string $currentPage;
+
+    protected static array $data = [];
+
+    public static function setPage(HydePage $page): void
+    {
+        static::$page = $page;
+        static::$currentRoute = $page->getRoute();
+        static::$currentPage = $page->getRouteKey();
+    }
+
+    public static function getPage(): HydePage
+    {
+        return static::$page;
+    }
+
+    public static function getCurrentRoute(): Route
+    {
+        return static::$currentRoute;
+    }
+
+    public static function getCurrentPage(): string
+    {
+        return static::$currentPage;
+    }
+
+    public static function share(string $key, mixed $value): void
+    {
+        static::$data[$key] = $value;
+    }
+
+    public static function shared(string $key, mixed $default = null): mixed
+    {
+        return static::$data[$key] ?? $default;
+    }
+
+    public static function has(string $key): bool
+    {
+        return isset(static::$data[$key]);
+    }
 }

--- a/packages/framework/src/Support/Models/Render.php
+++ b/packages/framework/src/Support/Models/Render.php
@@ -55,6 +55,9 @@ class Render
     public function clearData(): void
     {
         unset($this->page, $this->currentRoute, $this->currentPage);
+        View::share('page');
+        View::share('currentRoute');
+        View::share('currentPage');
     }
 
     /** @codeCoverageIgnore */

--- a/packages/framework/src/Support/Models/Render.php
+++ b/packages/framework/src/Support/Models/Render.php
@@ -79,12 +79,12 @@ class Render implements Arrayable
     }
 
     /** @codeCoverageIgnore */
-    protected function handleFallback(string $property): mixed
+    protected static function handleFallback(string $property): mixed
     {
         $shared = View::shared($property);
 
         if ($shared !== null) {
-            $this->{$property} = $shared;
+            trigger_error("Setting page rendering data via the view facade is deprecated. Use `Render::share('$property', \$value)` instead", E_USER_ERROR);
         }
 
         return $shared;

--- a/packages/framework/src/Support/Models/Render.php
+++ b/packages/framework/src/Support/Models/Render.php
@@ -55,6 +55,8 @@ class Render implements Arrayable
     {
         unset($this->page, $this->currentRoute, $this->currentPage);
         View::share(['page' => null, 'currentRoute' => null, 'currentPage' => null]);
+
+        // TODO: Can be used when fallback is removed: View::share($this->toArray());
     }
 
     public function toArray(): array

--- a/packages/framework/src/Support/Models/Render.php
+++ b/packages/framework/src/Support/Models/Render.php
@@ -54,7 +54,7 @@ class Render
 
     public function clearData(): void
     {
-        // TODO
+        unset($this->page, $this->currentRoute, $this->currentPage);
     }
 
     /** @codeCoverageIgnore */

--- a/packages/framework/src/Support/Models/Render.php
+++ b/packages/framework/src/Support/Models/Render.php
@@ -35,17 +35,17 @@ class Render
 
     public static function getPage(): ?HydePage
     {
-        return static::$page ?? View::shared('page');
+        return static::$page ?? self::handleFallback('page');
     }
 
     public static function getCurrentRoute(): ?Route
     {
-        return static::$currentRoute ?? View::shared('currentRoute');
+        return static::$currentRoute ?? self::handleFallback('currentRoute');
     }
 
     public static function getCurrentPage(): ?string
     {
-        return static::$currentPage ?? View::shared('currentPage');
+        return static::$currentPage ?? self::handleFallback('currentPage');
     }
 
     public static function share(string $key, mixed $value): void
@@ -68,5 +68,17 @@ class Render
         View::share('page', static::getPage());
         View::share('currentRoute', static::getCurrentRoute());
         View::share('currentPage', static::getCurrentPage());
+    }
+
+    /** @codeCoverageIgnore */
+    protected static function handleFallback(string $property): mixed
+    {
+        $shared = View::shared($property);
+
+        if ($shared !== null) {
+            trigger_error("Setting page rendering data via the view facade is deprecated. Use the Render model/facade instead.", E_USER_DEPRECATED);
+        }
+
+        return $shared;
     }
 }

--- a/packages/framework/src/Support/Models/Render.php
+++ b/packages/framework/src/Support/Models/Render.php
@@ -16,8 +16,6 @@ use InvalidArgumentException;
  *
  * @see \Hyde\Support\Facades\Render
  * @see \Hyde\Framework\Testing\Feature\RenderHelperTest
- *
- * @todo Refactor to actually utilize this class
  */
 class Render implements Arrayable
 {

--- a/packages/framework/src/Support/Models/Render.php
+++ b/packages/framework/src/Support/Models/Render.php
@@ -35,17 +35,17 @@ class Render
 
     public static function getPage(): ?HydePage
     {
-        return static::$page ?? null;
+        return static::$page ?? View::shared('page');
     }
 
     public static function getCurrentRoute(): ?Route
     {
-        return static::$currentRoute ?? null;
+        return static::$currentRoute ?? View::shared('currentRoute');
     }
 
     public static function getCurrentPage(): ?string
     {
-        return static::$currentPage ?? null;
+        return static::$currentPage ?? View::shared('currentPage');
     }
 
     public static function share(string $key, mixed $value): void

--- a/packages/framework/src/Support/Models/Render.php
+++ b/packages/framework/src/Support/Models/Render.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Hyde\Support\Models;
 
 use Hyde\Pages\Concerns\HydePage;
+use Illuminate\Support\Facades\View;
 
 /**
  * Contains data for the current page being rendered/compiled.
@@ -64,6 +65,8 @@ class Render
 
     public static function shareToView(): void
     {
-        // TODO
+        View::share('page', static::$page);
+        View::share('currentRoute', static::$currentRoute);
+        View::share('currentPage', static::$currentPage);
     }
 }

--- a/packages/framework/src/Support/Models/Render.php
+++ b/packages/framework/src/Support/Models/Render.php
@@ -57,7 +57,7 @@ class Render implements Arrayable
         if (property_exists($this, $key)) {
             $this->{$key} = $value;
         } else {
-            throw new InvalidArgumentException("Property '$key' does not exist on " . self::class);
+            throw new InvalidArgumentException("Property '$key' does not exist on ".self::class);
         }
     }
 

--- a/packages/framework/src/Support/Models/Render.php
+++ b/packages/framework/src/Support/Models/Render.php
@@ -20,37 +20,42 @@ use Illuminate\Support\Facades\View;
  */
 class Render
 {
-    protected static HydePage $page;
-    protected static Route $currentRoute;
-    protected static string $currentPage;
+    protected HydePage $page;
+    protected Route $currentRoute;
+    protected string $currentPage;
 
-    public static function setPage(HydePage $page): void
+    public function setPage(HydePage $page): void
     {
-        static::$page = $page;
-        static::$currentRoute = $page->getRoute();
-        static::$currentPage = $page->getRouteKey();
+        $this->page = $page;
+        $this->currentRoute = $page->getRoute();
+        $this->currentPage = $page->getRouteKey();
     }
 
-    public static function getPage(): ?HydePage
+    public function getPage(): ?HydePage
     {
-        return static::$page ?? self::handleFallback('page');
+        return $this->page ?? self::handleFallback('page');
     }
 
-    public static function getCurrentRoute(): ?Route
+    public function getCurrentRoute(): ?Route
     {
-        return static::$currentRoute ?? self::handleFallback('currentRoute');
+        return $this->currentRoute ?? self::handleFallback('currentRoute');
     }
 
-    public static function getCurrentPage(): ?string
+    public function getCurrentPage(): ?string
     {
-        return static::$currentPage ?? self::handleFallback('currentPage');
+        return $this->currentPage ?? self::handleFallback('currentPage');
     }
 
-    public static function shareToView(): void
+    public function shareToView(): void
     {
-        View::share('page', static::getPage());
-        View::share('currentRoute', static::getCurrentRoute());
-        View::share('currentPage', static::getCurrentPage());
+        View::share('page', $this->getPage());
+        View::share('currentRoute', $this->getCurrentRoute());
+        View::share('currentPage', $this->getCurrentPage());
+    }
+
+    public function clearData(): void
+    {
+        // TODO
     }
 
     /** @codeCoverageIgnore */

--- a/packages/framework/src/Support/Models/Render.php
+++ b/packages/framework/src/Support/Models/Render.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Hyde\Support\Models;
 
+use Hyde\Pages\Concerns\HydePage;
+
 /**
  * Contains data for the current page being rendered/compiled.
  *
@@ -13,5 +15,7 @@ namespace Hyde\Support\Models;
  */
 class Render
 {
-    //
+    protected static HydePage $page;
+    protected static Route $currentRoute;
+    protected static string $currentPage;
 }

--- a/packages/framework/src/Support/Models/Render.php
+++ b/packages/framework/src/Support/Models/Render.php
@@ -32,19 +32,19 @@ class Render
         static::$currentPage = $page->getRouteKey();
     }
 
-    public static function getPage(): HydePage
+    public static function getPage(): ?HydePage
     {
-        return static::$page;
+        return static::$page ?? null;
     }
 
-    public static function getCurrentRoute(): Route
+    public static function getCurrentRoute(): ?Route
     {
-        return static::$currentRoute;
+        return static::$currentRoute ?? null;
     }
 
-    public static function getCurrentPage(): string
+    public static function getCurrentPage(): ?string
     {
-        return static::$currentPage;
+        return static::$currentPage ?? null;
     }
 
     public static function share(string $key, mixed $value): void

--- a/packages/framework/src/Support/Models/Render.php
+++ b/packages/framework/src/Support/Models/Render.php
@@ -24,8 +24,6 @@ class Render
     protected static Route $currentRoute;
     protected static string $currentPage;
 
-    protected static array $data = [];
-
     public static function setPage(HydePage $page): void
     {
         static::$page = $page;
@@ -46,21 +44,6 @@ class Render
     public static function getCurrentPage(): ?string
     {
         return static::$currentPage ?? self::handleFallback('currentPage');
-    }
-
-    public static function share(string $key, mixed $value): void
-    {
-        static::$data[$key] = $value;
-    }
-
-    public static function shared(string $key, mixed $default = null): mixed
-    {
-        return static::$data[$key] ?? $default;
-    }
-
-    public static function has(string $key): bool
-    {
-        return isset(static::$data[$key]);
     }
 
     public static function shareToView(): void

--- a/packages/framework/src/Support/Models/Render.php
+++ b/packages/framework/src/Support/Models/Render.php
@@ -79,12 +79,12 @@ class Render implements Arrayable
     }
 
     /** @codeCoverageIgnore */
-    protected static function handleFallback(string $property): mixed
+    protected function handleFallback(string $property): mixed
     {
         $shared = View::shared($property);
 
         if ($shared !== null) {
-            trigger_error("Setting page rendering data via the view facade is deprecated. Use `Render::share('$property', \$value)` instead", E_USER_ERROR);
+            $this->{$property} = $shared;
         }
 
         return $shared;

--- a/packages/framework/src/Support/Models/Render.php
+++ b/packages/framework/src/Support/Models/Render.php
@@ -47,17 +47,17 @@ class Render
 
     public function shareToView(): void
     {
-        View::share('page', $this->getPage());
-        View::share('currentRoute', $this->getCurrentRoute());
-        View::share('currentPage', $this->getCurrentPage());
+        View::share([
+            'page' => $this->getPage(),
+            'currentRoute' => $this->getCurrentRoute(),
+            'currentPage' => $this->getCurrentPage()
+        ]);
     }
 
     public function clearData(): void
     {
         unset($this->page, $this->currentRoute, $this->currentPage);
-        View::share('page');
-        View::share('currentRoute');
-        View::share('currentPage');
+        View::share(['page' => null, 'currentRoute' => null, 'currentPage' => null]);
     }
 
     /** @codeCoverageIgnore */

--- a/packages/framework/src/Support/Models/Render.php
+++ b/packages/framework/src/Support/Models/Render.php
@@ -11,7 +11,7 @@ use Hyde\Pages\Concerns\HydePage;
  *
  * All public data here will be available in the Blade views through @see ManagesViewData::shareViewData().
  *
- * @see \Hyde\Facades\Render
+ * @see \Hyde\Support\Facades\Render
  * @see \Hyde\Framework\Testing\Feature\RenderHelperTest
  *
  * @todo Refactor into singleton and add facade

--- a/packages/framework/src/Support/Models/Render.php
+++ b/packages/framework/src/Support/Models/Render.php
@@ -87,7 +87,7 @@ class Render implements Arrayable
         $shared = View::shared($property);
 
         if ($shared !== null) {
-            trigger_error("Setting page rendering data via the view facade is deprecated. Use `Render::share('$property', \$value)` instead", E_USER_ERROR);
+            trigger_error("Setting page rendering data via the view facade is deprecated. Use `Render::share('$property', \$value)` instead", E_USER_DEPRECATED);
         }
 
         return $shared;

--- a/packages/framework/src/Support/Models/Render.php
+++ b/packages/framework/src/Support/Models/Render.php
@@ -5,6 +5,10 @@ declare(strict_types=1);
 namespace Hyde\Support\Models;
 
 /**
+ * Contains data for the current page being rendered/compiled.
+ *
+ * All public data here will be available in the Blade views through @see ManagesViewData::shareViewData().
+ *
  * @see \Hyde\Framework\Testing\Feature\RenderHelperTest
  */
 class Render

--- a/packages/framework/src/Support/Models/Render.php
+++ b/packages/framework/src/Support/Models/Render.php
@@ -78,7 +78,10 @@ class Render implements Arrayable
         ];
     }
 
-    /** @codeCoverageIgnore */
+    /**
+     * @deprecated
+     * @codeCoverageIgnore
+     */
     protected static function handleFallback(string $property): mixed
     {
         $shared = View::shared($property);

--- a/packages/framework/src/Support/Models/Render.php
+++ b/packages/framework/src/Support/Models/Render.php
@@ -56,6 +56,7 @@ class Render implements Arrayable
     {
         if (property_exists($this, $key)) {
             $this->{$key} = $value;
+            $this->shareToView();
         } else {
             throw new InvalidArgumentException("Property '$key' does not exist on ".self::class);
         }

--- a/packages/framework/src/Support/Models/Render.php
+++ b/packages/framework/src/Support/Models/Render.php
@@ -11,6 +11,7 @@ use Hyde\Pages\Concerns\HydePage;
  *
  * All public data here will be available in the Blade views through @see ManagesViewData::shareViewData().
  *
+ * @see \Hyde\Facades\Render
  * @see \Hyde\Framework\Testing\Feature\RenderHelperTest
  *
  * @todo Refactor into singleton and add facade

--- a/packages/framework/src/Support/Models/Render.php
+++ b/packages/framework/src/Support/Models/Render.php
@@ -84,7 +84,7 @@ class Render implements Arrayable
         $shared = View::shared($property);
 
         if ($shared !== null) {
-            trigger_error('Setting page rendering data via the view facade is deprecated. Use the Render model/facade instead.', E_USER_ERROR);
+            trigger_error("Setting page rendering data via the view facade is deprecated. Use `Render::share('$property', \$value)` instead", E_USER_ERROR);
         }
 
         return $shared;

--- a/packages/framework/src/Support/Models/Render.php
+++ b/packages/framework/src/Support/Models/Render.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Hyde\Support\Models;
 
 use Hyde\Pages\Concerns\HydePage;
+use Illuminate\Contracts\Support\Arrayable;
 use Illuminate\Support\Facades\View;
 
 /**
@@ -17,7 +18,7 @@ use Illuminate\Support\Facades\View;
  *
  * @todo Refactor to actually utilize this class
  */
-class Render
+class Render implements Arrayable
 {
     protected HydePage $page;
     protected Route $currentRoute;
@@ -47,17 +48,22 @@ class Render
 
     public function shareToView(): void
     {
-        View::share([
-            'page' => $this->getPage(),
-            'currentRoute' => $this->getCurrentRoute(),
-            'currentPage' => $this->getCurrentPage()
-        ]);
+        View::share($this->toArray());
     }
 
     public function clearData(): void
     {
         unset($this->page, $this->currentRoute, $this->currentPage);
         View::share(['page' => null, 'currentRoute' => null, 'currentPage' => null]);
+    }
+
+    public function toArray(): array
+    {
+        return [
+            'page' => $this->getPage(),
+            'currentRoute' => $this->getCurrentRoute(),
+            'currentPage' => $this->getCurrentPage()
+        ];
     }
 
     /** @codeCoverageIgnore */

--- a/packages/framework/src/Support/Models/Render.php
+++ b/packages/framework/src/Support/Models/Render.php
@@ -61,4 +61,9 @@ class Render
     {
         return isset(static::$data[$key]);
     }
+
+    public static function shareToView(): void
+    {
+        // TODO
+    }
 }

--- a/packages/framework/tests/Feature/GlobalMetadataBagTest.php
+++ b/packages/framework/tests/Feature/GlobalMetadataBagTest.php
@@ -7,8 +7,8 @@ namespace Hyde\Framework\Testing\Feature;
 use Hyde\Facades\Meta;
 use Hyde\Framework\Features\Metadata\GlobalMetadataBag;
 use Hyde\Pages\MarkdownPage;
+use Hyde\Support\Facades\Render;
 use Hyde\Testing\TestCase;
-use Illuminate\Support\Facades\View;
 
 /**
  * @covers \Hyde\Framework\Features\Metadata\GlobalMetadataBag
@@ -119,8 +119,8 @@ class GlobalMetadataBagTest extends TestCase
         $page = new MarkdownPage('foo');
         $page->metadata->add($duplicate);
 
-        View::share('currentPage', 'foo');
-        View::share('page', $page);
+        Render::share('currentPage', 'foo');
+        Render::share('page', $page);
 
         $this->assertEquals(['metadata:keep' => $keep], GlobalMetadataBag::make()->get());
     }
@@ -134,8 +134,8 @@ class GlobalMetadataBagTest extends TestCase
         $page = new MarkdownPage('foo');
         $page->metadata->add(Meta::name('foo', 'baz'));
 
-        View::share('currentPage', 'foo');
-        View::share('page', $page);
+        Render::share('currentPage', 'foo');
+        Render::share('page', $page);
 
         $this->assertEquals([], GlobalMetadataBag::make()->get());
     }

--- a/packages/framework/tests/Feature/HydeKernelTest.php
+++ b/packages/framework/tests/Feature/HydeKernelTest.php
@@ -15,10 +15,10 @@ use Hyde\Pages\DocumentationPage;
 use Hyde\Pages\HtmlPage;
 use Hyde\Pages\MarkdownPage;
 use Hyde\Pages\MarkdownPost;
+use Hyde\Support\Facades\Render;
 use Hyde\Support\Models\Route;
 use Hyde\Testing\TestCase;
 use Illuminate\Support\Facades\Config;
-use Illuminate\Support\Facades\View;
 use Illuminate\Support\HtmlString;
 
 /**
@@ -76,14 +76,14 @@ class HydeKernelTest extends TestCase
 
     public function test_current_page_helper_returns_current_page_name()
     {
-        View::share('currentPage', 'foo');
+        Render::share('currentPage', 'foo');
         $this->assertEquals('foo', Hyde::currentPage());
     }
 
     public function test_current_route_helper_returns_current_route_object()
     {
         $expected = new Route(new MarkdownPage());
-        View::share('currentRoute', $expected);
+        Render::share('currentRoute', $expected);
         $this->assertInstanceOf(Route::class, Hyde::currentRoute());
         $this->assertEquals($expected, Hyde::currentRoute());
         $this->assertSame($expected, Hyde::currentRoute());
@@ -112,20 +112,20 @@ class HydeKernelTest extends TestCase
 
     public function test_relative_link_helper_returns_relative_link_to_destination()
     {
-        View::share('currentPage', 'bar');
+        Render::share('currentPage', 'bar');
         $this->assertEquals('foo', Hyde::relativeLink('foo'));
 
-        View::share('currentPage', 'foo/bar');
+        Render::share('currentPage', 'foo/bar');
         $this->assertEquals('../foo', Hyde::relativeLink('foo'));
     }
 
     public function test_image_helper_returns_image_path_for_given_name()
     {
-        View::share('currentPage', 'foo');
+        Render::share('currentPage', 'foo');
         $this->assertEquals('media/foo.jpg', Hyde::image('foo.jpg'));
         $this->assertEquals('https://example.com/foo.jpg', Hyde::image('https://example.com/foo.jpg'));
 
-        View::share('currentPage', 'foo/bar');
+        Render::share('currentPage', 'foo/bar');
         $this->assertEquals('../media/foo.jpg', Hyde::image('foo.jpg'));
         $this->assertEquals('https://example.com/foo.jpg', Hyde::image('https://example.com/foo.jpg'));
     }

--- a/packages/framework/tests/Feature/RenderHelperTest.php
+++ b/packages/framework/tests/Feature/RenderHelperTest.php
@@ -61,4 +61,27 @@ class RenderHelperTest extends TestCase
         Render::clearData();
         $this->assertNull(Render::getPage());
     }
+
+    public function testClearDataCascadesToClearItsViewData()
+    {
+        Render::setPage(new MarkdownPage());
+        Render::shareToView();
+
+        $this->assertNotNull(View::shared('page'));
+        $this->assertNotNull(View::shared('currentRoute'));
+        $this->assertNotNull(View::shared('currentPage'));
+
+        Render::clearData();
+
+        $this->assertNull(View::shared('page'));
+        $this->assertNull(View::shared('currentRoute'));
+        $this->assertNull(View::shared('currentPage'));
+
+
+        View::share('keep', 'this');
+        $this->assertNotNull(View::shared('keep'));
+
+        Render::clearData();
+        $this->assertNotNull(View::shared('keep'));
+    }
 }

--- a/packages/framework/tests/Feature/RenderHelperTest.php
+++ b/packages/framework/tests/Feature/RenderHelperTest.php
@@ -69,6 +69,14 @@ class RenderHelperTest extends TestCase
         Render::share('foo', 'bar');
     }
 
+    public function testShareCascadesDataToView()
+    {
+        $this->assertNull(View::shared('currentPage'));
+
+        Render::share('currentPage', 'bar');
+        $this->assertSame('bar', View::shared('currentPage'));
+    }
+
     public function testClearData()
     {
         Render::setPage(new MarkdownPage());

--- a/packages/framework/tests/Feature/RenderHelperTest.php
+++ b/packages/framework/tests/Feature/RenderHelperTest.php
@@ -117,7 +117,7 @@ class RenderHelperTest extends TestCase
             'page' => null,
             'currentRoute' => null,
             'currentPage' => null,
-        ], Render::toArray());
+        ], Render::getFacadeRoot()->toArray());
 
         Render::setPage($page = new MarkdownPage());
         $this->assertEquals([
@@ -125,6 +125,6 @@ class RenderHelperTest extends TestCase
             'page' => $page,
             'currentRoute' => $page->getRoute(),
             'currentPage' => $page->getRouteKey(),
-        ], Render::toArray());
+        ], Render::getFacadeRoot()->toArray());
     }
 }

--- a/packages/framework/tests/Feature/RenderHelperTest.php
+++ b/packages/framework/tests/Feature/RenderHelperTest.php
@@ -16,18 +16,24 @@ class RenderHelperTest extends TestCase
 {
     public function testSetAndGetPage()
     {
+        $this->assertNull(Render::getPage());
+
         Render::setPage($page = new MarkdownPage());
         $this->assertSame($page, Render::getPage());
     }
 
     public function testGetCurrentRoute()
     {
+        $this->assertNull(Render::getCurrentRoute());
+
         Render::setPage($page = new MarkdownPage());
         $this->assertEquals($page->getRoute(), Render::getCurrentRoute());
     }
 
     public function testGetCurrentPage()
     {
+        $this->assertNull(Render::getCurrentPage());
+
         Render::setPage($page = new MarkdownPage());
         $this->assertSame($page->getRouteKey(), Render::getCurrentPage());
     }

--- a/packages/framework/tests/Feature/RenderHelperTest.php
+++ b/packages/framework/tests/Feature/RenderHelperTest.php
@@ -107,4 +107,20 @@ class RenderHelperTest extends TestCase
         Render::clearData();
         $this->assertNotNull(View::shared('keep'));
     }
+
+    public function testToArray()
+    {
+        $this->assertSame([
+            'page' => null,
+            'currentRoute' => null,
+            'currentPage' => null,
+        ], Render::toArray());
+
+        Render::setPage($page = new MarkdownPage());
+        $this->assertEquals([
+            'page' => $page,
+            'currentRoute' => $page->getRoute(),
+            'currentPage' => $page->getRouteKey(),
+        ], Render::toArray());
+    }
 }

--- a/packages/framework/tests/Feature/RenderHelperTest.php
+++ b/packages/framework/tests/Feature/RenderHelperTest.php
@@ -53,6 +53,22 @@ class RenderHelperTest extends TestCase
         $this->assertSame($page->getRouteKey(), View::shared('currentPage'));
     }
 
+    public function testShare()
+    {
+        $this->assertNull(Render::getCurrentPage());
+
+        Render::share('currentPage', 'bar');
+        $this->assertSame('bar', Render::getCurrentPage());
+    }
+
+    public function testShareInvalidProperty()
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage("Property 'foo' does not exist on Hyde\Support\Models\Render");
+
+        Render::share('foo', 'bar');
+    }
+
     public function testClearData()
     {
         Render::setPage(new MarkdownPage());

--- a/packages/framework/tests/Feature/RenderHelperTest.php
+++ b/packages/framework/tests/Feature/RenderHelperTest.php
@@ -112,19 +112,20 @@ class RenderHelperTest extends TestCase
 
     public function testToArray()
     {
+        $render = Render::getFacadeRoot();
         $this->assertSame([
-            'render' => Render::getFacadeRoot(),
+            'render' => $render,
             'page' => null,
             'currentRoute' => null,
             'currentPage' => null,
-        ], Render::getFacadeRoot()->toArray());
+        ], $render->toArray());
 
         Render::setPage($page = new MarkdownPage());
         $this->assertEquals([
-            'render' => Render::getFacadeRoot(),
+            'render' => $render,
             'page' => $page,
             'currentRoute' => $page->getRoute(),
             'currentPage' => $page->getRouteKey(),
-        ], Render::getFacadeRoot()->toArray());
+        ], $render->toArray());
     }
 }

--- a/packages/framework/tests/Feature/RenderHelperTest.php
+++ b/packages/framework/tests/Feature/RenderHelperTest.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace Hyde\Framework\Testing\Feature;
 
 use Hyde\Pages\MarkdownPage;
-use Hyde\Support\Models\Render;
+use Hyde\Facades\Render;
 use Hyde\Testing\TestCase;
 
 /**

--- a/packages/framework/tests/Feature/RenderHelperTest.php
+++ b/packages/framework/tests/Feature/RenderHelperTest.php
@@ -10,6 +10,7 @@ use Hyde\Testing\TestCase;
 
 /**
  * @covers \Hyde\Support\Models\Render
+ * @covers \Hyde\Facades\Render
  */
 class RenderHelperTest extends TestCase
 {

--- a/packages/framework/tests/Feature/RenderHelperTest.php
+++ b/packages/framework/tests/Feature/RenderHelperTest.php
@@ -37,22 +37,4 @@ class RenderHelperTest extends TestCase
         Render::setPage($page = new MarkdownPage());
         $this->assertSame($page->getRouteKey(), Render::getCurrentPage());
     }
-
-    public function testShareAndShared()
-    {
-        Render::share('foo', 'bar');
-        $this->assertEquals('bar', Render::shared('foo'));
-    }
-
-    public function testSharedWithDefault()
-    {
-        $this->assertEquals('bar', Render::shared('foo', 'bar'));
-    }
-
-    public function testHas()
-    {
-        Render::share('foo', 'bar');
-        $this->assertTrue(Render::has('foo'));
-        $this->assertFalse(Render::has('bar'));
-    }
 }

--- a/packages/framework/tests/Feature/RenderHelperTest.php
+++ b/packages/framework/tests/Feature/RenderHelperTest.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Hyde\Framework\Testing\Feature;
+
+use Hyde\Support\Models\Render;
+use Hyde\Testing\TestCase;
+
+/**
+ * @covers \Hyde\Support\Models\Render
+ */
+class RenderHelperTest extends TestCase
+{
+    //
+}

--- a/packages/framework/tests/Feature/RenderHelperTest.php
+++ b/packages/framework/tests/Feature/RenderHelperTest.php
@@ -7,6 +7,7 @@ namespace Hyde\Framework\Testing\Feature;
 use Hyde\Pages\MarkdownPage;
 use Hyde\Support\Facades\Render;
 use Hyde\Testing\TestCase;
+use Illuminate\Support\Facades\View;
 
 /**
  * @covers \Hyde\Support\Models\Render
@@ -36,6 +37,20 @@ class RenderHelperTest extends TestCase
 
         Render::setPage($page = new MarkdownPage());
         $this->assertSame($page->getRouteKey(), Render::getCurrentPage());
+    }
+
+    public function testShareToView()
+    {
+        $this->assertNull(View::shared('page'));
+        $this->assertNull(View::shared('currentRoute'));
+        $this->assertNull(View::shared('currentPage'));
+
+        Render::setPage($page = new MarkdownPage());
+        Render::shareToView();
+
+        $this->assertSame($page, View::shared('page'));
+        $this->assertEquals($page->getRoute(), View::shared('currentRoute'));
+        $this->assertSame($page->getRouteKey(), View::shared('currentPage'));
     }
 
     public function testClearData()

--- a/packages/framework/tests/Feature/RenderHelperTest.php
+++ b/packages/framework/tests/Feature/RenderHelperTest.php
@@ -94,12 +94,14 @@ class RenderHelperTest extends TestCase
         $this->assertNotNull(View::shared('page'));
         $this->assertNotNull(View::shared('currentRoute'));
         $this->assertNotNull(View::shared('currentPage'));
+        $this->assertNotNull(View::shared('render'));
 
         Render::clearData();
 
         $this->assertNull(View::shared('page'));
         $this->assertNull(View::shared('currentRoute'));
         $this->assertNull(View::shared('currentPage'));
+        $this->assertNotNull(View::shared('render'));
 
         View::share('keep', 'this');
         $this->assertNotNull(View::shared('keep'));
@@ -111,6 +113,7 @@ class RenderHelperTest extends TestCase
     public function testToArray()
     {
         $this->assertSame([
+            'render' => Render::getFacadeRoot(),
             'page' => null,
             'currentRoute' => null,
             'currentPage' => null,
@@ -118,6 +121,7 @@ class RenderHelperTest extends TestCase
 
         Render::setPage($page = new MarkdownPage());
         $this->assertEquals([
+            'render' => Render::getFacadeRoot(),
             'page' => $page,
             'currentRoute' => $page->getRoute(),
             'currentPage' => $page->getRouteKey(),

--- a/packages/framework/tests/Feature/RenderHelperTest.php
+++ b/packages/framework/tests/Feature/RenderHelperTest.php
@@ -94,20 +94,29 @@ class RenderHelperTest extends TestCase
         $this->assertNotNull(View::shared('page'));
         $this->assertNotNull(View::shared('currentRoute'));
         $this->assertNotNull(View::shared('currentPage'));
-        $this->assertNotNull(View::shared('render'));
 
         Render::clearData();
-
         $this->assertNull(View::shared('page'));
         $this->assertNull(View::shared('currentRoute'));
         $this->assertNull(View::shared('currentPage'));
-        $this->assertNotNull(View::shared('render'));
+    }
 
-        View::share('keep', 'this');
-        $this->assertNotNull(View::shared('keep'));
+    public function testClearDataDoesNotClearOtherViewData()
+    {
+        View::share('foo', 'bar');
+        $this->assertNotNull(View::shared('foo'));
 
         Render::clearData();
-        $this->assertNotNull(View::shared('keep'));
+        $this->assertNotNull(View::shared('foo'));
+    }
+
+    public function testClearDataDoesNotClearRenderInstanceFromViewData()
+    {
+        Render::shareToView();
+        $this->assertNotNull(View::shared('render'));
+
+        Render::clearData();
+        $this->assertNotNull(View::shared('render'));
     }
 
     public function testToArray()

--- a/packages/framework/tests/Feature/RenderHelperTest.php
+++ b/packages/framework/tests/Feature/RenderHelperTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Hyde\Framework\Testing\Feature;
 
 use Hyde\Support\Models\Render;

--- a/packages/framework/tests/Feature/RenderHelperTest.php
+++ b/packages/framework/tests/Feature/RenderHelperTest.php
@@ -23,6 +23,14 @@ class RenderHelperTest extends TestCase
         $this->assertSame($page, Render::getPage());
     }
 
+    public function testSetPageSharesDataToViewAutomatically()
+    {
+        $this->assertNull(View::shared('page'));
+
+        Render::setPage($page = new MarkdownPage());
+        $this->assertSame($page, View::shared('page'));
+    }
+
     public function testGetCurrentRoute()
     {
         $this->assertNull(Render::getCurrentRoute());
@@ -46,7 +54,6 @@ class RenderHelperTest extends TestCase
         $this->assertNull(View::shared('currentPage'));
 
         Render::setPage($page = new MarkdownPage());
-        Render::shareToView();
 
         $this->assertSame($page, View::shared('page'));
         $this->assertEquals($page->getRoute(), View::shared('currentRoute'));
@@ -89,7 +96,6 @@ class RenderHelperTest extends TestCase
     public function testClearDataCascadesToClearItsViewData()
     {
         Render::setPage(new MarkdownPage());
-        Render::shareToView();
 
         $this->assertNotNull(View::shared('page'));
         $this->assertNotNull(View::shared('currentRoute'));

--- a/packages/framework/tests/Feature/RenderHelperTest.php
+++ b/packages/framework/tests/Feature/RenderHelperTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Hyde\Framework\Testing\Feature;
 
+use Hyde\Pages\MarkdownPage;
 use Hyde\Support\Models\Render;
 use Hyde\Testing\TestCase;
 
@@ -12,5 +13,39 @@ use Hyde\Testing\TestCase;
  */
 class RenderHelperTest extends TestCase
 {
-    //
+    public function testSetAndGetPage()
+    {
+        Render::setPage($page = new MarkdownPage());
+        $this->assertSame($page, Render::getPage());
+    }
+
+    public function testGetCurrentRoute()
+    {
+        Render::setPage($page = new MarkdownPage());
+        $this->assertEquals($page->getRoute(), Render::getCurrentRoute());
+    }
+
+    public function testGetCurrentPage()
+    {
+        Render::setPage($page = new MarkdownPage());
+        $this->assertSame($page->getRouteKey(), Render::getCurrentPage());
+    }
+
+    public function testShareAndShared()
+    {
+        Render::share('foo', 'bar');
+        $this->assertEquals('bar', Render::shared('foo'));
+    }
+
+    public function testSharedWithDefault()
+    {
+        $this->assertEquals('bar', Render::shared('foo', 'bar'));
+    }
+
+    public function testHas()
+    {
+        Render::share('foo', 'bar');
+        $this->assertTrue(Render::has('foo'));
+        $this->assertFalse(Render::has('bar'));
+    }
 }

--- a/packages/framework/tests/Feature/RenderHelperTest.php
+++ b/packages/framework/tests/Feature/RenderHelperTest.php
@@ -37,4 +37,13 @@ class RenderHelperTest extends TestCase
         Render::setPage($page = new MarkdownPage());
         $this->assertSame($page->getRouteKey(), Render::getCurrentPage());
     }
+
+    public function testClearData()
+    {
+        Render::setPage(new MarkdownPage());
+        $this->assertNotNull(Render::getPage());
+
+        Render::clearData();
+        $this->assertNull(Render::getPage());
+    }
 }

--- a/packages/framework/tests/Feature/RenderHelperTest.php
+++ b/packages/framework/tests/Feature/RenderHelperTest.php
@@ -5,12 +5,12 @@ declare(strict_types=1);
 namespace Hyde\Framework\Testing\Feature;
 
 use Hyde\Pages\MarkdownPage;
-use Hyde\Facades\Render;
+use Hyde\Support\Facades\Render;
 use Hyde\Testing\TestCase;
 
 /**
  * @covers \Hyde\Support\Models\Render
- * @covers \Hyde\Facades\Render
+ * @covers \Hyde\Support\Facades\Render
  */
 class RenderHelperTest extends TestCase
 {

--- a/packages/framework/tests/Feature/RouteTest.php
+++ b/packages/framework/tests/Feature/RouteTest.php
@@ -8,6 +8,7 @@ use Hyde\Framework\Exceptions\RouteNotFoundException;
 use Hyde\Hyde;
 use Hyde\Pages\BladePage;
 use Hyde\Pages\MarkdownPage;
+use Hyde\Support\Facades\Render;
 use Hyde\Support\Models\Route;
 use Hyde\Support\Models\RouteKey;
 use Hyde\Testing\TestCase;
@@ -116,7 +117,7 @@ class RouteTest extends TestCase
     public function test_get_link_returns_correct_path_for_nested_current_page()
     {
         $route = new Route(new MarkdownPage('foo'));
-        view()->share('currentPage', 'foo/bar');
+        Render::share('currentPage', 'foo/bar');
         $this->assertEquals(Hyde::relativeLink($route->getOutputPath()), $route->getLink());
         $this->assertEquals('../foo.html', $route->getLink());
     }
@@ -138,7 +139,7 @@ class RouteTest extends TestCase
     public function test_current_returns_current_route()
     {
         $route = new Route(new MarkdownPage('foo'));
-        view()->share('currentRoute', $route);
+        Render::share('currentRoute', $route);
         $this->assertEquals($route, Route::current());
     }
 

--- a/packages/framework/tests/Unit/HydeFileHelpersTest.php
+++ b/packages/framework/tests/Unit/HydeFileHelpersTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Hyde\Framework\Testing\Unit;
 
 use Hyde\Hyde;
+use Hyde\Support\Facades\Render;
 use Hyde\Support\Models\Route;
 use Hyde\Testing\TestCase;
 
@@ -15,7 +16,7 @@ class HydeFileHelpersTest extends TestCase
 {
     public function test_current_page_returns_current_page_view_property()
     {
-        view()->share('currentPage', 'foo');
+        Render::share('currentPage', 'foo');
         $this->assertEquals('foo', Hyde::currentPage());
     }
 
@@ -26,7 +27,7 @@ class HydeFileHelpersTest extends TestCase
 
     public function test_current_route_returns_current_route_view_property()
     {
-        view()->share('currentRoute', Route::get('index'));
+        Render::share('currentRoute', Route::get('index'));
         $this->assertEquals(Route::get('index'), Hyde::currentRoute());
     }
 

--- a/packages/framework/tests/Unit/Views/Components/LinkComponentTest.php
+++ b/packages/framework/tests/Unit/Views/Components/LinkComponentTest.php
@@ -4,9 +4,9 @@ declare(strict_types=1);
 
 namespace Hyde\Framework\Testing\Unit\Views\Components;
 
+use Hyde\Support\Facades\Render;
 use Hyde\Testing\TestCase;
 use Illuminate\Support\Facades\Blade;
-use Illuminate\Support\Facades\View;
 
 /**
  * @covers \Hyde\Framework\Views\Components\LinkComponent
@@ -27,7 +27,7 @@ class LinkComponentTest extends TestCase
 
     public function test_link_component_can_be_rendered_with_route_for_nested_pages()
     {
-        View::share('currentPage', 'foo/bar');
+        Render::share('currentPage', 'foo/bar');
         $route = \Hyde\Support\Models\Route::get('index');
         $this->assertEquals('<a href="../index.html">bar</a>', rtrim(
             Blade::render('<x-link href="'.$route.'">bar</x-link>')));

--- a/packages/framework/tests/Unit/Views/ScriptsComponentViewTest.php
+++ b/packages/framework/tests/Unit/Views/ScriptsComponentViewTest.php
@@ -18,7 +18,7 @@ class ScriptsComponentViewTest extends TestCase
     protected function renderTestView(): string
     {
         config(['hyde.cache_busting' => false]);
-        view()->share('currentPage', $this->mockCurrentPage ?? '');
+        $this->mockCurrentPage($this->mockCurrentPage ?? '');
 
         return Blade::render(file_get_contents(
             Hyde::vendorPath('resources/views/layouts/scripts.blade.php')

--- a/packages/framework/tests/Unit/Views/StylesComponentViewTest.php
+++ b/packages/framework/tests/Unit/Views/StylesComponentViewTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Hyde\Framework\Testing\Unit\Views;
 
+use Hyde\Support\Facades\Render;
 use function config;
 use Hyde\Facades\Asset;
 use Hyde\Hyde;
@@ -57,7 +58,7 @@ class StylesComponentViewTest extends TestCase
 
     public function test_styles_can_be_pushed_to_the_component_styles_stack()
     {
-        view()->share('currentPage', '');
+        Render::share('currentPage', '');
 
         $this->assertStringContainsString('foo bar',
              Blade::render('

--- a/packages/framework/tests/Unit/Views/StylesComponentViewTest.php
+++ b/packages/framework/tests/Unit/Views/StylesComponentViewTest.php
@@ -4,10 +4,10 @@ declare(strict_types=1);
 
 namespace Hyde\Framework\Testing\Unit\Views;
 
-use Hyde\Support\Facades\Render;
 use function config;
 use Hyde\Facades\Asset;
 use Hyde\Hyde;
+use Hyde\Support\Facades\Render;
 use Hyde\Testing\TestCase;
 use Illuminate\Support\Facades\Blade;
 

--- a/packages/framework/tests/Unit/Views/StylesComponentViewTest.php
+++ b/packages/framework/tests/Unit/Views/StylesComponentViewTest.php
@@ -20,7 +20,7 @@ class StylesComponentViewTest extends TestCase
     protected function renderTestView(): string
     {
         config(['hyde.cache_busting' => false]);
-        view()->share('currentPage', $this->mockCurrentPage ?? '');
+        $this->mockCurrentPage($this->mockCurrentPage ?? '');
 
         return Blade::render(file_get_contents(
             Hyde::vendorPath('resources/views/layouts/styles.blade.php')

--- a/packages/testing/src/TestCase.php
+++ b/packages/testing/src/TestCase.php
@@ -8,6 +8,7 @@ use Hyde\Framework\Actions\ConvertsArrayToFrontMatter;
 use Hyde\Hyde;
 use Hyde\Pages\Concerns\HydePage;
 use Hyde\Pages\MarkdownPage;
+use Hyde\Support\Facades\Render;
 use Hyde\Support\Models\Route;
 use Illuminate\View\Component;
 use LaravelZero\Framework\Testing\TestCase as BaseTestCase;
@@ -72,20 +73,20 @@ abstract class TestCase extends BaseTestCase
     /** @internal */
     protected function mockRoute(?Route $route = null)
     {
-        view()->share('currentRoute', $route ?? (new Route(new MarkdownPage())));
+        Render::share('currentRoute', $route ?? (new Route(new MarkdownPage())));
     }
 
     /** @internal */
     protected function mockPage(?HydePage $page = null, ?string $currentPage = null)
     {
-        view()->share('page', $page ?? new MarkdownPage());
-        view()->share('currentPage', $currentPage ?? 'PHPUnit');
+        Render::share('page', $page ?? new MarkdownPage());
+        Render::share('currentPage', $currentPage ?? 'PHPUnit');
     }
 
     /** @internal */
     protected function mockCurrentPage(string $currentPage)
     {
-        view()->share('currentPage', $currentPage);
+        Render::share('currentPage', $currentPage);
     }
 
     /**


### PR DESCRIPTION
## About

Resolves the following todo in [ManagesViewData.php](https://github.com/hydephp/develop/blob/c11fa85ffe3e038da0fa3c3f8383752744c6924b/packages/framework/src/Foundation/Concerns/ManagesViewData.php#L14-L15):
> "Consider if this logic is better suited for a "Render" class solely for handling data related to the current render."

I think this change in addition to having a stricter schema for these very important core properties will also further separate concerns by bringing this out of the HydeKernel which is used to store information about the project, whereas this render data is for the specific page being compiled and should be reset after each page compile.

### Migration

To migrate existing code, replace the following (and only these specific keys need to be replaced)

#### Replace this

```php
use Illuminate\Support\Facades\View;

View::share('page', $value);
View::share('currentPage', $value);
View::share('currentRoute', $value);
```

#### With this

```php
use Hyde\Support\Facades\Render;

Render::share('page', $value);
Render::share('currentPage', $value);
Render::share('currentRoute', $value);
```

See [this diff](https://github.com/hydephp/develop/commit/adb59b1d4322135d6bc61b913950b532f2bb738a?diff=split) for an example