### PR TITLE
Add simple class to compile any Blade file without having to register it as a view path

### DIFF
--- a/packages/framework/src/Framework/Actions/AnonymousViewCompiler.php
+++ b/packages/framework/src/Framework/Actions/AnonymousViewCompiler.php
@@ -4,7 +4,9 @@ declare(strict_types=1);
 
 namespace Hyde\Framework\Actions;
 
-class AnonymousViewCompiler
+use Hyde\Framework\Concerns\InvokableAction;
+
+class AnonymousViewCompiler extends InvokableAction
 {
     //
 }

--- a/packages/framework/src/Framework/Actions/AnonymousViewCompiler.php
+++ b/packages/framework/src/Framework/Actions/AnonymousViewCompiler.php
@@ -9,7 +9,6 @@ use Hyde\Framework\Concerns\InvokableAction;
 use Hyde\Framework\Exceptions\FileNotFoundException;
 use Illuminate\Support\Facades\Blade;
 
-
 /**
  * Compile any Blade file using the Blade facade as it allows us to render
  * it without having to register the directory with the view finder.

--- a/packages/framework/src/Framework/Actions/AnonymousViewCompiler.php
+++ b/packages/framework/src/Framework/Actions/AnonymousViewCompiler.php
@@ -13,5 +13,12 @@ use Hyde\Framework\Concerns\InvokableAction;
  */
 class AnonymousViewCompiler extends InvokableAction
 {
-    //
+    protected string $viewPath;
+    protected array $data;
+
+    public function __construct(string $viewPath, array $data = [])
+    {
+        $this->viewPath = $viewPath;
+        $this->data = $data;
+    }
 }

--- a/packages/framework/src/Framework/Actions/AnonymousViewCompiler.php
+++ b/packages/framework/src/Framework/Actions/AnonymousViewCompiler.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Hyde\Framework\Actions;
 
 use Hyde\Framework\Concerns\InvokableAction;
+use Hyde\Framework\Exceptions\FileNotFoundException;
 use Hyde\Hyde;
 use Illuminate\Support\Facades\Blade;
 use InvalidArgumentException;
