### PR TITLE
Add normalizeNewlines helper to the Hyde facade and refactor related methods

### DIFF
--- a/packages/framework/src/Foundation/Concerns/ImplementsStringHelpers.php
+++ b/packages/framework/src/Foundation/Concerns/ImplementsStringHelpers.php
@@ -16,14 +16,14 @@ use Illuminate\Support\Str;
  */
 trait ImplementsStringHelpers
 {
-    public function makeTitle(string $slug): string
+    public function makeTitle(string $value): string
     {
         $alwaysLowercase = ['a', 'an', 'the', 'in', 'on', 'by', 'with', 'of', 'and', 'or', 'but'];
 
         return ucfirst(str_ireplace(
             $alwaysLowercase,
             $alwaysLowercase,
-            Str::headline($slug)
+            Str::headline($value)
         ));
     }
 

--- a/packages/framework/src/Foundation/Concerns/ImplementsStringHelpers.php
+++ b/packages/framework/src/Foundation/Concerns/ImplementsStringHelpers.php
@@ -35,7 +35,7 @@ trait ImplementsStringHelpers
     public function markdown(string $text, bool $stripIndentation = false): HtmlString
     {
         if ($stripIndentation) {
-            $text = MarkdownService::stripIndentation($text);
+            $text = MarkdownService::normalizeIndentationLevel($text);
         }
 
         return new HtmlString(Markdown::render($text));

--- a/packages/framework/src/Foundation/Concerns/ImplementsStringHelpers.php
+++ b/packages/framework/src/Foundation/Concerns/ImplementsStringHelpers.php
@@ -27,6 +27,11 @@ trait ImplementsStringHelpers
         ));
     }
 
+    public function normalizeNewlines(string $string): string
+    {
+        return str_replace(["\r\n"], "\n", $string);
+    }
+
     public function markdown(string $text, bool $stripIndentation = false): HtmlString
     {
         if ($stripIndentation) {

--- a/packages/framework/src/Foundation/Concerns/ImplementsStringHelpers.php
+++ b/packages/framework/src/Foundation/Concerns/ImplementsStringHelpers.php
@@ -32,9 +32,9 @@ trait ImplementsStringHelpers
         return str_replace(["\r\n"], "\n", $string);
     }
 
-    public function markdown(string $text, bool $stripIndentation = false): HtmlString
+    public function markdown(string $text, bool $normalizeIndentation = false): HtmlString
     {
-        if ($stripIndentation) {
+        if ($normalizeIndentation) {
             $text = MarkdownService::normalizeIndentationLevel($text);
         }
 

--- a/packages/framework/src/Framework/Actions/CreatesNewPageSourceFile.php
+++ b/packages/framework/src/Framework/Actions/CreatesNewPageSourceFile.php
@@ -143,6 +143,6 @@ class CreatesNewPageSourceFile
     {
         $this->prepareOutputDirectory();
 
-        file_put_contents($this->outputPath, str_replace(["\r\n"], "\n", $contents));
+        file_put_contents($this->outputPath, Hyde::normalizeNewlines($contents));
     }
 }

--- a/packages/framework/src/Framework/Services/MarkdownService.php
+++ b/packages/framework/src/Framework/Services/MarkdownService.php
@@ -213,7 +213,7 @@ class MarkdownService
     /**
      * Normalize indentation for an un-compiled Markdown string.
      */
-    public static function stripIndentation(string $string): string
+    public static function normalizeIndentationLevel(string $string): string
     {
         $string = str_replace("\t", '    ', $string);
         $string = str_replace("\r\n", "\n", $string);

--- a/packages/framework/src/Hyde.php
+++ b/packages/framework/src/Hyde.php
@@ -39,6 +39,7 @@ use Illuminate\Support\HtmlString;
  * @method static string image(string $name, bool $preferQualifiedUrl = false)
  * @method static string url(string $path = '')
  * @method static string makeTitle(string $slug)
+ * @method static string normalizeNewlines(string $string)
  * @method static HtmlString markdown(string $text, bool $stripIndentation = false)
  * @method static string currentPage()
  * @method static string getBasePath()

--- a/packages/framework/tests/Feature/HydeKernelTest.php
+++ b/packages/framework/tests/Feature/HydeKernelTest.php
@@ -94,7 +94,7 @@ class HydeKernelTest extends TestCase
         $this->assertEquals('Foo Bar', Hyde::makeTitle('foo-bar'));
     }
 
-    public function test_normalizeNewlines_replaces_carriage_returns_with_unis_endings()
+    public function test_normalize_newlines_replaces_carriage_returns_with_unis_endings()
     {
         $this->assertEquals("foo\nbar\nbaz", Hyde::normalizeNewlines("foo\nbar\r\nbaz"));
     }

--- a/packages/framework/tests/Feature/HydeKernelTest.php
+++ b/packages/framework/tests/Feature/HydeKernelTest.php
@@ -94,6 +94,11 @@ class HydeKernelTest extends TestCase
         $this->assertEquals('Foo Bar', Hyde::makeTitle('foo-bar'));
     }
 
+    public function test_normalizeNewlines_replaces_carriage_returns_with_unis_endings()
+    {
+        $this->assertEquals("foo\nbar\nbaz", Hyde::normalizeNewlines("foo\nbar\r\nbaz"));
+    }
+
     public function test_markdown_helper_converts_markdown_to_html()
     {
         $this->assertEquals(new HtmlString("<p>foo</p>\n"), Hyde::markdown('foo'));

--- a/packages/framework/tests/Feature/MarkdownServiceTest.php
+++ b/packages/framework/tests/Feature/MarkdownServiceTest.php
@@ -225,7 +225,7 @@ class MarkdownServiceTest extends TestCase
         $service = $this->makeService();
 
         $markdown = "foo\nbar\nbaz";
-        $this->assertSame($markdown, $service->stripIndentation($markdown));
+        $this->assertSame($markdown, $service->normalizeIndentationLevel($markdown));
     }
 
     public function test_stripIndentation_method_with_indented_markdown()
@@ -233,13 +233,13 @@ class MarkdownServiceTest extends TestCase
         $service = $this->makeService();
 
         $markdown = "foo\n  bar\n  baz";
-        $this->assertSame("foo\nbar\nbaz", $service->stripIndentation($markdown));
+        $this->assertSame("foo\nbar\nbaz", $service->normalizeIndentationLevel($markdown));
 
         $markdown = "  foo\n  bar\n  baz";
-        $this->assertSame("foo\nbar\nbaz", $service->stripIndentation($markdown));
+        $this->assertSame("foo\nbar\nbaz", $service->normalizeIndentationLevel($markdown));
 
         $markdown = "    foo\n    bar\n    baz";
-        $this->assertSame("foo\nbar\nbaz", $service->stripIndentation($markdown));
+        $this->assertSame("foo\nbar\nbaz", $service->normalizeIndentationLevel($markdown));
     }
 
     public function test_stripIndentation_method_with_tab_indented_markdown()
