### PR TITLE
Refactor Markdown processing to improve usability and remove unnecessary internal code

### DIFF
--- a/docs/digging-deeper/advanced-markdown.md
+++ b/docs/digging-deeper/advanced-markdown.md
@@ -121,27 +121,41 @@ Note that these currently do not support multi-line blockquotes.
 ## Code block filepaths
 
 When browsing these documentation pages you may have noticed a label in the top right corner of code blocks specifying the file path.
-These are, of course, also created by using a custom Hyde feature that turns code comments into automatic code blocks.
+These are also created by using a custom Hyde feature that turns code comments into automatic code blocks.
 
 Simply add a code comment in the **first line** of a `fenced code block` like so:
 
 ````markdown
-// Filepath: _docs\markdown-features.md
-```markdown
-// Filepath: _docs\markdown-features.md // HYDE! {"shortcodes": false} HYDE! // 
+// Filepath: _docs/advanced-markdown.md
+```php
+// Filepath: hello-world.php // HYDE! {"shortcodes": false} HYDE! // 
 
-# Automatic Filepaths! 
-[...]
+echo 'Hello World!';
 ```
 ````
 
-The syntax is rather forgiving by design, and supports a number of common code comment markers:
+Which becomes:
+
+```php
+// Filepath: hello-world.php 
+
+echo 'Hello World!';
+```
+
+#### Alternative syntax
+
+The syntax is rather forgiving by design, and supports using both `//` and `#` for comments.
+The colon is also optional, and the 'f' can be both upper or lower case. So the following is also perfectly valid:
 
 ````markdown
-// filepath: You can of course put anything here if you wanted
-```php
-// filepath: hello-world.php // HYDE! {"shortcodes": false} HYDE! // 
-
-echo 'Hello Horld!';
+```js
+// filepath hello.js // HYDE! {"shortcodes": false} HYDE! //
+console.log('Hello World!');
 ```
 ````
+
+If you have a newline after the filepath like in the first example, it will be removed so your code stays readable.
+
+#### Limitations
+
+The filepaths are hidden on mobile devices using CSS to prevent them from overlapping with the code block.

--- a/docs/digging-deeper/advanced-markdown.md
+++ b/docs/digging-deeper/advanced-markdown.md
@@ -150,6 +150,17 @@ console.log('Hello World!');
 
 If you have a newline after the filepath like in the first example, it will be removed so your code stays readable.
 
+#### Advanced usage
+
+If you have enabled HTML in Markdown by setting the `allow_html` option to true in your `config/markdown.php` file,
+anything within the path label will be rendered as HTML. This means you can add links, or even images to the label.
+
+````markdown
+// Filepath: <a href="https://github.com">View file on Github</a>
+```markdown
+‎// Filepath: <a href="https://github.com">View file on Github</a>
+```
+````
 #### Limitations
 
 The filepaths are hidden on mobile devices using CSS to prevent them from overlapping with the code block.

--- a/docs/digging-deeper/advanced-markdown.md
+++ b/docs/digging-deeper/advanced-markdown.md
@@ -122,7 +122,7 @@ Simply add a code comment in the **first line** of a `fenced code block` like so
 ````markdown
 // Filepath: _docs/advanced-markdown.md
 ```php
-// Filepath: hello-world.php // HYDE! {"shortcodes": false} HYDE! // 
+‎// Filepath: hello-world.php 
 
 echo 'Hello World!';
 ```
@@ -143,7 +143,7 @@ The colon is also optional, and the 'filepath' string is case-insensitive. So th
 
 ````markdown
 ```js
-// filepath hello.js // HYDE! {"shortcodes": false} HYDE! //
+‎// filepath hello.js
 console.log('Hello World!');
 ```
 ````

--- a/docs/digging-deeper/advanced-markdown.md
+++ b/docs/digging-deeper/advanced-markdown.md
@@ -139,7 +139,7 @@ echo 'Hello World!';
 #### Alternative syntax
 
 The syntax is rather forgiving by design, and supports using both `//` and `#` for comments.
