### PR TITLE
Remove range values from publications to reduce complexity

### DIFF
--- a/packages/framework/src/Console/Commands/MakePublicationCommand.php
+++ b/packages/framework/src/Console/Commands/MakePublicationCommand.php
@@ -189,19 +189,6 @@ class MakePublicationCommand extends ValidatingCommand
         $fieldRules = Collection::make($field->type->rules());
         if ($fieldRules->contains('between')) {
             $fieldRules->forget($fieldRules->search('between'));
-            if ($field->min && $field->max) {
-                switch ($field->type) {
-                    case 'string':
-                    case 'integer':
-                    case 'float':
-                        $fieldRules->add("between:$field->min,$field->max");
-                        break;
-                    case 'datetime':
-                        $fieldRules->add("after:$field->min");
-                        $fieldRules->add("before:$field->max");
-                        break;
-                }
-            }
         }
 
         return $fieldRules;

--- a/packages/framework/src/Console/Commands/MakePublicationTypeCommand.php
+++ b/packages/framework/src/Console/Commands/MakePublicationTypeCommand.php
@@ -87,11 +87,6 @@ class MakePublicationTypeCommand extends ValidatingCommand
             $type = $this->getFieldType();
 
             if ($type < 10) {
-                do {
-                    $fieldData['min'] = trim($this->askWithValidation('min', 'Min value (see Documentation)', ['required', 'string'], 0));
-                    $fieldData['max'] = trim($this->askWithValidation('max', 'Max value (see Documentation)', ['required', 'string'], 0));
-                    $lengthsValid = $this->validateLengths($fieldData['min'], $fieldData['max']);
-                } while (! $lengthsValid);
             } else {
                 $fieldData = $this->getFieldDataForTag($fieldData);
             }

