### PR TITLE
Refactor markdown file parsing

### DIFF
--- a/packages/framework/src/Framework/Actions/MarkdownFileParser.php
+++ b/packages/framework/src/Framework/Actions/MarkdownFileParser.php
@@ -42,7 +42,7 @@ class MarkdownFileParser
             }
 
             if ($object->body()) {
-                $this->markdown = $object->body();
+                $this->markdown = rtrim($object->body());
             }
         } else {
             $this->markdown = $stream;

--- a/packages/framework/src/Framework/Actions/MarkdownFileParser.php
+++ b/packages/framework/src/Framework/Actions/MarkdownFileParser.php
@@ -39,9 +39,6 @@ class MarkdownFileParser
 
             if ($object->matter()) {
                 $this->matter = $object->matter();
-
-                // Unset the slug from the matter, as it can cause problems if it exists.
-                unset($this->matter['slug']);
             }
 
             if ($object->body()) {

--- a/packages/framework/tests/Feature/MarkdownFileParserTest.php
+++ b/packages/framework/tests/Feature/MarkdownFileParserTest.php
@@ -57,8 +57,11 @@ This is a post stub used in the automated tests
         ]), $document->matter);
 
         $this->assertEquals(
-            '# My New PostThis is a post stub used in the automated tests',
-            str_replace(["\n", "\r"], '', (string) $document->markdown)
+            '# My New Post
+
+This is a post stub used in the automated tests
+',
+            str_replace("\r", '', (string) $document->markdown)
         );
     }
 
@@ -82,8 +85,11 @@ This is a post stub used in the automated tests
         $this->assertEquals('blog', $post->matter('category'));
 
         $this->assertEquals(
-            '# My New PostThis is a post stub used in the automated tests',
-            str_replace(["\n", "\r"], '', (string) $post->markdown)
+            '# My New Post
+
+This is a post stub used in the automated tests
+',
+            str_replace("\r", '', (string) $post->markdown)
         );
     }
 }

--- a/packages/framework/tests/Feature/MarkdownFileParserTest.php
+++ b/packages/framework/tests/Feature/MarkdownFileParserTest.php
@@ -72,15 +72,6 @@ This is a post stub used in the automated tests
         $this->assertEquals('blog', $post->matter('category'));
     }
 
-    public function test_parsed_front_matter_does_not_contain_slug_key()
-    {
-        file_put_contents(Hyde::path('_posts/test-post.md'), "---\nslug: foo\n---\n");
-
-        $post = (new MarkdownFileParser(('_posts/test-post.md')))->get();
-        $this->assertNull($post->matter('slug'));
-        $this->assertEquals(FrontMatter::fromArray([]), $post->matter);
-    }
-
     public function test_static_parse_shorthand()
     {
         $this->makeTestPost();

--- a/packages/framework/tests/Feature/MarkdownFileParserTest.php
+++ b/packages/framework/tests/Feature/MarkdownFileParserTest.php
@@ -59,8 +59,7 @@ This is a post stub used in the automated tests
         $this->assertEquals(
             '# My New Post
 
-This is a post stub used in the automated tests
-',
+This is a post stub used in the automated tests',
             str_replace("\r", '', (string) $document->markdown)
         );
     }
@@ -87,8 +86,7 @@ This is a post stub used in the automated tests
         $this->assertEquals(
             '# My New Post
 
-This is a post stub used in the automated tests
-',
+This is a post stub used in the automated tests',
             str_replace("\r", '', (string) $post->markdown)
         );
     }


### PR DESCRIPTION
Makes the following changes:

- Remove data unsetter for property that hasn't been used in a long while
- Trims the end of the parsed markdown body as it leads to a more consistent data state (you can always add it back if needed)