### PR TITLE
Make navigation behaviour for nested pages configurable

### DIFF
--- a/config/hyde.php
+++ b/config/hyde.php
@@ -177,6 +177,10 @@ return [
         'custom' => [
             // NavItem::toLink('https://github.com/hydephp/hyde', 'GitHub', 200),
         ],
+
+        // How should pages in subdirectories be displayed in the menu?
+        // You can choose between 'dropdown', 'flat', and 'hidden'.
+        'subdirectories' => 'hidden',
     ],
 
     /*

--- a/packages/framework/config/hyde.php
+++ b/packages/framework/config/hyde.php
@@ -177,6 +177,10 @@ return [
         'custom' => [
             // NavItem::toLink('https://github.com/hydephp/hyde', 'GitHub', 200),
         ],
+
+        // How should pages in subdirectories be displayed in the menu?
+        // You can choose between 'dropdown', 'flat', and 'hidden'.
+        'subdirectories' => 'hidden',
     ],
 
     /*

--- a/packages/framework/src/Framework/Factories/NavigationDataFactory.php
+++ b/packages/framework/src/Framework/Factories/NavigationDataFactory.php
@@ -100,6 +100,10 @@ class NavigationDataFactory extends Concerns\PageDataFactory implements Navigati
             return true;
         }
 
+        if (Str::contains($this->identifier, '/')) {
+            return true;
+        }
+
         return false;
     }
 

--- a/packages/framework/src/Framework/Factories/NavigationDataFactory.php
+++ b/packages/framework/src/Framework/Factories/NavigationDataFactory.php
@@ -83,7 +83,6 @@ class NavigationDataFactory extends Concerns\PageDataFactory implements Navigati
             return $this->getDocumentationPageGroup();
         }
 
-        // TODO If config is set to group subdirectory pages, set the group to the subdirectory name
         if (Str::contains($this->identifier, '/') && config('hyde.navigation.subdirectories', 'hidden') === 'dropdown') {
             return Str::before($this->identifier, '/');
         }

--- a/packages/framework/src/Framework/Factories/NavigationDataFactory.php
+++ b/packages/framework/src/Framework/Factories/NavigationDataFactory.php
@@ -84,6 +84,9 @@ class NavigationDataFactory extends Concerns\PageDataFactory implements Navigati
         }
 
         // TODO If config is set to group subdirectory pages, set the group to the subdirectory name
+        if (Str::contains($this->identifier, '/') && config('hyde.navigation.subdirectories', 'hidden') === 'dropdown') {
+            return Str::before($this->identifier, '/');
+        }
 
         return null;
     }

--- a/packages/framework/src/Framework/Factories/NavigationDataFactory.php
+++ b/packages/framework/src/Framework/Factories/NavigationDataFactory.php
@@ -87,6 +87,8 @@ class NavigationDataFactory extends Concerns\PageDataFactory implements Navigati
             return Str::before($this->identifier, '/');
         }
 
+        // TODO Check in front matter for group?
+
         return null;
     }
 

--- a/packages/framework/src/Framework/Factories/NavigationDataFactory.php
+++ b/packages/framework/src/Framework/Factories/NavigationDataFactory.php
@@ -100,6 +100,7 @@ class NavigationDataFactory extends Concerns\PageDataFactory implements Navigati
             return true;
         }
 
+        // TODO make this configurable
         if (Str::contains($this->identifier, '/')) {
             return true;
         }

--- a/packages/framework/src/Framework/Factories/NavigationDataFactory.php
+++ b/packages/framework/src/Framework/Factories/NavigationDataFactory.php
@@ -83,6 +83,8 @@ class NavigationDataFactory extends Concerns\PageDataFactory implements Navigati
             return $this->getDocumentationPageGroup();
         }
 
+        // TODO If config is set to group subdirectory pages, set the group to the subdirectory name
+
         return null;
     }
 

--- a/packages/framework/src/Framework/Factories/NavigationDataFactory.php
+++ b/packages/framework/src/Framework/Factories/NavigationDataFactory.php
@@ -83,7 +83,7 @@ class NavigationDataFactory extends Concerns\PageDataFactory implements Navigati
             return $this->getDocumentationPageGroup();
         }
 
-        if (Str::contains($this->identifier, '/') && config('hyde.navigation.subdirectories', 'hidden') === 'dropdown') {
+        if (Str::contains($this->identifier, '/') && $this->getSubdirectoryConfiguration() === 'dropdown') {
             return Str::before($this->identifier, '/');
         }
 
@@ -104,7 +104,7 @@ class NavigationDataFactory extends Concerns\PageDataFactory implements Navigati
             return true;
         }
 
-        if (Str::contains($this->identifier, '/') && config('hyde.navigation.subdirectories', 'hidden') === 'hidden') {
+        if (Str::contains($this->identifier, '/') && $this->getSubdirectoryConfiguration() === 'hidden') {
             return true;
         }
 
@@ -174,5 +174,10 @@ class NavigationDataFactory extends Concerns\PageDataFactory implements Navigati
         return $this->matter('navigation.group')
             ?? $this->matter('navigation.category')
             ?? 'other';
+    }
+
+    protected static function getSubdirectoryConfiguration(): string
+    {
+        return config('hyde.navigation.subdirectories', 'hidden');
     }
 }

--- a/packages/framework/src/Framework/Factories/NavigationDataFactory.php
+++ b/packages/framework/src/Framework/Factories/NavigationDataFactory.php
@@ -102,8 +102,7 @@ class NavigationDataFactory extends Concerns\PageDataFactory implements Navigati
             return true;
         }
 
-        // TODO make this configurable
-        if (Str::contains($this->identifier, '/')) {
+        if (Str::contains($this->identifier, '/') && config('hyde.navigation.subdirectories', 'hidden') === 'hidden') {
             return true;
         }
 

--- a/packages/framework/src/Framework/Features/Navigation/NavigationMenu.php
+++ b/packages/framework/src/Framework/Features/Navigation/NavigationMenu.php
@@ -32,11 +32,11 @@ class NavigationMenu
     /** @return $this */
     public function generate(): static
     {
-        Router::each(function (Route $route) {
+        Router::each(function (Route $route): void {
             $this->items->push(NavItem::fromRoute($route));
         });
 
-        collect(config('hyde.navigation.custom', []))->each(function (NavItem $item) {
+        collect(config('hyde.navigation.custom', []))->each(function (NavItem $item): void {
             $this->items->push($item);
         });
 
@@ -62,14 +62,14 @@ class NavigationMenu
 
     protected function filterHiddenItems(): Collection
     {
-        return $this->items->reject(function (NavItem $item) {
+        return $this->items->reject(function (NavItem $item): bool {
             return $item->hidden || $this->filterDocumentationPage($item);
         })->values();
     }
 
     protected function filterDuplicateItems(): Collection
     {
-        return $this->items->unique(function (NavItem $item) {
+        return $this->items->unique(function (NavItem $item): string {
             return $item->resolveLink();
         });
     }

--- a/packages/framework/tests/Feature/HydePageTest.php
+++ b/packages/framework/tests/Feature/HydePageTest.php
@@ -973,6 +973,37 @@ class HydePageTest extends TestCase
         }
     }
 
+    public function test_navigation_data_factory_hides_page_from_navigation_when_in_a_subdirectory()
+    {
+        $page = MarkdownPage::make('foo/bar');
+        $this->assertFalse($page->showInNavigation());
+        $this->assertNull($page->navigationMenuGroup());
+    }
+
+    public function test_navigation_data_factory_hides_page_from_navigation_when_in_a_and_config_is_set_to_hidden()
+    {
+        config(['hyde.navigation.subdirectories' => 'hidden']);
+        $page = MarkdownPage::make('foo/bar');
+        $this->assertFalse($page->showInNavigation());
+        $this->assertNull($page->navigationMenuGroup());
+    }
+
+    public function test_navigation_data_factory_does_not_hide_page_from_navigation_when_in_a_subdirectory_and_allowed_in_configuration()
+    {
+        config(['hyde.navigation.subdirectories' => 'flat']);
+        $page = MarkdownPage::make('foo/bar');
+        $this->assertTrue($page->showInNavigation());
+        $this->assertNull($page->navigationMenuGroup());
+    }
+
+    public function test_navigation_data_factory_allows_show_in_navigation_and_sets_group_when_dropdown_is_selected_in_config()
+    {
+        config(['hyde.navigation.subdirectories' => 'dropdown']);
+        $page = MarkdownPage::make('foo/bar');
+        $this->assertTrue($page->showInNavigation());
+        $this->assertEquals('foo', $page->navigationMenuGroup());
+    }
+
     protected function assertSameIgnoringDirSeparatorType(string $expected, string $actual): void
     {
         $this->assertSame(

--- a/packages/framework/tests/Feature/NavigationMenuTest.php
+++ b/packages/framework/tests/Feature/NavigationMenuTest.php
@@ -222,4 +222,36 @@ class NavigationMenuTest extends TestCase
         $this->assertCount(count($expected), $menu->items);
         $this->assertEquals($expected, $menu->items);
     }
+
+    public function test_pages_in_subdirectories_can_be_added_to_the_navigation_menu_with_config_flat_setting()
+    {
+        config(['hyde.navigation.subdirectories' => 'flat']);
+        $this->directory('_pages/foo');
+        Hyde::touch('_pages/foo/bar.md');
+
+        $menu = NavigationMenu::create();
+        $expected = collect([
+            NavItem::fromRoute(Route::get('index')),
+            NavItem::fromRoute(Route::get('foo/bar')),
+        ]);
+
+        $this->assertCount(count($expected), $menu->items);
+        $this->assertEquals($expected, $menu->items);
+    }
+
+    public function test_pages_in_subdirectories_can_be_added_to_the_navigation_menu_with_config_dropdown_setting()
+    {
+        config(['hyde.navigation.subdirectories' => 'dropdown']);
+        $this->directory('_pages/foo');
+        Hyde::touch('_pages/foo/bar.md');
+
+        $menu = NavigationMenu::create();
+        $expected = collect([
+            NavItem::fromRoute(Route::get('index')),
+            NavItem::fromRoute(Route::get('foo/bar')),
+        ]);
+
+        $this->assertCount(count($expected), $menu->items);
+        $this->assertEquals($expected, $menu->items);
+    }
 }

--- a/packages/framework/tests/Feature/NavigationMenuTest.php
+++ b/packages/framework/tests/Feature/NavigationMenuTest.php
@@ -217,10 +217,7 @@ class NavigationMenuTest extends TestCase
         Hyde::touch('_pages/foo/bar.md');
 
         $menu = NavigationMenu::create();
-
-        $expected = collect([
-            NavItem::fromRoute(Route::get('index')),
-        ]);
+        $expected = collect([NavItem::fromRoute(Route::get('index'))]);
 
         $this->assertCount(count($expected), $menu->items);
         $this->assertEquals($expected, $menu->items);

--- a/packages/framework/tests/Feature/NavigationMenuTest.php
+++ b/packages/framework/tests/Feature/NavigationMenuTest.php
@@ -210,4 +210,19 @@ class NavigationMenuTest extends TestCase
         Hyde::unlink('_docs/foo.md');
         Hyde::unlink('_docs/index.md');
     }
+
+    public function test_pages_in_subdirectories_are_not_added_to_the_navigation_menu()
+    {
+        $this->directory('_pages/foo');
+        Hyde::touch('_pages/foo/bar.md');
+
+        $menu = NavigationMenu::create();
+
+        $expected = collect([
+            NavItem::fromRoute(Route::get('index')),
+        ]);
+
+        $this->assertCount(count($expected), $menu->items);
+        $this->assertEquals($expected, $menu->items);
+    }
 }

--- a/packages/framework/tests/Unit/RelativeLinksAcrossPagesRetainsIntegrityTest.php
+++ b/packages/framework/tests/Unit/RelativeLinksAcrossPagesRetainsIntegrityTest.php
@@ -8,6 +8,7 @@ use Hyde\Framework\Concerns\InteractsWithDirectories;
 use Hyde\Hyde;
 use Hyde\Testing\TestCase;
 use Illuminate\Support\Facades\File;
+use function config;
 
 class RelativeLinksAcrossPagesRetainsIntegrityTest extends TestCase
 {
@@ -18,6 +19,7 @@ class RelativeLinksAcrossPagesRetainsIntegrityTest extends TestCase
         parent::setUp();
 
         config(['hyde.cache_busting' => false]);
+        config(['hyde.navigation.subdirectories' => 'flat']);
 
         $this->needsDirectory('_pages/nested');
         $this->file('_pages/root.md');


### PR DESCRIPTION
Implements the data generation backend for this feature.  We are still going to need to actually implement frontend code to support automatic dropdowns.

> https://github.com/hydephp/develop/issues/669
>
> Say we have a structure like this, where pages are in a directory of their source directory:
> 
> ```
> _pages/about/foo.md
> _pages/about/bar.md
> ```
> 
> How should Hyde handle the navigation for these pages? Currently they get added to the navigation menu, but maybe they shouldn't? I have a few ideas for improvement, and I think this should be configurable. I am very happy to get input on this, and also which option should be the default.
> 
> 1. Add the pages to the navigation menu (current behaviour)
> 2. Put them in an automatic dropdown based on the subdirectory name (my fav)
> 3. Don't show them at all