--- a/packages/framework/src/Console/Commands/ValidatePublicationsCommand.php
+++ b/packages/framework/src/Console/Commands/ValidatePublicationsCommand.php
@@ -68,7 +68,7 @@ class ValidatePublicationsCommand extends ValidatingCommand
                 foreach ($publication->type->fields as $field) {
                     $countFields++;
                     $fieldName = $field['name'];
-                    $pubTypeField = new PublicationField($field['type'], $fieldName, $field['min'], $field['max'], $field['tagGroup'] ?? null, $pubType);
+                    $pubTypeField = new PublicationField($field['type'], $fieldName, $field['tagGroup'] ?? null, $pubType);
 
                     try {
                         if ($verbose) {

--- a/packages/framework/src/Framework/Features/Publications/Models/PublicationField.php
+++ b/packages/framework/src/Framework/Features/Publications/Models/PublicationField.php
@@ -27,10 +27,6 @@ class PublicationField implements SerializableContract
     use Serializable;
 
     public readonly PublicationFieldTypes $type;
-    /** @deprecated https://github.com/hydephp/develop/pull/685#issuecomment-1361565809 */
-    public readonly string $max;
-    /** @deprecated https://github.com/hydephp/develop/pull/685#issuecomment-1361565809 */
-    public readonly string $min;
     public readonly string $name;
     public readonly ?string $tagGroup;
     public readonly ?PublicationType $publicationType; // Only used for validation command, interactive command doesn't need this
@@ -40,12 +36,10 @@ class PublicationField implements SerializableContract
         return new static(...$array);
     }
 
-    public function __construct(PublicationFieldTypes|string $type, string $name, #[Deprecated] int | string | null $min = '0', #[Deprecated] int | string | null $max = '0', ?string $tagGroup = null, PublicationType $publicationType = null)
+    public function __construct(PublicationFieldTypes|string $type, string $name, ?string $tagGroup = null, PublicationType $publicationType = null)
     {
         $this->type = $type instanceof PublicationFieldTypes ? $type : PublicationFieldTypes::from(strtolower($type));
         $this->name = Str::kebab($name);
-        $this->min = (string) $min;
-        $this->max = (string) $max;
         $this->tagGroup = $tagGroup;
         $this->publicationType = $publicationType;
 
@@ -59,8 +53,6 @@ class PublicationField implements SerializableContract
         return [
             'type' => $this->type->value,
             'name' => $this->name,
-            'min'  => $this->min,
-            'max'  => $this->max,
             'tagGroup' => $this->tagGroup,
         ];
     }

--- a/packages/framework/src/Framework/Features/Publications/Models/PublicationField.php
+++ b/packages/framework/src/Framework/Features/Publications/Models/PublicationField.php
@@ -9,10 +9,7 @@ use Hyde\Framework\Features\Publications\PublicationFieldTypes;
 use Hyde\Framework\Features\Publications\PublicationService;
 use Hyde\Support\Concerns\Serializable;
 use Hyde\Support\Contracts\SerializableContract;
-use Illuminate\Support\Carbon;
 use Illuminate\Support\Str;
-use InvalidArgumentException;
-use JetBrains\PhpStorm\Deprecated;
 use Rgasch\Collection\Collection;
 use function strtolower;
 

--- a/packages/framework/src/Framework/Features/Publications/Models/PublicationType.php
+++ b/packages/framework/src/Framework/Features/Publications/Models/PublicationType.php
@@ -121,7 +121,7 @@ class PublicationType implements SerializableContract
     public function getCanonicalFieldDefinition(): PublicationField
     {
         if (str_starts_with($this->canonicalField, '__')) {
-            return new PublicationField('string', $this->canonicalField, 0, 0);
+            return new PublicationField('string', $this->canonicalField);
         }
 
         return $this->getFields()->filter(fn (PublicationField $field): bool => $field->name === $this->canonicalField)->first();

--- a/packages/framework/tests/Feature/Actions/CreatesNewPublicationPageTest.php
+++ b/packages/framework/tests/Feature/Actions/CreatesNewPublicationPageTest.php
@@ -62,13 +62,9 @@ title: Hello World
         $pubType = $this->makePublicationType([[
             'type' => 'string',
             'name' => 'title',
-            'min'  => 0,
-            'max'  => 128,
         ], [
             'type' => 'text',
             'name' => 'description',
-            'min'  => 0,
-            'max'  => 128,
         ]]);
 
         $fieldData = Collection::make([
@@ -99,13 +95,9 @@ description: |
         $pubType = $this->makePublicationType([[
             'type' => 'string',
             'name' => 'title',
-            'min'  => 0,
-            'max'  => 128,
         ], [
             'type' => 'array',
             'name' => 'tags',
-            'min'  => 0,
-            'max'  => 128,
         ]]);
 
         $fieldData = Collection::make([
@@ -146,13 +138,9 @@ tags:
         $pubType = $this->makePublicationType([[
             'type' => 'string',
             'name' => 'title',
-            'min'  => 0,
-            'max'  => 128,
         ], [
             'type' => 'string',
             'name' => 'slug',
-            'min'  => 0,
-            'max'  => 128,
         ]]);
 
         $fieldData = Collection::make([
@@ -181,19 +169,13 @@ title: Hello World
         $pubType = $this->makePublicationType([[
             'type' => 'string',
             'name' => 'title',
-            'min'  => 0,
-            'max'  => 128,
         ], [
             'type' => 'text',
             'name' => 'description',
-            'min'  => 0,
-            'max'  => 128,
         ], [
 
             'type' => 'array',
             'name' => 'tags',
-            'min'  => 0,
-            'max'  => 128,
         ]]);
 
         $fieldData = Collection::make([
@@ -242,8 +224,6 @@ It can be multiple lines.
         [
             'type' => 'string',
             'name' => 'title',
-            'min'  => 0,
-            'max'  => 128,
         ],
     ]): PublicationType
     {

--- a/packages/framework/tests/Feature/Commands/MakePublicationCommandTest.php
+++ b/packages/framework/tests/Feature/Commands/MakePublicationCommandTest.php
@@ -166,8 +166,6 @@ __createdAt: 2022-01-01 00:00:00
             'fields'         =>  [[
                 'type' => 'text',
                 'name' => 'description',
-                'min'  => '0',
-                'max'  => '0',
             ],
             ],
         ]);
@@ -196,8 +194,6 @@ description: |
             'fields'         =>  [[
                 'type' => 'array',
                 'name' => 'tags',
-                'min'  => '0',
-                'max'  => '0',
             ],
             ],
         ]);
@@ -237,8 +233,6 @@ tags:
                 'fields'         =>  [
                     [
                         'name' => 'title',
-                        'min'  => '0',
-                        'max'  => '0',
                         'type' => 'string',
                     ],
                 ],

--- a/packages/framework/tests/Feature/Commands/MakePublicationTypeCommandTest.php
+++ b/packages/framework/tests/Feature/Commands/MakePublicationTypeCommandTest.php
@@ -39,8 +39,6 @@ class MakePublicationTypeCommandTest extends TestCase
                 9 => 'Local Image',
                 10 => 'Tag (select value from list)',
             ])
-            ->expectsQuestion('Min value (see Documentation)', '0')
-            ->expectsQuestion('Max value (see Documentation)', '0')
             ->expectsQuestion('<bg=magenta;fg=white>Add another field (y/n)</>', 'n')
             ->expectsChoice('Choose the default field you wish to sort by', 'dateCreated (meta field)', [
                 'dateCreated (meta field)',
@@ -78,8 +76,6 @@ class MakePublicationTypeCommandTest extends TestCase
                     {
                         "type": "string",
                         "name": "publication-title",
-                        "min": "0",
-                        "max": "0",
                         "tagGroup": null
                     }
                 ]
@@ -89,28 +85,6 @@ class MakePublicationTypeCommandTest extends TestCase
         );
 
         // TODO: Assert Blade templates were created?
-
-        Filesystem::deleteDirectory('test-publication');
-    }
-
-    public function test_cannot_create_field_with_lower_max_than_min_value()
-    {
-        $this->artisan('make:publicationType test-publication')
-             ->expectsQuestion('Field name', 'foo')
-             ->expectsQuestion('Field type', 'foo')
-             ->expectsQuestion('Min value (see Documentation)', 10)
-             ->expectsQuestion('Max value (see Documentation)', 5)
-             ->expectsQuestion('Min value (see Documentation)', 5)
-             ->expectsQuestion('Max value (see Documentation)', 10)
-
-             ->expectsQuestion('<bg=magenta;fg=white>Add another field (y/n)</>', 'n')
-             ->expectsQuestion('Choose the default field you wish to sort by', 'foo')
-             ->expectsQuestion('Choose the default sort direction', 'Ascending (oldest items first if sorting by dateCreated)')
-             ->expectsQuestion('Enter the pageSize (0 for no limit)', 10)
-             ->expectsQuestion('Generate previous/next links in detail view (y/n)', 'n')
-             ->expectsQuestion('Choose a canonical name field (the values of this field have to be unique!)', 'foo')
-             ->expectsOutputToContain('Creating a new Publication Type!')
-             ->assertSuccessful();
 
         Filesystem::deleteDirectory('test-publication');
     }

--- a/packages/framework/tests/Feature/PublicationFieldTest.php
+++ b/packages/framework/tests/Feature/PublicationFieldTest.php
@@ -22,8 +22,6 @@ class PublicationFieldTest extends TestCase
 
         $this->assertSame(PublicationFieldTypes::String, $field->type);
         $this->assertSame('test', $field->name);
-        $this->assertSame('1', $field->min);
-        $this->assertSame('10', $field->max);
     }
 
     public function test_from_array_method()
@@ -31,16 +29,12 @@ class PublicationFieldTest extends TestCase
         $field = PublicationField::fromArray([
             'type' => 'string',
             'name' => 'test',
-            'min'  => '1',
-            'max'  => '10',
         ]);
 
         $this->assertInstanceOf(PublicationField::class, $field);
 
         $this->assertSame(PublicationFieldTypes::String, $field->type);
         $this->assertSame('test', $field->name);
-        $this->assertSame('1', $field->min);
-        $this->assertSame('10', $field->max);
     }
 
     public function test_can_get_field_as_array()
@@ -48,15 +42,13 @@ class PublicationFieldTest extends TestCase
         $this->assertSame([
             'type' => 'string',
             'name' => 'test',
-            'min'  => '1',
-            'max'  => '10',
             'tagGroup' => null,
         ], $this->makeField()->toArray());
     }
 
     public function test_can_encode_field_as_json()
     {
-        $this->assertSame('{"type":"string","name":"test","min":"1","max":"10","tagGroup":null}', json_encode($this->makeField()));
+        $this->assertSame('{"type":"string","name":"test","tagGroup":null}', json_encode($this->makeField()));
     }
 
     public function test_can_construct_type_using_enum_case()
@@ -68,47 +60,6 @@ class PublicationFieldTest extends TestCase
         $this->assertSame(PublicationFieldTypes::String, $field2->type);
 
         $this->assertEquals($field1, $field2);
-    }
-
-    public function test_default_range_values()
-    {
-        $field = new PublicationField('string', 'test');
-        $this->assertSame('0', $field->min);
-        $this->assertSame('0', $field->max);
-    }
-
-    public function test_null_range_values_are_cast_to_empty_string()
-    {
-        $field = new PublicationField('string', 'test');
-        $this->assertSame('', $field->min);
-        $this->assertSame('', $field->max);
-    }
-
-    public function test_max_value_cannot_be_less_than_min_value()
-    {
-        $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage("The 'max' value cannot be less than the 'min' value.");
-
-        new PublicationField('string', 'test');
-    }
-
-    public function test_only_min_value_can_be_set()
-    {
-        new PublicationField('string', 'test');
-        $this->assertTrue(true);
-    }
-
-    public function test_only_max_value_can_be_set()
-    {
-        new PublicationField('string', 'test');
-        $this->assertTrue(true);
-    }
-
-    public function test_integers_can_be_added_as_strings()
-    {
-        $field = new PublicationField('string', 'test');
-        $this->assertSame('1', $field->min);
-        $this->assertSame('10', $field->max);
     }
 
     public function test_type_must_be_valid()

