### PR TITLE
Extract class for pagination settings

### DIFF
--- a/packages/framework/src/Console/Commands/MakePublicationTypeCommand.php
+++ b/packages/framework/src/Console/Commands/MakePublicationTypeCommand.php
@@ -62,7 +62,7 @@ class MakePublicationTypeCommand extends ValidatingCommand implements CommandHan
 
         $canonicalField = $this->getCanonicalField($fields);
 
-        $creator = new CreatesNewPublicationType($title, $fields, $canonicalField, $sortField, $sortAscending, $pageSize, $prevNextLinks, $this->output);
+        $creator = new CreatesNewPublicationType($title, $fields, $canonicalField, $sortField, $sortAscending, $prevNextLinks, $pageSize, $this->output);
         $creator->create();
 
         $this->info('Publication type created successfully!');

--- a/packages/framework/src/Console/Commands/MakePublicationTypeCommand.php
+++ b/packages/framework/src/Console/Commands/MakePublicationTypeCommand.php
@@ -55,14 +55,14 @@ class MakePublicationTypeCommand extends ValidatingCommand implements CommandHan
 
         $sortField = $this->getSortField($fields);
 
-        $sortDirection = $this->getSortDirection();
+        $sortAscending = $this->getSortDirection();
 
         $pageSize = $this->getPageSize();
         $prevNextLinks = $this->getPrevNextLinks();
 
         $canonicalField = $this->getCanonicalField($fields);
 
-        $creator = new CreatesNewPublicationType($title, $fields, $canonicalField, $sortField, $sortDirection, $pageSize, $prevNextLinks, $this->output);
+        $creator = new CreatesNewPublicationType($title, $fields, $canonicalField, $sortField, $sortAscending, $pageSize, $prevNextLinks, $this->output);
         $creator->create();
 
         $this->info('Publication type created successfully!');

--- a/packages/framework/src/Console/Commands/MakePublicationTypeCommand.php
+++ b/packages/framework/src/Console/Commands/MakePublicationTypeCommand.php
@@ -131,11 +131,11 @@ class MakePublicationTypeCommand extends ValidatingCommand implements CommandHan
         return $selected === 'dateCreated (meta field)' ? '__createdAt' : $options[(array_flip($options)[$selected])];
     }
 
-    protected function getSortDirection(): string
+    protected function getSortDirection(): bool
     {
         $options = [
             'Ascending (oldest items first if sorting by dateCreated)'  => true,
-            'Descending (newest items first if sorting by dateCreated)' => true,
+            'Descending (newest items first if sorting by dateCreated)' => false,
         ];
 
         return $options[$this->choice('Choose the default sort direction', array_keys($options), 'Ascending (oldest items first if sorting by dateCreated)')];

--- a/packages/framework/src/Console/Commands/MakePublicationTypeCommand.php
+++ b/packages/framework/src/Console/Commands/MakePublicationTypeCommand.php
@@ -134,8 +134,8 @@ class MakePublicationTypeCommand extends ValidatingCommand implements CommandHan
     protected function getSortDirection(): string
     {
         $options = [
-            'Ascending (oldest items first if sorting by dateCreated)'  => 'ASC',
-            'Descending (newest items first if sorting by dateCreated)' => 'DESC',
+            'Ascending (oldest items first if sorting by dateCreated)'  => true,
+            'Descending (newest items first if sorting by dateCreated)' => true,
         ];
 
         return $options[$this->choice('Choose the default sort direction', array_keys($options), 'Ascending (oldest items first if sorting by dateCreated)')];

--- a/packages/framework/src/Framework/Actions/CreatesNewPublicationType.php
+++ b/packages/framework/src/Framework/Actions/CreatesNewPublicationType.php
@@ -39,12 +39,14 @@ class CreatesNewPublicationType extends CreateAction implements CreateActionCont
         $type = new PublicationType(
             $this->name,
             $this->canonicalField,
-            $this->sortField,
-            $this->sortDirection,
-            $this->pageSize,
-            $this->prevNextLinks,
             "{$this->dirName}_detail",
             "{$this->dirName}_list",
+            [
+                $this->sortField,
+                $this->sortDirection,
+                $this->pageSize,
+                $this->prevNextLinks,
+            ],
             $this->fields->toArray()
         );
 

--- a/packages/framework/src/Framework/Actions/CreatesNewPublicationType.php
+++ b/packages/framework/src/Framework/Actions/CreatesNewPublicationType.php
@@ -25,7 +25,7 @@ class CreatesNewPublicationType extends CreateAction implements CreateActionCont
         protected Collection $fields,
         protected string $canonicalField,
         protected string $sortField,
-        protected string $sortAscending,
+        protected bool $sortAscending,
         protected int $pageSize,
         protected bool $prevNextLinks,
         protected ?OutputStyle $output = null,

--- a/packages/framework/src/Framework/Actions/CreatesNewPublicationType.php
+++ b/packages/framework/src/Framework/Actions/CreatesNewPublicationType.php
@@ -26,8 +26,8 @@ class CreatesNewPublicationType extends CreateAction implements CreateActionCont
         protected string $canonicalField,
         protected string $sortField,
         protected bool $sortAscending,
-        protected int $pageSize,
         protected bool $prevNextLinks,
+        protected int $pageSize,
         protected ?OutputStyle $output = null,
     ) {
         $this->dirName = $this->formatStringForStorage($this->name);
@@ -44,8 +44,8 @@ class CreatesNewPublicationType extends CreateAction implements CreateActionCont
             [
                 $this->sortField,
                 $this->sortAscending,
-                $this->pageSize,
                 $this->prevNextLinks,
+                $this->pageSize,
             ],
             $this->fields->toArray()
         );

--- a/packages/framework/src/Framework/Actions/CreatesNewPublicationType.php
+++ b/packages/framework/src/Framework/Actions/CreatesNewPublicationType.php
@@ -25,7 +25,7 @@ class CreatesNewPublicationType extends CreateAction implements CreateActionCont
         protected Collection $fields,
         protected string $canonicalField,
         protected string $sortField,
-        protected string $sortDirection,
+        protected string $sortAscending,
         protected int $pageSize,
         protected bool $prevNextLinks,
         protected ?OutputStyle $output = null,
@@ -43,7 +43,7 @@ class CreatesNewPublicationType extends CreateAction implements CreateActionCont
             "{$this->dirName}_list",
             [
                 $this->sortField,
-                $this->sortDirection,
+                $this->sortAscending,
                 $this->pageSize,
                 $this->prevNextLinks,
             ],

--- a/packages/framework/src/Framework/Features/Publications/Models/PaginationSettings.php
+++ b/packages/framework/src/Framework/Features/Publications/Models/PaginationSettings.php
@@ -23,9 +23,9 @@ class PaginationSettings implements SerializableContract
 
     public function __construct(string $sortField = '__createdAt', bool $sortAscending = true, int $pageSize = 25, bool $prevNextLinks = true)
     {
-        $this->sortField     = $sortField;
+        $this->sortField = $sortField;
         $this->sortAscending = $sortAscending;
-        $this->pageSize      = $pageSize;
+        $this->pageSize = $pageSize;
         $this->prevNextLinks = $prevNextLinks;
     }
 

--- a/packages/framework/src/Framework/Features/Publications/Models/PaginationSettings.php
+++ b/packages/framework/src/Framework/Features/Publications/Models/PaginationSettings.php
@@ -21,7 +21,8 @@ class PaginationSettings implements SerializableContract
         return new static(...$data);
     }
 
