### PR TITLE
Generate list and detail pages when creating publication types 

### DIFF
--- a/packages/framework/src/Console/Commands/MakePublicationTypeCommand.php
+++ b/packages/framework/src/Console/Commands/MakePublicationTypeCommand.php
@@ -53,7 +53,7 @@ class MakePublicationTypeCommand extends ValidatingCommand
 
         $canonicalField = $this->getCanonicalField();
 
-        $creator = new CreatesNewPublicationType($title, $this->fields, $canonicalField->name, $sortField, $sortAscending, $prevNextLinks, $pageSize, $this->output);
+        $creator = new CreatesNewPublicationType($title, $this->fields, $canonicalField->name, $sortField, $sortAscending, $prevNextLinks, $pageSize);
         $this->output->writeln("Saving publication data to [{$creator->getOutputPath()}]");
         $creator->create();
 

--- a/packages/framework/src/Console/Commands/MakePublicationTypeCommand.php
+++ b/packages/framework/src/Console/Commands/MakePublicationTypeCommand.php
@@ -54,6 +54,7 @@ class MakePublicationTypeCommand extends ValidatingCommand
         $canonicalField = $this->getCanonicalField();
 
         $creator = new CreatesNewPublicationType($title, $this->fields, $canonicalField->name, $sortField, $sortAscending, $prevNextLinks, $pageSize, $this->output);
+        $this->output->writeln("Saving publication data to [{$creator->getOutputPath()}]");
         $creator->create();
 
         $this->info('Publication type created successfully!');

--- a/packages/framework/src/Framework/Actions/CreatesNewPublicationType.php
+++ b/packages/framework/src/Framework/Actions/CreatesNewPublicationType.php
@@ -37,8 +37,8 @@ class CreatesNewPublicationType extends CreateAction implements CreateActionCont
         $type = new PublicationType(
             $this->name,
             $this->canonicalField,
-            "{$this->directoryName}_detail",
-            "{$this->directoryName}_list",
+            $this->detailTemplateName(),
+            $this->listTemplateName(),
             [
                 $this->sortField ?? '__createdAt',
                 $this->sortAscending ?? true,
@@ -51,5 +51,15 @@ class CreatesNewPublicationType extends CreateAction implements CreateActionCont
         $type->save($this->outputPath);
 
         // TODO: Generate the detail and list templates
+    }
+
+    protected function detailTemplateName(): string
+    {
+        return "{$this->directoryName}_detail";
+    }
+
+    protected function listTemplateName(): string
+    {
+        return "{$this->directoryName}_list";
     }
 }

--- a/packages/framework/src/Framework/Actions/CreatesNewPublicationType.php
+++ b/packages/framework/src/Framework/Actions/CreatesNewPublicationType.php
@@ -82,11 +82,14 @@ class CreatesNewPublicationType extends CreateAction implements CreateActionCont
 
         <article class="prose dark:prose-invert">
             <h2>Front Matter Data</h2>
-            @foreach($publication->matter->data as $key => $value)
-                <p>
-                    <strong>{{ $key }}</strong>: {{ is_array($value) ? '(array) '. implode(', ', $value) : $value }}
-                </p>
-            @endforeach
+            <div class="p-4">
+                @foreach($publication->matter->data as $key => $value)
+                    <dt class="font-bold">{{ $key }}</dt>
+                    <dd class="ml-4">
+                        {{ is_array($value) ? '(array) '. implode(', ', $value) : $value }}
+                    </dd>
+                @endforeach
+            </div>
         </article>
         BLADE);
 

--- a/packages/framework/src/Framework/Actions/CreatesNewPublicationType.php
+++ b/packages/framework/src/Framework/Actions/CreatesNewPublicationType.php
@@ -7,9 +7,7 @@ namespace Hyde\Framework\Actions;
 use Hyde\Framework\Actions\Concerns\CreateAction;
 use Hyde\Framework\Actions\Contracts\CreateActionContract;
 use Hyde\Framework\Features\Publications\Models\PublicationType;
-use Illuminate\Console\OutputStyle;
 use Illuminate\Support\Collection;
