### PR TITLE
Get page routes from the route index

### DIFF
--- a/monorepo/HydeStan/HydeStan.php
+++ b/monorepo/HydeStan/HydeStan.php
@@ -31,8 +31,10 @@ class HydeStan
             number_format(count($this->files)))
         );
 
-        // Forward warnings to GitHub Actions
-        $this->console->line(sprintf("\n%s", implode("\n", self::$warnings)));
+        if (count(self::$warnings) > 0) {
+            // Forward warnings to GitHub Actions
+            $this->console->line(sprintf("\n%s", implode("\n", self::$warnings)));
+        }
     }
 
     public function run(): void

--- a/packages/framework/src/Pages/Concerns/HydePage.php
+++ b/packages/framework/src/Pages/Concerns/HydePage.php
@@ -223,7 +223,7 @@ abstract class HydePage implements PageSchema
      */
     public function getRoute(): Route
     {
-        return \Hyde\Facades\Route::get($this->getRouteKey());
+        return \Hyde\Facades\Route::get($this->getRouteKey()) ?? new Route($this);
     }
 
     /**

--- a/packages/framework/src/Pages/Concerns/HydePage.php
+++ b/packages/framework/src/Pages/Concerns/HydePage.php
@@ -223,7 +223,7 @@ abstract class HydePage implements PageSchema
      */
     public function getRoute(): Route
     {
-        return new Route($this);
+        return \Hyde\Facades\Route::get($this->getRouteKey());
     }
 
     /**

--- a/packages/framework/tests/Feature/HydePageTest.php
+++ b/packages/framework/tests/Feature/HydePageTest.php
@@ -501,6 +501,13 @@ class HydePageTest extends TestCase
         $this->assertEquals(new Route($page), $page->getRoute());
     }
 
+    public function test_get_route_returns_the_route_object_from_the_router_index()
+    {
+        $this->file('_pages/foo.md');
+        $page = MarkdownPage::parse('foo');
+        $this->assertSame(\Hyde\Facades\Route::get('foo'), $page->getRoute());
+    }
+
     public function test_html_title_returns_site_name_plus_page_title()
     {
         $this->assertEquals('HydePHP - Foo', MarkdownPage::make('', ['title' => 'Foo'])->htmlTitle());

--- a/packages/framework/tests/Feature/HydePageTest.php
+++ b/packages/framework/tests/Feature/HydePageTest.php
@@ -969,6 +969,7 @@ class HydePageTest extends TestCase
             $this->assertArrayHasKey($page->getRouteKey(), Hyde::routes());
 
             unlink($page::sourcePath('foo'));
+            Hyde::boot();
         }
     }
 


### PR DESCRIPTION
I think there's no point in creating a bunch of new objects each time we want to access a route, however since only pages with actual source files generally get added to the route index, the old behaviour is present as a fall back (for example when using `new MarkdownPage` in a test)