-    public function __construct(string $sortField = '__createdAt', string $sortDirection = 'DESC', int $pageSize = 25, bool $prevNextLinks = true) {
+    public function __construct(string $sortField = '__createdAt', string $sortDirection = 'DESC', int $pageSize = 25, bool $prevNextLinks = true)
+    {
         $this->sortField = $sortField;
         $this->sortDirection = $sortDirection;
         $this->pageSize = $pageSize;

--- a/packages/framework/src/Framework/Features/Publications/Models/PaginationSettings.php
+++ b/packages/framework/src/Framework/Features/Publications/Models/PaginationSettings.php
@@ -12,7 +12,7 @@ class PaginationSettings implements SerializableContract
     use Serializable;
 
     public string $sortField = '__createdAt';
-    public string $sortAscending = 'DESC';
+    public bool $sortAscending = true;
     public int $pageSize = 25;
     public bool $prevNextLinks = true;
 
@@ -21,7 +21,7 @@ class PaginationSettings implements SerializableContract
         return new static(...$data);
     }
 
-    public function __construct(string $sortField = '__createdAt', string $sortAscending = 'DESC', int $pageSize = 25, bool $prevNextLinks = true)
+    public function __construct(string $sortField = '__createdAt', bool $sortAscending = true, int $pageSize = 25, bool $prevNextLinks = true)
     {
         $this->sortField     = $sortField;
         $this->sortAscending = $sortAscending;

--- a/packages/framework/src/Framework/Features/Publications/Models/PaginationSettings.php
+++ b/packages/framework/src/Framework/Features/Publications/Models/PaginationSettings.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Hyde\Framework\Features\Publications\Models;
+
+use Hyde\Support\Concerns\Serializable;
+use Hyde\Support\Contracts\SerializableContract;
+
+class PaginationSettings implements SerializableContract
+{
+    use Serializable;
+
+    public string $sortField = '__createdAt';
+    public string $sortDirection = 'DESC';
+    public int $pageSize = 25;
+    public bool $prevNextLinks = true;
+
+    public static function fromArray(array $data): static
+    {
+        return new static(...$data);
+    }
+
+    public function __construct(string $sortField = '__createdAt', string $sortDirection = 'DESC', int $pageSize = 25, bool $prevNextLinks = true) {
+        $this->sortField = $sortField;
+        $this->sortDirection = $sortDirection;
+        $this->pageSize = $pageSize;
+        $this->prevNextLinks = $prevNextLinks;
+    }
+
+    public function toArray(): array
+    {
+        return [
+            'sortField' => $this->sortField,
+            'sortDirection' => $this->sortDirection,
+            'pageSize' => $this->pageSize,
+            'prevNextLinks' => $this->prevNextLinks,
+        ];
+    }
+}

--- a/packages/framework/src/Framework/Features/Publications/Models/PaginationSettings.php
+++ b/packages/framework/src/Framework/Features/Publications/Models/PaginationSettings.php
@@ -12,7 +12,7 @@ class PaginationSettings implements SerializableContract
     use Serializable;
 
     public string $sortField = '__createdAt';
-    public string $sortDirection = 'DESC';
+    public string $sortAscending = 'DESC';
     public int $pageSize = 25;
     public bool $prevNextLinks = true;
 
@@ -21,11 +21,11 @@ class PaginationSettings implements SerializableContract
         return new static(...$data);
     }
 
-    public function __construct(string $sortField = '__createdAt', string $sortDirection = 'DESC', int $pageSize = 25, bool $prevNextLinks = true)
+    public function __construct(string $sortField = '__createdAt', string $sortAscending = 'DESC', int $pageSize = 25, bool $prevNextLinks = true)
     {
-        $this->sortField = $sortField;
-        $this->sortDirection = $sortDirection;
-        $this->pageSize = $pageSize;
+        $this->sortField     = $sortField;
+        $this->sortAscending = $sortAscending;
+        $this->pageSize      = $pageSize;
         $this->prevNextLinks = $prevNextLinks;
     }
 
@@ -33,7 +33,7 @@ class PaginationSettings implements SerializableContract
     {
         return [
             'sortField' => $this->sortField,
-            'sortDirection' => $this->sortDirection,
+            'sortAscending' => $this->sortAscending,
             'pageSize' => $this->pageSize,
             'prevNextLinks' => $this->prevNextLinks,
         ];

--- a/packages/framework/src/Framework/Features/Publications/Models/PaginationSettings.php
+++ b/packages/framework/src/Framework/Features/Publications/Models/PaginationSettings.php
@@ -13,20 +13,20 @@ class PaginationSettings implements SerializableContract
 
     public string $sortField = '__createdAt';
     public bool $sortAscending = true;
-    public int $pageSize = 25;
     public bool $prevNextLinks = true;
+    public int $pageSize = 25;
 
     public static function fromArray(array $data): static
     {
         return new static(...$data);
     }
 
-    public function __construct(string $sortField = '__createdAt', bool $sortAscending = true, int $pageSize = 25, bool $prevNextLinks = true)
+    public function __construct(string $sortField = '__createdAt', bool $sortAscending = true, bool $prevNextLinks = true, int $pageSize = 25)
     {
         $this->sortField = $sortField;
         $this->sortAscending = $sortAscending;
-        $this->pageSize = $pageSize;
         $this->prevNextLinks = $prevNextLinks;
+        $this->pageSize = $pageSize;
     }
 
     public function toArray(): array
@@ -34,8 +34,8 @@ class PaginationSettings implements SerializableContract
         return [
             'sortField' => $this->sortField,
             'sortAscending' => $this->sortAscending,
-            'pageSize' => $this->pageSize,
             'prevNextLinks' => $this->prevNextLinks,
+            'pageSize' => $this->pageSize,
         ];
     }
 }