-use JetBrains\PhpStorm\Deprecated;
 
 /**
  * Scaffold a new publication type schema.

--- a/packages/framework/src/Framework/Actions/CreatesNewPublicationType.php
+++ b/packages/framework/src/Framework/Actions/CreatesNewPublicationType.php
@@ -53,8 +53,6 @@ class CreatesNewPublicationType extends CreateAction implements CreateActionCont
             $this->fields->toArray()
         );
 
-        $this->output?->writeln("Saving publication data to [$this->outputPath]");
-
         $type->save($this->outputPath);
 
         // TODO: Generate the detail and list templates

--- a/packages/framework/src/Framework/Actions/CreatesNewPublicationType.php
+++ b/packages/framework/src/Framework/Actions/CreatesNewPublicationType.php
@@ -68,14 +68,14 @@ class CreatesNewPublicationType extends CreateAction implements CreateActionCont
 
     protected function createDetailTemplate(): void
     {
-        $contents = $this->stubContents();
+        $contents = $this->stubContents('// detail');
 
         $this->savePublicationFile("{$this->detailTemplateName()}.blade.php", $contents);
     }
 
     protected function createListTemplate(): void
     {
-        $contents = $this->stubContents();
+        $contents = $this->stubContents('// list');
 
         $this->savePublicationFile("{$this->listTemplateName()}.blade.php", $contents);
     }
@@ -85,14 +85,14 @@ class CreatesNewPublicationType extends CreateAction implements CreateActionCont
         return file_put_contents(Hyde::path("$this->directoryName/$filename"), "$contents\n");
     }
 
-    protected function stubContents(): string
+    protected function stubContents(string $slot): string
     {
-        return <<<'BLADE'
+        return <<<BLADE
         @extends('hyde::layouts.app')
         @section('content')
         
             <main id="content" class="mx-auto max-w-7xl py-16 px-8">
-                {{ $slot }}
+                $slot
             </main>
         
         @endsection

--- a/packages/framework/src/Framework/Actions/CreatesNewPublicationType.php
+++ b/packages/framework/src/Framework/Actions/CreatesNewPublicationType.php
@@ -71,32 +71,31 @@ class CreatesNewPublicationType extends CreateAction implements CreateActionCont
         $contents = <<<'BLADE'
         @extends('hyde::layouts.app')
         @section('content')
-        <main id="content" class="mx-auto max-w-7xl py-16 px-8">
-            <article class="prose dark:prose-invert">
-                @php/** @var \Hyde\Pages\PublicationPage $publication*/@endphp
-                <h1>{{ $publication->title }}</h1>
-                <p>
-                    {{ $publication->markdown }}
-                </p>
-            </article>
-            
-            <div class="prose dark:prose-invert my-8">
-                <hr>
-            </div>
-            
-            <article class="prose dark:prose-invert">
-                <h3>Front Matter Data</h3>
-                <div class="ml-4">
-                    @foreach($publication->matter->data as $key => $value)
-                    <dt class="font-bold">{{ $key }}</dt>
-                    <dd class="ml-4">
-                        {{ is_array($value) ? '(array) '. implode(', ', $value) : $value }}
-                    </dd>
-                    @endforeach
+            <main id="content" class="mx-auto max-w-7xl py-16 px-8">
+                <article class="prose dark:prose-invert">
+                    @php/** @var \Hyde\Pages\PublicationPage $publication*/@endphp
+                    <h1>{{ $publication->title }}</h1>
+                    <p>
+                        {{ $publication->markdown }}
+                    </p>
+                </article>
+                
+                <div class="prose dark:prose-invert my-8">
+                    <hr>
                 </div>
-            </article>
-        </main>
-
+                
+                <article class="prose dark:prose-invert">
+                    <h3>Front Matter Data</h3>
+                    <div class="ml-4">
+                        @foreach($publication->matter->data as $key => $value)
+                        <dt class="font-bold">{{ $key }}</dt>
+                        <dd class="ml-4">
+                            {{ is_array($value) ? '(array) '. implode(', ', $value) : $value }}
+                        </dd>
+                        @endforeach
+                    </div>
+                </article>
+            </main>
         @endsection
         BLADE;
 
@@ -121,7 +120,6 @@ class CreatesNewPublicationType extends CreateAction implements CreateActionCont
                     </ol>
                 </div>
             </main>
-
         @endsection
         BLADE;
 

--- a/packages/framework/src/Framework/Actions/CreatesNewPublicationType.php
+++ b/packages/framework/src/Framework/Actions/CreatesNewPublicationType.php
@@ -81,7 +81,7 @@ class CreatesNewPublicationType extends CreateAction implements CreateActionCont
 
         BLADE;
 
-        file_put_contents(Hyde::path("$this->directoryName/{$this->detailTemplateName()}.blade.php"), $contents);
+        $this->savePublicationFile("{$this->detailTemplateName()}.blade.php", $contents);
     }
 
     protected function createListTemplate(): void
@@ -98,6 +98,11 @@ class CreatesNewPublicationType extends CreateAction implements CreateActionCont
 
         BLADE;
 
-        file_put_contents(Hyde::path("$this->directoryName/{$this->listTemplateName()}.blade.php"), $contents);
+        $this->savePublicationFile("{$this->listTemplateName()}.blade.php", $contents);
+    }
+
+    protected function savePublicationFile(string $filename, string $contents): int
+    {
+        return file_put_contents(Hyde::path("$this->directoryName/$filename"), $contents);
     }
 }

--- a/packages/framework/src/Framework/Actions/CreatesNewPublicationType.php
+++ b/packages/framework/src/Framework/Actions/CreatesNewPublicationType.php
@@ -9,6 +9,7 @@ use Hyde\Framework\Actions\Contracts\CreateActionContract;
 use Hyde\Framework\Features\Publications\Models\PublicationType;
 use Illuminate\Console\OutputStyle;
 use Illuminate\Support\Collection;
