### PR TITLE
Properly implement reloadable choice helper for the validating command class

### DIFF
--- a/packages/framework/src/Console/Commands/MakePublicationCommand.php
+++ b/packages/framework/src/Console/Commands/MakePublicationCommand.php
@@ -188,6 +188,7 @@ class MakePublicationCommand extends ValidatingCommand
         $this->line("<fg=bright-blue>Tip:</> $message");
     }
 
+    /** @return Closure<array<string>> */
     protected function getTagValuesArrayClosure(): Closure
     {
         return function (): array {

--- a/packages/framework/src/Console/Commands/MakePublicationCommand.php
+++ b/packages/framework/src/Console/Commands/MakePublicationCommand.php
@@ -162,6 +162,7 @@ class MakePublicationCommand extends ValidatingCommand
         $closure = function (): array {
             return PublicationService::getValuesForTagName($this->publicationType->getIdentifier())->toArray();
         };
+
         return $this->reloadableChoice($closure,
             'Which tag would you like to use?',
             'Reload tags.json',

--- a/packages/framework/src/Console/Commands/MakePublicationCommand.php
+++ b/packages/framework/src/Console/Commands/MakePublicationCommand.php
@@ -160,17 +160,11 @@ class MakePublicationCommand extends ValidatingCommand
 
         $this->tip('You can enter multiple tags separated by commas');
 
-        $reloadMessage = '<fg=bright-blue>[Reload tags.json]</>';
-        do {
-            $options = PublicationService::getValuesForTagName($this->publicationType->getIdentifier());
-            $selection = $this->choice(
-                'Which tag would you like to use?',
-                array_merge([$reloadMessage], $options->toArray()),
-                multiple: true
-            );
-        } while (in_array($reloadMessage, (array) $selection));
-
-        return $selection;
+        return $this->reloadableChoice(PublicationService::getValuesForTagName($this->publicationType->getIdentifier())->toArray(),
+            'Which tag would you like to use?',
+            'Reload tags.json',
+            true
+        );
     }
 
     /** @return null */

--- a/packages/framework/src/Console/Commands/MakePublicationCommand.php
+++ b/packages/framework/src/Console/Commands/MakePublicationCommand.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Hyde\Console\Commands;
 
+use Closure;
 use Hyde\Console\Commands\Helpers\InputStreamHandler;
 use Hyde\Console\Concerns\ValidatingCommand;
 use Hyde\Framework\Actions\CreatesNewPublicationPage;
@@ -159,11 +160,7 @@ class MakePublicationCommand extends ValidatingCommand
 
         $this->tip('You can enter multiple tags separated by commas');
 
-        $closure = function (): array {
-            return PublicationService::getValuesForTagName($this->publicationType->getIdentifier())->toArray();
-        };
-
-        return $this->reloadableChoice($closure,
+        return $this->reloadableChoice($this->getTagValuesArrayClosure(),
             'Which tag would you like to use?',
             'Reload tags.json',
             true
@@ -189,5 +186,12 @@ class MakePublicationCommand extends ValidatingCommand
     protected function tip(string $message): void
     {
         $this->line("<fg=bright-blue>Tip:</> $message");
+    }
+
+    protected function getTagValuesArrayClosure(): Closure
+    {
+        return function (): array {
+            return PublicationService::getValuesForTagName($this->publicationType->getIdentifier())->toArray();
+        };
     }
 }

--- a/packages/framework/src/Console/Commands/MakePublicationCommand.php
+++ b/packages/framework/src/Console/Commands/MakePublicationCommand.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Hyde\Console\Commands;
 
-use function array_merge;
 use Hyde\Console\Commands\Helpers\InputStreamHandler;
 use Hyde\Console\Concerns\ValidatingCommand;
 use Hyde\Framework\Actions\CreatesNewPublicationPage;

--- a/packages/framework/src/Console/Commands/MakePublicationCommand.php
+++ b/packages/framework/src/Console/Commands/MakePublicationCommand.php
@@ -159,7 +159,10 @@ class MakePublicationCommand extends ValidatingCommand
 
         $this->tip('You can enter multiple tags separated by commas');
 
-        return $this->reloadableChoice(PublicationService::getValuesForTagName($this->publicationType->getIdentifier())->toArray(),
+        $closure = function (): array {
+            return PublicationService::getValuesForTagName($this->publicationType->getIdentifier())->toArray();
+        };
+        return $this->reloadableChoice($closure,
             'Which tag would you like to use?',
             'Reload tags.json',
             true

--- a/packages/framework/src/Console/Concerns/ValidatingCommand.php
+++ b/packages/framework/src/Console/Concerns/ValidatingCommand.php
@@ -82,7 +82,7 @@ class ValidatingCommand extends Command
         return $this->askWithValidation($name, $question, $rules, $default, $retryCount + 1);
     }
 
-    /** @param  callable<array>  $options */
+    /** @param  callable<array>  $options A function that returns an array of options. It will be re-run if the user hits selects the added 'reload' option. */
     public function reloadableChoice(callable $options, string $question, string $reloadMessage = 'Reload options', bool $multiple = false): string|array
     {
         $reloadMessage = "<fg=bright-blue>[$reloadMessage]</>";

--- a/packages/framework/src/Console/Concerns/ValidatingCommand.php
+++ b/packages/framework/src/Console/Concerns/ValidatingCommand.php
@@ -87,11 +87,7 @@ class ValidatingCommand extends Command
     {
         $reloadMessage = "<fg=bright-blue>[$reloadMessage]</>";
         do {
-            $selection = $this->choice(
-                $question,
-                array_merge([$reloadMessage], $options),
-                multiple: $multiple
-            );
+            $selection = $this->choice($question, array_merge([$reloadMessage], $options), multiple: $multiple);
         } while (in_array($reloadMessage, (array) $selection));
 
         return $selection;

--- a/packages/framework/src/Console/Concerns/ValidatingCommand.php
+++ b/packages/framework/src/Console/Concerns/ValidatingCommand.php
@@ -4,14 +4,13 @@ declare(strict_types=1);
 
 namespace Hyde\Console\Concerns;
 
-use Hyde\Framework\Features\Publications\PublicationService;
 use function __;
+use function array_merge;
 use Exception;
 use Illuminate\Support\Facades\Validator;
+use function in_array;
 use LaravelZero\Framework\Commands\Command;
 use RuntimeException;
-use function array_merge;
-use function in_array;
 use function str_ends_with;
 use function ucfirst;
 

--- a/packages/framework/src/Console/Concerns/ValidatingCommand.php
+++ b/packages/framework/src/Console/Concerns/ValidatingCommand.php
@@ -4,11 +4,14 @@ declare(strict_types=1);
 
 namespace Hyde\Console\Concerns;
 
+use Hyde\Framework\Features\Publications\PublicationService;
 use function __;
 use Exception;
 use Illuminate\Support\Facades\Validator;
 use LaravelZero\Framework\Commands\Command;
 use RuntimeException;
+use function array_merge;
+use function in_array;
 use function str_ends_with;
 use function ucfirst;
 
@@ -78,6 +81,20 @@ class ValidatingCommand extends Command
         }
 
         return $this->askWithValidation($name, $question, $rules, $default, $retryCount + 1);
+    }
+
+    public function reloadableChoice(array $options, string $question, string $reloadMessage = 'Reload options', bool $multiple = false): string|array
+    {
+        $reloadMessage = "<fg=bright-blue>[$reloadMessage]</>";
+        do {
+            $selection = $this->choice(
+                $question,
+                array_merge([$reloadMessage], $options),
+                multiple: $multiple
+            );
+        } while (in_array($reloadMessage, (array) $selection));
+
+        return $selection;
     }
 
     /**

--- a/packages/framework/src/Console/Concerns/ValidatingCommand.php
+++ b/packages/framework/src/Console/Concerns/ValidatingCommand.php
@@ -86,8 +86,7 @@ class ValidatingCommand extends Command
     {
         $reloadMessage = "<fg=bright-blue>[$reloadMessage]</>";
         do {
-            $optionsArray = $options();
-            $selection = $this->choice($question, array_merge([$reloadMessage], $optionsArray), multiple: $multiple);
+            $selection = $this->choice($question, array_merge([$reloadMessage], $options()), multiple: $multiple);
         } while (in_array($reloadMessage, (array) $selection));
 
         return $selection;

--- a/packages/framework/src/Console/Concerns/ValidatingCommand.php
+++ b/packages/framework/src/Console/Concerns/ValidatingCommand.php
@@ -82,7 +82,7 @@ class ValidatingCommand extends Command
         return $this->askWithValidation($name, $question, $rules, $default, $retryCount + 1);
     }
 
-    /** @param  callable<array>  $options A function that returns an array of options. It will be re-run if the user hits selects the added 'reload' option. */
+    /** @param  callable<array<string>>  $options A function that returns an array of options. It will be re-run if the user hits selects the added 'reload' option. */
     public function reloadableChoice(callable $options, string $question, string $reloadMessage = 'Reload options', bool $multiple = false): string|array
     {
         $reloadMessage = "<fg=bright-blue>[$reloadMessage]</>";

--- a/packages/framework/src/Console/Concerns/ValidatingCommand.php
+++ b/packages/framework/src/Console/Concerns/ValidatingCommand.php
@@ -82,11 +82,12 @@ class ValidatingCommand extends Command
         return $this->askWithValidation($name, $question, $rules, $default, $retryCount + 1);
     }
 
-    public function reloadableChoice(array $options, string $question, string $reloadMessage = 'Reload options', bool $multiple = false): string|array
+    public function reloadableChoice(callable $options, string $question, string $reloadMessage = 'Reload options', bool $multiple = false): string|array
     {
         $reloadMessage = "<fg=bright-blue>[$reloadMessage]</>";
         do {
-            $selection = $this->choice($question, array_merge([$reloadMessage], $options), multiple: $multiple);
+            $optionsArray = $options();
+            $selection = $this->choice($question, array_merge([$reloadMessage], $optionsArray), multiple: $multiple);
         } while (in_array($reloadMessage, (array) $selection));
 
         return $selection;

--- a/packages/framework/src/Console/Concerns/ValidatingCommand.php
+++ b/packages/framework/src/Console/Concerns/ValidatingCommand.php
@@ -82,6 +82,7 @@ class ValidatingCommand extends Command
         return $this->askWithValidation($name, $question, $rules, $default, $retryCount + 1);
     }
 
+    /** @param  callable<array>  $options */
     public function reloadableChoice(callable $options, string $question, string $reloadMessage = 'Reload options', bool $multiple = false): string|array
     {
         $reloadMessage = "<fg=bright-blue>[$reloadMessage]</>";

--- a/packages/framework/tests/Feature/ValidatingCommandTest.php
+++ b/packages/framework/tests/Feature/ValidatingCommandTest.php
@@ -125,7 +125,15 @@ class ValidatingCommandTest extends TestCase
         $command = new ReloadableChoiceTestCommand();
         $output = Mockery::mock(OutputStyle::class);
 
-        $output->shouldReceive('askQuestion')->once()->andReturn('foo');
+        $output->shouldReceive('askQuestion')->once()->withArgs(function (ChoiceQuestion $question) {
+            return $this->assertEqualsAsBoolean(new ChoiceQuestion('Select an option', [
+                '<fg=bright-blue>[Reload options]</>',
+                'foo',
+                'bar',
+                'baz',
+            ], null), $question);
+        })->andReturn('foo');
+
         $output->shouldReceive('writeln')->once()->withArgs(function (string $message) {
             return $message === 'You selected foo';
         });

--- a/packages/framework/tests/Feature/ValidatingCommandTest.php
+++ b/packages/framework/tests/Feature/ValidatingCommandTest.php
@@ -134,13 +134,7 @@ class ValidatingCommandTest extends TestCase
                 3 => 'baz',
             ], null);
 
-            try {
-                $this->assertEquals($expected, $question);
-            } catch (ExpectationFailedException) {
-                return false;
-            }
-
-            return true;
+            return $this->assertEqualsAsBoolean($expected, $question);
         })->andReturn('<fg=bright-blue>[Reload options]</>');
 
         $output->shouldReceive('askQuestion')->once()->withArgs(function (ChoiceQuestion $question) {
@@ -151,13 +145,7 @@ class ValidatingCommandTest extends TestCase
                 3 => 'qux',
             ], null);
 
-            try {
-                $this->assertEquals($expected, $question);
-            } catch (ExpectationFailedException) {
-                return false;
-            }
-
-            return true;
+            return $this->assertEqualsAsBoolean($expected, $question);
         })->andReturn('qux');
 
         $output->shouldReceive('writeln')->once()->withArgs(function (string $message) {
@@ -259,6 +247,17 @@ class ValidatingCommandTest extends TestCase
 
         $command->setOutput($output);
         $command->handle();
+    }
+
+    protected function assertEqualsAsBoolean($expected, $question): bool
+    {
+        try {
+            $this->assertEquals($expected, $question);
+        } catch (ExpectationFailedException) {
+            return false;
+        }
+
+        return true;
     }
 }
 

