### PR TITLE
Add helper to strip indentation from a Markdown string

### DIFF
--- a/packages/framework/src/Foundation/Concerns/ImplementsStringHelpers.php
+++ b/packages/framework/src/Foundation/Concerns/ImplementsStringHelpers.php
@@ -32,6 +32,7 @@ trait ImplementsStringHelpers
         if ($stripIndentation) {
             $text = MarkdownService::stripIndentation($text);
         }
+
         return new HtmlString(Markdown::render($text));
     }
 }

--- a/packages/framework/src/Foundation/Concerns/ImplementsStringHelpers.php
+++ b/packages/framework/src/Foundation/Concerns/ImplementsStringHelpers.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Hyde\Foundation\Concerns;
 
+use Hyde\Framework\Services\MarkdownService;
 use Hyde\Markdown\Models\Markdown;
 use Illuminate\Support\HtmlString;
 use Illuminate\Support\Str;
@@ -26,8 +27,11 @@ trait ImplementsStringHelpers
         ));
     }
 
-    public function markdown(string $text): HtmlString
+    public function markdown(string $text, bool $stripIndentation = false): HtmlString
     {
+        if ($stripIndentation) {
+            $text = MarkdownService::stripIndentation($text);
+        }
         return new HtmlString(Markdown::render($text));
     }
 }

--- a/packages/framework/src/Framework/Services/MarkdownService.php
+++ b/packages/framework/src/Framework/Services/MarkdownService.php
@@ -209,4 +209,39 @@ class MarkdownService
             ],
         ], $this->config);
     }
+
+    /**
+     * Normalize indentation for an un-compiled Markdown string.
+     */
+    public static function stripIndentation(string $string): string
+    {
+        $string = str_replace("\t", '    ', $string);
+        $lines = explode("\n", $string);
+        $indentationLevel = 0;
+        $offset = 0;
+
+        // Find the indentation level of the first line that has content
+        foreach ($lines as $index => $line) {
+            $lineLen = strlen($line);
+            $stripLen = strlen(ltrim($line));
+
+            if ($lineLen === $stripLen) {
+                continue;
+            }
+
+            $offset = $index;
+            $indentationLevel = $lineLen - $stripLen;
+            break;
+        }
+
+        foreach ($lines as $index => $line) {
+            if ($index < $offset) {
+                continue;
+            }
+
+            $lines[$index] = substr($line, $indentationLevel);
+        }
+
+        return implode("\n", $lines);
+    }
 }