+use JetBrains\PhpStorm\Deprecated;
 
 /**
  * Scaffold a new publication type schema.
@@ -19,6 +20,7 @@ use Illuminate\Support\Collection;
 class CreatesNewPublicationType extends CreateAction implements CreateActionContract
 {
     protected string $dirName;
+    #[Deprecated] protected ?OutputStyle $output = null;
 
     public function __construct(
         protected string $name,
@@ -28,8 +30,9 @@ class CreatesNewPublicationType extends CreateAction implements CreateActionCont
         protected ?bool $sortAscending,
         protected ?bool $prevNextLinks,
         protected ?int $pageSize,
-        protected ?OutputStyle $output = null,
+        #[Deprecated] ?OutputStyle $output = null,
     ) {
+        $this->output = $output;
         $this->dirName = $this->formatStringForStorage($this->name);
         $this->outputPath = "$this->dirName/schema.json";
     }

--- a/packages/framework/src/Framework/Actions/CreatesNewPublicationType.php
+++ b/packages/framework/src/Framework/Actions/CreatesNewPublicationType.php
@@ -82,9 +82,11 @@ class CreatesNewPublicationType extends CreateAction implements CreateActionCont
 
         <article class="prose dark:prose-invert">
             <h2>Front Matter Data</h2>
-            <pre>
-                {{ $publication->matter }}
-            </pre>
+            @foreach($publication->matter->data as $key => $value)
+                <p>
+                    <strong>{{ $key }}</strong>: {{ $value }}
+                </p>
+            @endforeach
         </article>
         BLADE);
 

--- a/packages/framework/src/Framework/Actions/CreatesNewPublicationType.php
+++ b/packages/framework/src/Framework/Actions/CreatesNewPublicationType.php
@@ -17,7 +17,7 @@ use Illuminate\Support\Collection;
  */
 class CreatesNewPublicationType extends CreateAction implements CreateActionContract
 {
-    protected string $dirName;
+    protected string $directoryName;
 
     public function __construct(
         protected string $name,
@@ -28,8 +28,8 @@ class CreatesNewPublicationType extends CreateAction implements CreateActionCont
         protected ?bool $prevNextLinks = null,
         protected ?int $pageSize = null,
     ) {
-        $this->dirName = $this->formatStringForStorage($this->name);
-        $this->outputPath = "$this->dirName/schema.json";
+        $this->directoryName = $this->formatStringForStorage($this->name);
+        $this->outputPath = "$this->directoryName/schema.json";
     }
 
     protected function handleCreate(): void
@@ -37,8 +37,8 @@ class CreatesNewPublicationType extends CreateAction implements CreateActionCont
         $type = new PublicationType(
             $this->name,
             $this->canonicalField,
-            "{$this->dirName}_detail",
-            "{$this->dirName}_list",
+            "{$this->directoryName}_detail",
+            "{$this->directoryName}_list",
             [
                 $this->sortField ?? '__createdAt',
                 $this->sortAscending ?? true,

--- a/packages/framework/src/Framework/Actions/CreatesNewPublicationType.php
+++ b/packages/framework/src/Framework/Actions/CreatesNewPublicationType.php
@@ -81,7 +81,7 @@ class CreatesNewPublicationType extends CreateAction implements CreateActionCont
         </div>
 
         <article class="prose dark:prose-invert">
-            <h2>Front Matter Data</h2>
+            <h3>Front Matter Data</h3>
             <div class="p-4">
                 @foreach($publication->matter->data as $key => $value)
                     <dt class="font-bold">{{ $key }}</dt>

--- a/packages/framework/src/Framework/Actions/CreatesNewPublicationType.php
+++ b/packages/framework/src/Framework/Actions/CreatesNewPublicationType.php
@@ -50,7 +50,8 @@ class CreatesNewPublicationType extends CreateAction implements CreateActionCont
 
         $type->save($this->outputPath);
 
-        // TODO: Generate the detail and list templates
+        $this->createDetailTemplate();
+        $this->createListTemplate();
     }
 
     protected function detailTemplateName(): string
@@ -61,5 +62,15 @@ class CreatesNewPublicationType extends CreateAction implements CreateActionCont
     protected function listTemplateName(): string
     {
         return "{$this->directoryName}_list";
+    }
+
+    protected function createDetailTemplate(): void
+    {
+        // TODO: Implement createDetailTemplate() method.
+    }
+
+    protected function createListTemplate(): void
+    {
+        // TODO: Implement createListTemplate() method.
     }
 }

--- a/packages/framework/src/Framework/Actions/CreatesNewPublicationType.php
+++ b/packages/framework/src/Framework/Actions/CreatesNewPublicationType.php
@@ -84,7 +84,7 @@ class CreatesNewPublicationType extends CreateAction implements CreateActionCont
             <h2>Front Matter Data</h2>
             @foreach($publication->matter->data as $key => $value)
                 <p>
-                    <strong>{{ $key }}</strong>: {{ is_array($value) ? implode(', ', $value) : $value }}
+                    <strong>{{ $key }}</strong>: {{ is_array($value) ? '(array) '. implode(', ', $value) : $value }}
                 </p>
             @endforeach
         </article>

--- a/packages/framework/src/Framework/Actions/CreatesNewPublicationType.php
+++ b/packages/framework/src/Framework/Actions/CreatesNewPublicationType.php
@@ -7,7 +7,10 @@ namespace Hyde\Framework\Actions;
 use Hyde\Framework\Actions\Concerns\CreateAction;
 use Hyde\Framework\Actions\Contracts\CreateActionContract;
 use Hyde\Framework\Features\Publications\Models\PublicationType;
+use Hyde\Hyde;
 use Illuminate\Support\Collection;
+
+use function file_put_contents;
 
 /**
  * Scaffold a new publication type schema.
@@ -66,7 +69,19 @@ class CreatesNewPublicationType extends CreateAction implements CreateActionCont
 
     protected function createDetailTemplate(): void
     {
-        // TODO: Implement createDetailTemplate() method.
+        $contents = <<<'BLADE'
+        @extends('hyde::layouts.app')
+        @section('content')
+        
+            <main id="content" class="mx-auto max-w-7xl py-16 px-8">
+                {{ $slot }}
+            </main>
+        
+        @endsection
+
+        BLADE;
+
+        file_put_contents(Hyde::path("$this->directoryName/{$this->detailTemplateName()}.blade.php"), $contents);
     }
 
     protected function createListTemplate(): void

--- a/packages/framework/src/Framework/Actions/CreatesNewPublicationType.php
+++ b/packages/framework/src/Framework/Actions/CreatesNewPublicationType.php
@@ -78,7 +78,6 @@ class CreatesNewPublicationType extends CreateAction implements CreateActionCont
             </main>
         
         @endsection
-
         BLADE;
 
         $this->savePublicationFile("{$this->detailTemplateName()}.blade.php", $contents);
@@ -95,7 +94,6 @@ class CreatesNewPublicationType extends CreateAction implements CreateActionCont
             </main>
         
         @endsection
-
         BLADE;
 
         $this->savePublicationFile("{$this->listTemplateName()}.blade.php", $contents);
@@ -103,6 +101,6 @@ class CreatesNewPublicationType extends CreateAction implements CreateActionCont
 
     protected function savePublicationFile(string $filename, string $contents): int
     {
-        return file_put_contents(Hyde::path("$this->directoryName/$filename"), $contents);
+        return file_put_contents(Hyde::path("$this->directoryName/$filename"), "$contents\n");
     }
 }

--- a/packages/framework/src/Framework/Actions/CreatesNewPublicationType.php
+++ b/packages/framework/src/Framework/Actions/CreatesNewPublicationType.php
@@ -84,7 +84,7 @@ class CreatesNewPublicationType extends CreateAction implements CreateActionCont
             <h2>Front Matter Data</h2>
             @foreach($publication->matter->data as $key => $value)
                 <p>
-                    <strong>{{ $key }}</strong>: {{ $value }}
+                    <strong>{{ $key }}</strong>: {{ is_array($value) ? implode(', ', $value) : $value }}
                 </p>
             @endforeach
         </article>

--- a/packages/framework/src/Framework/Actions/CreatesNewPublicationType.php
+++ b/packages/framework/src/Framework/Actions/CreatesNewPublicationType.php
@@ -75,7 +75,19 @@ class CreatesNewPublicationType extends CreateAction implements CreateActionCont
 
     protected function createListTemplate(): void
     {
-        $contents = $this->stubContents('// list');
+        $contents = $this->stubContents(<<<'BLADE'
+        <div class="prose dark:prose-invert">
+            <h1>Publications for type {{ $page->type->name }}</h1>
+
+            <ol>
+                @foreach($publications as $publication)
+                    <li>
+                        <x-link :href="$publication->getRoute()">{{ $publication->title }}</x-link>
+                    </li>
+                @endforeach
+            </ol>
+        </div>
+        BLADE);
 
         $this->savePublicationFile("{$this->listTemplateName()}.blade.php", $contents);
     }

--- a/packages/framework/src/Framework/Actions/CreatesNewPublicationType.php
+++ b/packages/framework/src/Framework/Actions/CreatesNewPublicationType.php
@@ -68,51 +68,62 @@ class CreatesNewPublicationType extends CreateAction implements CreateActionCont
 
     protected function createDetailTemplate(): void
     {
-        $contents = $this->stubContents(<<<'BLADE'
-        <article class="prose dark:prose-invert">
-            @php/** @var \Hyde\Pages\PublicationPage $publication*/@endphp
-            <h1>{{ $publication->title }}</h1>
-            <p>
-                {{ $publication->markdown }}
-            </p>
-        </article>
-
-        <div class="prose dark:prose-invert my-8">
-            <hr>
-        </div>
-
-        <article class="prose dark:prose-invert">
-            <h3>Front Matter Data</h3>
-            <div class="ml-4">
-                @foreach($publication->matter->data as $key => $value)
+        $contents = <<<'BLADE'
+        @extends('hyde::layouts.app')
+        @section('content')
+        <main id="content" class="mx-auto max-w-7xl py-16 px-8">
+            <article class="prose dark:prose-invert">
+                @php/** @var \Hyde\Pages\PublicationPage $publication*/@endphp
+                <h1>{{ $publication->title }}</h1>
+                <p>
+                    {{ $publication->markdown }}
+                </p>
+            </article>
+            
+            <div class="prose dark:prose-invert my-8">
+                <hr>
+            </div>
+            
+            <article class="prose dark:prose-invert">
+                <h3>Front Matter Data</h3>
+                <div class="ml-4">
+                    @foreach($publication->matter->data as $key => $value)
                     <dt class="font-bold">{{ $key }}</dt>
                     <dd class="ml-4">
                         {{ is_array($value) ? '(array) '. implode(', ', $value) : $value }}
                     </dd>
-                @endforeach
-            </div>
-        </article>
-        BLADE);
+                    @endforeach
+                </div>
+            </article>
+        </main>
+
+        @endsection
+        BLADE;
 
         $this->savePublicationFile("{$this->detailTemplateName()}.blade.php", $contents);
     }
 
     protected function createListTemplate(): void
     {
-        $contents = $this->stubContents(<<<'BLADE'
-        <div class="prose dark:prose-invert">
-            <h1>Publications for type {{ $page->type->name }}</h1>
+        $contents = <<<'BLADE'
+        @extends('hyde::layouts.app')
+        @section('content')
+            <main id="content" class="mx-auto max-w-7xl py-16 px-8">
+                <div class="prose dark:prose-invert">
+                    <h1>Publications for type {{ $page->type->name }}</h1>
+                    <ol>
+                        @php/** @var \Hyde\Pages\PublicationPage $publication*/@endphp
+                        @foreach($publications as $publication)
+                        <li>
+                            <x-link :href="$publication->getRoute()">{{ $publication->title }}</x-link>
+                        </li>
+                        @endforeach
+                    </ol>
+                </div>
+            </main>
 
-            <ol>
-                @php/** @var \Hyde\Pages\PublicationPage $publication*/@endphp
-                @foreach($publications as $publication)
-                    <li>
-                        <x-link :href="$publication->getRoute()">{{ $publication->title }}</x-link>
-                    </li>
-                @endforeach
-            </ol>
-        </div>
-        BLADE);
+        @endsection
+        BLADE;
 
         $this->savePublicationFile("{$this->listTemplateName()}.blade.php", $contents);
     }