--- a/packages/framework/tests/Feature/PublicationFieldTest.php
+++ b/packages/framework/tests/Feature/PublicationFieldTest.php
@@ -7,7 +7,6 @@ namespace Hyde\Framework\Testing\Feature;
 use Hyde\Framework\Features\Publications\Models\PublicationField;
 use Hyde\Framework\Features\Publications\PublicationFieldTypes;
 use Hyde\Testing\TestCase;
-use InvalidArgumentException;
 use ValueError;
 
 /**

--- a/packages/framework/tests/Feature/PublicationFieldTest.php
+++ b/packages/framework/tests/Feature/PublicationFieldTest.php
@@ -61,10 +61,10 @@ class PublicationFieldTest extends TestCase
 
     public function test_can_construct_type_using_enum_case()
     {
-        $field1 = new PublicationField(PublicationFieldTypes::String, 'test', 1, 10);
+        $field1 = new PublicationField(PublicationFieldTypes::String, 'test');
         $this->assertSame(PublicationFieldTypes::String, $field1->type);
 
-        $field2 = new PublicationField('string', 'test', 1, 10);
+        $field2 = new PublicationField('string', 'test');
         $this->assertSame(PublicationFieldTypes::String, $field2->type);
 
         $this->assertEquals($field1, $field2);
@@ -79,7 +79,7 @@ class PublicationFieldTest extends TestCase
 
     public function test_null_range_values_are_cast_to_empty_string()
     {
-        $field = new PublicationField('string', 'test', null, null);
+        $field = new PublicationField('string', 'test');
         $this->assertSame('', $field->min);
         $this->assertSame('', $field->max);
     }
@@ -89,24 +89,24 @@ class PublicationFieldTest extends TestCase
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage("The 'max' value cannot be less than the 'min' value.");
 
-        new PublicationField('string', 'test', '10', '1');
+        new PublicationField('string', 'test');
     }
 
     public function test_only_min_value_can_be_set()
     {
-        new PublicationField('string', 'test', '1');
+        new PublicationField('string', 'test');
         $this->assertTrue(true);
     }
 
     public function test_only_max_value_can_be_set()
     {
-        new PublicationField('string', 'test', null, '10');
+        new PublicationField('string', 'test');
         $this->assertTrue(true);
     }
 
     public function test_integers_can_be_added_as_strings()
     {
-        $field = new PublicationField('string', 'test', '1', '10');
+        $field = new PublicationField('string', 'test');
         $this->assertSame('1', $field->min);
         $this->assertSame('10', $field->max);
     }
@@ -116,18 +116,18 @@ class PublicationFieldTest extends TestCase
         $this->expectException(ValueError::class);
         $this->expectExceptionMessage('"invalid" is not a valid backing value for enum "'.PublicationFieldTypes::class.'"');
 
-        new PublicationField('invalid', 'test', '1', '10');
+        new PublicationField('invalid', 'test');
     }
 
     public function test_type_input_is_case_insensitive()
     {
-        $field = new PublicationField('STRING', 'test', '1', '10');
+        $field = new PublicationField('STRING', 'test');
         $this->assertSame(PublicationFieldTypes::String, $field->type);
     }
 
     public function test_name_gets_stored_as_kebab_case()
     {
-        $field = new PublicationField('string', 'Test Field', '1', '10');
+        $field = new PublicationField('string', 'Test Field');
         $this->assertSame('test-field', $field->name);
     }
 
@@ -138,6 +138,6 @@ class PublicationFieldTest extends TestCase
 
     protected function makeField(): PublicationField
     {
-        return new PublicationField('string', 'test', 1, '10');
+        return new PublicationField('string', 'test');
     }
 }

--- a/packages/framework/tests/Feature/PublicationPageTest.php
+++ b/packages/framework/tests/Feature/PublicationPageTest.php
@@ -127,8 +127,6 @@ class PublicationPageTest extends TestCase
   "fields": [
     {
       "name": "slug",
-      "min": "4",
-      "max": "32",
       "type": "string"
     }
   ]

--- a/packages/framework/tests/Feature/PublicationTypeTest.php
+++ b/packages/framework/tests/Feature/PublicationTypeTest.php
@@ -139,7 +139,7 @@ class PublicationTypeTest extends TestCase
         $this->assertInstanceOf(Collection::class, $collection);
         $this->assertInstanceOf(PublicationField::class, $collection->first());
         $this->assertEquals(new \Rgasch\Collection\Collection([
-            'title' => new PublicationField('string', 'title', 0, 128),
+            'title' => new PublicationField('string', 'title'),
         ]), $collection);
     }
 

--- a/packages/framework/tests/Feature/PublicationTypeTest.php
+++ b/packages/framework/tests/Feature/PublicationTypeTest.php
@@ -169,7 +169,7 @@ class PublicationTypeTest extends TestCase
     {
         $publicationType = new PublicationType(...$this->getTestData());
         $this->assertEquals([
-            'title' => ['between:0,128'],
+            'title' => [],
         ], $publicationType->getFieldRules()->toArray());
     }
 
@@ -189,8 +189,6 @@ class PublicationTypeTest extends TestCase
             'fields'         => [
                 [
                     'name' => 'title',
-                    'min'  => '0',
-                    'max'  => '128',
                     'type' => 'string',
                 ],
             ],

--- a/packages/framework/tests/Unit/PublicationFieldValidationRulesTest.php
+++ b/packages/framework/tests/Unit/PublicationFieldValidationRulesTest.php
@@ -79,7 +79,7 @@ class PublicationFieldValidationRulesTest extends TestCase
         $this->directory('_media/foo');
         $this->file('_media/foo/bar.jpg');
         $this->file('_media/foo/baz.png');
-        $rules = (new PublicationField('image', 'myImage', publicationType: new PublicationType('foo')))->getValidationRules();
+        $rules = (new PublicationField('image', 'myImage', null, publicationType: new PublicationType('foo')))->getValidationRules();
         $this->assertSame(['in:_media/foo/bar.jpg,_media/foo/baz.png'], $rules->toArray());
     }
 

--- a/tests/fixtures/test-publication-schema.json
+++ b/tests/fixtures/test-publication-schema.json
@@ -12,8 +12,6 @@
     "fields": [
         {
             "name": "title",
-            "min": "0",
-            "max": "128",
             "type": "string"
         }
     ]


### PR DESCRIPTION
The range validations add a very large amount of complexity. I'm starting to think about how much we really need them. Sure length validation for article descriptions might be good, but do we really need to validate date ranges and integer values? Maybe it would be better to allow arbitrary Laravel validation rules to be specified in the schema file instead of its min/max values.

> _Originally posted by @caendesilva in https://github.com/hydephp/develop/issues/765#issuecomment-1361564784_