### PR TITLE
Add base class for invokable action classes

### DIFF
--- a/packages/framework/src/Framework/Concerns/InvokableAction.php
+++ b/packages/framework/src/Framework/Concerns/InvokableAction.php
@@ -6,6 +6,8 @@ namespace Hyde\Framework\Concerns;
 
 /**
  * Base class for invokable actions. Provides a helper to invoke the action statically.
+ *
+ * @see \Hyde\Framework\Testing\Feature\InvokableActionTest
  */
 abstract class InvokableAction
 {

--- a/packages/framework/src/Framework/Concerns/InvokableAction.php
+++ b/packages/framework/src/Framework/Concerns/InvokableAction.php
@@ -7,4 +7,9 @@ namespace Hyde\Framework\Concerns;
 abstract class InvokableAction
 {
     abstract public function __invoke();
+
+    public static function call(...$args)
+    {
+        return (new static(...$args))->__invoke();
+    }
 }

--- a/packages/framework/src/Framework/Concerns/InvokableAction.php
+++ b/packages/framework/src/Framework/Concerns/InvokableAction.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Hyde\Framework\Concerns;
+
+abstract class InvokableAction
+{
+    //
+}

--- a/packages/framework/src/Framework/Concerns/InvokableAction.php
+++ b/packages/framework/src/Framework/Concerns/InvokableAction.php
@@ -4,6 +4,9 @@ declare(strict_types=1);
 
 namespace Hyde\Framework\Concerns;
 
+/**
+ * Base class for invokable actions. Provides a helper to invoke the action statically.
+ */
 abstract class InvokableAction
 {
     abstract public function __invoke();

--- a/packages/framework/src/Framework/Concerns/InvokableAction.php
+++ b/packages/framework/src/Framework/Concerns/InvokableAction.php
@@ -6,5 +6,5 @@ namespace Hyde\Framework\Concerns;
 
 abstract class InvokableAction
 {
-    //
+    abstract public function __invoke();
 }

--- a/packages/framework/tests/Feature/InvokableActionTest.php
+++ b/packages/framework/tests/Feature/InvokableActionTest.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Hyde\Framework\Testing\Feature;
+
+use Hyde\Testing\TestCase;
+
+/**
+ * @covers \Hyde\Framework\Concerns\InvokableAction
+ */
+class InvokableActionTest extends TestCase
+{
+    //
+}


### PR DESCRIPTION
Adds an experimental base action that adds a static call method to provide syntactic sugar for invokable classes. This PR cherry picks this feature from the publications-feature branch, originally added by https://github.com/hydephp/develop/pull/726.

The short snippet shows the call method alternative. Both lines to the exact same thing.

```php
return (new ExampleAction($this))->__invoke();

return ExampleAction::call($this);
```