@@ -120,19 +131,5 @@ class CreatesNewPublicationType extends CreateAction implements CreateActionCont
     protected function savePublicationFile(string $filename, string $contents): int
     {
         return file_put_contents(Hyde::path("$this->directoryName/$filename"), "$contents\n");
-    }
-
-    protected function stubContents(string $slot): string
-    {
-        return <<<BLADE
-        @extends('hyde::layouts.app')
-        @section('content')
-        
-            <main id="content" class="mx-auto max-w-7xl py-16 px-8">
-                $slot
-            </main>
-        
-        @endsection
-        BLADE;
     }
 }

--- a/packages/framework/src/Framework/Actions/CreatesNewPublicationType.php
+++ b/packages/framework/src/Framework/Actions/CreatesNewPublicationType.php
@@ -4,13 +4,12 @@ declare(strict_types=1);
 
 namespace Hyde\Framework\Actions;
 
+use function file_put_contents;
 use Hyde\Framework\Actions\Concerns\CreateAction;
 use Hyde\Framework\Actions\Contracts\CreateActionContract;
 use Hyde\Framework\Features\Publications\Models\PublicationType;
 use Hyde\Hyde;
 use Illuminate\Support\Collection;
-
-use function file_put_contents;
 
 /**
  * Scaffold a new publication type schema.

--- a/packages/framework/src/Framework/Actions/CreatesNewPublicationType.php
+++ b/packages/framework/src/Framework/Actions/CreatesNewPublicationType.php
@@ -96,10 +96,11 @@ class CreatesNewPublicationType extends CreateAction implements CreateActionCont
                 </div>
             </article>
         </main>
+
         @endsection
         BLADE;
 
-        $this->savePublicationFile("{$this->detailTemplateName()}.blade.php", "$contents\n");
+        $this->savePublicationFile("{$this->detailTemplateName()}.blade.php", $contents);
     }
 
     protected function createListTemplate(): void
@@ -120,10 +121,11 @@ class CreatesNewPublicationType extends CreateAction implements CreateActionCont
                     </ol>
                 </div>
             </main>
+
         @endsection
         BLADE;
 
-        $this->savePublicationFile("{$this->listTemplateName()}.blade.php", "$contents\n");
+        $this->savePublicationFile("{$this->listTemplateName()}.blade.php", $contents);
     }
 
     protected function savePublicationFile(string $filename, string $contents): int

--- a/packages/framework/src/Framework/Actions/CreatesNewPublicationType.php
+++ b/packages/framework/src/Framework/Actions/CreatesNewPublicationType.php
@@ -23,10 +23,10 @@ class CreatesNewPublicationType extends CreateAction implements CreateActionCont
         protected string $name,
         protected Collection $fields,
         protected string $canonicalField,
-        protected ?string $sortField,
-        protected ?bool $sortAscending,
-        protected ?bool $prevNextLinks,
-        protected ?int $pageSize,
+        protected ?string $sortField = null,
+        protected ?bool $sortAscending = null,
+        protected ?bool $prevNextLinks = null,
+        protected ?int $pageSize = null,
     ) {
         $this->dirName = $this->formatStringForStorage($this->name);
         $this->outputPath = "$this->dirName/schema.json";

--- a/packages/framework/src/Framework/Actions/CreatesNewPublicationType.php
+++ b/packages/framework/src/Framework/Actions/CreatesNewPublicationType.php
@@ -96,11 +96,10 @@ class CreatesNewPublicationType extends CreateAction implements CreateActionCont
                 </div>
             </article>
         </main>
-
         @endsection
         BLADE;
 
-        $this->savePublicationFile("{$this->detailTemplateName()}.blade.php", $contents);
+        $this->savePublicationFile("{$this->detailTemplateName()}.blade.php", "$contents\n");
     }
 
     protected function createListTemplate(): void
@@ -121,11 +120,10 @@ class CreatesNewPublicationType extends CreateAction implements CreateActionCont
                     </ol>
                 </div>
             </main>
-
         @endsection
         BLADE;
 
-        $this->savePublicationFile("{$this->listTemplateName()}.blade.php", $contents);
+        $this->savePublicationFile("{$this->listTemplateName()}.blade.php", "$contents\n");
     }
 
     protected function savePublicationFile(string $filename, string $contents): int

--- a/packages/framework/src/Framework/Actions/CreatesNewPublicationType.php
+++ b/packages/framework/src/Framework/Actions/CreatesNewPublicationType.php
@@ -70,6 +70,7 @@ class CreatesNewPublicationType extends CreateAction implements CreateActionCont
     {
         $contents = $this->stubContents(<<<'BLADE'
         <article class="prose dark:prose-invert">
+            @php/** @var \Hyde\Pages\PublicationPage $publication*/@endphp
             <h1>{{ $publication->title }}</h1>
             <p>
                 {{ $publication->markdown }}