@@ -247,7 +247,7 @@ class MarkdownServiceTest extends TestCase
         $service = $this->makeService();
 
         $markdown = "foo\n\tbar\n\tbaz";
-        $this->assertSame("foo\nbar\nbaz", $service->stripIndentation($markdown));
+        $this->assertSame("foo\nbar\nbaz", $service->normalizeIndentationLevel($markdown));
     }
 
     public function test_stripIndentation_method_with_carriage_return_line_feed()
@@ -255,7 +255,7 @@ class MarkdownServiceTest extends TestCase
         $service = $this->makeService();
 
         $markdown = "foo\r\n  bar\r\n  baz";
-        $this->assertSame("foo\nbar\nbaz", $service->stripIndentation($markdown));
+        $this->assertSame("foo\nbar\nbaz", $service->normalizeIndentationLevel($markdown));
     }
 
     public function test_stripIndentation_method_with_code_indentation()
@@ -263,7 +263,7 @@ class MarkdownServiceTest extends TestCase
         $service = $this->makeService();
 
         $markdown = "foo\n    bar\n        baz";
-        $this->assertSame("foo\nbar\n    baz", $service->stripIndentation($markdown));
+        $this->assertSame("foo\nbar\n    baz", $service->normalizeIndentationLevel($markdown));
     }
 
     public function test_stripIndentation_method_with_empty_newlines()
@@ -271,10 +271,10 @@ class MarkdownServiceTest extends TestCase
         $service = $this->makeService();
 
         $markdown = "foo\n\n  bar\n  baz";
-        $this->assertSame("foo\n\nbar\nbaz", $service->stripIndentation($markdown));
+        $this->assertSame("foo\n\nbar\nbaz", $service->normalizeIndentationLevel($markdown));
 
         $markdown = "foo\n   \n  bar\n  baz";
-        $this->assertSame("foo\n   \nbar\nbaz", $service->stripIndentation($markdown));
+        $this->assertSame("foo\n   \nbar\nbaz", $service->normalizeIndentationLevel($markdown));
     }
 
     public function test_stripIndentation_method_with_trailing_newline()
@@ -282,7 +282,7 @@ class MarkdownServiceTest extends TestCase
         $service = $this->makeService();
 
         $markdown = "foo\n  bar\n  baz\n";
-        $this->assertSame("foo\nbar\nbaz\n", $service->stripIndentation($markdown));
+        $this->assertSame("foo\nbar\nbaz\n", $service->normalizeIndentationLevel($markdown));
     }
 
     protected function makeService()


### PR DESCRIPTION
Adds a simple helper method that normalizes Windows line ending sequences to the (in my opinion, much cleaner) Unix LF endings. Also adds some related refactors.