@@ -32,7 +33,7 @@ class AnonymousViewCompiler extends InvokableAction
     public function __invoke(): string
     {
         if (! file_exists(Hyde::path($this->viewPath))) {
-            throw new InvalidArgumentException(sprintf('View [%s] not found.', $this->viewPath));
+            throw new FileNotFoundException($this->viewPath);
         }
 
         return Blade::render(

--- a/packages/framework/src/Framework/Actions/AnonymousViewCompiler.php
+++ b/packages/framework/src/Framework/Actions/AnonymousViewCompiler.php
@@ -8,11 +8,9 @@ use Hyde\Framework\Concerns\InvokableAction;
 use Hyde\Framework\Exceptions\FileNotFoundException;
 use Hyde\Hyde;
 use Illuminate\Support\Facades\Blade;
-use InvalidArgumentException;
 
 use function file_exists;
 use function file_get_contents;
-use function sprintf;
 
 
 /**

--- a/packages/framework/src/Framework/Actions/AnonymousViewCompiler.php
+++ b/packages/framework/src/Framework/Actions/AnonymousViewCompiler.php
@@ -6,6 +6,11 @@ namespace Hyde\Framework\Actions;
 
 use Hyde\Framework\Concerns\InvokableAction;
 
+
+/**
+ * Compile any Blade file using the Blade facade as it allows us to render
+ * it without having to register the directory with the view finder.
+ */
 class AnonymousViewCompiler extends InvokableAction
 {
     //

--- a/packages/framework/src/Framework/Actions/AnonymousViewCompiler.php
+++ b/packages/framework/src/Framework/Actions/AnonymousViewCompiler.php
@@ -4,13 +4,10 @@ declare(strict_types=1);
 
 namespace Hyde\Framework\Actions;
 
+use Hyde\Facades\Filesystem;
 use Hyde\Framework\Concerns\InvokableAction;
 use Hyde\Framework\Exceptions\FileNotFoundException;
-use Hyde\Hyde;
 use Illuminate\Support\Facades\Blade;
-
-use function file_exists;
-use function file_get_contents;
 
 
 /**
@@ -30,12 +27,12 @@ class AnonymousViewCompiler extends InvokableAction
 
     public function __invoke(): string
     {
-        if (! file_exists(Hyde::path($this->viewPath))) {
+        if (Filesystem::missing($this->viewPath)) {
             throw new FileNotFoundException($this->viewPath);
         }
 
         return Blade::render(
-            file_get_contents(Hyde::path($this->viewPath)),
+            Filesystem::getContents($this->viewPath),
             $this->data
         );
     }

--- a/packages/framework/src/Framework/Actions/AnonymousViewCompiler.php
+++ b/packages/framework/src/Framework/Actions/AnonymousViewCompiler.php
@@ -5,6 +5,13 @@ declare(strict_types=1);
 namespace Hyde\Framework\Actions;
 
 use Hyde\Framework\Concerns\InvokableAction;
+use Hyde\Hyde;
+use Illuminate\Support\Facades\Blade;
+use InvalidArgumentException;
+
+use function file_exists;
+use function file_get_contents;
+use function sprintf;
 
 
 /**
@@ -20,5 +27,17 @@ class AnonymousViewCompiler extends InvokableAction
     {
         $this->viewPath = $viewPath;
         $this->data = $data;
+    }
+
+    public function __invoke(): string
+    {
+        if (! file_exists(Hyde::path($this->viewPath))) {
+            throw new InvalidArgumentException(sprintf('View [%s] not found.', $this->viewPath));
+        }
+
+        return Blade::render(
+            file_get_contents(Hyde::path($this->viewPath)),
+            $this->data
+        );
     }
 }

--- a/packages/framework/src/Framework/Actions/AnonymousViewCompiler.php
+++ b/packages/framework/src/Framework/Actions/AnonymousViewCompiler.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Hyde\Framework\Actions;
+
+class AnonymousViewCompiler
+{
+    //
+}

--- a/packages/framework/tests/Feature/Actions/AnonymousViewCompilerTest.php
+++ b/packages/framework/tests/Feature/Actions/AnonymousViewCompilerTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Hyde\Framework\Testing\Feature\Actions;
 
 use Hyde\Framework\Actions\AnonymousViewCompiler;
+use Hyde\Framework\Exceptions\FileNotFoundException;
 use Hyde\Hyde;
 use Hyde\Testing\TestCase;
 
@@ -33,8 +34,8 @@ class AnonymousViewCompilerTest extends TestCase
 
     public function testWithMissingView()
     {
-        $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('View [foo.blade.php] not found.');
+        $this->expectException(FileNotFoundException::class);
+        $this->expectExceptionMessage('File foo.blade.php not found.');
 
         AnonymousViewCompiler::call('foo.blade.php');
     }

--- a/packages/framework/tests/Feature/Actions/AnonymousViewCompilerTest.php
+++ b/packages/framework/tests/Feature/Actions/AnonymousViewCompilerTest.php
@@ -6,12 +6,7 @@ namespace Hyde\Framework\Testing\Feature\Actions;
 
 use Hyde\Framework\Actions\AnonymousViewCompiler;
 use Hyde\Framework\Exceptions\FileNotFoundException;
-use Hyde\Hyde;
 use Hyde\Testing\TestCase;
-
-use InvalidArgumentException;
-
-use function file_put_contents;
 
 /**
  * @covers \Hyde\Framework\Actions\AnonymousViewCompiler

--- a/packages/framework/tests/Feature/Actions/AnonymousViewCompilerTest.php
+++ b/packages/framework/tests/Feature/Actions/AnonymousViewCompilerTest.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Hyde\Framework\Testing\Feature\Actions;
+
+use Hyde\Framework\Actions\AnonymousViewCompiler;
+use Hyde\Testing\TestCase;
+
+/**
+ * @covers \Hyde\Framework\Actions\AnonymousViewCompiler
+ */
+class AnonymousViewCompilerTest extends TestCase
+{
+    //
+}

--- a/packages/framework/tests/Feature/Actions/AnonymousViewCompilerTest.php
+++ b/packages/framework/tests/Feature/Actions/AnonymousViewCompilerTest.php
@@ -5,12 +5,37 @@ declare(strict_types=1);
 namespace Hyde\Framework\Testing\Feature\Actions;
 
 use Hyde\Framework\Actions\AnonymousViewCompiler;
+use Hyde\Hyde;
 use Hyde\Testing\TestCase;
+
+use InvalidArgumentException;
+
+use function file_put_contents;
 
 /**
  * @covers \Hyde\Framework\Actions\AnonymousViewCompiler
  */
 class AnonymousViewCompilerTest extends TestCase
 {
-    //
+    public function testCanCompileBladeFile()
+    {
+        $this->file('foo.blade.php', "{{ 'Hello World' }}");
+
+        $this->assertSame('Hello World', AnonymousViewCompiler::call('foo.blade.php'));
+    }
+
+    public function testCanCompileBladeFileWithData()
+    {
+        $this->file('foo.blade.php', '{{ $foo }}');
+
+        $this->assertSame('bar', AnonymousViewCompiler::call('foo.blade.php', ['foo' => 'bar']));
+    }
+
+    public function testWithMissingView()
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('View [foo.blade.php] not found.');
+
+        AnonymousViewCompiler::call('foo.blade.php');
+    }
 }


### PR DESCRIPTION
Adds a class to compile any Blade file using the Blade facade as it allows us to render it without having to register the directory with the view finder.