@@ -103,6 +104,7 @@ class CreatesNewPublicationType extends CreateAction implements CreateActionCont
             <h1>Publications for type {{ $page->type->name }}</h1>
 
             <ol>
+                @php/** @var \Hyde\Pages\PublicationPage $publication*/@endphp
                 @foreach($publications as $publication)
                     <li>
                         <x-link :href="$publication->getRoute()">{{ $publication->title }}</x-link>

--- a/packages/framework/src/Framework/Actions/CreatesNewPublicationType.php
+++ b/packages/framework/src/Framework/Actions/CreatesNewPublicationType.php
@@ -82,7 +82,7 @@ class CreatesNewPublicationType extends CreateAction implements CreateActionCont
 
         <article class="prose dark:prose-invert">
             <h3>Front Matter Data</h3>
-            <div class="p-4">
+            <div class="ml-4">
                 @foreach($publication->matter->data as $key => $value)
                     <dt class="font-bold">{{ $key }}</dt>
                     <dd class="ml-4">

--- a/packages/framework/src/Framework/Actions/CreatesNewPublicationType.php
+++ b/packages/framework/src/Framework/Actions/CreatesNewPublicationType.php
@@ -68,7 +68,21 @@ class CreatesNewPublicationType extends CreateAction implements CreateActionCont
 
     protected function createDetailTemplate(): void
     {
-        $contents = $this->stubContents('// detail');
+        $contents = $this->stubContents(<<<'BLADE'
+        <article class="prose dark:prose-invert">
+            <h1>{{ $publication->title }}</h1>
+            <p>
+                {{ $publication->markdown }}
+            </p>
+
+            <hr>
+
+            <h2>Front Matter Data</h2>
+            <pre>
+                {{ $publication->matter }}
+            </pre>
+        </article>
+        BLADE);
 
         $this->savePublicationFile("{$this->detailTemplateName()}.blade.php", $contents);
     }