--- a/packages/framework/tests/Feature/ValidatingCommandTest.php
+++ b/packages/framework/tests/Feature/ValidatingCommandTest.php
@@ -123,7 +123,6 @@ class ValidatingCommandTest extends TestCase
     public function testReloadableChoiceHelper()
     {
         $command = new ReloadableChoiceTestCommand();
-
         $output = Mockery::mock(OutputStyle::class);
 
         $output->shouldReceive('askQuestion')->once()->withArgs(function (ChoiceQuestion $question) {
@@ -155,7 +154,6 @@ class ValidatingCommandTest extends TestCase
     public function testReloadableChoiceHelperSelectingReload()
     {
         $command = new ReloadableChoiceTestCommand();
-
         $output = Mockery::mock(OutputStyle::class);
 
         $output->shouldReceive('askQuestion')->once()->andReturn('foo');

--- a/packages/framework/tests/Feature/ValidatingCommandTest.php
+++ b/packages/framework/tests/Feature/ValidatingCommandTest.php
@@ -12,9 +12,8 @@ use Illuminate\Support\Facades\Validator;
 use Mockery;
 use PHPUnit\Framework\ExpectationFailedException;
 use RuntimeException;
-use Symfony\Component\Console\Question\ChoiceQuestion;
-
 use function str_starts_with;
+use Symfony\Component\Console\Question\ChoiceQuestion;
 
 /**
  * @covers \Hyde\Console\Concerns\ValidatingCommand
@@ -308,6 +307,7 @@ class ReloadableChoiceTestCommand extends ValidatingCommand
         $selection = $this->reloadableChoice(function () {
             if ($this->isFirstRun) {
                 $this->isFirstRun = false;
+
                 return ['foo', 'bar', 'baz'];
             }
 

--- a/packages/framework/tests/Feature/ValidatingCommandTest.php
+++ b/packages/framework/tests/Feature/ValidatingCommandTest.php
@@ -118,6 +118,21 @@ class ValidatingCommandTest extends TestCase
         $command->handle();
     }
 
+    public function testReloadableChoiceHelper()
+    {
+        $command = new ReloadableChoiceTestCommand();
+
+        $output = Mockery::mock(OutputStyle::class);
+
+        $output->shouldReceive('askQuestion')->once()->andReturn('foo');
+        $output->shouldReceive('writeln')->once()->withArgs(function (string $message) {
+            return $message === 'You selected foo';
+        });
+
+        $command->setOutput($output);
+        $command->handle();
+    }
+
     public function testHandleException()
     {
         $command = new ThrowingValidatingTestCommand();
@@ -230,6 +245,17 @@ class ThrowingValidatingTestCommand extends ValidatingCommand
         } catch (RuntimeException $exception) {
             return $this->handleException($exception, $file, $line);
         }
+    }
+}
+
+class ReloadableChoiceTestCommand extends ValidatingCommand
+{
+    public function handle(): int
+    {
+        $selection = $this->reloadableChoice(['bar', 'baz'], 'foo');
+        $this->output->writeln("You selected $selection");
+
+        return 0;
     }
 }
 

--- a/packages/framework/tests/Feature/ValidatingCommandTest.php
+++ b/packages/framework/tests/Feature/ValidatingCommandTest.php
@@ -128,10 +128,10 @@ class ValidatingCommandTest extends TestCase
 
         $output->shouldReceive('askQuestion')->once()->withArgs(function (ChoiceQuestion $question) {
             $expected = new ChoiceQuestion('Select an option', [
-                0 => '<fg=bright-blue>[Reload options]</>',
-                1 => 'foo',
-                2 => 'bar',
-                3 => 'baz',
+                '<fg=bright-blue>[Reload options]</>',
+                'foo',
+                'bar',
+                'baz',
             ], null);
 
             return $this->assertEqualsAsBoolean($expected, $question);
@@ -139,10 +139,10 @@ class ValidatingCommandTest extends TestCase
 
         $output->shouldReceive('askQuestion')->once()->withArgs(function (ChoiceQuestion $question) {
             $expected = new ChoiceQuestion('Select an option', [
-                0 => '<fg=bright-blue>[Reload options]</>',
-                1 => 'bar',
-                2 => 'baz',
-                3 => 'qux',
+                '<fg=bright-blue>[Reload options]</>',
+                'bar',
+                'baz',
+                'qux',
             ], null);
 
             return $this->assertEqualsAsBoolean($expected, $question);

--- a/packages/framework/tests/Feature/ValidatingCommandTest.php
+++ b/packages/framework/tests/Feature/ValidatingCommandTest.php
@@ -252,7 +252,10 @@ class ReloadableChoiceTestCommand extends ValidatingCommand
 {
     public function handle(): int
     {
-        $selection = $this->reloadableChoice(['bar', 'baz'], 'foo');
+        $selection = $this->reloadableChoice(function () {
+            return ['foo', 'bar', 'baz'];
+        }, 'Select an option');
+
         $this->output->writeln("You selected $selection");
 
         return 0;

--- a/packages/framework/tests/Feature/ValidatingCommandTest.php
+++ b/packages/framework/tests/Feature/ValidatingCommandTest.php
@@ -125,6 +125,20 @@ class ValidatingCommandTest extends TestCase
         $command = new ReloadableChoiceTestCommand();
         $output = Mockery::mock(OutputStyle::class);
 
+        $output->shouldReceive('askQuestion')->once()->andReturn('foo');
+        $output->shouldReceive('writeln')->once()->withArgs(function (string $message) {
+            return $message === 'You selected foo';
+        });
+
+        $command->setOutput($output);
+        $command->handle();
+    }
+
+    public function testReloadableChoiceHelperSelectingReload()
+    {
+        $command = new ReloadableChoiceTestCommand();
+        $output = Mockery::mock(OutputStyle::class);
+
         $output->shouldReceive('askQuestion')->once()->withArgs(function (ChoiceQuestion $question) {
             return $this->assertEqualsAsBoolean(new ChoiceQuestion('Select an option', [
                 '<fg=bright-blue>[Reload options]</>',
@@ -145,20 +159,6 @@ class ValidatingCommandTest extends TestCase
 
         $output->shouldReceive('writeln')->once()->withArgs(function (string $message) {
             return $message === 'You selected qux';
-        });
-
-        $command->setOutput($output);
-        $command->handle();
-    }
-
-    public function testReloadableChoiceHelperSelectingReload()
-    {
-        $command = new ReloadableChoiceTestCommand();
-        $output = Mockery::mock(OutputStyle::class);
-
-        $output->shouldReceive('askQuestion')->once()->andReturn('foo');
-        $output->shouldReceive('writeln')->once()->withArgs(function (string $message) {
-            return $message === 'You selected foo';
         });
 
         $command->setOutput($output);

--- a/packages/framework/tests/Feature/ValidatingCommandTest.php
+++ b/packages/framework/tests/Feature/ValidatingCommandTest.php
@@ -127,25 +127,21 @@ class ValidatingCommandTest extends TestCase
         $output = Mockery::mock(OutputStyle::class);
 
         $output->shouldReceive('askQuestion')->once()->withArgs(function (ChoiceQuestion $question) {
-            $expected = new ChoiceQuestion('Select an option', [
+            return $this->assertEqualsAsBoolean(new ChoiceQuestion('Select an option', [
                 '<fg=bright-blue>[Reload options]</>',
                 'foo',
                 'bar',
                 'baz',
-            ], null);
-
-            return $this->assertEqualsAsBoolean($expected, $question);
+            ], null), $question);
         })->andReturn('<fg=bright-blue>[Reload options]</>');
 
         $output->shouldReceive('askQuestion')->once()->withArgs(function (ChoiceQuestion $question) {
-            $expected = new ChoiceQuestion('Select an option', [
+            return $this->assertEqualsAsBoolean(new ChoiceQuestion('Select an option', [
                 '<fg=bright-blue>[Reload options]</>',
                 'bar',
                 'baz',
                 'qux',
-            ], null);
-
-            return $this->assertEqualsAsBoolean($expected, $question);
+            ], null), $question);
         })->andReturn('qux');
 
         $output->shouldReceive('writeln')->once()->withArgs(function (string $message) {


### PR DESCRIPTION
Refactors, fixes, and integrates, a console choice helper that can reload the choices by evaluating a supplied closure.