### PR TITLE
Create object representation for the tags.json file.

### DIFF
--- a/packages/framework/src/Console/Commands/MakePublicationTagCommand.php
+++ b/packages/framework/src/Console/Commands/MakePublicationTagCommand.php
@@ -4,16 +4,13 @@ declare(strict_types=1);
 
 namespace Hyde\Console\Commands;
 
-use Hyde\Framework\Features\Publications\Models\PublicationTags;
-use function array_merge;
 use Hyde\Console\Commands\Helpers\InputStreamHandler;
 use Hyde\Console\Concerns\ValidatingCommand;
-use Hyde\Facades\Filesystem;
+use Hyde\Framework\Features\Publications\Models\PublicationTags;
 use Hyde\Framework\Features\Publications\PublicationService;
 use Hyde\Framework\Services\DiscoveryService;
 use Hyde\Hyde;
 use function implode;
-use function json_encode;
 use LaravelZero\Framework\Commands\Command;
 use RuntimeException;
 use function sprintf;

--- a/packages/framework/src/Console/Commands/MakePublicationTagCommand.php
+++ b/packages/framework/src/Console/Commands/MakePublicationTagCommand.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Hyde\Console\Commands;
 
+use Hyde\Framework\Features\Publications\Models\PublicationTags;
 use function array_merge;
 use Hyde\Console\Commands\Helpers\InputStreamHandler;
 use Hyde\Console\Concerns\ValidatingCommand;
@@ -96,8 +97,6 @@ class MakePublicationTagCommand extends ValidatingCommand
             DiscoveryService::createClickableFilepath(Hyde::path('tags.json'))
         );
 
-        Filesystem::putContents('tags.json', json_encode(array_merge(
-            PublicationService::getAllTags()->toArray(), $this->tags
-        ), JSON_PRETTY_PRINT));
+        app(PublicationTags::class)->addTagGroups($this->tags)->save();
     }
 }

--- a/packages/framework/src/Framework/Features/Publications/Models/PublicationTags.php
+++ b/packages/framework/src/Framework/Features/Publications/Models/PublicationTags.php
@@ -30,6 +30,13 @@ class PublicationTags
         return $this->tags;
     }
 
+    public function addTag(string $name, array $values): self
+    {
+        $this->tags->put($name, $values);
+
+        return $this;
+    }
+
     /**
      * Get all available tags.
      */

--- a/packages/framework/src/Framework/Features/Publications/Models/PublicationTags.php
+++ b/packages/framework/src/Framework/Features/Publications/Models/PublicationTags.php
@@ -49,9 +49,9 @@ class PublicationTags
     /**
      * Get all values for a given tag name.
      */
-    public static function getValuesForTagName(string $tagName): Collection
+    public static function getValuesForTagName(string $tagName): array
     {
-        return Collection::make(self::getAllTags()->get($tagName) ?? []);
+        return self::getAllTags()->get($tagName) ?? [];
     }
 
     protected function parseTagsFile(): array

--- a/packages/framework/src/Framework/Features/Publications/Models/PublicationTags.php
+++ b/packages/framework/src/Framework/Features/Publications/Models/PublicationTags.php
@@ -43,6 +43,17 @@ class PublicationTags
         return $this;
     }
 
+
+    /** @param  array<string, array<string>>  $tags */
+    public function addTags(array $tags): self
+    {
+        foreach ($tags as $name => $values) {
+            $this->addTag($name, $values);
+        }
+
+        return $this;
+    }
+
     /** Save the tags collection to disk. */
     public function save(): self
     {

--- a/packages/framework/src/Framework/Features/Publications/Models/PublicationTags.php
+++ b/packages/framework/src/Framework/Features/Publications/Models/PublicationTags.php
@@ -5,6 +5,8 @@ declare(strict_types=1);
 namespace Hyde\Framework\Features\Publications\Models;
 
 use Hyde\Facades\Filesystem;
+use Hyde\Framework\Exceptions\FileNotFoundException;
+use JsonException;
 use function file_exists;
 use function file_get_contents;
 use Hyde\Hyde;
@@ -67,6 +69,35 @@ class PublicationTags
     public static function getValuesForTagName(string $tagName): array
     {
         return self::getAllTags()->get($tagName) ?? [];
+    }
+
+    /**
+     * Validate the tags.json file is valid.
+     *
+     * @internal This method is experimental and may be removed without notice
+     */
+    public static function validateTagsFile(): bool
+    {
+        if (! file_exists(Hyde::path('tags.json'))) {
+            throw new FileNotFoundException('tags.json');
+        }
+
+        $tags = json_decode(file_get_contents(Hyde::path('tags.json')), true);
+
+        if (! is_array($tags) || empty($tags)) {
+            throw new JsonException('Could not decode tags.json');
+        }
+
+        foreach ($tags as $name => $values) {
+            assert(is_string($name));
+            assert(is_array($values));
+            foreach ($values as $key => $value) {
+                assert(is_int($key));
+                assert(is_string($value));
+            }
+        }
+
+        return true;
     }
 
     /** @return array<string, array<string>> */

--- a/packages/framework/src/Framework/Features/Publications/Models/PublicationTags.php
+++ b/packages/framework/src/Framework/Features/Publications/Models/PublicationTags.php
@@ -35,7 +35,10 @@ class PublicationTags
         return $this->tags;
     }
 