--- a/packages/framework/src/Framework/Actions/CreatesNewPublicationType.php
+++ b/packages/framework/src/Framework/Actions/CreatesNewPublicationType.php
@@ -68,32 +68,14 @@ class CreatesNewPublicationType extends CreateAction implements CreateActionCont
 
     protected function createDetailTemplate(): void
     {
-        $contents = <<<'BLADE'
-        @extends('hyde::layouts.app')
-        @section('content')
-        
-            <main id="content" class="mx-auto max-w-7xl py-16 px-8">
-                {{ $slot }}
-            </main>
-        
-        @endsection
-        BLADE;
+        $contents = $this->stubContents();
 
         $this->savePublicationFile("{$this->detailTemplateName()}.blade.php", $contents);
     }
 
     protected function createListTemplate(): void
     {
-        $contents = <<<'BLADE'
-        @extends('hyde::layouts.app')
-        @section('content')
-        
-            <main id="content" class="mx-auto max-w-7xl py-16 px-8">
-                {{ $slot }}
-            </main>
-        
-        @endsection
-        BLADE;
+        $contents = $this->stubContents();
 
         $this->savePublicationFile("{$this->listTemplateName()}.blade.php", $contents);
     }
@@ -101,5 +83,19 @@ class CreatesNewPublicationType extends CreateAction implements CreateActionCont
     protected function savePublicationFile(string $filename, string $contents): int
     {
         return file_put_contents(Hyde::path("$this->directoryName/$filename"), "$contents\n");
+    }
+
+    protected function stubContents(): string
+    {
+        return <<<'BLADE'
+        @extends('hyde::layouts.app')
+        @section('content')
+        
+            <main id="content" class="mx-auto max-w-7xl py-16 px-8">
+                {{ $slot }}
+            </main>
+        
+        @endsection
+        BLADE;
     }
 }

--- a/packages/framework/src/Framework/Actions/CreatesNewPublicationType.php
+++ b/packages/framework/src/Framework/Actions/CreatesNewPublicationType.php
@@ -20,7 +20,6 @@ use JetBrains\PhpStorm\Deprecated;
 class CreatesNewPublicationType extends CreateAction implements CreateActionContract
 {
     protected string $dirName;
-    #[Deprecated] protected ?OutputStyle $output = null;
 
     public function __construct(
         protected string $name,
@@ -30,9 +29,7 @@ class CreatesNewPublicationType extends CreateAction implements CreateActionCont
         protected ?bool $sortAscending,
         protected ?bool $prevNextLinks,
         protected ?int $pageSize,
-        #[Deprecated] ?OutputStyle $output = null,
     ) {
-        $this->output = $output;
         $this->dirName = $this->formatStringForStorage($this->name);
         $this->outputPath = "$this->dirName/schema.json";
     }

--- a/packages/framework/src/Framework/Actions/CreatesNewPublicationType.php
+++ b/packages/framework/src/Framework/Actions/CreatesNewPublicationType.php
@@ -74,9 +74,13 @@ class CreatesNewPublicationType extends CreateAction implements CreateActionCont
             <p>
                 {{ $publication->markdown }}
             </p>
+        </article>
 
+        <div class="prose dark:prose-invert my-8">
             <hr>
+        </div>
 
+        <article class="prose dark:prose-invert">
             <h2>Front Matter Data</h2>
             <pre>
                 {{ $publication->matter }}

--- a/packages/framework/src/Framework/Actions/CreatesNewPublicationType.php
+++ b/packages/framework/src/Framework/Actions/CreatesNewPublicationType.php
@@ -86,6 +86,18 @@ class CreatesNewPublicationType extends CreateAction implements CreateActionCont
 
     protected function createListTemplate(): void
     {
-        // TODO: Implement createListTemplate() method.
+        $contents = <<<'BLADE'
+        @extends('hyde::layouts.app')
+        @section('content')
+        
+            <main id="content" class="mx-auto max-w-7xl py-16 px-8">
+                {{ $slot }}
+            </main>
+        
+        @endsection
+
+        BLADE;
+
+        file_put_contents(Hyde::path("$this->directoryName/{$this->listTemplateName()}.blade.php"), $contents);
     }
 }

--- a/packages/framework/tests/Feature/Actions/CreatesNewPublicationTypeTest.php
+++ b/packages/framework/tests/Feature/Actions/CreatesNewPublicationTypeTest.php
@@ -24,7 +24,6 @@ class CreatesNewPublicationTypeTest extends TestCase
 
         $this->assertFileExists(Hyde::path('test-publication/schema.json'));
 
-        $result = file_get_contents(Hyde::path('test-publication/schema.json'));
         $this->assertSame(<<<'JSON'
             {
                 "name": "Test Publication",
@@ -39,7 +38,7 @@ class CreatesNewPublicationTypeTest extends TestCase
                 },
                 "fields": []
             }
-            JSON, $result);
+            JSON, file_get_contents(Hyde::path('test-publication/schema.json')));
         Filesystem::deleteDirectory('test-publication');
     }
 }

--- a/packages/framework/tests/Feature/Actions/CreatesNewPublicationTypeTest.php
+++ b/packages/framework/tests/Feature/Actions/CreatesNewPublicationTypeTest.php
@@ -40,7 +40,6 @@ class CreatesNewPublicationTypeTest extends TestCase
         $creator->create();
 
         $this->assertFileExists(Hyde::path('test-publication/schema.json'));
