### PR TITLE
Refactor view finder for publication templates to check file extensions instead of if view exists

### DIFF
--- a/packages/framework/src/Framework/Actions/CreatesNewPublicationType.php
+++ b/packages/framework/src/Framework/Actions/CreatesNewPublicationType.php
@@ -87,7 +87,7 @@ class CreatesNewPublicationType extends CreateAction implements CreateActionCont
         @endsection
         BLADE;
 
-        $this->savePublicationFile("detail.blade.php", $contents);
+        $this->savePublicationFile('detail.blade.php', $contents);
     }
 
     protected function createListTemplate(): void
@@ -111,7 +111,7 @@ class CreatesNewPublicationType extends CreateAction implements CreateActionCont
         @endsection
         BLADE;
 
-        $this->savePublicationFile("list.blade.php", $contents);
+        $this->savePublicationFile('list.blade.php', $contents);
     }
 
     protected function savePublicationFile(string $filename, string $contents): int

--- a/packages/framework/src/Framework/Actions/PublicationPageCompiler.php
+++ b/packages/framework/src/Framework/Actions/PublicationPageCompiler.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Hyde\Framework\Actions;
 
+use Hyde\Facades\Filesystem;
 use Hyde\Framework\Concerns\InvokableAction;
 use Hyde\Framework\Features\Publications\Models\PublicationListPage;
 use Hyde\Framework\Features\Publications\PublicationService;
@@ -47,7 +48,7 @@ class PublicationPageCompiler extends InvokableAction
 
     protected function compileView(string $template, array $data): string
     {
-        return View::exists($template)
+        return ! Filesystem::exists($this->getTemplateFilePath($template))
             ? View::make($template, $data)->render()
             : AnonymousViewCompiler::call($this->getTemplateFilePath($template), $data);
     }

--- a/packages/framework/src/Framework/Actions/PublicationPageCompiler.php
+++ b/packages/framework/src/Framework/Actions/PublicationPageCompiler.php
@@ -55,6 +55,7 @@ class PublicationPageCompiler extends InvokableAction
 
     protected function getTemplateFilePath(string $template): string
     {
+        $template = basename($template, '.blade.php');
         return "{$this->page->type->getDirectory()}/$template.blade.php";
     }
 }

--- a/packages/framework/src/Framework/Actions/PublicationPageCompiler.php
+++ b/packages/framework/src/Framework/Actions/PublicationPageCompiler.php
@@ -11,6 +11,8 @@ use Hyde\Framework\Features\Publications\PublicationService;
 use Hyde\Pages\PublicationPage;
 use Illuminate\Support\Facades\View;
 
