### PR TITLE
Simplify publication tag handling

### DIFF
--- a/packages/framework/src/Console/Commands/MakePublicationCommand.php
+++ b/packages/framework/src/Console/Commands/MakePublicationCommand.php
@@ -174,7 +174,7 @@ class MakePublicationCommand extends ValidatingCommand
         $this->output->writeln($field->name.' (enter 0 to reload tag definitions)');
         do {
             $offset = 0;
-            $tagsForGroup = PublicationService::getAllTags()->{$field->tagGroup};
+            $tagsForGroup = PublicationService::getAllTags()->{$this->pubType->name};
             foreach ($tagsForGroup as $index => $value) {
                 $offset = $index + 1;
                 $this->output->writeln("  $offset: $value");

--- a/packages/framework/src/Console/Commands/MakePublicationCommand.php
+++ b/packages/framework/src/Console/Commands/MakePublicationCommand.php
@@ -33,14 +33,16 @@ class MakePublicationCommand extends ValidatingCommand
     /** @var string */
     protected $description = 'Create a new publication item';
 
+    protected PublicationType $pubType;
+
     public function safeHandle(): int
     {
         $this->title('Creating a new Publication!');
 
-        $pubType = $this->getPubTypeSelection($this->getPublicationTypes());
-        $fieldData = $this->collectFieldData($pubType);
+        $this->pubType = $this->getPubTypeSelection($this->getPublicationTypes());
+        $fieldData = $this->collectFieldData($this->pubType);
 
-        $creator = new CreatesNewPublicationPage($pubType, $fieldData, $this->hasForceOption(), $this->output);
+        $creator = new CreatesNewPublicationPage($this->pubType, $fieldData, $this->hasForceOption(), $this->output);
         if ($creator->hasFileConflict()) {
             $this->error('Error: A publication already exists with the same canonical field value');
             if ($this->confirm('Do you wish to overwrite the existing file?')) {

--- a/packages/framework/src/Console/Commands/ValidatePublicationsCommand.php
+++ b/packages/framework/src/Console/Commands/ValidatePublicationsCommand.php
@@ -68,7 +68,7 @@ class ValidatePublicationsCommand extends ValidatingCommand
                 foreach ($publication->type->fields as $field) {
                     $countFields++;
                     $fieldName = $field['name'];
-                    $pubTypeField = new PublicationField($field['type'], $fieldName, $field['tagGroup'] ?? null);
+                    $pubTypeField = new PublicationField($field['type'], $fieldName);
 
                     try {
                         if ($verbose) {

--- a/packages/framework/src/Framework/Actions/SeedsPublicationFiles.php
+++ b/packages/framework/src/Framework/Actions/SeedsPublicationFiles.php
@@ -98,7 +98,7 @@ class SeedsPublicationFiles
             'image' => 'https://picsum.photos/id/'.rand(1, 1000).'/400/400',
             'integer' => rand(-100000, 100000),
             'string' => substr($this->fakeSentence(10), 0, rand(0, 255)),
-            'tag' => $this->getTags($field),
+            'tag' => $this->getTags(),
             'text' => $this->getTextValue(rand(3, 20)),
             'url' => $this->fakeUrl(),
         };
@@ -128,9 +128,9 @@ class SeedsPublicationFiles
         return $arrayItems;
     }
 
-    protected function getTags(PublicationField $field): string
+    protected function getTags(): string
     {
-        $tags = PublicationService::getValuesForTagName($field->tagGroup, false);
+        $tags = PublicationService::getValuesForTagName($this->pubType->name, false);
 
         return $tags->isEmpty() ? '' : $tags->random();
     }

--- a/packages/framework/src/Framework/Actions/SeedsPublicationFiles.php
+++ b/packages/framework/src/Framework/Actions/SeedsPublicationFiles.php
@@ -130,7 +130,7 @@ class SeedsPublicationFiles
 
     protected function getTags(): string
     {
-        $tags = PublicationService::getValuesForTagName($this->pubType->getIdentifier(), false);
+        $tags = PublicationService::getValuesForTagName($this->pubType->getIdentifier());
 
         return $tags->isEmpty() ? '' : $tags->random();
     }

--- a/packages/framework/src/Framework/Actions/SeedsPublicationFiles.php
+++ b/packages/framework/src/Framework/Actions/SeedsPublicationFiles.php
@@ -130,7 +130,7 @@ class SeedsPublicationFiles
 
     protected function getTags(): string
     {
-        $tags = PublicationService::getValuesForTagName($this->pubType->name, false);
+        $tags = PublicationService::getValuesForTagName($this->pubType->getIdentifier(), false);
 
         return $tags->isEmpty() ? '' : $tags->random();
     }

--- a/packages/framework/src/Framework/Features/Publications/Models/PublicationField.php
+++ b/packages/framework/src/Framework/Features/Publications/Models/PublicationField.php
@@ -72,7 +72,7 @@ class PublicationField implements SerializableContract
                 $fieldRules->add("in:$valueList");
                 break;
             case 'tag':
-                $tagValues = PublicationService::getValuesForTagName($this->tagGroup) ?? collect([]);
+                $tagValues = PublicationService::getValuesForTagName($publicationType->name) ?? collect([]);
                 $valueList = $tagValues->implode(',');
                 $fieldRules->add("in:$valueList");
                 break;

--- a/packages/framework/src/Framework/Features/Publications/Models/PublicationField.php
+++ b/packages/framework/src/Framework/Features/Publications/Models/PublicationField.php
@@ -27,7 +27,6 @@ class PublicationField implements SerializableContract
 
     public readonly PublicationFieldTypes $type;
     public readonly string $name;
-    public readonly ?string $tagGroup;
     public readonly array $rules;
 
     public static function fromArray(array $array): static
@@ -39,7 +38,6 @@ class PublicationField implements SerializableContract
     {
         $this->type = $type instanceof PublicationFieldTypes ? $type : PublicationFieldTypes::from(strtolower($type));
         $this->name = Str::kebab($name);
-        $this->tagGroup = $tagGroup;
         $this->rules = $rules;
     }
 
@@ -48,7 +46,6 @@ class PublicationField implements SerializableContract
         return array_filter([
             'type' => $this->type->value,
             'name' => $this->name,
-            'tagGroup' => $this->tagGroup,
             'rules' => $this->rules,
         ]);
     }

--- a/packages/framework/src/Framework/Features/Publications/Models/PublicationField.php
+++ b/packages/framework/src/Framework/Features/Publications/Models/PublicationField.php
@@ -34,7 +34,7 @@ class PublicationField implements SerializableContract
         return new static(...$array);
     }
 
-    public function __construct(PublicationFieldTypes|string $type, string $name, ?string $tagGroup = null, array $rules = [])
+    public function __construct(PublicationFieldTypes|string $type, string $name, array $rules = [])
     {
         $this->type = $type instanceof PublicationFieldTypes ? $type : PublicationFieldTypes::from(strtolower($type));
         $this->name = Str::kebab($name);

--- a/packages/framework/src/Framework/Features/Publications/Models/PublicationField.php
+++ b/packages/framework/src/Framework/Features/Publications/Models/PublicationField.php
@@ -72,7 +72,7 @@ class PublicationField implements SerializableContract
                 $fieldRules->add("in:$valueList");
                 break;
             case 'tag':
-                $tagValues = PublicationService::getValuesForTagName($publicationType?->name ?? '') ?? collect([]);
+                $tagValues = PublicationService::getValuesForTagName($publicationType?->getIdentifier() ?? '') ?? collect([]);
                 $valueList = $tagValues->implode(',');
                 $fieldRules->add("in:$valueList");
                 break;

--- a/packages/framework/src/Framework/Features/Publications/Models/PublicationField.php
+++ b/packages/framework/src/Framework/Features/Publications/Models/PublicationField.php
@@ -72,7 +72,7 @@ class PublicationField implements SerializableContract
                 $fieldRules->add("in:$valueList");
                 break;
             case 'tag':
-                $tagValues = PublicationService::getValuesForTagName($publicationType->name) ?? collect([]);
+                $tagValues = PublicationService::getValuesForTagName($publicationType?->name ?? '') ?? collect([]);
                 $valueList = $tagValues->implode(',');
                 $fieldRules->add("in:$valueList");
                 break;

--- a/packages/framework/src/Framework/Features/Publications/PublicationService.php
+++ b/packages/framework/src/Framework/Features/Publications/PublicationService.php
@@ -65,11 +65,9 @@ class PublicationService
      */
     public static function getAllTags(): Collection
     {
-        if (! file_exists(Hyde::path('tags.json'))) {
-            return Collection::create();
-        }
-
-        return Collection::create(json_decode(file_get_contents(Hyde::path('tags.json')), true))->sortKeys();
+        return file_exists(Hyde::path('tags.json'))
+            ? Collection::create(json_decode(file_get_contents(Hyde::path('tags.json')), true))->sortKeys()
+            : Collection::create();
     }
 
     /**

--- a/packages/framework/src/Framework/Features/Publications/PublicationService.php
+++ b/packages/framework/src/Framework/Features/Publications/PublicationService.php
@@ -70,12 +70,7 @@ class PublicationService
             return Collection::create();
         }
 
-        static $tags = null;
-        if (! $tags) {
-            $tags = Collection::create(json_decode(file_get_contents($filename), true))->sortKeys();
-        }
-
-        return $tags;
+        return Collection::create(json_decode(file_get_contents($filename), true))->sortKeys();
     }
 
     /**

--- a/packages/framework/src/Framework/Features/Publications/PublicationService.php
+++ b/packages/framework/src/Framework/Features/Publications/PublicationService.php
@@ -10,6 +10,8 @@ use Hyde\Hyde;
 use Hyde\Pages\PublicationPage;
 use Illuminate\Support\Str;
 use Rgasch\Collection\Collection;
+
+use function file_exists;
 use function Safe\file_get_contents;
 use function Safe\glob;
 use function Safe\json_decode;
@@ -60,9 +62,7 @@ class PublicationService
      */
     public static function getAllTags(): Collection
     {
-        return file_exists(Hyde::path('tags.json'))
-            ? Collection::create(json_decode(file_get_contents(Hyde::path('tags.json')), true))->sortKeys()
-            : Collection::create();
+        return Collection::create(self::parseTagsFile())->sortKeys();
     }
 
     /**
@@ -104,5 +104,14 @@ class PublicationService
     protected static function getMediaFiles(string $directory, string $extensions = '{jpg,jpeg,png,gif,pdf}'): array
     {
         return glob(Hyde::path("_media/$directory/*.$extensions"), GLOB_BRACE);
+    }
+
+    protected static function parseTagsFile(): array
+    {
+        if (file_exists(Hyde::path('tags.json'))) {
+            return json_decode(file_get_contents(Hyde::path('tags.json')), true);
+        }
+
+        return [];
     }
 }

--- a/packages/framework/src/Framework/Features/Publications/PublicationService.php
+++ b/packages/framework/src/Framework/Features/Publications/PublicationService.php
@@ -81,12 +81,7 @@ class PublicationService
      */
     public static function getValuesForTagName(string $tagName): Collection
     {
-        $tags = self::getAllTags();
-        if (! $tags->get($tagName)) {
-            return Collection::create();
-        }
-
-        return $tags->$tagName;
+        return self::getAllTags()->get($tagName) ?? Collection::create();
     }
 
     /**

--- a/packages/framework/src/Framework/Features/Publications/PublicationService.php
+++ b/packages/framework/src/Framework/Features/Publications/PublicationService.php
@@ -58,13 +58,12 @@ class PublicationService
     /**
      * Get all available tags.
      *
-     * @param  bool  $reload  Reload the tags from the filesystem
      * @return \Rgasch\Collection\Collection
      *
      * @throws \Safe\Exceptions\FilesystemException
      * @throws \Safe\Exceptions\JsonException
      */
-    public static function getAllTags(bool $reload = true): Collection
+    public static function getAllTags(): Collection
     {
         $filename = Hyde::path('tags.json');
         if (! file_exists($filename)) {
@@ -72,7 +71,7 @@ class PublicationService
         }
 
         static $tags = null;
-        if (! $tags || $reload) {
+        if (! $tags) {
             $tags = Collection::create(json_decode(file_get_contents($filename), true))->sortKeys();
         }
 
@@ -83,15 +82,14 @@ class PublicationService
      * Get all values for a given tag name.
      *
      * @param  string  $tagName
-     * @param  bool  $reload  Reload the tags from the filesystem
      * @return \Rgasch\Collection\Collection
      *
      * @throws \Safe\Exceptions\FilesystemException
      * @throws \Safe\Exceptions\JsonException
      */
-    public static function getValuesForTagName(string $tagName, bool $reload = true): Collection
+    public static function getValuesForTagName(string $tagName): Collection
     {
-        $tags = self::getAllTags($reload);
+        $tags = self::getAllTags();
         if (! $tags->get($tagName)) {
             return Collection::create();
         }

--- a/packages/framework/src/Framework/Features/Publications/PublicationService.php
+++ b/packages/framework/src/Framework/Features/Publications/PublicationService.php
@@ -65,12 +65,11 @@ class PublicationService
      */
     public static function getAllTags(): Collection
     {
-        $filename = Hyde::path('tags.json');
-        if (! file_exists($filename)) {
+        if (! file_exists(Hyde::path('tags.json'))) {
             return Collection::create();
         }
 
-        return Collection::create(json_decode(file_get_contents($filename), true))->sortKeys();
+        return Collection::create(json_decode(file_get_contents(Hyde::path('tags.json')), true))->sortKeys();
     }
 
     /**

--- a/packages/framework/src/Framework/Features/Publications/PublicationService.php
+++ b/packages/framework/src/Framework/Features/Publications/PublicationService.php
@@ -4,14 +4,13 @@ declare(strict_types=1);
 
 namespace Hyde\Framework\Features\Publications;
 
+use function file_exists;
 use Hyde\Framework\Actions\SourceFileParser;
 use Hyde\Framework\Features\Publications\Models\PublicationType;
 use Hyde\Hyde;
 use Hyde\Pages\PublicationPage;
 use Illuminate\Support\Str;
 use Rgasch\Collection\Collection;
-
-use function file_exists;
 use function Safe\file_get_contents;
 use function Safe\glob;
 use function Safe\json_decode;

--- a/packages/framework/src/Framework/Features/Publications/PublicationService.php
+++ b/packages/framework/src/Framework/Features/Publications/PublicationService.php
@@ -57,11 +57,6 @@ class PublicationService
 
     /**
      * Get all available tags.
-     *
-     * @return \Rgasch\Collection\Collection
-     *
-     * @throws \Safe\Exceptions\FilesystemException
-     * @throws \Safe\Exceptions\JsonException
      */
     public static function getAllTags(): Collection
     {
@@ -72,12 +67,6 @@ class PublicationService
 
     /**
      * Get all values for a given tag name.
-     *
-     * @param  string  $tagName
-     * @return \Rgasch\Collection\Collection
-     *
-     * @throws \Safe\Exceptions\FilesystemException
-     * @throws \Safe\Exceptions\JsonException
      */
     public static function getValuesForTagName(string $tagName): Collection
     {

--- a/packages/framework/tests/Feature/Actions/SeedsPublicationFilesTest.php
+++ b/packages/framework/tests/Feature/Actions/SeedsPublicationFilesTest.php
@@ -131,7 +131,7 @@ class SeedsPublicationFilesTest extends TestCase
 
     public function testWithTagType()
     {
-        $tags = ['Test Publication' => ['foo', 'bar', 'baz']];
+        $tags = ['test-publication' => ['foo', 'bar', 'baz']];
         $this->file('tags.json', json_encode($tags));
         $this->updateSchema('tag', 'tag');
         (new SeedsPublicationFiles($this->pubType))->create();
@@ -141,7 +141,7 @@ class SeedsPublicationFilesTest extends TestCase
         $this->assertBaseline($publication);
         $this->assertNotEmpty($publication->matter('tag'));
         $this->assertIsString($publication->matter('tag'));
-        $this->assertTrue(in_array($publication->matter('tag'), $tags['Test Publication']));
+        $this->assertTrue(in_array($publication->matter('tag'), $tags['test-publication']));
     }
 
     public function testWithTextType()

--- a/packages/framework/tests/Feature/Actions/SeedsPublicationFilesTest.php
+++ b/packages/framework/tests/Feature/Actions/SeedsPublicationFilesTest.php
@@ -185,7 +185,7 @@ class SeedsPublicationFilesTest extends TestCase
     protected function updateSchema(string $type, string $name, ?string $tagGroup = null): void
     {
         $this->pubType->fields = [
-            (new PublicationField($type, $name, tagGroup: $tagGroup))->toArray(),
+            (new PublicationField($type, $name))->toArray(),
         ];
         $this->pubType->save();
     }

--- a/packages/framework/tests/Feature/Actions/SeedsPublicationFilesTest.php
+++ b/packages/framework/tests/Feature/Actions/SeedsPublicationFilesTest.php
@@ -133,7 +133,7 @@ class SeedsPublicationFilesTest extends TestCase
     {
         $tags = ['foo' => ['foo', 'bar', 'baz']];
         $this->file('tags.json', json_encode($tags));
-        $this->updateSchema('tag', 'tag', tagGroup: 'foo');
+        $this->updateSchema('tag', 'tag');
         (new SeedsPublicationFiles($this->pubType))->create();
 
         $publication = $this->firstPublication();
@@ -182,7 +182,7 @@ class SeedsPublicationFilesTest extends TestCase
         return MarkdownDocument::parse(Hyde::pathToRelative($this->getPublicationFiles()[0]));
     }
 
-    protected function updateSchema(string $type, string $name, ?string $tagGroup = null): void
+    protected function updateSchema(string $type, string $name): void
     {
         $this->pubType->fields = [
             (new PublicationField($type, $name))->toArray(),

--- a/packages/framework/tests/Feature/Actions/SeedsPublicationFilesTest.php
+++ b/packages/framework/tests/Feature/Actions/SeedsPublicationFilesTest.php
@@ -131,7 +131,7 @@ class SeedsPublicationFilesTest extends TestCase
 
     public function testWithTagType()
     {
-        $tags = ['foo' => ['foo', 'bar', 'baz']];
+        $tags = ['Test Publication' => ['foo', 'bar', 'baz']];
         $this->file('tags.json', json_encode($tags));
         $this->updateSchema('tag', 'tag');
         (new SeedsPublicationFiles($this->pubType))->create();
@@ -141,7 +141,7 @@ class SeedsPublicationFilesTest extends TestCase
         $this->assertBaseline($publication);
         $this->assertNotEmpty($publication->matter('tag'));
         $this->assertIsString($publication->matter('tag'));
-        $this->assertTrue(in_array($publication->matter('tag'), $tags['foo']));
+        $this->assertTrue(in_array($publication->matter('tag'), $tags['Test Publication']));
     }
 
     public function testWithTextType()

--- a/packages/framework/tests/Feature/PublicationFieldTest.php
+++ b/packages/framework/tests/Feature/PublicationFieldTest.php
@@ -51,7 +51,6 @@ class PublicationFieldTest extends TestCase
         $this->assertSame([
             'type' => 'string',
             'name' => 'test',
-            'tagGroup' => 'foo',
             'rules' => ['required'],
         ], (new PublicationField('string', 'test', ['required']))->toArray());
     }
@@ -63,7 +62,7 @@ class PublicationFieldTest extends TestCase
 
     public function test_can_get_field_with_optional_properties_as_json()
     {
-        $this->assertSame('{"type":"string","name":"test","tagGroup":"foo","rules":["required"]}', json_encode(new PublicationField('string',
+        $this->assertSame('{"type":"string","name":"test","rules":["required"]}', json_encode(new PublicationField('string',
             'test',
             ['required']
         )));

--- a/packages/framework/tests/Feature/PublicationFieldTest.php
+++ b/packages/framework/tests/Feature/PublicationFieldTest.php
@@ -53,7 +53,7 @@ class PublicationFieldTest extends TestCase
             'name' => 'test',
             'tagGroup' => 'foo',
             'rules' => ['required'],
-        ], (new PublicationField('string', 'test', 'foo', ['required']))->toArray());
+        ], (new PublicationField('string', 'test', ['required']))->toArray());
     }
 
     public function test_can_encode_field_as_json()
@@ -63,7 +63,10 @@ class PublicationFieldTest extends TestCase
 
     public function test_can_get_field_with_optional_properties_as_json()
     {
-        $this->assertSame('{"type":"string","name":"test","tagGroup":"foo","rules":["required"]}', json_encode(new PublicationField('string', 'test', 'foo', ['required'])));
+        $this->assertSame('{"type":"string","name":"test","tagGroup":"foo","rules":["required"]}', json_encode(new PublicationField('string',
+            'test',
+            ['required']
+        )));
     }
 
     public function test_can_construct_type_using_enum_case()
@@ -225,7 +228,7 @@ class PublicationFieldTest extends TestCase
 
     public function testGetRulesForTag()
     {
-        $rules = (new PublicationField('tag', 'myTag', tagGroup: 'foo'))->getValidationRules();
+        $rules = (new PublicationField('tag', 'myTag'))->getValidationRules();
         $this->assertSame(['in:'], $rules->toArray());
     }
 


### PR DESCRIPTION
Simplifies how publication tags are handled.

Notably:
- The tagGroup property is now removed. It's assumed the tag group is the same as the publication type's identifier (same as the publication's directory name)
- Removes the $reload parameter and the caching of tags