-
         $this->assertSame(<<<'JSON'
             {
                 "name": "Test Publication",
@@ -69,7 +68,6 @@ class CreatesNewPublicationTypeTest extends TestCase
         $creator->create();
 
         $this->assertFileExists(Hyde::path('test-publication/schema.json'));
-
         $this->assertSame(<<<'JSON'
             {
                 "name": "Test Publication",

--- a/packages/framework/tests/Feature/Actions/CreatesNewPublicationTypeTest.php
+++ b/packages/framework/tests/Feature/Actions/CreatesNewPublicationTypeTest.php
@@ -17,6 +17,13 @@ use Illuminate\Support\Collection;
  */
 class CreatesNewPublicationTypeTest extends TestCase
 {
+    protected function tearDown(): void
+    {
+        Filesystem::deleteDirectory('test-publication');
+
+        parent::tearDown();
+    }
+
     public function test_it_creates_a_new_publication_type()
     {
         $creator = new CreatesNewPublicationType('Test Publication', new Collection(), 'canonical', 'sort', true, true, 10);
@@ -40,7 +47,5 @@ class CreatesNewPublicationTypeTest extends TestCase
             }
             JSON, file_get_contents(Hyde::path('test-publication/schema.json'))
         );
-
-        Filesystem::deleteDirectory('test-publication');
     }
 }

--- a/packages/framework/tests/Feature/Actions/CreatesNewPublicationTypeTest.php
+++ b/packages/framework/tests/Feature/Actions/CreatesNewPublicationTypeTest.php
@@ -31,8 +31,8 @@ class CreatesNewPublicationTypeTest extends TestCase
             new Collection(),
             'canonical',
             'sort',
-            true,
-            true,
+            false,
+            false,
             10
         );
         $creator->create();
@@ -47,8 +47,8 @@ class CreatesNewPublicationTypeTest extends TestCase
                 "listTemplate": "test-publication_list",
                 "pagination": {
                     "sortField": "sort",
-                    "sortAscending": true,
-                    "prevNextLinks": true,
+                    "sortAscending": false,
+                    "prevNextLinks": false,
                     "pageSize": 10
                 },
                 "fields": []

--- a/packages/framework/tests/Feature/Actions/CreatesNewPublicationTypeTest.php
+++ b/packages/framework/tests/Feature/Actions/CreatesNewPublicationTypeTest.php
@@ -25,19 +25,21 @@ class CreatesNewPublicationTypeTest extends TestCase
         $this->assertFileExists(Hyde::path('name/schema.json'));
 
         $result = file_get_contents(Hyde::path('name/schema.json'));
-        $this->assertSame('{
-    "name": "name",
-    "canonicalField": "canonical",
-    "detailTemplate": "name_detail",
-    "listTemplate": "name_list",
-    "pagination": {
-        "sortField": "sort",
-        "sortAscending": true,
-        "prevNextLinks": true,
-        "pageSize": 10
-    },
-    "fields": []
-}', $result);
+        $this->assertSame(<<<'JSON'
+            {
+                "name": "name",
+                "canonicalField": "canonical",
+                "detailTemplate": "name_detail",
+                "listTemplate": "name_list",
+                "pagination": {
+                    "sortField": "sort",
+                    "sortAscending": true,
+                    "prevNextLinks": true,
+                    "pageSize": 10
+                },
+                "fields": []
+            }
+            JSON, $result);
         Filesystem::deleteDirectory('name');
     }
 }

--- a/packages/framework/tests/Feature/Actions/CreatesNewPublicationTypeTest.php
+++ b/packages/framework/tests/Feature/Actions/CreatesNewPublicationTypeTest.php
@@ -10,6 +10,8 @@ use Hyde\Hyde;
 use Hyde\Testing\TestCase;
 use Illuminate\Support\Collection;
 
