### PR TITLE
Add default values to the publication type class

### DIFF
--- a/packages/framework/src/Framework/Features/Publications/Models/PublicationType.php
+++ b/packages/framework/src/Framework/Features/Publications/Models/PublicationType.php
@@ -39,7 +39,7 @@ class PublicationType implements SerializableContract
         try {
             return new static(...array_merge(
                 static::parseSchemaFile($schemaFile),
-                static::getRelativeDirectoryName($schemaFile))
+                static::getRelativeDirectoryEntry($schemaFile))
             );
         } catch (Exception $exception) {
             throw new RuntimeException("Could not parse schema file $schemaFile", 0, $exception);
@@ -122,7 +122,7 @@ class PublicationType implements SerializableContract
         return json_decode(file_get_contents(Hyde::path($schemaFile)), true, 512, JSON_THROW_ON_ERROR);
     }
 
-    protected static function getRelativeDirectoryName(string $schemaFile): array
+    protected static function getRelativeDirectoryEntry(string $schemaFile): array
     {
         return ['directory' => Hyde::pathToRelative(dirname($schemaFile))];
     }

--- a/packages/framework/src/Framework/Features/Publications/Models/PublicationType.php
+++ b/packages/framework/src/Framework/Features/Publications/Models/PublicationType.php
@@ -28,10 +28,10 @@ class PublicationType implements SerializableContract
 
     public string $name;
     public string $canonicalField;
-    public string $sortField;
-    public string $sortDirection;
-    public int $pageSize;
-    public bool $prevNextLinks;
+    public string $sortField = '__createdAt';
+    public string $sortDirection = 'DESC';
+    public int $pageSize = 25;
+    public bool $prevNextLinks = true;
     public string $detailTemplate;
     public string $listTemplate;
 

--- a/packages/framework/src/Framework/Features/Publications/Models/PublicationType.php
+++ b/packages/framework/src/Framework/Features/Publications/Models/PublicationType.php
@@ -55,7 +55,7 @@ class PublicationType implements SerializableContract
         }
     }
 
-    public function __construct(string $name, string $canonicalField, string $sortField = '__createdAt', string $sortDirection = 'DESC', int $pageSize = 25, bool $prevNextLinks = true, string $detailTemplate = 'detail', string $listTemplate = 'list', array $fields = [], ?string $directory = null)
+    public function __construct(string $name, string $canonicalField = 'identifier', string $sortField = '__createdAt', string $sortDirection = 'DESC', int $pageSize = 25, bool $prevNextLinks = true, string $detailTemplate = 'detail', string $listTemplate = 'list', array $fields = [], ?string $directory = null)
     {
         $this->name = $name;
         $this->canonicalField = $canonicalField;

--- a/packages/framework/src/Framework/Features/Publications/Models/PublicationType.php
+++ b/packages/framework/src/Framework/Features/Publications/Models/PublicationType.php
@@ -55,8 +55,7 @@ class PublicationType implements SerializableContract
         }
     }
 
