### PR TITLE
Fix visual bug where there is no spacing before the finishing message of a site build

### DIFF
--- a/packages/framework/src/Console/Commands/BuildSiteCommand.php
+++ b/packages/framework/src/Console/Commands/BuildSiteCommand.php
@@ -106,7 +106,7 @@ class BuildSiteCommand extends Command
     {
         $execution_time = (microtime(true) - $time_start);
         $this->info(sprintf(
-            'All done! Finished in %s seconds. (%sms)',
+            "\nAll done! Finished in %s seconds. (%sms)",
             number_format($execution_time, 2),
             number_format($execution_time * 1000, 2)
         ));


### PR DESCRIPTION
> https://github.com/hydephp/develop/issues/643
>
> There should be a vertical space before "All done"
>
> ![image](https://user-images.githubusercontent.com/95144705/199830747-5dec77b6-036f-4265-96bf-f78de69f5098.png)