-    /** @param  array<string>  $values */
+    /**
+     * @param  array<string>|string  $values
+     * @return $this
+     */
     public function addTag(string $name, array|string $values): self
     {
         $this->tags->put($name, (array) $values);
@@ -44,7 +47,11 @@ class PublicationTags
     }
 
 
-    /** @param  array<string, array<string>>  $tags */
+    /**
+     * @param  array<string, array<string>|string>  $tags
+     *
+     * @return $this
+     */
     public function addTags(array $tags): self
     {
         foreach ($tags as $name => $values) {
@@ -54,7 +61,11 @@ class PublicationTags
         return $this;
     }
 
-    /** Save the tags collection to disk. */
+    /**
+     * Save the tags collection to disk.
+     *
+     * @return $this
+     */
     public function save(): self
     {
         Filesystem::putContents('tags.json', json_encode($this->tags, JSON_PRETTY_PRINT));

--- a/packages/framework/src/Framework/Features/Publications/Models/PublicationTags.php
+++ b/packages/framework/src/Framework/Features/Publications/Models/PublicationTags.php
@@ -4,6 +4,11 @@ declare(strict_types=1);
 
 namespace Hyde\Framework\Features\Publications\Models;
 
+/**
+ * Object representation for the tags.json file.
+ *
+ * @see \Hyde\Framework\Testing\Feature\PublicationTagsTest
+ */
 class PublicationTags
 {
     //

--- a/packages/framework/src/Framework/Features/Publications/Models/PublicationTags.php
+++ b/packages/framework/src/Framework/Features/Publications/Models/PublicationTags.php
@@ -17,12 +17,19 @@ use function json_decode;
  */
 class PublicationTags
 {
+    protected array $tags;
+
+    public function __construct()
+    {
+        $this->tags = $this->parseTagsFile();
+    }
+
     /**
      * Get all available tags.
      */
     public static function getAllTags(): Collection
     {
-        return Collection::make(self::parseTagsFile())->sortKeys();
+        return Collection::make((new self())->tags)->sortKeys();
     }
 
     /**
@@ -33,7 +40,7 @@ class PublicationTags
         return Collection::make(self::getAllTags()->get($tagName) ?? []);
     }
 
-    protected static function parseTagsFile(): array
+    protected function parseTagsFile(): array
     {
         if (file_exists(Hyde::path('tags.json'))) {
             return json_decode(file_get_contents(Hyde::path('tags.json')), true);

--- a/packages/framework/src/Framework/Features/Publications/Models/PublicationTags.php
+++ b/packages/framework/src/Framework/Features/Publications/Models/PublicationTags.php
@@ -17,6 +17,7 @@ use function json_decode;
  */
 class PublicationTags
 {
+    /** @var array<string, array<string>> */
     protected array $tags;
 
     public function __construct()

--- a/packages/framework/src/Framework/Features/Publications/Models/PublicationTags.php
+++ b/packages/framework/src/Framework/Features/Publications/Models/PublicationTags.php
@@ -4,6 +4,14 @@ declare(strict_types=1);
 
 namespace Hyde\Framework\Features\Publications\Models;
 
+use Hyde\Hyde;
+
+use Illuminate\Support\Collection;
+
+use function file_exists;
+use function file_get_contents;
+use function json_decode;
+
 /**
  * Object representation for the tags.json file.
  *
@@ -11,5 +19,28 @@ namespace Hyde\Framework\Features\Publications\Models;
  */
 class PublicationTags
 {
-    //
+    /**
+     * Get all available tags.
+     */
+    public static function getAllTags(): Collection
+    {
+        return Collection::make(self::parseTagsFile())->sortKeys();
+    }
+
+    /**
+     * Get all values for a given tag name.
+     */
+    public static function getValuesForTagName(string $tagName): Collection
+    {
+        return Collection::make(self::getAllTags()->get($tagName) ?? []);
+    }
+
+    protected static function parseTagsFile(): array
+    {
+        if (file_exists(Hyde::path('tags.json'))) {
+            return json_decode(file_get_contents(Hyde::path('tags.json')), true);
+        }
+
+        return [];
+    }
 }

--- a/packages/framework/src/Framework/Features/Publications/Models/PublicationTags.php
+++ b/packages/framework/src/Framework/Features/Publications/Models/PublicationTags.php
@@ -46,10 +46,8 @@ class PublicationTags
         return $this;
     }
 
-
     /**
      * @param  array<string, array<string>|string>  $tags
-     *
      * @return $this
      */
     public function addTags(array $tags): self

--- a/packages/framework/src/Framework/Features/Publications/Models/PublicationTags.php
+++ b/packages/framework/src/Framework/Features/Publications/Models/PublicationTags.php
@@ -4,11 +4,13 @@ declare(strict_types=1);
 
 namespace Hyde\Framework\Features\Publications\Models;
 
+use Hyde\Facades\Filesystem;
 use function file_exists;
 use function file_get_contents;
 use Hyde\Hyde;
 use Illuminate\Support\Collection;
 use function json_decode;
+use function json_encode;
 
 /**
  * Object representation for the tags.json file.
@@ -34,6 +36,14 @@ class PublicationTags
     public function addTag(string $name, array|string $values): self
     {
         $this->tags->put($name, (array) $values);
+
+        return $this;
+    }
+
+    /** Save the tags collection to disk. */
+    public function save(): self
+    {
+        Filesystem::putContents('tags.json', json_encode($this->tags, JSON_PRETTY_PRINT));
 
         return $this;
     }

--- a/packages/framework/src/Framework/Features/Publications/Models/PublicationTags.php
+++ b/packages/framework/src/Framework/Features/Publications/Models/PublicationTags.php
@@ -30,6 +30,7 @@ class PublicationTags
         return $this->tags;
     }
 
+    /** @param  array<string>  $values */
     public function addTag(string $name, array $values): self
     {
         $this->tags->put($name, $values);

--- a/packages/framework/src/Framework/Features/Publications/Models/PublicationTags.php
+++ b/packages/framework/src/Framework/Features/Publications/Models/PublicationTags.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Hyde\Framework\Features\Publications\Models;
+
+class PublicationTags
+{
+    //
+}

--- a/packages/framework/src/Framework/Features/Publications/Models/PublicationTags.php
+++ b/packages/framework/src/Framework/Features/Publications/Models/PublicationTags.php
@@ -76,7 +76,7 @@ class PublicationTags
      *
      * @internal This method is experimental and may be removed without notice
      */
-    public static function validateTagsFile(): bool
+    public static function validateTagsFile(): void
     {
         if (! file_exists(Hyde::path('tags.json'))) {
             throw new FileNotFoundException('tags.json');
@@ -93,8 +93,6 @@ class PublicationTags
                 assert(is_string($value));
             }
         }
-
-        return true;
     }
 
     /** @return array<string, array<string>> */

--- a/packages/framework/src/Framework/Features/Publications/Models/PublicationTags.php
+++ b/packages/framework/src/Framework/Features/Publications/Models/PublicationTags.php
@@ -17,15 +17,15 @@ use function json_decode;
  */
 class PublicationTags
 {
-    /** @var array<string, array<string>> */
-    protected array $tags;
+    /** @var Collection<string, array<string>> */
+    protected Collection $tags;
 
     public function __construct()
     {
-        $this->tags = $this->parseTagsFile();
+        $this->tags = Collection::make($this->parseTagsFile());
     }
 
-    public function getTags(): array
+    public function getTags(): Collection
     {
         return $this->tags;
     }
@@ -35,7 +35,7 @@ class PublicationTags
      */
     public static function getAllTags(): Collection
     {
-        return Collection::make((new self())->getTags())->sortKeys();
+        return (new self())->getTags()->sortKeys();
     }
 
     /**

--- a/packages/framework/src/Framework/Features/Publications/Models/PublicationTags.php
+++ b/packages/framework/src/Framework/Features/Publications/Models/PublicationTags.php
@@ -60,6 +60,17 @@ class PublicationTags
     }
 
     /**
+     * @param  array<string>|string  $values
+     * @return $this
+     */
+    public function addTagsToGroup(string $name, array|string $values): self
+    {
+        $this->tags->put($name, array_merge($this->tags->get($name, []), (array) $values));
+
+        return $this;
+    }
+
+    /**
      * Save the tags collection to disk.
      *
      * @return $this

--- a/packages/framework/src/Framework/Features/Publications/Models/PublicationTags.php
+++ b/packages/framework/src/Framework/Features/Publications/Models/PublicationTags.php
@@ -31,9 +31,9 @@ class PublicationTags
     }
 
     /** @param  array<string>  $values */
-    public function addTag(string $name, array $values): self
+    public function addTag(string $name, array|string $values): self
     {
-        $this->tags->put($name, $values);
+        $this->tags->put($name, (array) $values);
 
         return $this;
     }

--- a/packages/framework/src/Framework/Features/Publications/Models/PublicationTags.php
+++ b/packages/framework/src/Framework/Features/Publications/Models/PublicationTags.php
@@ -27,6 +27,7 @@ class PublicationTags
         $this->tags = Collection::make($this->parseTagsFile());
     }
 
+    /** @return \Illuminate\Support\Collection<string, array<string>> */
     public function getTags(): Collection
     {
         return $this->tags;
@@ -50,6 +51,8 @@ class PublicationTags
 
     /**
      * Get all available tags.
+     *
+     * @return Collection<string, array<string>>
      */
     public static function getAllTags(): Collection
     {
@@ -58,12 +61,15 @@ class PublicationTags
 
     /**
      * Get all values for a given tag name.
+     *
+     * @return array<string>
      */
     public static function getValuesForTagName(string $tagName): array
     {
         return self::getAllTags()->get($tagName) ?? [];
     }
 
+    /** @return array<string, array<string>> */
     protected function parseTagsFile(): array
     {
         if (file_exists(Hyde::path('tags.json'))) {

--- a/packages/framework/src/Framework/Features/Publications/Models/PublicationTags.php
+++ b/packages/framework/src/Framework/Features/Publications/Models/PublicationTags.php
@@ -35,6 +35,12 @@ class PublicationTags
         return $this->tags;
     }
 
+    /** @return array<string> */
+    public function getTagsInGroup(string $name): array
+    {
+        return $this->tags->get($name) ?? [];
+    }
+
     /**
      * @param  array<string>|string  $values
      * @return $this
@@ -65,7 +71,7 @@ class PublicationTags
      */
     public function addTagsToGroup(string $name, array|string $values): self
     {
-        $this->tags->put($name, array_merge($this->tags->get($name, []), (array) $values));
+        $this->tags->put($name, array_merge($this->getTagsInGroup($name), (array) $values));
 
         return $this;
     }

--- a/packages/framework/src/Framework/Features/Publications/Models/PublicationTags.php
+++ b/packages/framework/src/Framework/Features/Publications/Models/PublicationTags.php
@@ -4,15 +4,15 @@ declare(strict_types=1);
 
 namespace Hyde\Framework\Features\Publications\Models;
 
-use Hyde\Facades\Filesystem;
-use Hyde\Framework\Exceptions\FileNotFoundException;
-use JsonException;
 use function file_exists;
 use function file_get_contents;
+use Hyde\Facades\Filesystem;
+use Hyde\Framework\Exceptions\FileNotFoundException;
 use Hyde\Hyde;
 use Illuminate\Support\Collection;
 use function json_decode;
 use function json_encode;
+use JsonException;
 
 /**
  * Object representation for the tags.json file.

--- a/packages/framework/src/Framework/Features/Publications/Models/PublicationTags.php
+++ b/packages/framework/src/Framework/Features/Publications/Models/PublicationTags.php
@@ -82,11 +82,8 @@ class PublicationTags
             throw new FileNotFoundException('tags.json');
         }
 
-        $tags = json_decode(file_get_contents(Hyde::path('tags.json')), true);
-
-        if (! is_array($tags) || empty($tags)) {
-            throw new JsonException('Could not decode tags.json');
-        }
+        $tags = json_decode(file_get_contents(Hyde::path('tags.json')), true)
+            ?: throw new JsonException('Could not decode tags.json');
 
         foreach ($tags as $name => $values) {
             assert(is_string($name));

--- a/packages/framework/src/Framework/Features/Publications/Models/PublicationTags.php
+++ b/packages/framework/src/Framework/Features/Publications/Models/PublicationTags.php
@@ -4,12 +4,10 @@ declare(strict_types=1);
 
 namespace Hyde\Framework\Features\Publications\Models;
 
-use Hyde\Hyde;
-
-use Illuminate\Support\Collection;
-
 use function file_exists;
 use function file_get_contents;
+use Hyde\Hyde;
+use Illuminate\Support\Collection;
 use function json_decode;
 
 /**

--- a/packages/framework/src/Framework/Features/Publications/Models/PublicationTags.php
+++ b/packages/framework/src/Framework/Features/Publications/Models/PublicationTags.php
@@ -82,8 +82,11 @@ class PublicationTags
             throw new FileNotFoundException('tags.json');
         }
 
-        $tags = json_decode(file_get_contents(Hyde::path('tags.json')), true)
-            ?: throw new JsonException('Could not decode tags.json');
+        $tags = json_decode(file_get_contents(Hyde::path('tags.json')), true);
+
+        if (! is_array($tags) || empty($tags)) {
+            throw new JsonException('Could not decode tags.json');
+        }
 
         foreach ($tags as $name => $values) {
             assert(is_string($name));

--- a/packages/framework/src/Framework/Features/Publications/Models/PublicationTags.php
+++ b/packages/framework/src/Framework/Features/Publications/Models/PublicationTags.php
@@ -24,12 +24,17 @@ class PublicationTags
         $this->tags = $this->parseTagsFile();
     }
 
+    public function getTags(): array
+    {
+        return $this->tags;
+    }
+
     /**
      * Get all available tags.
      */
     public static function getAllTags(): Collection
     {
-        return Collection::make((new self())->tags)->sortKeys();
+        return Collection::make((new self())->getTags())->sortKeys();
     }
 
     /**

--- a/packages/framework/src/Framework/Features/Publications/Models/PublicationTags.php
+++ b/packages/framework/src/Framework/Features/Publications/Models/PublicationTags.php
@@ -39,7 +39,7 @@ class PublicationTags
      * @param  array<string>|string  $values
      * @return $this
      */
-    public function addTag(string $name, array|string $values): self
+    public function addTagGroup(string $name, array|string $values): self
     {
         $this->tags->put($name, (array) $values);
 
@@ -50,10 +50,10 @@ class PublicationTags
      * @param  array<string, array<string>|string>  $tags
      * @return $this
      */
-    public function addTags(array $tags): self
+    public function addTagGroups(array $tags): self
     {
         foreach ($tags as $name => $values) {
-            $this->addTag($name, $values);
+            $this->addTagGroup($name, $values);
         }
 
         return $this;

--- a/packages/framework/src/Framework/Features/Publications/PublicationService.php
+++ b/packages/framework/src/Framework/Features/Publications/PublicationService.php
@@ -67,7 +67,7 @@ class PublicationService
      */
     public static function getValuesForTagName(string $tagName): Collection
     {
-        return PublicationTags::getValuesForTagName($tagName);
+        return collect(PublicationTags::getValuesForTagName($tagName));
     }
 
     /**

--- a/packages/framework/src/Framework/Features/Publications/PublicationService.php
+++ b/packages/framework/src/Framework/Features/Publications/PublicationService.php
@@ -4,8 +4,7 @@ declare(strict_types=1);
 
 namespace Hyde\Framework\Features\Publications;
 
-use function file_exists;
-use function file_get_contents;
+use Hyde\Framework\Features\Publications\Models\PublicationTags;
 use function glob;
 use Hyde\Framework\Actions\SourceFileParser;
 use Hyde\Framework\Features\Publications\Models\PublicationType;
@@ -13,7 +12,6 @@ use Hyde\Hyde;
 use Hyde\Pages\PublicationPage;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Str;
-use function json_decode;
 
 /**
  * @see \Hyde\Framework\Testing\Feature\Services\PublicationServiceTest
@@ -61,7 +59,7 @@ class PublicationService
      */
     public static function getAllTags(): Collection
     {
-        return Collection::make(self::parseTagsFile())->sortKeys();
+        return PublicationTags::getAllTags();
     }
 
     /**
@@ -69,7 +67,7 @@ class PublicationService
      */
     public static function getValuesForTagName(string $tagName): Collection
     {
-        return Collection::make(self::getAllTags()->get($tagName) ?? []);
+        return PublicationTags::getValuesForTagName($tagName);
     }
 
     /**
@@ -103,14 +101,5 @@ class PublicationService
     protected static function getMediaFiles(string $directory, string $extensions = '{jpg,jpeg,png,gif,pdf}'): array
     {
         return glob(Hyde::path("_media/$directory/*.$extensions"), GLOB_BRACE);
-    }
-
-    protected static function parseTagsFile(): array
-    {
-        if (file_exists(Hyde::path('tags.json'))) {
-            return json_decode(file_get_contents(Hyde::path('tags.json')), true);
-        }
-
-        return [];
     }
 }

--- a/packages/framework/src/Framework/Features/Publications/PublicationService.php
+++ b/packages/framework/src/Framework/Features/Publications/PublicationService.php
@@ -4,9 +4,9 @@ declare(strict_types=1);
 
 namespace Hyde\Framework\Features\Publications;
 
-use Hyde\Framework\Features\Publications\Models\PublicationTags;
 use function glob;
 use Hyde\Framework\Actions\SourceFileParser;
+use Hyde\Framework\Features\Publications\Models\PublicationTags;
 use Hyde\Framework\Features\Publications\Models\PublicationType;
 use Hyde\Hyde;
 use Hyde\Pages\PublicationPage;

--- a/packages/framework/tests/Feature/PublicationTagsTest.php
+++ b/packages/framework/tests/Feature/PublicationTagsTest.php
@@ -4,10 +4,15 @@ declare(strict_types=1);
 
 namespace Hyde\Framework\Testing\Feature;
 
+use Hyde\Framework\Exceptions\FileNotFoundException;
 use Hyde\Framework\Features\Publications\Models\PublicationTags;
 use Hyde\Hyde;
 use Hyde\Testing\TestCase;
 use Illuminate\Support\Collection;
+
+use JsonException;
+
+use function json_encode;
 
 /**
  * @covers \Hyde\Framework\Features\Publications\Models\PublicationTags
@@ -123,5 +128,34 @@ class PublicationTagsTest extends TestCase
     public function testGetValuesForTagNameWithNoTags()
     {
         $this->assertSame([], PublicationTags::getValuesForTagName('foo'));
+    }
+
+    public function testValidateTagsFileWithValidFile()
+    {
+        $this->file('tags.json', json_encode(['foo' => ['bar', 'baz']]));
+
+        $this->assertTrue(PublicationTags::validateTagsFile());
+    }
+
+    public function testValidateTagsFileWithInvalidFile()
+    {
+        $this->file('tags.json', 'invalid json');
+
+        $this->expectException(JsonException::class);
+        PublicationTags::validateTagsFile();
+    }
+
+    public function testValidateTagsFileWithNoFile()
+    {
+        $this->expectException(FileNotFoundException::class);
+        PublicationTags::validateTagsFile();
+    }
+
+    public function testValidateTagsFileWithEmptyJsonFile()
+    {
+        $this->file('tags.json', json_encode([]));
+
+        $this->expectException(JsonException::class);
+        PublicationTags::validateTagsFile();
     }
 }

--- a/packages/framework/tests/Feature/PublicationTagsTest.php
+++ b/packages/framework/tests/Feature/PublicationTagsTest.php
@@ -134,7 +134,8 @@ class PublicationTagsTest extends TestCase
     {
         $this->file('tags.json', json_encode(['foo' => ['bar', 'baz']]));
 
-        $this->assertTrue(PublicationTags::validateTagsFile());
+        PublicationTags::validateTagsFile();
+        $this->assertTrue(true);
     }
 
     public function testValidateTagsFileWithInvalidFile()

--- a/packages/framework/tests/Feature/PublicationTagsTest.php
+++ b/packages/framework/tests/Feature/PublicationTagsTest.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Hyde\Framework\Testing\Feature;
+
+use Hyde\Framework\Features\Publications\Models\PublicationTags;
+use Hyde\Testing\TestCase;
+
+/**
+ * @covers \Hyde\Framework\Features\Publications\Models\PublicationTags
+ */
+class PublicationTagsTest extends TestCase
+{
+    //
+}

--- a/packages/framework/tests/Feature/PublicationTagsTest.php
+++ b/packages/framework/tests/Feature/PublicationTagsTest.php
@@ -73,6 +73,28 @@ class PublicationTagsTest extends TestCase
         ], $tags->getTags()->toArray());
     }
 
+    public function testCanAddTagsToExistingGroup()
+    {
+        $tags = new PublicationTags();
+        $tags->addTagGroup('test', ['foo']);
+        $tags->addTagsToGroup('test', ['bar', 'baz']);
+
+        $this->assertEquals(new Collection([
+            'test' => ['foo', 'bar', 'baz'],
+        ]), $tags->getTags());
+    }
+
+    public function testCanAddSingleTagToExistingGroup()
+    {
+        $tags = new PublicationTags();
+        $tags->addTagGroup('test', ['foo']);
+        $tags->addTagsToGroup('test', 'bar');
+
+        $this->assertEquals(new Collection([
+            'test' => ['foo', 'bar'],
+        ]), $tags->getTags());
+    }
+
     public function testCanSaveTagsToDisk()
     {
         $tags = new PublicationTags();

--- a/packages/framework/tests/Feature/PublicationTagsTest.php
+++ b/packages/framework/tests/Feature/PublicationTagsTest.php
@@ -23,6 +23,16 @@ class PublicationTagsTest extends TestCase
         ]), $tags->getTags());
     }
 
+    public function testCanAddTagsWithSingleValue()
+    {
+        $tags = new PublicationTags();
+        $tags->addTag('test', 'test1');
+
+        $this->assertEquals(new Collection([
+            'test' => ['test1'],
+        ]), $tags->getTags());
+    }
+
     public function testGetAllTags()
     {
         $tags = [

--- a/packages/framework/tests/Feature/PublicationTagsTest.php
+++ b/packages/framework/tests/Feature/PublicationTagsTest.php
@@ -9,10 +9,8 @@ use Hyde\Framework\Features\Publications\Models\PublicationTags;
 use Hyde\Hyde;
 use Hyde\Testing\TestCase;
 use Illuminate\Support\Collection;
-
-use JsonException;
-
 use function json_encode;
+use JsonException;
 
 /**
  * @covers \Hyde\Framework\Features\Publications\Models\PublicationTags

--- a/packages/framework/tests/Feature/PublicationTagsTest.php
+++ b/packages/framework/tests/Feature/PublicationTagsTest.php
@@ -65,7 +65,7 @@ class PublicationTagsTest extends TestCase
 
         $this->file('tags.json', json_encode($tags));
 
-        $this->assertSame(['bar', 'baz'], PublicationTags::getValuesForTagName('foo')->toArray());
+        $this->assertSame(['bar', 'baz'], PublicationTags::getValuesForTagName('foo'));
     }
 
     public function testGetValuesForTagNameWithMissingTagName()
@@ -79,11 +79,11 @@ class PublicationTagsTest extends TestCase
 
         $this->file('tags.json', json_encode($tags));
 
-        $this->assertSame([], PublicationTags::getValuesForTagName('bar')->toArray());
+        $this->assertSame([], PublicationTags::getValuesForTagName('bar'));
     }
 
     public function testGetValuesForTagNameWithNoTags()
     {
-        $this->assertSame([], PublicationTags::getValuesForTagName('foo')->toArray());
+        $this->assertSame([], PublicationTags::getValuesForTagName('foo'));
     }
 }

--- a/packages/framework/tests/Feature/PublicationTagsTest.php
+++ b/packages/framework/tests/Feature/PublicationTagsTest.php
@@ -54,6 +54,25 @@ class PublicationTagsTest extends TestCase
         ]), $tags->getTags());
     }
 
+    public function testCanAddMultipleTags()
+    {
+        $expected = new PublicationTags();
+        $expected->addTag('test', ['test1', 'test2']);
+        $expected->addTag('test2', ['test3', 'test4']);
+
+        $tags = new PublicationTags();
+        $tags->addTags([
+            'test' => ['test1', 'test2'],
+            'test2' => ['test3', 'test4'],
+        ]);
+
+        $this->assertEquals($expected->getTags(), $tags->getTags());
+        $this->assertSame([
+            'test' => ['test1', 'test2'],
+            'test2' => ['test3', 'test4'],
+        ], $tags->getTags()->toArray());
+    }
+
     public function testCanSaveTagsToDisk()
     {
         $tags = new PublicationTags();

--- a/packages/framework/tests/Feature/PublicationTagsTest.php
+++ b/packages/framework/tests/Feature/PublicationTagsTest.php
@@ -14,6 +14,23 @@ use Illuminate\Support\Collection;
  */
 class PublicationTagsTest extends TestCase
 {
+    public function canConstructNewTagsInstance()
+    {
+        $this->assertInstanceOf(PublicationTags::class, new PublicationTags());
+    }
+
+    public function testConstructorAutomaticallyLoadsTagsFile()
+    {
+        $this->file('tags.json', json_encode(['foo' => ['bar', 'baz']]));
+
+        $this->assertEquals(new Collection(['foo' => ['bar', 'baz']]), (new PublicationTags())->getTags());
+    }
+
+    public function testConstructorAddsEmptyArrayWhenThereIsNoTagsFile()
+    {
+        $this->assertEquals(new Collection(), (new PublicationTags())->getTags());
+    }
+
     public function testCanAddTags()
     {
         $tags = new PublicationTags();

--- a/packages/framework/tests/Feature/PublicationTagsTest.php
+++ b/packages/framework/tests/Feature/PublicationTagsTest.php
@@ -41,6 +41,30 @@ class PublicationTagsTest extends TestCase
         $this->assertEquals(new Collection(['foo' => ['bar', 'baz']]), (new PublicationTags())->getTags());
     }
 
+    public function testGetTagsInGroup()
+    {
+        $this->file('tags.json', json_encode(['foo' => ['bar', 'baz']]));
+
+        $this->assertEquals(['bar', 'baz'], (new PublicationTags())->getTagsInGroup('foo'));
+    }
+
+    public function testGetTagsInGroupOnlyReturnTagsForTheSpecifiedGroup()
+    {
+        $this->file('tags.json', json_encode([
+            'foo' => ['bar', 'baz'],
+            'bar' => ['foo', 'baz'],
+        ]));
+
+        $this->assertEquals(['foo', 'baz'], (new PublicationTags())->getTagsInGroup('bar'));
+    }
+
+    public function testGetTagsInGroupReturnsEmptyArrayWhenGroupDoesNotExist()
+    {
+        $this->file('tags.json', json_encode(['foo' => ['bar', 'baz']]));
+
+        $this->assertEquals([], (new PublicationTags())->getTagsInGroup('bar'));
+    }
+
     public function testCanAddTagGroup()
     {
         $tags = new PublicationTags();

--- a/packages/framework/tests/Feature/PublicationTagsTest.php
+++ b/packages/framework/tests/Feature/PublicationTagsTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Hyde\Framework\Testing\Feature;
 
 use Hyde\Framework\Features\Publications\Models\PublicationTags;
+use Hyde\Hyde;
 use Hyde\Testing\TestCase;
 use Illuminate\Support\Collection;
 
@@ -31,6 +32,26 @@ class PublicationTagsTest extends TestCase
         $this->assertEquals(new Collection([
             'test' => ['test1'],
         ]), $tags->getTags());
+    }
+
+    public function testCanSaveTagsToDisk()
+    {
+        $tags = new PublicationTags();
+        $tags->addTag('test', ['test1', 'test2']);
+        $tags->save();
+
+        $this->assertSame(
+            <<<'JSON'
+            {
+                "test": [
+                    "test1",
+                    "test2"
+                ]
+            }
+            JSON, file_get_contents(Hyde::path('tags.json'))
+        );
+
+        unlink(Hyde::path('tags.json'));
     }
 
     public function testGetAllTags()

--- a/packages/framework/tests/Feature/PublicationTagsTest.php
+++ b/packages/framework/tests/Feature/PublicationTagsTest.php
@@ -26,7 +26,7 @@ class PublicationTagsTest extends TestCase
     {
         $this->file('tags.json', json_encode(['foo' => ['bar', 'baz']]));
 
-        $this->assertEquals(new Collection(['foo' => ['bar', 'baz']]), (new PublicationTags())->getTags());
+        $this->assertSame(['foo' => ['bar', 'baz']], (new PublicationTags())->getTags()->toArray());
     }
 
     public function testConstructorAddsEmptyArrayWhenThereIsNoTagsFile()

--- a/packages/framework/tests/Feature/PublicationTagsTest.php
+++ b/packages/framework/tests/Feature/PublicationTagsTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Hyde\Framework\Testing\Feature;
 
+use Hyde\Framework\Features\Publications\Models\PublicationTags;
 use Hyde\Testing\TestCase;
 
 /**
@@ -11,5 +12,57 @@ use Hyde\Testing\TestCase;
  */
 class PublicationTagsTest extends TestCase
 {
-    //
+    public function testGetAllTags()
+    {
+        $tags = [
+            'foo' => [
+                'bar',
+                'baz',
+            ],
+        ];
+        $this->file('tags.json', json_encode($tags));
+        $this->assertSame($tags, PublicationTags::getAllTags()->toArray());
+    }
+
+    public function testGetAllTagsWithNoTags()
+    {
+        $this->assertSame([], PublicationTags::getAllTags()->toArray());
+    }
+
+    public function testGetValuesForTagName()
+    {
+        $tags = [
+            'foo' => [
+                'bar',
+                'baz',
+            ],
+            'bar' => [
+                'baz',
+                'qux',
+            ],
+        ];
+
+        $this->file('tags.json', json_encode($tags));
+
+        $this->assertSame(['bar', 'baz'], PublicationTags::getValuesForTagName('foo')->toArray());
+    }
+
+    public function testGetValuesForTagNameWithMissingTagName()
+    {
+        $tags = [
+            'foo' => [
+                'bar',
+                'baz',
+            ],
+        ];
+
+        $this->file('tags.json', json_encode($tags));
+
+        $this->assertSame([], PublicationTags::getValuesForTagName('bar')->toArray());
+    }
+
+    public function testGetValuesForTagNameWithNoTags()
+    {
+        $this->assertSame([], PublicationTags::getValuesForTagName('foo')->toArray());
+    }
 }

--- a/packages/framework/tests/Feature/PublicationTagsTest.php
+++ b/packages/framework/tests/Feature/PublicationTagsTest.php
@@ -6,12 +6,23 @@ namespace Hyde\Framework\Testing\Feature;
 
 use Hyde\Framework\Features\Publications\Models\PublicationTags;
 use Hyde\Testing\TestCase;
+use Illuminate\Support\Collection;
 
 /**
  * @covers \Hyde\Framework\Features\Publications\Models\PublicationTags
  */
 class PublicationTagsTest extends TestCase
 {
+    public function testCanAddTags()
+    {
+        $tags = new PublicationTags();
+        $tags->addTag('test', ['test1', 'test2']);
+
+        $this->assertEquals(new Collection([
+            'test' => ['test1', 'test2'],
+        ]), $tags->getTags());
+    }
+
     public function testGetAllTags()
     {
         $tags = [

--- a/packages/framework/tests/Feature/PublicationTagsTest.php
+++ b/packages/framework/tests/Feature/PublicationTagsTest.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Hyde\Framework\Testing\Feature;
 
-use Hyde\Framework\Features\Publications\Models\PublicationTags;
 use Hyde\Testing\TestCase;
 
 /**

--- a/packages/framework/tests/Feature/PublicationTagsTest.php
+++ b/packages/framework/tests/Feature/PublicationTagsTest.php
@@ -34,34 +34,34 @@ class PublicationTagsTest extends TestCase
         $this->assertEquals(new Collection(), (new PublicationTags())->getTags());
     }
 
-    public function testCanAddTags()
+    public function testCanAddTagGroup()
     {
         $tags = new PublicationTags();
-        $tags->addTag('test', ['test1', 'test2']);
+        $tags->addTagGroup('test', ['test1', 'test2']);
 
         $this->assertEquals(new Collection([
             'test' => ['test1', 'test2'],
         ]), $tags->getTags());
     }
 
-    public function testCanAddTagsWithSingleValue()
+    public function testCanAddTagGroupWithSingleValue()
     {
         $tags = new PublicationTags();
-        $tags->addTag('test', 'test1');
+        $tags->addTagGroup('test', 'test1');
 
         $this->assertEquals(new Collection([
             'test' => ['test1'],
         ]), $tags->getTags());
     }
 
-    public function testCanAddMultipleTags()
+    public function testCanAddMultipleTagGroups()
     {
         $expected = new PublicationTags();
-        $expected->addTag('test', ['test1', 'test2']);
-        $expected->addTag('test2', ['test3', 'test4']);
+        $expected->addTagGroup('test', ['test1', 'test2']);
+        $expected->addTagGroup('test2', ['test3', 'test4']);
 
         $tags = new PublicationTags();
-        $tags->addTags([
+        $tags->addTagGroups([
             'test' => ['test1', 'test2'],
             'test2' => ['test3', 'test4'],
         ]);
@@ -76,7 +76,7 @@ class PublicationTagsTest extends TestCase
     public function testCanSaveTagsToDisk()
     {
         $tags = new PublicationTags();
-        $tags->addTag('test', ['test1', 'test2']);
+        $tags->addTagGroup('test', ['test1', 'test2']);
         $tags->save();
 
         $this->assertSame(

--- a/packages/framework/tests/Feature/PublicationTagsTest.php
+++ b/packages/framework/tests/Feature/PublicationTagsTest.php
@@ -34,6 +34,13 @@ class PublicationTagsTest extends TestCase
         $this->assertEquals(new Collection(), (new PublicationTags())->getTags());
     }
 
+    public function testGetTags()
+    {
+        $this->file('tags.json', json_encode(['foo' => ['bar', 'baz']]));
+
+        $this->assertEquals(new Collection(['foo' => ['bar', 'baz']]), (new PublicationTags())->getTags());
+    }
+
     public function testCanAddTagGroup()
     {
         $tags = new PublicationTags();

--- a/packages/framework/tests/Feature/Services/PublicationServiceTest.php
+++ b/packages/framework/tests/Feature/Services/PublicationServiceTest.php
@@ -148,6 +148,7 @@ class PublicationServiceTest extends TestCase
         $this->assertTrue(PublicationService::publicationTypeExists('test-publication'));
         $this->assertFalse(PublicationService::publicationTypeExists('foo'));
     }
+
     public function testGetAllTags()
     {
         $tags = [

--- a/packages/framework/tests/Feature/Services/PublicationServiceTest.php
+++ b/packages/framework/tests/Feature/Services/PublicationServiceTest.php
@@ -148,7 +148,6 @@ class PublicationServiceTest extends TestCase
         $this->assertTrue(PublicationService::publicationTypeExists('test-publication'));
         $this->assertFalse(PublicationService::publicationTypeExists('foo'));
     }
-
     public function testGetAllTags()
     {
         $tags = [
@@ -159,11 +158,6 @@ class PublicationServiceTest extends TestCase
         ];
         $this->file('tags.json', json_encode($tags));
         $this->assertSame($tags, PublicationService::getAllTags()->toArray());
-    }
-
-    public function testGetAllTagsWithNoTags()
-    {
-        $this->assertSame([], PublicationService::getAllTags()->toArray());
     }
 
     public function testGetValuesForTagName()
@@ -182,25 +176,6 @@ class PublicationServiceTest extends TestCase
         $this->file('tags.json', json_encode($tags));
 
         $this->assertSame(['bar', 'baz'], PublicationService::getValuesForTagName('foo')->toArray());
-    }
-
-    public function testGetValuesForTagNameWithMissingTagName()
-    {
-        $tags = [
-            'foo' => [
-                'bar',
-                'baz',
-            ],
-        ];
-
-        $this->file('tags.json', json_encode($tags));
-
-        $this->assertSame([], PublicationService::getValuesForTagName('bar')->toArray());
-    }
-
-    public function testGetValuesForTagNameWithNoTags()
-    {
-        $this->assertSame([], PublicationService::getValuesForTagName('foo')->toArray());
     }
 
     protected function createPublicationType(): void


### PR DESCRIPTION
This refactor solves two problems:
1. It groups together related logic in a single class
2. It makes the data structure of the tags file more clear and structured thanks to rich type annotations