-    public function __construct(string $name, string $canonicalField, string $sortField, string $sortDirection, int $pageSize, bool $prevNextLinks, string $detailTemplate, string $listTemplate, array $fields, ?string $directory = null)
-    {
+    public function __construct(string $name, string $canonicalField, string $sortField = '__createdAt', string $sortDirection = 'DESC', int $pageSize = 25, bool $prevNextLinks = true, string $detailTemplate = 'detail', string $listTemplate = 'list', array $fields = [], ?string $directory = null) {
         $this->name = $name;
         $this->canonicalField = $canonicalField;
         $this->sortField = $sortField;

--- a/packages/framework/src/Framework/Features/Publications/Models/PublicationType.php
+++ b/packages/framework/src/Framework/Features/Publications/Models/PublicationType.php
@@ -36,7 +36,7 @@ class PublicationType implements SerializableContract
     public string $listTemplate = 'list';
 
     /** @var array<array<string, mixed>> */
-    public array $fields;
+    public array $fields = [];
 
     public static function get(string $name): static
     {

--- a/packages/framework/src/Framework/Features/Publications/Models/PublicationType.php
+++ b/packages/framework/src/Framework/Features/Publications/Models/PublicationType.php
@@ -27,7 +27,7 @@ class PublicationType implements SerializableContract
     protected string $directory;
 
     public string $name;
-    public string $canonicalField;
+    public string $canonicalField = 'identifier';
     public string $sortField = '__createdAt';
     public string $sortDirection = 'DESC';
     public int $pageSize = 25;

--- a/packages/framework/src/Framework/Features/Publications/Models/PublicationType.php
+++ b/packages/framework/src/Framework/Features/Publications/Models/PublicationType.php
@@ -69,6 +69,8 @@ class PublicationType implements SerializableContract
 
         if ($directory) {
             $this->directory = $directory;
+        } else {
+            $this->directory = Str::slug($name);
         }
     }
 

--- a/packages/framework/src/Framework/Features/Publications/Models/PublicationType.php
+++ b/packages/framework/src/Framework/Features/Publications/Models/PublicationType.php
@@ -67,11 +67,7 @@ class PublicationType implements SerializableContract
         $this->listTemplate = $listTemplate;
         $this->fields = $fields;
 
-        if ($directory) {
-            $this->directory = $directory;
-        } else {
-            $this->directory = Str::slug($name);
-        }
+        $this->directory = $directory ?? Str::slug($name);
     }
 
     public function toArray(): array

--- a/packages/framework/src/Framework/Features/Publications/Models/PublicationType.php
+++ b/packages/framework/src/Framework/Features/Publications/Models/PublicationType.php
@@ -100,7 +100,7 @@ class PublicationType implements SerializableContract
     /** @return \Illuminate\Support\Collection<string, \Hyde\Framework\Features\Publications\Models\PublicationFieldType> */
     public function getFields(): Collection
     {
-        return collect($this->fields)->mapWithKeys(function (array $data) {
+        return collect($this->fields)->mapWithKeys(function (array $data): array {
             return [$data['name'] => new PublicationFieldType(...$data)];
         });
     }

--- a/packages/framework/src/Framework/Features/Publications/Models/PublicationType.php
+++ b/packages/framework/src/Framework/Features/Publications/Models/PublicationType.php
@@ -55,7 +55,8 @@ class PublicationType implements SerializableContract
         }
     }
 
-    public function __construct(string $name, string $canonicalField, string $sortField = '__createdAt', string $sortDirection = 'DESC', int $pageSize = 25, bool $prevNextLinks = true, string $detailTemplate = 'detail', string $listTemplate = 'list', array $fields = [], ?string $directory = null) {
+    public function __construct(string $name, string $canonicalField, string $sortField = '__createdAt', string $sortDirection = 'DESC', int $pageSize = 25, bool $prevNextLinks = true, string $detailTemplate = 'detail', string $listTemplate = 'list', array $fields = [], ?string $directory = null)
+    {
         $this->name = $name;
         $this->canonicalField = $canonicalField;
         $this->sortField = $sortField;

--- a/packages/framework/src/Framework/Features/Publications/Models/PublicationType.php
+++ b/packages/framework/src/Framework/Features/Publications/Models/PublicationType.php
@@ -32,8 +32,8 @@ class PublicationType implements SerializableContract
     public string $sortDirection = 'DESC';
     public int $pageSize = 25;
     public bool $prevNextLinks = true;
-    public string $detailTemplate;
-    public string $listTemplate;
+    public string $detailTemplate = 'detail';
+    public string $listTemplate = 'list';
 
     /** @var array<array<string, mixed>> */
     public array $fields;

--- a/packages/framework/src/Framework/Features/Publications/Models/PublicationType.php
+++ b/packages/framework/src/Framework/Features/Publications/Models/PublicationType.php
@@ -26,15 +26,6 @@ class PublicationType implements SerializableContract
 
     protected string $directory;
 
-    public string $name;
-    public string $canonicalField = 'identifier';
-    public string $sortField = '__createdAt';
-    public string $sortDirection = 'DESC';
-    public int $pageSize = 25;
-    public bool $prevNextLinks = true;
-    public string $detailTemplate = 'detail';
-    public string $listTemplate = 'list';
-
     /** @var array<array<string, mixed>> */
     public array $fields = [];
 
@@ -55,18 +46,19 @@ class PublicationType implements SerializableContract
         }
     }
 
-    public function __construct(string $name, string $canonicalField = 'identifier', string $sortField = '__createdAt', string $sortDirection = 'DESC', int $pageSize = 25, bool $prevNextLinks = true, string $detailTemplate = 'detail', string $listTemplate = 'list', array $fields = [], ?string $directory = null)
-    {
-        $this->name = $name;
-        $this->canonicalField = $canonicalField;
-        $this->sortField = $sortField;
-        $this->sortDirection = $sortDirection;
-        $this->pageSize = $pageSize;
-        $this->prevNextLinks = $prevNextLinks;
-        $this->detailTemplate = $detailTemplate;
-        $this->listTemplate = $listTemplate;
+    public function __construct(
+        public string $name,
+        public string $canonicalField = 'identifier',
+        public string $sortField = '__createdAt',
+        public string $sortDirection = 'DESC',
+        public int $pageSize = 25,
+        public bool $prevNextLinks = true,
+        public string $detailTemplate = 'detail',
+        public string $listTemplate = 'list',
+        array $fields = [],
+        ?string $directory = null
+    ) {
         $this->fields = $fields;
-
         $this->directory = $directory ?? Str::slug($name);
     }
 

--- a/packages/framework/tests/Feature/Actions/CreatesNewPublicationPageTest.php
+++ b/packages/framework/tests/Feature/Actions/CreatesNewPublicationPageTest.php
@@ -51,7 +51,6 @@ title: Hello World
 ## Write something awesome.
 
 ', file_get_contents(Hyde::path('test-publication/hello-world.md')));
-
     }
 
     protected function makePublicationType(): PublicationType

--- a/packages/framework/tests/Feature/PublicationTypeTest.php
+++ b/packages/framework/tests/Feature/PublicationTypeTest.php
@@ -30,9 +30,9 @@ class PublicationTypeTest extends TestCase
 
     public function testConstructWithDefaultValues()
     {
-        $publicationType = new PublicationType('test');
+        $publicationType = new PublicationType('Test Publication');
 
-        $this->assertEquals('test', $publicationType->name);
+        $this->assertEquals('Test Publication', $publicationType->name);
         $this->assertEquals('identifier', $publicationType->canonicalField);
         $this->assertEquals('__createdAt', $publicationType->sortField);
         $this->assertEquals('DESC', $publicationType->sortDirection);
@@ -41,6 +41,8 @@ class PublicationTypeTest extends TestCase
         $this->assertEquals('detail', $publicationType->detailTemplate);
         $this->assertEquals('list', $publicationType->listTemplate);
         $this->assertEquals([], $publicationType->fields);
+
+        $this->assertEquals('test-publication', $publicationType->getDirectory());
     }
 
     public function test_class_is_arrayable()

--- a/packages/framework/tests/Feature/PublicationTypeTest.php
+++ b/packages/framework/tests/Feature/PublicationTypeTest.php
@@ -28,6 +28,21 @@ class PublicationTypeTest extends TestCase
         }
     }
 
+    public function testConstructWithDefaultValues()
+    {
+        $publicationType = new PublicationType('test');
+
+        $this->assertEquals('test', $publicationType->name);
+        $this->assertEquals('identifier', $publicationType->canonicalField);
+        $this->assertEquals('__createdAt', $publicationType->sortField);
+        $this->assertEquals('DESC', $publicationType->sortDirection);
+        $this->assertEquals(25, $publicationType->pageSize);
+        $this->assertEquals(true, $publicationType->prevNextLinks);
+        $this->assertEquals('detail', $publicationType->detailTemplate);
+        $this->assertEquals('list', $publicationType->listTemplate);
+        $this->assertEquals([], $publicationType->fields);
+    }
+
     public function test_class_is_arrayable()
     {
         $publicationType = new PublicationType(...$this->getTestData());


### PR DESCRIPTION
Resolves the following:

> I think the default values used in the make pubtype command can be set as default values in the constructor as it is extremely verbose, making it bulky to test.

_Originally posted by @caendesilva in https://github.com/hydephp/develop/issues/685#issuecomment-1336199055_
      