### PR TITLE
Move Markdown end-of-document normalizer from parser to constructor

### DIFF
--- a/packages/framework/src/Framework/Actions/MarkdownFileParser.php
+++ b/packages/framework/src/Framework/Actions/MarkdownFileParser.php
@@ -42,7 +42,7 @@ class MarkdownFileParser
             }
 
             if ($object->body()) {
-                $this->markdown = rtrim($object->body());
+                $this->markdown = $object->body();
             }
         } else {
             $this->markdown = $stream;

--- a/packages/framework/src/Markdown/Models/Markdown.php
+++ b/packages/framework/src/Markdown/Models/Markdown.php
@@ -25,7 +25,7 @@ class Markdown implements Arrayable, Stringable, Htmlable
      */
     public function __construct(string $body = '')
     {
-        $this->body = $body;
+        $this->body = rtrim($body);
     }
 
     /**


### PR DESCRIPTION
This provides an even more consistent state than in https://github.com/hydephp/develop/pull/723