### PR TITLE
Wrap the file path in brackets for the FileNotFoundException

### DIFF
--- a/packages/framework/src/Framework/Exceptions/FileNotFoundException.php
+++ b/packages/framework/src/Framework/Exceptions/FileNotFoundException.php
@@ -16,7 +16,7 @@ class FileNotFoundException extends Exception
 
     public function __construct(?string $path = null, ?string $message = null)
     {
-        $this->message = $message ?? ($path ? "File $path not found." : $this->message);
+        $this->message = $message ?? ($path ? "File [$path] not found." : $this->message);
 
         parent::__construct($this->message, $this->code);
     }

--- a/packages/framework/tests/Feature/Actions/AnonymousViewCompilerTest.php
+++ b/packages/framework/tests/Feature/Actions/AnonymousViewCompilerTest.php
@@ -30,7 +30,7 @@ class AnonymousViewCompilerTest extends TestCase
     public function testWithMissingView()
     {
         $this->expectException(FileNotFoundException::class);
-        $this->expectExceptionMessage('File foo.blade.php not found.');
+        $this->expectExceptionMessage('File [foo.blade.php] not found.');
 
         AnonymousViewCompiler::call('foo.blade.php');
     }


### PR DESCRIPTION
This adds more visual consistency and makes it easier to distinguish the path