-The colon is also optional, and the 'f' can be both upper or lower case. So the following is also perfectly valid:
+The colon is also optional, and the 'filepath' string is case-insensitive. So the following is also perfectly valid:
 
 ````markdown
 ```js

--- a/docs/digging-deeper/advanced-markdown.md
+++ b/docs/digging-deeper/advanced-markdown.md
@@ -68,25 +68,17 @@ The HydePHP Markdown converter also supports some extra directives and features.
 
 
 ```markdown
-> Normal Blockquote
-
->info Info Blockquote
-
->warning Warning Blockquote
-
->danger Danger Blockquote
-
->success Success Blockquote
+‎> Normal Blockquote
+‎>info Info Blockquote
+‎>warning Warning Blockquote
+‎>danger Danger Blockquote
+‎>success Success Blockquote
 ```
 
 > Normal Blockquote
-
 >info Info Blockquote
-
 >warning Warning Blockquote
-
 >danger Danger Blockquote
-
 >success Success Blockquote
 
 #### Customizations
@@ -95,6 +87,8 @@ You can easily customize these styles too by adding and editing the following in
 The code examples here use the Tailwind `@apply` directives, but you could also use `border-color: blue;` just as well.
 
 ```css
+/* filepath resources/app.css
+
 /* Markdown Features */
 
 .prose blockquote.info {

--- a/docs/digging-deeper/advanced-markdown.md
+++ b/docs/digging-deeper/advanced-markdown.md
@@ -156,7 +156,7 @@ If you have enabled HTML in Markdown by setting the `allow_html` option to true 
 anything within the path label will be rendered as HTML. This means you can add links, or even images to the label.
 
 ````markdown
-// Filepath: <a href="https://github.com">View file on Github</a>
+// Filepath: <a href="https://github.com/hydephp/develop/blob/master/docs/digging-deeper/advanced-markdown.md" rel="nofollow noopener" target="_blank">View file on Github</a>
 ```markdown
 ‎// Filepath: <a href="https://github.com">View file on Github</a>
 ```

--- a/packages/framework/resources/views/components/filepath-label.blade.php
+++ b/packages/framework/resources/views/components/filepath-label.blade.php
@@ -1,1 +1,1 @@
-<small class="filepath"><span class="sr-only">Filepath: </span>{{ $path }}</small>
+<small class="filepath not-prose"><span class="sr-only">Filepath: </span>{{ $path }}</small>

--- a/packages/framework/src/Framework/Services/MarkdownService.php
+++ b/packages/framework/src/Framework/Services/MarkdownService.php
@@ -100,7 +100,14 @@ class MarkdownService
         }
 
         // Remove any Hyde annotations (everything between `// HYDE!` and `HYDE! //`) (must be done last)
-        $this->html = preg_replace('/ \/\/ HYDE!.*HYDE! \/\//s', '', $this->html);
+        $htmlLines = explode("\n", $this->html);
+        foreach ($htmlLines as $index => $line) {
+            $newLine = preg_replace('/ \/\/ HYDE!.*HYDE! \/\//s', '', $line);
+            if ($newLine !== null) {
+                $htmlLines[$index] = $newLine;
+            }
+        }
+        $this->html = implode("\n", $htmlLines);
     }
 
     public function getExtensions(): array

--- a/packages/framework/src/Framework/Services/MarkdownService.php
+++ b/packages/framework/src/Framework/Services/MarkdownService.php
@@ -98,16 +98,6 @@ class MarkdownService
         foreach ($this->postprocessors as $postprocessor) {
             $this->html = $postprocessor::postprocess($this->html);
         }
-
-        // Remove any Hyde annotations (everything between `// HYDE!` and `HYDE! //`) (must be done last)
-        $htmlLines = explode("\n", $this->html);
-        foreach ($htmlLines as $index => $line) {
-            $newLine = preg_replace('/ \/\/ HYDE!.*HYDE! \/\//s', '', $line);
-            if ($newLine !== null) {
-                $htmlLines[$index] = $newLine;
-            }
-        }
-        $this->html = implode("\n", $htmlLines);
     }
 
     public function getExtensions(): array

