### PR TITLE
Normalize CRLF sequences to LF in parsed Markdown objects

### DIFF
--- a/packages/framework/src/Markdown/Models/Markdown.php
+++ b/packages/framework/src/Markdown/Models/Markdown.php
@@ -25,7 +25,7 @@ class Markdown implements Arrayable, Stringable, Htmlable
      */
     public function __construct(string $body = '')
     {
-        $this->body = rtrim($body);
+        $this->body = str_replace("\r\n", "\n", rtrim($body));
     }
 
     /**

--- a/packages/framework/tests/Unit/MarkdownDocumentTest.php
+++ b/packages/framework/tests/Unit/MarkdownDocumentTest.php
@@ -78,4 +78,10 @@ class MarkdownDocumentTest extends TestCase
         $this->assertEquals('Hello, world!', $markdown->body());
         unlink(Hyde::path('_pages/foo.md'));
     }
+
+    public function end_of_markdown_body_is_trimmed()
+    {
+        $markdown = new Markdown("Hello, world!\n\r\t   ");
+        $this->assertEquals("Hello, world!", $markdown->body());
+    }
 }

--- a/packages/framework/tests/Unit/MarkdownDocumentTest.php
+++ b/packages/framework/tests/Unit/MarkdownDocumentTest.php
@@ -82,7 +82,7 @@ class MarkdownDocumentTest extends TestCase
     public function end_of_markdown_body_is_trimmed()
     {
         $markdown = new Markdown("Hello, world!\n\r\t   ");
-        $this->assertEquals("Hello, world!", $markdown->body());
+        $this->assertEquals('Hello, world!', $markdown->body());
     }
 
     public function test_carriage_returns_are_normalized()

--- a/packages/framework/tests/Unit/MarkdownDocumentTest.php
+++ b/packages/framework/tests/Unit/MarkdownDocumentTest.php
@@ -84,4 +84,16 @@ class MarkdownDocumentTest extends TestCase
         $markdown = new Markdown("Hello, world!\n\r\t   ");
         $this->assertEquals("Hello, world!", $markdown->body());
     }
+
+    public function test_carriage_returns_are_normalized()
+    {
+        $markdown = new Markdown("foo\rbar");
+        $this->assertEquals("foo\rbar", $markdown->body());
+
+        $markdown = new Markdown("foo\r\nbar");
+        $this->assertEquals("foo\nbar", $markdown->body());
+
+        $markdown = new Markdown("foo\nbar");
+        $this->assertEquals("foo\nbar", $markdown->body());
+    }
 }


### PR DESCRIPTION
Further provides a more consistent state across platforms, see https://github.com/hydephp/develop/pull/723 and https://github.com/hydephp/develop/pull/724.