--- a/packages/framework/src/Framework/Features/Publications/Models/PublicationType.php
+++ b/packages/framework/src/Framework/Features/Publications/Models/PublicationType.php
@@ -24,6 +24,7 @@ class PublicationType implements SerializableContract
     use Serializable;
     use InteractsWithDirectories;
 
+    public PaginationSettings|array $paginationSettings = [];
     protected string $directory;
 
     /** @var array<array<string, mixed>> */
@@ -49,17 +50,17 @@ class PublicationType implements SerializableContract
     public function __construct(
         public string $name,
         public string $canonicalField = 'identifier',
-        public string $sortField = '__createdAt',
-        public string $sortDirection = 'DESC',
-        public int $pageSize = 25,
-        public bool $prevNextLinks = true,
         public string $detailTemplate = 'detail',
         public string $listTemplate = 'list',
+        array|PaginationSettings $paginationSettings = [],
         array $fields = [],
         ?string $directory = null
     ) {
-        $this->fields = $fields;
-        $this->directory = $directory ?? Str::slug($name);
+        $this->fields             = $fields;
+        $this->directory          = $directory ?? Str::slug($name);
+        $this->paginationSettings = $paginationSettings instanceof PaginationSettings
+            ? $paginationSettings
+            : PaginationSettings::fromArray($paginationSettings);
     }
 
     public function toArray(): array
@@ -67,12 +68,9 @@ class PublicationType implements SerializableContract
         return [
             'name' => $this->name,
             'canonicalField' => $this->canonicalField,
-            'sortField' => $this->sortField,
-            'sortDirection' => $this->sortDirection,
-            'pageSize' => $this->pageSize,
-            'prevNextLinks' => $this->prevNextLinks,
             'detailTemplate' => $this->detailTemplate,
             'listTemplate' => $this->listTemplate,
+            'paginationSettings' => $this->paginationSettings->toArray(),
             'fields' => $this->fields,
         ];
     }

--- a/packages/framework/src/Framework/Features/Publications/Models/PublicationType.php
+++ b/packages/framework/src/Framework/Features/Publications/Models/PublicationType.php
@@ -24,7 +24,7 @@ class PublicationType implements SerializableContract
     use Serializable;
     use InteractsWithDirectories;
 
-    public PaginationSettings|array $paginationSettings = [];
+    public PaginationSettings|array $pagination = [];
     protected string $directory;
 
     /** @var array<array<string, mixed>> */
@@ -52,15 +52,15 @@ class PublicationType implements SerializableContract
         public string $canonicalField = 'identifier',
         public string $detailTemplate = 'detail',
         public string $listTemplate = 'list',
-        array|PaginationSettings $paginationSettings = [],
+        array|PaginationSettings $pagination = [],
         array $fields = [],
         ?string $directory = null
     ) {
         $this->fields = $fields;
         $this->directory = $directory ?? Str::slug($name);
-        $this->paginationSettings = $paginationSettings instanceof PaginationSettings
-            ? $paginationSettings
-            : PaginationSettings::fromArray($paginationSettings);
+        $this->pagination = $pagination instanceof PaginationSettings
+            ? $pagination
+            : PaginationSettings::fromArray($pagination);
     }
 
     public function toArray(): array
@@ -70,7 +70,7 @@ class PublicationType implements SerializableContract
             'canonicalField' => $this->canonicalField,
             'detailTemplate' => $this->detailTemplate,
             'listTemplate' => $this->listTemplate,
-            'paginationSettings' => $this->paginationSettings->toArray(),
+            'pagination' => $this->pagination->toArray(),
             'fields' => $this->fields,
         ];
     }