--- a/packages/framework/src/Framework/Services/MarkdownService.php
+++ b/packages/framework/src/Framework/Services/MarkdownService.php
@@ -216,6 +216,7 @@ class MarkdownService
     public static function stripIndentation(string $string): string
     {
         $string = str_replace("\t", '    ', $string);
+        $string = str_replace("\r\n", "\n", $string);
         $lines = explode("\n", $string);
         $indentationLevel = 0;
         $offset = 0;

--- a/packages/framework/src/Framework/Services/MarkdownService.php
+++ b/packages/framework/src/Framework/Services/MarkdownService.php
@@ -223,6 +223,10 @@ class MarkdownService
 
         // Find the indentation level of the first line that has content
         foreach ($lines as $index => $line) {
+            if (empty(trim($line))) {
+                continue;
+            }
+
             $lineLen = strlen($line);
             $stripLen = strlen(ltrim($line)); // Length of the line without indentation lets is know it's indentation level
 

--- a/packages/framework/src/Framework/Services/MarkdownService.php
+++ b/packages/framework/src/Framework/Services/MarkdownService.php
@@ -224,7 +224,7 @@ class MarkdownService
         // Find the indentation level of the first line that has content
         foreach ($lines as $index => $line) {
             $lineLen = strlen($line);
-            $stripLen = strlen(ltrim($line));
+            $stripLen = strlen(ltrim($line)); // Length of the line without indentation lets is know it's indentation level
 
             if ($lineLen === $stripLen) {
                 continue;

--- a/packages/framework/src/Hyde.php
+++ b/packages/framework/src/Hyde.php
@@ -39,7 +39,7 @@ use Illuminate\Support\HtmlString;
  * @method static string image(string $name, bool $preferQualifiedUrl = false)
  * @method static string url(string $path = '')
  * @method static string makeTitle(string $slug)
- * @method static HtmlString markdown(string $text)
+ * @method static HtmlString markdown(string $text, bool $stripIndentation = false)
  * @method static string currentPage()
  * @method static string getBasePath()
  * @method static string getSourceRoot()

--- a/packages/framework/tests/Feature/HydeKernelTest.php
+++ b/packages/framework/tests/Feature/HydeKernelTest.php
@@ -99,6 +99,11 @@ class HydeKernelTest extends TestCase
         $this->assertEquals(new HtmlString("<p>foo</p>\n"), Hyde::markdown('foo'));
     }
 
+    public function test_markdown_helper_converts_indented_markdown_to_html()
+    {
+        $this->assertEquals(new HtmlString("<p>foo</p>\n"), Hyde::markdown('    foo', true));
+    }
+
     public function test_format_html_path_helper_formats_path_according_to_config_rules()
     {
         Config::set('site.pretty_urls', false);

--- a/packages/framework/tests/Feature/MarkdownServiceTest.php
+++ b/packages/framework/tests/Feature/MarkdownServiceTest.php
@@ -266,6 +266,25 @@ class MarkdownServiceTest extends TestCase
         $this->assertSame("foo\nbar\n    baz", $service->stripIndentation($markdown));
     }
 
+    public function test_stripIndentation_method_with_empty_newlines()
+    {
+        $service = $this->makeService();
+
+        $markdown = "foo\n\n  bar\n  baz";
+        $this->assertSame("foo\n\nbar\nbaz", $service->stripIndentation($markdown));
+
+        $markdown = "foo\n   \n  bar\n  baz";
+        $this->assertSame("foo\n   \nbar\nbaz", $service->stripIndentation($markdown));
+    }
+
+    public function test_stripIndentation_method_with_trailing_newline()
+    {
+        $service = $this->makeService();
+
+        $markdown = "foo\n  bar\n  baz\n";
+        $this->assertSame("foo\nbar\nbaz\n", $service->stripIndentation($markdown));
+    }
+
     protected function makeService()
     {
         return new class extends MarkdownService

--- a/packages/framework/tests/Feature/MarkdownServiceTest.php
+++ b/packages/framework/tests/Feature/MarkdownServiceTest.php
@@ -220,6 +220,52 @@ class MarkdownServiceTest extends TestCase
         $this->assertFalse($service->canEnableTorchlight());
     }
 
+    public function test_stripIndentation_method_with_unindented_markdown()
+    {
+        $service = $this->makeService();
+
+        $markdown = "foo\nbar\nbaz";
+        $this->assertSame($markdown, $service->stripIndentation($markdown));
+    }
+
+    public function test_stripIndentation_method_with_indented_markdown()
+    {
+        $service = $this->makeService();
+
+        $markdown = "foo\n  bar\n  baz";
+        $this->assertSame("foo\nbar\nbaz", $service->stripIndentation($markdown));
+
+        $markdown = "  foo\n  bar\n  baz";
+        $this->assertSame("foo\nbar\nbaz", $service->stripIndentation($markdown));
+
+        $markdown = "    foo\n    bar\n    baz";
+        $this->assertSame("foo\nbar\nbaz", $service->stripIndentation($markdown));
+    }
+
+    public function test_stripIndentation_method_with_tab_indented_markdown()
+    {
+        $service = $this->makeService();
+
+        $markdown = "foo\n\tbar\n\tbaz";
+        $this->assertSame("foo\nbar\nbaz", $service->stripIndentation($markdown));
+    }
+
+    public function test_stripIndentation_method_with_carriage_return_line_feed()
+    {
+        $service = $this->makeService();
+
+        $markdown = "foo\r\n  bar\r\n  baz";
+        $this->assertSame("foo\nbar\nbaz", $service->stripIndentation($markdown));
+    }
+
+    public function test_stripIndentation_method_with_code_indentation()
+    {
+        $service = $this->makeService();
+
+        $markdown = "foo\n    bar\n        baz";
+        $this->assertSame("foo\nbar\n    baz", $service->stripIndentation($markdown));
+    }
+
     protected function makeService()
     {
         return new class extends MarkdownService


### PR DESCRIPTION
This will ease usages for things like https://github.com/hydephp/develop/pull/668 where the source markdown might be indented.

This means a Markdown document like this:

```markdown
    ## Foo Bar
    
    Lorem Ipsum...
    
        Indented code block
```

Will be normalized to this:

```markdown
## Foo Bar

Lorem Ipsum...

    Indented code block
```

Since it auto-detects the root indentation level, it still allows for code blocks to be created by indentation. Tabs will also be converted to four spaces.