### PR TITLE
Extract action for publications compiling

### DIFF
--- a/packages/framework/src/Framework/Actions/PublicationPageCompiler.php
+++ b/packages/framework/src/Framework/Actions/PublicationPageCompiler.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Hyde\Framework\Actions;
+
+class PublicationPageCompiler
+{
+    //
+}

--- a/packages/framework/src/Framework/Actions/PublicationPageCompiler.php
+++ b/packages/framework/src/Framework/Actions/PublicationPageCompiler.php
@@ -4,6 +4,9 @@ declare(strict_types=1);
 
 namespace Hyde\Framework\Actions;
 
+/**
+ * @see \Hyde\Framework\Testing\Feature\Actions\PublicationPageCompilerTest
+ */
 class PublicationPageCompiler
 {
     //

--- a/packages/framework/src/Framework/Actions/PublicationPageCompiler.php
+++ b/packages/framework/src/Framework/Actions/PublicationPageCompiler.php
@@ -4,17 +4,15 @@ declare(strict_types=1);
 
 namespace Hyde\Framework\Actions;
 
+use function file_exists;
+use function file_get_contents;
 use Hyde\Framework\Concerns\InvokableAction;
 use Hyde\Framework\Features\Publications\Models\PublicationListPage;
 use Hyde\Framework\Features\Publications\PublicationService;
 use Hyde\Hyde;
 use Hyde\Pages\PublicationPage;
 use Illuminate\Support\Facades\Blade;
-
 use InvalidArgumentException;
-
-use function file_exists;
-use function file_get_contents;
 use function view;
 
 /**

--- a/packages/framework/src/Framework/Actions/PublicationPageCompiler.php
+++ b/packages/framework/src/Framework/Actions/PublicationPageCompiler.php
@@ -5,7 +5,16 @@ declare(strict_types=1);
 namespace Hyde\Framework\Actions;
 
 use Hyde\Framework\Features\Publications\Models\PublicationListPage;
+use Hyde\Framework\Features\Publications\PublicationService;
+use Hyde\Hyde;
 use Hyde\Pages\PublicationPage;
+use Illuminate\Support\Facades\Blade;
+
+use InvalidArgumentException;
+
+use function file_exists;
+use function file_get_contents;
+use function view;
 
 /**
  * @see \Hyde\Framework\Testing\Feature\Actions\PublicationPageCompilerTest
@@ -21,6 +30,47 @@ class PublicationPageCompiler
 
     public function __invoke(): string
     {
-        // TODO: Implement __invoke() method.
+        return $this->page instanceof PublicationPage
+            ? $this->compilePublicationPage()
+            : $this->compilePublicationListPage();
+    }
+
+    public function compilePublicationPage(): string
+    {
+        $data = [
+            'publication' => $this->page,
+        ];
+
+        $template = $this->page->type->detailTemplate;
+        if (str_contains($template, '::')) {
+            return view($template, $data)->render();
+        }
+
+        // Using the Blade facade we can render any file without having to register the directory with the view finder.
+        return Blade::render(
+            file_get_contents(Hyde::path("{$this->page->type->getDirectory()}/$template.blade.php")), $data
+        );
+    }
+
+    public function compilePublicationListPage(): string
+    {
+        $data = [
+            'publications' => PublicationService::getPublicationsForPubType($this->page->type),
+        ];
+
+        $template = $this->page->type->listTemplate;
+        if (str_contains($template, '::')) {
+            return view($template, $data)->render();
+        }
+
+        // Using the Blade facade we can render any file without having to register the directory with the view finder.
+        $viewPath = Hyde::path("{$this->page->type->getDirectory()}/$template").'.blade.php';
+        if (! file_exists($viewPath)) {
+            throw new InvalidArgumentException("View [$viewPath] not found.");
+        }
+
+        return Blade::render(
+            file_get_contents($viewPath), $data
+        );
     }
 }

--- a/packages/framework/src/Framework/Actions/PublicationPageCompiler.php
+++ b/packages/framework/src/Framework/Actions/PublicationPageCompiler.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Hyde\Framework\Actions;
 
+use Hyde\Framework\Concerns\InvokableAction;
 use Hyde\Framework\Features\Publications\Models\PublicationListPage;
 use Hyde\Framework\Features\Publications\PublicationService;
 use Hyde\Hyde;
@@ -19,7 +20,7 @@ use function view;
 /**
  * @see \Hyde\Framework\Testing\Feature\Actions\PublicationPageCompilerTest
  */
-class PublicationPageCompiler
+class PublicationPageCompiler extends InvokableAction
 {
     protected PublicationPage|PublicationListPage $page;
 

--- a/packages/framework/src/Framework/Actions/PublicationPageCompiler.php
+++ b/packages/framework/src/Framework/Actions/PublicationPageCompiler.php
@@ -4,10 +4,23 @@ declare(strict_types=1);
 
 namespace Hyde\Framework\Actions;
 
+use Hyde\Framework\Features\Publications\Models\PublicationListPage;
+use Hyde\Pages\PublicationPage;
+
 /**
  * @see \Hyde\Framework\Testing\Feature\Actions\PublicationPageCompilerTest
  */
 class PublicationPageCompiler
 {
-    //
+    protected PublicationPage|PublicationListPage $page;
+
+    public function __construct(PublicationPage|PublicationListPage $page)
+    {
+        $this->page = $page;
+    }
+
+    public function __invoke(): string
+    {
+        // TODO: Implement __invoke() method.
+    }
 }

--- a/packages/framework/src/Framework/Concerns/InvokableAction.php
+++ b/packages/framework/src/Framework/Concerns/InvokableAction.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Hyde\Framework\Concerns;
+
+abstract class InvokableAction
+{
+    abstract public function __invoke();
+
+    public static function call(...$args)
+    {
+        return (new static(...$args))->__invoke();
+    }
+}

--- a/packages/framework/src/Framework/Features/Publications/Models/PublicationListPage.php
+++ b/packages/framework/src/Framework/Features/Publications/Models/PublicationListPage.php
@@ -4,15 +4,9 @@ declare(strict_types=1);
 
 namespace Hyde\Framework\Features\Publications\Models;
 
-use function file_get_contents;
-use Hyde\Framework\Features\Publications\PublicationService;
-use Hyde\Hyde;
+use Hyde\Framework\Actions\PublicationPageCompiler;
 use Hyde\Pages\BladePage;
 use Hyde\Support\Contracts\DynamicPage;
-use Illuminate\Support\Facades\Blade;
-use InvalidArgumentException;
-use function str_contains;
-use function view;
 
 /**
  * @see \Hyde\Pages\PublicationPage
@@ -35,24 +29,7 @@ class PublicationListPage extends BladePage implements DynamicPage
 
     public function compile(): string
     {
-        $data = [
-            'publications' => PublicationService::getPublicationsForPubType($this->type),
-        ];
-
-        $template = $this->type->listTemplate;
-        if (str_contains($template, '::')) {
-            return view($template, $data)->render();
-        }
-
-        // Using the Blade facade we can render any file without having to register the directory with the view finder.
-        $viewPath = Hyde::path("{$this->type->getDirectory()}/$template").'.blade.php';
-        if (! file_exists($viewPath)) {
-            throw new InvalidArgumentException("View [$viewPath] not found.");
-        }
-
-        return Blade::render(
-            file_get_contents($viewPath), $data
-        );
+        return (new PublicationPageCompiler($this))->__invoke();
     }
 
     public function getSourcePath(): string

--- a/packages/framework/src/Framework/Features/Publications/Models/PublicationListPage.php
+++ b/packages/framework/src/Framework/Features/Publications/Models/PublicationListPage.php
@@ -29,7 +29,7 @@ class PublicationListPage extends BladePage implements DynamicPage
 
     public function compile(): string
     {
-        return (new PublicationPageCompiler($this))->__invoke();
+        return PublicationPageCompiler::call($this);
     }
 
     public function getSourcePath(): string

--- a/packages/framework/src/Pages/PublicationPage.php
+++ b/packages/framework/src/Pages/PublicationPage.php
@@ -4,12 +4,10 @@ declare(strict_types=1);
 
 namespace Hyde\Pages;
 
-use function file_get_contents;
+use Hyde\Framework\Actions\PublicationPageCompiler;
 use Hyde\Framework\Features\Publications\Models\PublicationType;
-use Hyde\Hyde;
 use Hyde\Markdown\Models\FrontMatter;
 use Hyde\Markdown\Models\Markdown;
-use Illuminate\Support\Facades\Blade;
 use Illuminate\Support\HtmlString;
 use function str_starts_with;
 use function view;
@@ -49,19 +47,7 @@ class PublicationPage extends Concerns\BaseMarkdownPage
 
     protected function renderComponent(): string
     {
-        $data = [
-            'publication' => $this,
-        ];
-
-        $template = $this->type->detailTemplate;
-        if (str_contains($template, '::')) {
-            return view($template, $data)->render();
-        }
-
-        // Using the Blade facade we can render any file without having to register the directory with the view finder.
-        return Blade::render(
-            file_get_contents(Hyde::path("{$this->type->getDirectory()}/$template.blade.php")), $data
-        );
+        return (new PublicationPageCompiler($this))->__invoke();
     }
 
     protected static function normaliseIdentifier(string $directory, string $identifier): string

--- a/packages/framework/src/Pages/PublicationPage.php
+++ b/packages/framework/src/Pages/PublicationPage.php
@@ -47,7 +47,7 @@ class PublicationPage extends Concerns\BaseMarkdownPage
 
     protected function renderComponent(): string
     {
-        return (new PublicationPageCompiler($this))->__invoke();
+        return PublicationPageCompiler::call($this);
     }
 
     protected static function normaliseIdentifier(string $directory, string $identifier): string

--- a/packages/framework/tests/Feature/Actions/PublicationPageCompilerTest.php
+++ b/packages/framework/tests/Feature/Actions/PublicationPageCompilerTest.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Hyde\Framework\Testing\Feature\Actions;
+
+use Hyde\Framework\Actions\PublicationPageCompiler;
+use Hyde\Testing\TestCase;
+
+/**
+ * @covers \Hyde\Framework\Actions\PublicationPageCompiler
+ */
+class PublicationPageCompilerTest extends TestCase
+{
+    //
+}

--- a/packages/framework/tests/Feature/Actions/PublicationPageCompilerTest.php
+++ b/packages/framework/tests/Feature/Actions/PublicationPageCompilerTest.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Hyde\Framework\Testing\Feature\Actions;
 
-use Hyde\Framework\Actions\PublicationPageCompiler;
 use Hyde\Testing\TestCase;
 
 /**

--- a/packages/framework/tests/Feature/Actions/PublicationPageCompilerTest.php
+++ b/packages/framework/tests/Feature/Actions/PublicationPageCompilerTest.php
@@ -4,6 +4,10 @@ declare(strict_types=1);
 
 namespace Hyde\Framework\Testing\Feature\Actions;
 
+use Hyde\Framework\Actions\PublicationPageCompiler;
+use Hyde\Framework\Features\Publications\Models\PublicationType;
+use Hyde\Hyde;
+use Hyde\Pages\PublicationPage;
 use Hyde\Testing\TestCase;
 
 /**
@@ -11,5 +15,28 @@ use Hyde\Testing\TestCase;
  */
 class PublicationPageCompilerTest extends TestCase
 {
-    //
+    public function testCanCompilePublicationPages()
+    {
+        $this->directory('test-publication');
+        $this->setupTestPublication();
+
+        file_put_contents(Hyde::path('test-publication/test-publication_detail.blade.php'), 'Detail: {{ $publication->title }}');
+
+        $string = PublicationPageCompiler::call(new PublicationPage('my-publication', type: PublicationType::get('test-publication')));
+
+        $this->assertEquals('Detail: My Publication', $string);
+    }
+
+    public function testCanCompilePublicationListPages()
+    {
+        $this->directory('test-publication');
+        $this->setupTestPublication();
+
+        file_put_contents(Hyde::path('test-publication/my-publication.md'), 'Foo');
+        file_put_contents(Hyde::path('test-publication/test-publication_list.blade.php'), 'List: {{ $publications->first()->title }}');
+
+        $string = PublicationPageCompiler::call(PublicationType::get('test-publication')->getListPage());
+
+        $this->assertEquals('List: My Publication', $string);
+    }
 }

--- a/packages/framework/tests/Feature/HydeServiceProviderTest.php
+++ b/packages/framework/tests/Feature/HydeServiceProviderTest.php
@@ -255,7 +255,7 @@ class HydeServiceProviderTest extends TestCase
     {
         return array_values(
             array_filter(get_declared_classes(), function ($class) {
-                return str_starts_with($class, 'Hyde\Pages') && !str_starts_with($class, 'Hyde\Pages\Concerns') && !is_subclass_of($class, DynamicPage::class);
+                return str_starts_with($class, 'Hyde\Pages') && ! str_starts_with($class, 'Hyde\Pages\Concerns') && ! is_subclass_of($class, DynamicPage::class);
             })
         );
     }

--- a/packages/framework/tests/Feature/PublicationTypeTest.php
+++ b/packages/framework/tests/Feature/PublicationTypeTest.php
@@ -4,9 +4,9 @@ declare(strict_types=1);
 
 namespace Hyde\Framework\Testing\Feature;
 
-use Hyde\Framework\Features\Publications\Models\PublicationListPage;
 use function array_merge;
 use Hyde\Framework\Features\Publications\Models\PublicationFieldType;
+use Hyde\Framework\Features\Publications\Models\PublicationListPage;
 use Hyde\Framework\Features\Publications\Models\PublicationType;
 use Hyde\Hyde;
 use Hyde\Testing\TestCase;


### PR DESCRIPTION
Since these page types have dynamic source files, their compiling logic is a bit more complex than other pages. This refactor PR moves these to a dedicated action, and adds an experimental base action that adds a static call method to provide syntactic sugar for invokable classes.

The short snippet shows the call method alternative. Both lines to the exact same thing.

```php
return (new PublicationPageCompiler($this))->__invoke();

return PublicationPageCompiler::call($this);
```