+use function file_get_contents;
+
 /**
  * @covers \Hyde\Framework\Actions\CreatesNewPublicationType
  *

--- a/packages/framework/tests/Feature/Actions/CreatesNewPublicationTypeTest.php
+++ b/packages/framework/tests/Feature/Actions/CreatesNewPublicationTypeTest.php
@@ -56,4 +56,33 @@ class CreatesNewPublicationTypeTest extends TestCase
             JSON, file_get_contents(Hyde::path('test-publication/schema.json'))
         );
     }
+
+    public function test_create_with_default_parameters()
+    {
+        $creator = new CreatesNewPublicationType(
+            'Test Publication',
+            new Collection(),
+            'canonical',
+        );
+        $creator->create();
+
+        $this->assertFileExists(Hyde::path('test-publication/schema.json'));
+
+        $this->assertSame(<<<'JSON'
+            {
+                "name": "Test Publication",
+                "canonicalField": "canonical",
+                "detailTemplate": "test-publication_detail",
+                "listTemplate": "test-publication_list",
+                "pagination": {
+                    "sortField": "__createdAt",
+                    "sortAscending": true,
+                    "prevNextLinks": true,
+                    "pageSize": 25
+                },
+                "fields": []
+            }
+            JSON, file_get_contents(Hyde::path('test-publication/schema.json'))
+        );
+    }
 }

--- a/packages/framework/tests/Feature/Actions/CreatesNewPublicationTypeTest.php
+++ b/packages/framework/tests/Feature/Actions/CreatesNewPublicationTypeTest.php
@@ -4,13 +4,12 @@ declare(strict_types=1);
 
 namespace Hyde\Framework\Testing\Feature\Actions;
 
+use function file_get_contents;
 use Hyde\Facades\Filesystem;
 use Hyde\Framework\Actions\CreatesNewPublicationType;
 use Hyde\Hyde;
 use Hyde\Testing\TestCase;
 use Illuminate\Support\Collection;
-
-use function file_get_contents;
 
 /**
  * @covers \Hyde\Framework\Actions\CreatesNewPublicationType

--- a/packages/framework/tests/Feature/Actions/CreatesNewPublicationTypeTest.php
+++ b/packages/framework/tests/Feature/Actions/CreatesNewPublicationTypeTest.php
@@ -19,18 +19,18 @@ class CreatesNewPublicationTypeTest extends TestCase
 {
     public function test_it_creates_a_new_publication_type()
     {
-        $creator = new CreatesNewPublicationType('name', new Collection(), 'canonical', 'sort', true, true, 10);
+        $creator = new CreatesNewPublicationType('Test Publication', new Collection(), 'canonical', 'sort', true, true, 10);
         $creator->create();
 
-        $this->assertFileExists(Hyde::path('name/schema.json'));
+        $this->assertFileExists(Hyde::path('test-publication/schema.json'));
 
-        $result = file_get_contents(Hyde::path('name/schema.json'));
+        $result = file_get_contents(Hyde::path('test-publication/schema.json'));
         $this->assertSame(<<<'JSON'
             {
-                "name": "name",
+                "name": "Test Publication",
                 "canonicalField": "canonical",
-                "detailTemplate": "name_detail",
-                "listTemplate": "name_list",
+                "detailTemplate": "test-publication_detail",
+                "listTemplate": "test-publication_list",
                 "pagination": {
                     "sortField": "sort",
                     "sortAscending": true,
@@ -40,6 +40,6 @@ class CreatesNewPublicationTypeTest extends TestCase
                 "fields": []
             }
             JSON, $result);
-        Filesystem::deleteDirectory('name');
+        Filesystem::deleteDirectory('test-publication');
     }
 }

--- a/packages/framework/tests/Feature/Actions/CreatesNewPublicationTypeTest.php
+++ b/packages/framework/tests/Feature/Actions/CreatesNewPublicationTypeTest.php
@@ -84,4 +84,17 @@ class CreatesNewPublicationTypeTest extends TestCase
             JSON, file_get_contents(Hyde::path('test-publication/schema.json'))
         );
     }
+
+    public function test_it_creates_list_and_detail_pages()
+    {
+        $creator = new CreatesNewPublicationType(
+            'Test Publication',
+            new Collection(),
+            'canonical',
+        );
+        $creator->create();
+
+        $this->assertFileExists(Hyde::path('test-publication/test-publication_detail.blade.php'));
+        $this->assertFileExists(Hyde::path('test-publication/test-publication_list.blade.php'));
+    }
 }

--- a/packages/framework/tests/Feature/Actions/CreatesNewPublicationTypeTest.php
+++ b/packages/framework/tests/Feature/Actions/CreatesNewPublicationTypeTest.php
@@ -26,7 +26,15 @@ class CreatesNewPublicationTypeTest extends TestCase
 
     public function test_it_creates_a_new_publication_type()
     {
-        $creator = new CreatesNewPublicationType('Test Publication', new Collection(), 'canonical', 'sort', true, true, 10);
+        $creator = new CreatesNewPublicationType(
+            'Test Publication',
+            new Collection(),
+            'canonical',
+            'sort',
+            true,
+            true,
+            10
+        );
         $creator->create();
 
         $this->assertFileExists(Hyde::path('test-publication/schema.json'));

--- a/packages/framework/tests/Feature/Actions/CreatesNewPublicationTypeTest.php
+++ b/packages/framework/tests/Feature/Actions/CreatesNewPublicationTypeTest.php
@@ -38,7 +38,9 @@ class CreatesNewPublicationTypeTest extends TestCase
                 },
                 "fields": []
             }
-            JSON, file_get_contents(Hyde::path('test-publication/schema.json')));
+            JSON, file_get_contents(Hyde::path('test-publication/schema.json'))
+        );
+
         Filesystem::deleteDirectory('test-publication');
     }
 }

--- a/packages/framework/tests/Feature/Actions/CreatesNewPublicationTypeTest.php
+++ b/packages/framework/tests/Feature/Actions/CreatesNewPublicationTypeTest.php
@@ -25,15 +25,19 @@ class CreatesNewPublicationTypeTest extends TestCase
         $this->assertFileExists(Hyde::path('name/schema.json'));
 
         $result = file_get_contents(Hyde::path('name/schema.json'));
-        $this->assertStringContainsString('"name": "name"', $result);
-        $this->assertStringContainsString('"canonicalField": "canonical"', $result);
-        $this->assertStringContainsString('"sortField": "sort"', $result);
-        $this->assertStringContainsString('"sortAscending": true', $result);
-        $this->assertStringContainsString('"pageSize": 10', $result);
-        $this->assertStringContainsString('"prevNextLinks": true', $result);
-        $this->assertStringContainsString('"detailTemplate": "name_detail"', $result);
-        $this->assertStringContainsString('"listTemplate": "name_list"', $result);
-
+        $this->assertSame('{
+    "name": "name",
+    "canonicalField": "canonical",
+    "detailTemplate": "name_detail",
+    "listTemplate": "name_list",
+    "pagination": {
+        "sortField": "sort",
+        "sortAscending": true,
+        "prevNextLinks": true,
+        "pageSize": 10
+    },
+    "fields": []
+}', $result);
         Filesystem::deleteDirectory('name');
     }
 }


### PR DESCRIPTION
        From Robert RE: Generate list and detail pages when creating publication types

> That is a good idea, it could just be a simple/stupid template which does
> <p>{{ $fieldName}}: {{ $fieldValue}</p>

> Maybe something a bit more involved, but some sort of basic generic template which displays the data

_Originally posted by @caendesilva in https://github.com/hydephp/develop/issues/685#issuecomment-1328113544_
      