+use function str_ends_with;
+
 /**
  * @todo Consider changing to check if template key ends with .blade.php and using that to signify if it's an anonymous view.
  *
@@ -48,7 +50,7 @@ class PublicationPageCompiler extends InvokableAction
 
     protected function compileView(string $template, array $data): string
     {
-        return Filesystem::exists($this->getTemplateFilePath($template))
+        return str_ends_with($template, '.blade.php')
             ? AnonymousViewCompiler::call($this->getTemplateFilePath($template), $data)
             : View::make($template, $data)->render();
     }

--- a/packages/framework/src/Framework/Actions/PublicationPageCompiler.php
+++ b/packages/framework/src/Framework/Actions/PublicationPageCompiler.php
@@ -4,13 +4,11 @@ declare(strict_types=1);
 
 namespace Hyde\Framework\Actions;
 
-use Hyde\Facades\Filesystem;
 use Hyde\Framework\Concerns\InvokableAction;
 use Hyde\Framework\Features\Publications\Models\PublicationListPage;
 use Hyde\Framework\Features\Publications\PublicationService;
 use Hyde\Pages\PublicationPage;
 use Illuminate\Support\Facades\View;
-
 use function str_ends_with;
 
 /**
@@ -58,6 +56,7 @@ class PublicationPageCompiler extends InvokableAction
     protected function getTemplateFilePath(string $template): string
     {
         $template = basename($template, '.blade.php');
+
         return "{$this->page->type->getDirectory()}/$template.blade.php";
     }
 }

--- a/packages/framework/src/Framework/Actions/PublicationPageCompiler.php
+++ b/packages/framework/src/Framework/Actions/PublicationPageCompiler.php
@@ -48,9 +48,9 @@ class PublicationPageCompiler extends InvokableAction
 
     protected function compileView(string $template, array $data): string
     {
-        return ! Filesystem::exists($this->getTemplateFilePath($template))
-            ? View::make($template, $data)->render()
-            : AnonymousViewCompiler::call($this->getTemplateFilePath($template), $data);
+        return Filesystem::exists($this->getTemplateFilePath($template))
+            ? AnonymousViewCompiler::call($this->getTemplateFilePath($template), $data)
+            : View::make($template, $data)->render();
     }
 
     protected function getTemplateFilePath(string $template): string

--- a/packages/framework/src/Framework/Features/Publications/Models/PublicationType.php
+++ b/packages/framework/src/Framework/Features/Publications/Models/PublicationType.php
@@ -51,8 +51,8 @@ class PublicationType implements SerializableContract
     public function __construct(
         public string $name,
         public string $canonicalField = 'identifier',
-        public string $detailTemplate = 'detail',
-        public string $listTemplate = 'list',
+        public string $detailTemplate = 'detail.blade.php',
+        public string $listTemplate = 'list.blade.php',
         array|PaginationSettings $pagination = [],
         array $fields = [],
         ?string $directory = null

--- a/packages/framework/tests/Feature/Actions/PublicationPageCompilerTest.php
+++ b/packages/framework/tests/Feature/Actions/PublicationPageCompilerTest.php
@@ -26,7 +26,7 @@ class PublicationPageCompilerTest extends TestCase
         $this->directory('test-publication');
         $this->setupTestPublication();
 
-        file_put_contents(Hyde::path('test-publication/test-publication_detail.blade.php'), 'Detail: {{ $publication->title }}');
+        file_put_contents(Hyde::path('test-publication/detail.blade.php'), 'Detail: {{ $publication->title }}');
 
         $string = PublicationPageCompiler::call(new PublicationPage('my-publication', type: PublicationType::get('test-publication')));
 
@@ -39,7 +39,7 @@ class PublicationPageCompilerTest extends TestCase
         $this->setupTestPublication();
 
         file_put_contents(Hyde::path('test-publication/my-publication.md'), 'Foo');
-        file_put_contents(Hyde::path('test-publication/test-publication_list.blade.php'), 'List: {{ $publications->first()->title }}');
+        file_put_contents(Hyde::path('test-publication/list.blade.php'), 'List: {{ $publications->first()->title }}');
 
         $string = PublicationPageCompiler::call(PublicationType::get('test-publication')->getListPage());
 
@@ -113,7 +113,7 @@ class PublicationPageCompilerTest extends TestCase
         $this->setupTestPublication();
 
         $this->expectException(FileNotFoundException::class);
-        $this->expectExceptionMessage('File [test-publication/test-publication_detail.blade.php] not found.');
+        $this->expectExceptionMessage('File [test-publication/detail.blade.php] not found.');
 
         PublicationPageCompiler::call(new PublicationPage('my-publication', type: PublicationType::get('test-publication')));
     }
@@ -124,7 +124,7 @@ class PublicationPageCompilerTest extends TestCase
         $this->setupTestPublication();
 
         $this->expectException(FileNotFoundException::class);
-        $this->expectExceptionMessage('File [test-publication/test-publication_list.blade.php] not found.');
+        $this->expectExceptionMessage('File [test-publication/list.blade.php] not found.');
 
         PublicationPageCompiler::call(PublicationType::get('test-publication')->getListPage());
     }

--- a/packages/framework/tests/Feature/Commands/MakePublicationCommandTest.php
+++ b/packages/framework/tests/Feature/Commands/MakePublicationCommandTest.php
@@ -360,8 +360,8 @@ class MakePublicationCommandTest extends TestCase
             json_encode(array_merge([
                 'name'           => 'Test Publication',
                 'canonicalField' => 'title',
-                'detailTemplate' => 'test-publication_detail',
-                'listTemplate'   => 'test-publication_list',
+                'detailTemplate' => 'detail',
+                'listTemplate'   => 'list',
                 'pagination' => [
                     'pageSize'       => 10,
                     'prevNextLinks'  => true,

--- a/packages/framework/tests/Feature/PublicationListPageTest.php
+++ b/packages/framework/tests/Feature/PublicationListPageTest.php
@@ -68,8 +68,8 @@ Hello World!
         return [
             'name'           => 'test',
             'canonicalField' => 'canonical',
-            'detailTemplate' => 'detail',
-            'listTemplate'   => 'list',
+            'detailTemplate' => 'detail.blade.php',
+            'listTemplate'   => 'list.blade.php',
             'pagination' => [
                 'sortField'      => 'sort',
                 'sortAscending'  => true,

--- a/packages/framework/tests/Feature/PublicationPageTest.php
+++ b/packages/framework/tests/Feature/PublicationPageTest.php
@@ -116,8 +116,8 @@ class PublicationPageTest extends TestCase
         file_put_contents(Hyde::path('test-publication/schema.json'), '{
   "name": "test",
   "canonicalField": "slug",
-  "detailTemplate": "test_detail",
-  "listTemplate": "test_list",
+  "detailTemplate": "test_detail.blade.php",
+  "listTemplate": "test_list.blade.php",
   "pagination": {
       "sortField": "__createdAt",
       "sortAscending": true,

--- a/packages/framework/tests/Feature/PublicationTypeTest.php
+++ b/packages/framework/tests/Feature/PublicationTypeTest.php
@@ -211,8 +211,8 @@ class PublicationTypeTest extends TestCase
         return array_merge([
             'name' => 'Test Publication',
             'canonicalField' => 'title',
-            'detailTemplate' => 'test-publication_detail',
-            'listTemplate' => 'test-publication_list',
+            'detailTemplate' => 'test-publication_detail.blade.php',
+            'listTemplate' => 'test-publication_list.blade.php',
             'pagination' => [
                 'sortField' => '__createdAt',
                 'sortAscending' => true,

--- a/packages/framework/tests/Feature/PublicationTypeTest.php
+++ b/packages/framework/tests/Feature/PublicationTypeTest.php
@@ -39,8 +39,8 @@ class PublicationTypeTest extends TestCase
 
         $this->assertEquals('Test Publication', $publicationType->name);
         $this->assertEquals('identifier', $publicationType->canonicalField);
-        $this->assertEquals('detail', $publicationType->detailTemplate);
-        $this->assertEquals('list', $publicationType->listTemplate);
+        $this->assertEquals('detail.blade.php', $publicationType->detailTemplate);
+        $this->assertEquals('list.blade.php', $publicationType->listTemplate);
         $this->assertEquals([], $publicationType->fields);
         $this->assertEquals(PaginationSettings::fromArray([
             'sortField' => '__createdAt',

--- a/packages/framework/tests/Feature/PublicationTypeTest.php
+++ b/packages/framework/tests/Feature/PublicationTypeTest.php
@@ -211,8 +211,8 @@ class PublicationTypeTest extends TestCase
         return array_merge([
             'name' => 'Test Publication',
             'canonicalField' => 'title',
-            'detailTemplate' => 'test-publication_detail.blade.php',
-            'listTemplate' => 'test-publication_list.blade.php',
+            'detailTemplate' => 'detail.blade.php',
+            'listTemplate' => 'list.blade.php',
             'pagination' => [
                 'sortField' => '__createdAt',
                 'sortAscending' => true,

--- a/packages/framework/tests/Unit/Pages/PublicationPageUnitTest.php
+++ b/packages/framework/tests/Unit/Pages/PublicationPageUnitTest.php
@@ -242,8 +242,8 @@ class PublicationPageUnitTest extends BaseMarkdownPageUnitTest
         return new PublicationType(
             'name',
             'canonicalField',
-            'detailTemplate',
-            'listTemplate',
+            'detailTemplate.blade.php',
+            'listTemplate.blade.php',
             ['sortField', true, true, 1],
             [],
             'directory'

--- a/packages/framework/tests/Unit/Pages/PublicationPageUnitTest.php
+++ b/packages/framework/tests/Unit/Pages/PublicationPageUnitTest.php
@@ -211,7 +211,7 @@ class PublicationPageUnitTest extends BaseMarkdownPageUnitTest
     public function testCompile()
     {
         $this->directory('directory');
-        Hyde::touch('directory/detailTemplate.blade.php');
+        Hyde::touch('directory/detail.blade.php');
 
         $page = new PublicationPage('foo', [], '', $this->pubType());
         Hyde::shareViewData($page);
@@ -242,8 +242,8 @@ class PublicationPageUnitTest extends BaseMarkdownPageUnitTest
         return new PublicationType(
             'name',
             'canonicalField',
-            'detailTemplate.blade.php',
-            'listTemplate.blade.php',
+            'detail.blade.php',
+            'list.blade.php',
             ['sortField', true, true, 1],
             [],
             'directory'

--- a/tests/fixtures/test-publication-schema.json
+++ b/tests/fixtures/test-publication-schema.json
@@ -1,8 +1,8 @@
 {
     "name": "Test Publication",
     "canonicalField": "title",
-    "detailTemplate": "test-publication_detail.blade.php",
-    "listTemplate": "test-publication_list.blade.php",
+    "detailTemplate": "detail.blade.php",
+    "listTemplate": "list.blade.php",
     "pagination": {
         "sortField": "__createdAt",
         "sortAscending": true,

--- a/tests/fixtures/test-publication-schema.json
+++ b/tests/fixtures/test-publication-schema.json
@@ -1,8 +1,8 @@
 {
     "name": "Test Publication",
     "canonicalField": "title",
-    "detailTemplate": "test-publication_detail",
-    "listTemplate": "test-publication_list",
+    "detailTemplate": "test-publication_detail.blade.php",
+    "listTemplate": "test-publication_list.blade.php",
     "pagination": {
         "sortField": "__createdAt",
         "sortAscending": true,


### PR DESCRIPTION
Refactors to check if template key ends with .blade.php and using that to signify if it's an anonymous view. This leads to a more verbose and intuitive system. If you specify a filename, Hyde will use the filename. If not, Hyde will assume it's a globally registered view.

This may break code on the [publications-feature](https://github.com/hydephp/develop/tree/publications-feature) branch as the schemas need to be updated: (see https://github.com/hydephp/develop/commit/9b471efa09c8c8ecd9b9d8ce394f0e5bb26daca9 for an example)

```diff
- "detailTemplate": "detail",
- "listTemplate": "list",
+ "detailTemplate": "detail.blade.php",
+ "listTemplate": "list.blade.php",
```

The files are still assumed to be in the same directory as the schema.json file.