--- a/packages/framework/src/Framework/Features/Publications/Models/PublicationType.php
+++ b/packages/framework/src/Framework/Features/Publications/Models/PublicationType.php
@@ -56,8 +56,8 @@ class PublicationType implements SerializableContract
         array $fields = [],
         ?string $directory = null
     ) {
-        $this->fields             = $fields;
-        $this->directory          = $directory ?? Str::slug($name);
+        $this->fields = $fields;
+        $this->directory = $directory ?? Str::slug($name);
         $this->paginationSettings = $paginationSettings instanceof PaginationSettings
             ? $paginationSettings
             : PaginationSettings::fromArray($paginationSettings);

--- a/packages/framework/tests/Feature/Actions/CreatesNewPublicationPageTest.php
+++ b/packages/framework/tests/Feature/Actions/CreatesNewPublicationPageTest.php
@@ -58,13 +58,7 @@ title: Hello World
         return new PublicationType(
             'test',
             'title',
-            'sort',
-            'asc',
-            10,
-            true,
-            'detail',
-            'list',
-            [
+            fields: [
                 [
                     'type' => 'string',
                     'name' => 'title',
@@ -72,7 +66,7 @@ title: Hello World
                     'max'  => 128,
                 ],
             ],
-            'test-publication',
+            directory: 'test-publication',
         );
     }
 }