--- a/packages/framework/src/Markdown/Processing/CodeblockFilepathProcessor.php
+++ b/packages/framework/src/Markdown/Processing/CodeblockFilepathProcessor.php
@@ -92,11 +92,9 @@ class CodeblockFilepathProcessor implements MarkdownPreProcessorContract, Markdo
 
     protected static function trimHydeDirective(string $line): string
     {
-        return trim(str_replace('-->', '', str_replace(
-            '<!-- HYDE[Filepath]',
-            '',
-            $line
-        )));
+        return trim(str_replace('-->', '',
+            str_replace('<!-- HYDE[Filepath]', '', $line)
+        ));
     }
 
     protected static function resolveTemplate(string $path): string

--- a/packages/framework/src/Markdown/Processing/CodeblockFilepathProcessor.php
+++ b/packages/framework/src/Markdown/Processing/CodeblockFilepathProcessor.php
@@ -7,7 +7,6 @@ namespace Hyde\Markdown\Processing;
 use Hyde\Markdown\Contracts\MarkdownPostProcessorContract;
 use Hyde\Markdown\Contracts\MarkdownPreProcessorContract;
 use Illuminate\Support\HtmlString;
-
 use function strtolower;
 
 /**

--- a/packages/framework/src/Markdown/Processing/CodeblockFilepathProcessor.php
+++ b/packages/framework/src/Markdown/Processing/CodeblockFilepathProcessor.php
@@ -6,14 +6,14 @@ namespace Hyde\Markdown\Processing;
 
 use Hyde\Markdown\Contracts\MarkdownPostProcessorContract;
 use Hyde\Markdown\Contracts\MarkdownPreProcessorContract;
+use Illuminate\Support\HtmlString;
+
 use function strtolower;
 
 /**
  * Resolves file path comments found in Markdown code blocks into a neat badge shown in the top right corner.
  *
  * @see \Hyde\Framework\Testing\Feature\Services\Markdown\CodeblockFilepathProcessorTest
- *
- * @todo Support Markdown in the comment so we can for example link to the file on GitHub.
  */
 class CodeblockFilepathProcessor implements MarkdownPreProcessorContract, MarkdownPostProcessorContract
 {
@@ -103,7 +103,7 @@ class CodeblockFilepathProcessor implements MarkdownPreProcessorContract, Markdo
     protected static function resolveTemplate(string $path): string
     {
         return view('hyde::components.filepath-label', [
-            'path' => $path,
+            'path' => config('markdown.allow_html') ? new HtmlString($path) : $path,
         ])->render();
     }
 

--- a/packages/framework/src/Markdown/Processing/CodeblockFilepathProcessor.php
+++ b/packages/framework/src/Markdown/Processing/CodeblockFilepathProcessor.php
@@ -7,6 +7,8 @@ namespace Hyde\Markdown\Processing;
 use Hyde\Markdown\Contracts\MarkdownPostProcessorContract;
 use Hyde\Markdown\Contracts\MarkdownPreProcessorContract;
 
+use function strtolower;
+
 /**
  * Resolves file path comments found in Markdown code blocks into a neat badge shown in the top right corner.
  *
@@ -27,7 +29,7 @@ class CodeblockFilepathProcessor implements MarkdownPreProcessorContract, Markdo
                 // This prevents the meta-block from interfering with other processes.
                 $lines[$index - 2] .= sprintf(
                     "\n<!-- HYDE[Filepath]%s -->",
-                    trim(str_replace(static::$patterns, '', $line))
+                    trim(str_ireplace(static::$patterns, '', $line))
                 );
 
                 // Remove the original comment lines
@@ -68,17 +70,11 @@ class CodeblockFilepathProcessor implements MarkdownPreProcessorContract, Markdo
 
     protected static array $patterns = [
         '// filepath: ',
-        '// Filepath: ',
         '# filepath: ',
-        '# Filepath: ',
         '// filepath ',
-        '// Filepath ',
         '# filepath ',
-        '# Filepath ',
         '/* filepath: ',
-        '/* Filepath: ',
         '/* filepath ',
-        '/* Filepath ',
     ];
 
     protected static string $torchlightKey = '<!-- Syntax highlighted by torchlight.dev -->';
@@ -86,7 +82,7 @@ class CodeblockFilepathProcessor implements MarkdownPreProcessorContract, Markdo
     protected static function lineMatchesPattern(string $line): bool
     {
         foreach (static::$patterns as $pattern) {
-            if (str_starts_with($line, (string) $pattern)) {
+            if (str_starts_with(strtolower($line), $pattern)) {
                 return true;
             }
         }

--- a/packages/framework/src/Markdown/Processing/CodeblockFilepathProcessor.php
+++ b/packages/framework/src/Markdown/Processing/CodeblockFilepathProcessor.php
@@ -13,6 +13,8 @@ use function strtolower;
  * Resolves file path comments found in Markdown code blocks into a neat badge shown in the top right corner.
  *
  * @see \Hyde\Framework\Testing\Feature\Services\Markdown\CodeblockFilepathProcessorTest
+ *
+ * @todo Support Markdown in the comment so we can for example link to the file on GitHub.
  */
 class CodeblockFilepathProcessor implements MarkdownPreProcessorContract, MarkdownPostProcessorContract
 {

--- a/packages/framework/src/Markdown/Processing/CodeblockFilepathProcessor.php
+++ b/packages/framework/src/Markdown/Processing/CodeblockFilepathProcessor.php
@@ -70,11 +70,11 @@ class CodeblockFilepathProcessor implements MarkdownPreProcessorContract, Markdo
 
     protected static array $patterns = [
         '// filepath: ',
-        '# filepath: ',
         '// filepath ',
-        '# filepath ',
         '/* filepath: ',
         '/* filepath ',
+        '# filepath: ',
+        '# filepath ',
     ];
 
     protected static string $torchlightKey = '<!-- Syntax highlighted by torchlight.dev -->';

--- a/packages/framework/src/Markdown/Processing/CodeblockFilepathProcessor.php
+++ b/packages/framework/src/Markdown/Processing/CodeblockFilepathProcessor.php
@@ -25,7 +25,7 @@ class CodeblockFilepathProcessor implements MarkdownPreProcessorContract, Markdo
         $lines = explode("\n", $markdown);
 
         foreach ($lines as $index => $line) {
-            if (static::lineMatchesPattern($line) && ! str_contains($line, '{"shortcodes": false}')) {
+            if (static::lineMatchesPattern($line)) {
                 // Add the meta-block two lines before the pattern, placing it just above the code block.
                 // This prevents the meta-block from interfering with other processes.
                 $lines[$index - 2] .= sprintf(

--- a/packages/framework/src/Markdown/Processing/CodeblockFilepathProcessor.php
+++ b/packages/framework/src/Markdown/Processing/CodeblockFilepathProcessor.php
@@ -75,6 +75,10 @@ class CodeblockFilepathProcessor implements MarkdownPreProcessorContract, Markdo
         '// Filepath ',
         '# filepath ',
         '# Filepath ',
+        '/* filepath: ',
+        '/* Filepath: ',
+        '/* filepath ',
+        '/* Filepath ',
     ];
 
     protected static string $torchlightKey = '<!-- Syntax highlighted by torchlight.dev -->';

--- a/packages/framework/tests/Feature/MarkdownServiceTest.php
+++ b/packages/framework/tests/Feature/MarkdownServiceTest.php
@@ -295,6 +295,18 @@ class MarkdownServiceTest extends TestCase
         $this->assertSame("<p>Example text</p>\n", $html);
     }
 
+    public function test_hyde_annotations_are_removed_with_multiple_annotations_on_different_lines()
+    {
+        $markdown = 'Example // HYDE!` **remove this** `HYDE! // text
+with // HYDE!` **remove this** `HYDE! // text';
+        $service = new MarkdownService($markdown);
+        $html = $service->parse();
+
+        $this->assertStringNotContainsString('remove this', $html);
+        $this->assertSame("<p>Example text
+with text</p>\n", $html);
+    }
+
     protected function makeService()
     {
         return new class extends MarkdownService

--- a/packages/framework/tests/Feature/MarkdownServiceTest.php
+++ b/packages/framework/tests/Feature/MarkdownServiceTest.php
@@ -285,28 +285,6 @@ class MarkdownServiceTest extends TestCase
         $this->assertSame("foo\nbar\nbaz\n", $service->normalizeIndentationLevel($markdown));
     }
 
-    public function test_hyde_annotations_are_removed()
-    {
-        $markdown = 'Example // HYDE!` **remove this** `HYDE! // text';
-        $service = new MarkdownService($markdown);
-        $html = $service->parse();
-
-        $this->assertStringNotContainsString('remove this', $html);
-        $this->assertSame("<p>Example text</p>\n", $html);
-    }
-
-    public function test_hyde_annotations_are_removed_with_multiple_annotations_on_different_lines()
-    {
-        $markdown = 'Example // HYDE!` **remove this** `HYDE! // text
-with // HYDE!` **remove this** `HYDE! // text';
-        $service = new MarkdownService($markdown);
-        $html = $service->parse();
-
-        $this->assertStringNotContainsString('remove this', $html);
-        $this->assertSame("<p>Example text
-with text</p>\n", $html);
-    }
-
     protected function makeService()
     {
         return new class extends MarkdownService

--- a/packages/framework/tests/Feature/MarkdownServiceTest.php
+++ b/packages/framework/tests/Feature/MarkdownServiceTest.php
@@ -285,6 +285,16 @@ class MarkdownServiceTest extends TestCase
         $this->assertSame("foo\nbar\nbaz\n", $service->normalizeIndentationLevel($markdown));
     }
 
+    public function test_hyde_annotations_are_removed()
+    {
+        $markdown = 'Example // HYDE!` **remove this** `HYDE! // text';
+        $service = new MarkdownService($markdown);
+        $html = $service->parse();
+
+        $this->assertStringNotContainsString('remove this', $html);
+        $this->assertSame("<p>Example text</p>\n", $html);
+    }
+
     protected function makeService()
     {
         return new class extends MarkdownService

--- a/packages/framework/tests/Feature/Services/Markdown/CodeblockFilepathProcessorTest.php
+++ b/packages/framework/tests/Feature/Services/Markdown/CodeblockFilepathProcessorTest.php
@@ -165,7 +165,7 @@ class CodeblockFilepathProcessorTest extends TestCase
         HTML;
 
         $expected = <<<'HTML'
-        <pre><code class="language-html"><small class="filepath"><span class="sr-only">Filepath: </span>foo.html</small></code></pre>
+        <pre><code class="language-html"><small class="filepath not-prose"><span class="sr-only">Filepath: </span>foo.html</small></code></pre>
         HTML;
 
         $this->assertSame($expected, CodeblockFilepathProcessor::postprocess($html));
@@ -179,7 +179,7 @@ class CodeblockFilepathProcessorTest extends TestCase
         HTML;
 
         $expected = <<<'HTML'
-        <pre><code class="torchlight"><!-- Syntax highlighted by torchlight.dev --><small class="filepath"><span class="sr-only">Filepath: </span>foo.html</small><div class="line"><span class="line-number">1</span>&nbsp;</div></code></pre>
+        <pre><code class="torchlight"><!-- Syntax highlighted by torchlight.dev --><small class="filepath not-prose"><span class="sr-only">Filepath: </span>foo.html</small><div class="line"><span class="line-number">1</span>&nbsp;</div></code></pre>
         HTML;
 
         $this->assertSame($expected, CodeblockFilepathProcessor::postprocess($html));

--- a/packages/framework/tests/Feature/Services/Markdown/CodeblockFilepathProcessorTest.php
+++ b/packages/framework/tests/Feature/Services/Markdown/CodeblockFilepathProcessorTest.php
@@ -184,4 +184,35 @@ class CodeblockFilepathProcessorTest extends TestCase
 
         $this->assertSame($expected, CodeblockFilepathProcessor::postprocess($html));
     }
+
+    public function test_processor_escapes_html_by_default()
+    {
+        $html = <<<'HTML'
+        <!-- HYDE[Filepath]<a href="">Link</a> -->
+        <pre><code class="language-html"></code></pre>
+        HTML;
+
+        $escaped = e('<a href="">Link</a>');
+        $expected = <<<HTML
+        <pre><code class="language-html"><small class="filepath not-prose"><span class="sr-only">Filepath: </span>$escaped</small></code></pre>
+        HTML;
+
+        $this->assertSame($expected, CodeblockFilepathProcessor::postprocess($html));
+    }
+
+    public function test_processor_does_not_escape_html_if_configured()
+    {
+        config(['markdown.allow_html' => true]);
+
+        $html = <<<'HTML'
+        <!-- HYDE[Filepath]<a href="">Link</a> -->
+        <pre><code class="language-html"></code></pre>
+        HTML;
+
+        $expected = <<<'HTML'
+        <pre><code class="language-html"><small class="filepath not-prose"><span class="sr-only">Filepath: </span><a href="">Link</a></small></code></pre>
+        HTML;
+
+        $this->assertSame($expected, CodeblockFilepathProcessor::postprocess($html));
+    }
 }

--- a/packages/framework/tests/Feature/Services/Markdown/CodeblockFilepathProcessorTest.php
+++ b/packages/framework/tests/Feature/Services/Markdown/CodeblockFilepathProcessorTest.php
@@ -41,6 +41,23 @@ class CodeblockFilepathProcessorTest extends TestCase
         }
     }
 
+    public function test_filepath_pattern_is_case_insensitive()
+    {
+        $patterns = [
+            '// filepath: ',
+            '// Filepath: ',
+            '// FilePath: ',
+            '// FILEPATH: ',
+        ];
+
+        foreach ($patterns as $pattern) {
+            $markdown = "\n```php\n{$pattern}foo.php\necho 'Hello World';\n```";
+            $expected = "\n<!-- HYDE[Filepath]foo.php -->\n```php\necho 'Hello World';\n```";
+
+            $this->assertEquals($expected, CodeblockFilepathProcessor::preprocess($markdown));
+        }
+    }
+
     public function test_preprocess_accepts_multiple_languages()
     {
         $languages = [


### PR DESCRIPTION
## About

### Major changes

#### Filepath code block changes

- Supports `/*` in filepath comments (just don't add a closing tagas that won't get removed)
- Refactor filepath patterns to be case insensitive as it makes no discernible performance difference but it does increase usability
- Removes support for the internal `{"shortcodes": false}` flag (see below) 42fade7ca1
- Echo filepath label as-is if HTML in Markdown is enabled to support links and more 7fe64842ff [^1]
- Adds the not-prose class to the filepath-label view 14b659be6f

#### Hyde Markdown Parser annotations removal (`// HYDE!`)

- Remove support for Hyde Markdown Parser annotations (`// HYDE!`) as they are only used in one place[^2] which is simplified (see above) f4fd751408

- <s>Remove Hyde annotations on a line-by-line basis as it breaks when there is more than one annotation (multiple annotations on the same line still break and could be fixed by further tokenization but I don't think it's worth the added complexity at this point as it's just an edge case for a feature that is still mostly needed for the official docs, and that might be removed all together since it's not documented and it's only needed for the official docs and can be replaced by using invisible characters to "trick" the parser to ignore directives.</s>


## Extra

Fun fact, pre and post-processing one filepath codeblock takes 0.155ms

```php
public function test_benchmark()
{
    $markdown = "\n```php\n// filepath: foo.php\necho 'Hello World';\n```";
    Benchmark::dd(function () use ($markdown) {
        CodeblockFilepathProcessor::postprocess(CodeblockFilepathProcessor::preprocess($markdown));
    }, 10000);
}
```

In the context of an actual use case, the entire page on advanced markdown uses about 1.334ms for preprocessing and 0.755ms for postprocessing. And this is a page that uses quite a lot of them.

[^1]: I think it could even be pretty cool if something similar to the "open page on GitHub" button could work for this to automatically link existing files to GitHub but that's out of scope for this PR

[^2]: Used only in the docs to tell Hyde to not parse filepath labels [advanced-markdown.md#L146](https://github.com/hydephp/develop/blob/2884460904cad0cebd43eba2e0697ee78255d3f7/docs/digging-deeper/advanced-markdown.md?plain=1#L146) which can be simplified by inserting an invisible character like the same file does for the coloured blockquotes.