--- a/packages/framework/tests/Feature/Actions/CreatesNewPublicationTypeTest.php
+++ b/packages/framework/tests/Feature/Actions/CreatesNewPublicationTypeTest.php
@@ -19,7 +19,7 @@ class CreatesNewPublicationTypeTest extends TestCase
 {
     public function test_it_creates_a_new_publication_type()
     {
-        $creator = new CreatesNewPublicationType('name', new Collection(), 'canonical', 'sort', true, 10, true);
+        $creator = new CreatesNewPublicationType('name', new Collection(), 'canonical', 'sort', true, true, 10);
         $creator->create();
 
         $this->assertFileExists(Hyde::path('name/schema.json'));

--- a/packages/framework/tests/Feature/Actions/CreatesNewPublicationTypeTest.php
+++ b/packages/framework/tests/Feature/Actions/CreatesNewPublicationTypeTest.php
@@ -28,7 +28,7 @@ class CreatesNewPublicationTypeTest extends TestCase
         $this->assertStringContainsString('"name": "name"', $result);
         $this->assertStringContainsString('"canonicalField": "canonical"', $result);
         $this->assertStringContainsString('"sortField": "sort"', $result);
-        $this->assertStringContainsString('"sortDirection": "asc"', $result);
+        $this->assertStringContainsString('"sortAscending": "asc"', $result);
         $this->assertStringContainsString('"pageSize": 10', $result);
         $this->assertStringContainsString('"prevNextLinks": true', $result);
         $this->assertStringContainsString('"detailTemplate": "name_detail"', $result);

--- a/packages/framework/tests/Feature/Actions/CreatesNewPublicationTypeTest.php
+++ b/packages/framework/tests/Feature/Actions/CreatesNewPublicationTypeTest.php
@@ -19,7 +19,7 @@ class CreatesNewPublicationTypeTest extends TestCase
 {
     public function test_it_creates_a_new_publication_type()
     {
-        $creator = new CreatesNewPublicationType('name', new Collection(), 'canonical', 'sort', 'asc', 10, true);
+        $creator = new CreatesNewPublicationType('name', new Collection(), 'canonical', 'sort', true, 10, true);
         $creator->create();
 
         $this->assertFileExists(Hyde::path('name/schema.json'));
@@ -28,7 +28,7 @@ class CreatesNewPublicationTypeTest extends TestCase
         $this->assertStringContainsString('"name": "name"', $result);
         $this->assertStringContainsString('"canonicalField": "canonical"', $result);
         $this->assertStringContainsString('"sortField": "sort"', $result);
-        $this->assertStringContainsString('"sortAscending": "asc"', $result);
+        $this->assertStringContainsString('"sortAscending": true', $result);
         $this->assertStringContainsString('"pageSize": 10', $result);
         $this->assertStringContainsString('"prevNextLinks": true', $result);
         $this->assertStringContainsString('"detailTemplate": "name_detail"', $result);

--- a/packages/framework/tests/Feature/Commands/MakePublicationCommandTest.php
+++ b/packages/framework/tests/Feature/Commands/MakePublicationCommandTest.php
@@ -137,12 +137,14 @@ class MakePublicationCommandTest extends TestCase
             json_encode([
                 'name'           => 'Test Publication',
                 'canonicalField' => 'title',
-                'sortField'      => '__createdAt',
-                'sortDirection'  => 'ASC',
-                'pageSize'       => 10,
-                'prevNextLinks'  => true,
                 'detailTemplate' => 'test-publication_detail',
                 'listTemplate'   => 'test-publication_list',
+                'paginationSettings' => [
+                    'pageSize'       => 10,
+                    'prevNextLinks'  => true,
+                    'sortField'      => '__createdAt',
+                    'sortDirection'  => 'ASC',
+                ],
                 'fields'         => [
                     [
                         'name' => 'title',

--- a/packages/framework/tests/Feature/Commands/MakePublicationCommandTest.php
+++ b/packages/framework/tests/Feature/Commands/MakePublicationCommandTest.php
@@ -143,7 +143,7 @@ class MakePublicationCommandTest extends TestCase
                     'pageSize'       => 10,
                     'prevNextLinks'  => true,
                     'sortField'      => '__createdAt',
-                    'sortAscending'  => 'ASC',
+                    'sortAscending'  => true,
                 ],
                 'fields'         => [
                     [

--- a/packages/framework/tests/Feature/Commands/MakePublicationCommandTest.php
+++ b/packages/framework/tests/Feature/Commands/MakePublicationCommandTest.php
@@ -139,7 +139,7 @@ class MakePublicationCommandTest extends TestCase
                 'canonicalField' => 'title',
                 'detailTemplate' => 'test-publication_detail',
                 'listTemplate'   => 'test-publication_list',
-                'paginationSettings' => [
+                'pagination' => [
                     'pageSize'       => 10,
                     'prevNextLinks'  => true,
                     'sortField'      => '__createdAt',

--- a/packages/framework/tests/Feature/Commands/MakePublicationCommandTest.php
+++ b/packages/framework/tests/Feature/Commands/MakePublicationCommandTest.php
@@ -143,7 +143,7 @@ class MakePublicationCommandTest extends TestCase
                     'pageSize'       => 10,
                     'prevNextLinks'  => true,
                     'sortField'      => '__createdAt',
-                    'sortDirection'  => 'ASC',
+                    'sortAscending'  => 'ASC',
                 ],
                 'fields'         => [
                     [

--- a/packages/framework/tests/Feature/Commands/MakePublicationTypeCommandTest.php
+++ b/packages/framework/tests/Feature/Commands/MakePublicationTypeCommandTest.php
@@ -77,7 +77,7 @@ class MakePublicationTypeCommandTest extends TestCase
                 "listTemplate": "test-publication_list",
                 "pagination": {
                     "sortField": "__createdAt",
-                    "sortDirection": "ASC",
+                    "sortAscending": "ASC",
                     "pageSize": 10,
                     "prevNextLinks": true
                 },

--- a/packages/framework/tests/Feature/Commands/MakePublicationTypeCommandTest.php
+++ b/packages/framework/tests/Feature/Commands/MakePublicationTypeCommandTest.php
@@ -75,7 +75,7 @@ class MakePublicationTypeCommandTest extends TestCase
                 "canonicalField": "publication-title",
                 "detailTemplate": "test-publication_detail",
                 "listTemplate": "test-publication_list",
-                "paginationSettings": {
+                "pagination": {
                     "sortField": "__createdAt",
                     "sortDirection": "ASC",
                     "pageSize": 10,

--- a/packages/framework/tests/Feature/Commands/MakePublicationTypeCommandTest.php
+++ b/packages/framework/tests/Feature/Commands/MakePublicationTypeCommandTest.php
@@ -77,7 +77,7 @@ class MakePublicationTypeCommandTest extends TestCase
                 "listTemplate": "test-publication_list",
                 "pagination": {
                     "sortField": "__createdAt",
-                    "sortAscending": "ASC",
+                    "sortAscending": true,
                     "pageSize": 10,
                     "prevNextLinks": true
                 },

--- a/packages/framework/tests/Feature/Commands/MakePublicationTypeCommandTest.php
+++ b/packages/framework/tests/Feature/Commands/MakePublicationTypeCommandTest.php
@@ -78,8 +78,8 @@ class MakePublicationTypeCommandTest extends TestCase
                 "pagination": {
                     "sortField": "__createdAt",
                     "sortAscending": true,
-                    "pageSize": 10,
-                    "prevNextLinks": true
+                    "prevNextLinks": true,
+                    "pageSize": 10
                 },
                 "fields": [
                     {

--- a/packages/framework/tests/Feature/Commands/MakePublicationTypeCommandTest.php
+++ b/packages/framework/tests/Feature/Commands/MakePublicationTypeCommandTest.php
@@ -73,12 +73,14 @@ class MakePublicationTypeCommandTest extends TestCase
             {
                 "name": "Test Publication",
                 "canonicalField": "publication-title",
-                "sortField": "__createdAt",
-                "sortDirection": "ASC",
-                "pageSize": 10,
-                "prevNextLinks": true,
                 "detailTemplate": "test-publication_detail",
                 "listTemplate": "test-publication_list",
+                "paginationSettings": {
+                    "sortField": "__createdAt",
+                    "sortDirection": "ASC",
+                    "pageSize": 10,
+                    "prevNextLinks": true
+                },
                 "fields": [
                     {
                         "type": "string",

--- a/packages/framework/tests/Feature/PublicationListPageTest.php
+++ b/packages/framework/tests/Feature/PublicationListPageTest.php
@@ -72,7 +72,7 @@ Hello World!
             'listTemplate'   => 'list',
             'pagination' => [
                 'sortField'      => 'sort',
-                'sortDirection'  => 'asc',
+                'sortAscending'  => 'asc',
                 'pageSize'       => 10,
                 'prevNextLinks'  => true,
             ],

--- a/packages/framework/tests/Feature/PublicationListPageTest.php
+++ b/packages/framework/tests/Feature/PublicationListPageTest.php
@@ -72,7 +72,7 @@ Hello World!
             'listTemplate'   => 'list',
             'pagination' => [
                 'sortField'      => 'sort',
-                'sortAscending'  => 'asc',
+                'sortAscending'  => true,
                 'pageSize'       => 10,
                 'prevNextLinks'  => true,
             ],

--- a/packages/framework/tests/Feature/PublicationListPageTest.php
+++ b/packages/framework/tests/Feature/PublicationListPageTest.php
@@ -68,12 +68,14 @@ Hello World!
         return [
             'name'           => 'test',
             'canonicalField' => 'canonical',
-            'sortField'      => 'sort',
-            'sortDirection'  => 'asc',
-            'pageSize'       => 10,
-            'prevNextLinks'  => true,
             'detailTemplate' => 'detail',
             'listTemplate'   => 'list',
+            'paginationSettings' => [
+                'sortField'      => 'sort',
+                'sortDirection'  => 'asc',
+                'pageSize'       => 10,
+                'prevNextLinks'  => true,
+            ],
             'fields'         => [
                 'foo' => 'bar',
             ],

--- a/packages/framework/tests/Feature/PublicationListPageTest.php
+++ b/packages/framework/tests/Feature/PublicationListPageTest.php
@@ -70,7 +70,7 @@ Hello World!
             'canonicalField' => 'canonical',
             'detailTemplate' => 'detail',
             'listTemplate'   => 'list',
-            'paginationSettings' => [
+            'pagination' => [
                 'sortField'      => 'sort',
                 'sortDirection'  => 'asc',
                 'pageSize'       => 10,

--- a/packages/framework/tests/Feature/PublicationPageTest.php
+++ b/packages/framework/tests/Feature/PublicationPageTest.php
@@ -121,7 +121,7 @@ class PublicationPageTest extends TestCase
   "listTemplate": "test_list",
   "pagination": {
       "sortField": "__createdAt",
-      "sortAscending": "DESC",
+      "sortAscending": true,
       "pageSize": 0,
       "prevNextLinks": true
   },

--- a/packages/framework/tests/Feature/PublicationPageTest.php
+++ b/packages/framework/tests/Feature/PublicationPageTest.php
@@ -117,12 +117,14 @@ class PublicationPageTest extends TestCase
         file_put_contents(Hyde::path('test-publication/schema.json'), '{
   "name": "test",
   "canonicalField": "slug",
-  "sortField": "__createdAt",
-  "sortDirection": "DESC",
-  "pageSize": 0,
-  "prevNextLinks": true,
   "detailTemplate": "test_detail",
   "listTemplate": "test_list",
+  "paginationSettings": {
+      "sortField": "__createdAt",
+      "sortDirection": "DESC",
+      "pageSize": 0,
+      "prevNextLinks": true
+  },
   "fields": [
     {
       "name": "slug",

--- a/packages/framework/tests/Feature/PublicationPageTest.php
+++ b/packages/framework/tests/Feature/PublicationPageTest.php
@@ -121,7 +121,7 @@ class PublicationPageTest extends TestCase
   "listTemplate": "test_list",
   "pagination": {
       "sortField": "__createdAt",
-      "sortDirection": "DESC",
+      "sortAscending": "DESC",
       "pageSize": 0,
       "prevNextLinks": true
   },

--- a/packages/framework/tests/Feature/PublicationPageTest.php
+++ b/packages/framework/tests/Feature/PublicationPageTest.php
@@ -119,7 +119,7 @@ class PublicationPageTest extends TestCase
   "canonicalField": "slug",
   "detailTemplate": "test_detail",
   "listTemplate": "test_list",
-  "paginationSettings": {
+  "pagination": {
       "sortField": "__createdAt",
       "sortDirection": "DESC",
       "pageSize": 0,

--- a/packages/framework/tests/Feature/PublicationTypeTest.php
+++ b/packages/framework/tests/Feature/PublicationTypeTest.php
@@ -44,7 +44,7 @@ class PublicationTypeTest extends TestCase
         $this->assertEquals([], $publicationType->fields);
         $this->assertEquals(PaginationSettings::fromArray([
             'sortField' => '__createdAt',
-            'sortAscending' => 'DESC',
+            'sortAscending' => true,
             'pageSize' => 25,
             'prevNextLinks' => true,
         ]), $publicationType->pagination);
@@ -162,7 +162,7 @@ class PublicationTypeTest extends TestCase
             'listTemplate'   => 'test-publication_list',
             'pagination' => [
                 'sortField'      => '__createdAt',
-                'sortAscending'  => 'DESC',
+                'sortAscending'  => true,
                 'pageSize'       => 25,
                 'prevNextLinks'  => true,
             ],

--- a/packages/framework/tests/Feature/PublicationTypeTest.php
+++ b/packages/framework/tests/Feature/PublicationTypeTest.php
@@ -4,9 +4,8 @@ declare(strict_types=1);
 
 namespace Hyde\Framework\Testing\Feature;
 
-use Hyde\Framework\Features\Publications\Models\PaginationSettings;
-use Illuminate\Contracts\Support\Arrayable;
 use function array_merge;
+use Hyde\Framework\Features\Publications\Models\PaginationSettings;
 use Hyde\Framework\Features\Publications\Models\PublicationFieldType;
 use Hyde\Framework\Features\Publications\Models\PublicationListPage;
 use Hyde\Framework\Features\Publications\Models\PublicationType;

--- a/packages/framework/tests/Feature/PublicationTypeTest.php
+++ b/packages/framework/tests/Feature/PublicationTypeTest.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Hyde\Framework\Testing\Feature;
 
+use Hyde\Framework\Features\Publications\Models\PaginationSettings;
+use Illuminate\Contracts\Support\Arrayable;
 use function array_merge;
 use Hyde\Framework\Features\Publications\Models\PublicationFieldType;
 use Hyde\Framework\Features\Publications\Models\PublicationListPage;
@@ -24,7 +26,11 @@ class PublicationTypeTest extends TestCase
         $publicationType = new PublicationType(...$this->getTestData());
 
         foreach ($this->getTestData() as $key => $property) {
-            $this->assertEquals($property, $publicationType->$key);
+            if ($key === 'paginationSettings') {
+                $this->assertEquals($property, $publicationType->$key->toArray());
+            } else {
+                $this->assertEquals($property, $publicationType->$key);
+            }
         }
     }
 
@@ -34,13 +40,15 @@ class PublicationTypeTest extends TestCase
 
         $this->assertEquals('Test Publication', $publicationType->name);
         $this->assertEquals('identifier', $publicationType->canonicalField);
-        $this->assertEquals('__createdAt', $publicationType->sortField);
-        $this->assertEquals('DESC', $publicationType->sortDirection);
-        $this->assertEquals(25, $publicationType->pageSize);
-        $this->assertEquals(true, $publicationType->prevNextLinks);
         $this->assertEquals('detail', $publicationType->detailTemplate);
         $this->assertEquals('list', $publicationType->listTemplate);
         $this->assertEquals([], $publicationType->fields);
+        $this->assertEquals(PaginationSettings::fromArray([
+            'sortField' => '__createdAt',
+            'sortDirection' => 'DESC',
+            'pageSize' => 25,
+            'prevNextLinks' => true,
+        ]), $publicationType->paginationSettings);
 
         $this->assertEquals('test-publication', $publicationType->getDirectory());
     }
@@ -151,12 +159,14 @@ class PublicationTypeTest extends TestCase
         return [
             'name'           => 'Test Publication',
             'canonicalField' => 'title',
-            'sortField'      => '__createdAt',
-            'sortDirection'  => 'DESC',
-            'pageSize'       => 25,
-            'prevNextLinks'  => true,
             'detailTemplate' => 'test-publication_detail',
             'listTemplate'   => 'test-publication_list',
+            'paginationSettings' => [
+                'sortField'      => '__createdAt',
+                'sortDirection'  => 'DESC',
+                'pageSize'       => 25,
+                'prevNextLinks'  => true,
+            ],
             'fields'         => [
                 [
                     'name' => 'title',

--- a/packages/framework/tests/Feature/PublicationTypeTest.php
+++ b/packages/framework/tests/Feature/PublicationTypeTest.php
@@ -163,8 +163,8 @@ class PublicationTypeTest extends TestCase
             'pagination' => [
                 'sortField'      => '__createdAt',
                 'sortAscending'  => true,
-                'pageSize'       => 25,
                 'prevNextLinks'  => true,
+                'pageSize'       => 25,
             ],
             'fields'         => [
                 [

--- a/packages/framework/tests/Feature/PublicationTypeTest.php
+++ b/packages/framework/tests/Feature/PublicationTypeTest.php
@@ -25,7 +25,7 @@ class PublicationTypeTest extends TestCase
         $publicationType = new PublicationType(...$this->getTestData());
 
         foreach ($this->getTestData() as $key => $property) {
-            if ($key === 'paginationSettings') {
+            if ($key === 'pagination') {
                 $this->assertEquals($property, $publicationType->$key->toArray());
             } else {
                 $this->assertEquals($property, $publicationType->$key);
@@ -47,7 +47,7 @@ class PublicationTypeTest extends TestCase
             'sortDirection' => 'DESC',
             'pageSize' => 25,
             'prevNextLinks' => true,
-        ]), $publicationType->paginationSettings);
+        ]), $publicationType->pagination);
 
         $this->assertEquals('test-publication', $publicationType->getDirectory());
     }
@@ -160,7 +160,7 @@ class PublicationTypeTest extends TestCase
             'canonicalField' => 'title',
             'detailTemplate' => 'test-publication_detail',
             'listTemplate'   => 'test-publication_list',
-            'paginationSettings' => [
+            'pagination' => [
                 'sortField'      => '__createdAt',
                 'sortDirection'  => 'DESC',
                 'pageSize'       => 25,

--- a/packages/framework/tests/Feature/PublicationTypeTest.php
+++ b/packages/framework/tests/Feature/PublicationTypeTest.php
@@ -44,7 +44,7 @@ class PublicationTypeTest extends TestCase
         $this->assertEquals([], $publicationType->fields);
         $this->assertEquals(PaginationSettings::fromArray([
             'sortField' => '__createdAt',
-            'sortDirection' => 'DESC',
+            'sortAscending' => 'DESC',
             'pageSize' => 25,
             'prevNextLinks' => true,
         ]), $publicationType->pagination);
@@ -162,7 +162,7 @@ class PublicationTypeTest extends TestCase
             'listTemplate'   => 'test-publication_list',
             'pagination' => [
                 'sortField'      => '__createdAt',
-                'sortDirection'  => 'DESC',
+                'sortAscending'  => 'DESC',
                 'pageSize'       => 25,
                 'prevNextLinks'  => true,
             ],

--- a/packages/framework/tests/Unit/Pages/PublicationPageUnitTest.php
+++ b/packages/framework/tests/Unit/Pages/PublicationPageUnitTest.php
@@ -244,7 +244,7 @@ class PublicationPageUnitTest extends BaseMarkdownPageUnitTest
             'canonicalField',
             'detailTemplate',
             'listTemplate',
-            ['sortField', 'sortDirection', 1, true],
+            ['sortField', 'sortAscending', 1, true],
             [],
             'directory'
         );

--- a/packages/framework/tests/Unit/Pages/PublicationPageUnitTest.php
+++ b/packages/framework/tests/Unit/Pages/PublicationPageUnitTest.php
@@ -244,7 +244,7 @@ class PublicationPageUnitTest extends BaseMarkdownPageUnitTest
             'canonicalField',
             'detailTemplate',
             'listTemplate',
-            ['sortField', true, 1, true],
+            ['sortField', true, true, 1],
             [],
             'directory'
         );

--- a/packages/framework/tests/Unit/Pages/PublicationPageUnitTest.php
+++ b/packages/framework/tests/Unit/Pages/PublicationPageUnitTest.php
@@ -244,7 +244,7 @@ class PublicationPageUnitTest extends BaseMarkdownPageUnitTest
             'canonicalField',
             'detailTemplate',
             'listTemplate',
-            ['sortField', 'sortAscending', 1, true],
+            ['sortField', true, 1, true],
             [],
             'directory'
         );

--- a/packages/framework/tests/Unit/Pages/PublicationPageUnitTest.php
+++ b/packages/framework/tests/Unit/Pages/PublicationPageUnitTest.php
@@ -242,12 +242,9 @@ class PublicationPageUnitTest extends BaseMarkdownPageUnitTest
         return new PublicationType(
             'name',
             'canonicalField',
-            'sortField',
-            'sortDirection',
-            1,
-            true,
             'detailTemplate',
             'listTemplate',
+            ['sortField', 'sortDirection', 1, true],
             [],
             'directory'
         );

--- a/packages/framework/tests/Unit/PaginationSettingsTest.php
+++ b/packages/framework/tests/Unit/PaginationSettingsTest.php
@@ -24,7 +24,7 @@ class PaginationSettingsTest extends TestCase
 
     public function testConstruct()
     {
-        $paginationSettings = new PaginationSettings('foo', false, 10, false);
+        $paginationSettings = new PaginationSettings('foo', false, false, 10);
 
         $this->assertSame('foo', $paginationSettings->sortField);
         $this->assertFalse($paginationSettings->sortAscending);
@@ -54,8 +54,8 @@ class PaginationSettingsTest extends TestCase
         $this->assertSame([
             'sortField' => '__createdAt',
             'sortAscending' => true,
-            'pageSize' => 25,
             'prevNextLinks' => true,
+            'pageSize' => 25,
         ], $paginationSettings->toArray());
     }
 
@@ -63,7 +63,7 @@ class PaginationSettingsTest extends TestCase
     {
         $paginationSettings = new PaginationSettings();
 
-        $this->assertSame('{"sortField":"__createdAt","sortAscending":true,"pageSize":25,"prevNextLinks":true}', $paginationSettings->toJson());
+        $this->assertSame('{"sortField":"__createdAt","sortAscending":true,"prevNextLinks":true,"pageSize":25}', $paginationSettings->toJson());
     }
 
     public function testJsonSerialize()

--- a/packages/framework/tests/Unit/PaginationSettingsTest.php
+++ b/packages/framework/tests/Unit/PaginationSettingsTest.php
@@ -1,0 +1,75 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Hyde\Framework\Testing\Unit;
+
+use Hyde\Framework\Features\Publications\Models\PaginationSettings;
+use Hyde\Testing\TestCase;
+
+/**
+ * @covers \Hyde\Framework\Features\Publications\Models\PaginationSettings
+ */
+class PaginationSettingsTest extends TestCase
+{
+    public function testConstructWithDefaultValues()
+    {
+        $paginationSettings = new PaginationSettings();
+
+        $this->assertSame('__createdAt', $paginationSettings->sortField);
+        $this->assertSame(true, $paginationSettings->sortAscending);
+        $this->assertSame(25, $paginationSettings->pageSize);
+        $this->assertSame(true, $paginationSettings->prevNextLinks);
+    }
+
+    public function testConstruct()
+    {
+        $paginationSettings = new PaginationSettings('foo', false, 10, false);
+
+        $this->assertSame('foo', $paginationSettings->sortField);
+        $this->assertFalse($paginationSettings->sortAscending);
+        $this->assertSame(10, $paginationSettings->pageSize);
+        $this->assertFalse($paginationSettings->prevNextLinks);
+    }
+
+    public function testFromArray()
+    {
+        $paginationSettings = PaginationSettings::fromArray([
+            'sortField' => 'foo',
+            'sortAscending' => false,
+            'pageSize' => 10,
+            'prevNextLinks' => false,
+        ]);
+
+        $this->assertSame('foo', $paginationSettings->sortField);
+        $this->assertSame(false, $paginationSettings->sortAscending);
+        $this->assertSame(10, $paginationSettings->pageSize);
+        $this->assertSame(false, $paginationSettings->prevNextLinks);
+    }
+
+    public function testToArray()
+    {
+        $paginationSettings = new PaginationSettings();
+
+        $this->assertSame([
+            'sortField' => '__createdAt',
+            'sortAscending' => true,
+            'pageSize' => 25,
+            'prevNextLinks' => true,
+        ], $paginationSettings->toArray());
+    }
+
+    public function testToJson()
+    {
+        $paginationSettings = new PaginationSettings();
+
+        $this->assertSame('{"sortField":"__createdAt","sortAscending":true,"pageSize":25,"prevNextLinks":true}', $paginationSettings->toJson());
+    }
+
+    public function testJsonSerialize()
+    {
+        $paginationSettings = new PaginationSettings();
+
+        $this->assertSame($paginationSettings->toArray(), $paginationSettings->jsonSerialize());
+    }
+}

--- a/tests/fixtures/test-publication-schema.json
+++ b/tests/fixtures/test-publication-schema.json
@@ -5,7 +5,7 @@
     "listTemplate": "test-publication_list",
     "pagination": {
         "sortField": "__createdAt",
-        "sortAscending": "DESC",
+        "sortAscending": true,
         "pageSize": 25,
         "prevNextLinks": true
     },

--- a/tests/fixtures/test-publication-schema.json
+++ b/tests/fixtures/test-publication-schema.json
@@ -1,12 +1,14 @@
 {
     "name": "Test Publication",
     "canonicalField": "title",
-    "sortField": "__createdAt",
-    "sortDirection": "DESC",
-    "pageSize": 25,
-    "prevNextLinks": true,
     "detailTemplate": "test-publication_detail",
     "listTemplate": "test-publication_list",
+    "paginationSettings": {
+        "sortField": "__createdAt",
+        "sortDirection": "DESC",
+        "pageSize": 25,
+        "prevNextLinks": true
+    },
     "fields": [
         {
             "name": "title",

--- a/tests/fixtures/test-publication-schema.json
+++ b/tests/fixtures/test-publication-schema.json
@@ -5,7 +5,7 @@
     "listTemplate": "test-publication_list",
     "pagination": {
         "sortField": "__createdAt",
-        "sortDirection": "DESC",
+        "sortAscending": "DESC",
         "pageSize": 25,
         "prevNextLinks": true
     },

--- a/tests/fixtures/test-publication-schema.json
+++ b/tests/fixtures/test-publication-schema.json
@@ -3,7 +3,7 @@
     "canonicalField": "title",
     "detailTemplate": "test-publication_detail",
     "listTemplate": "test-publication_list",
-    "paginationSettings": {
+    "pagination": {
         "sortField": "__createdAt",
         "sortDirection": "DESC",
         "pageSize": 25,


### PR DESCRIPTION
Changes the schema for pagination settings for publication types by putting the settings in a sub-array and using a data object internally. It also changes the sort direction string to be a boolean as I don't see the need for sorting in any other way than asc/desc. All in all this leads to a more consistent and predictable schema and state.