### PR TITLE
Add back the tagGroup option for publication tag fields

### DIFF
--- a/packages/framework/src/Console/Commands/MakePublicationCommand.php
+++ b/packages/framework/src/Console/Commands/MakePublicationCommand.php
@@ -155,7 +155,7 @@ class MakePublicationCommand extends ValidatingCommand
 
     protected function captureTagFieldInput(PublicationFieldDefinition $field): ?PublicationFieldValue
     {
-        $tagGroup = $field->tagGroup;
+        $tagGroup = $field->tagGroup ?? throw new InvalidArgumentException("Tag field $field->name is missing tagGroup property");
         $this->infoComment('Select a tag for field', $field->name, "from the $tagGroup group");
 
         $options = PublicationService::getValuesForTagName($tagGroup);

--- a/packages/framework/src/Console/Commands/MakePublicationCommand.php
+++ b/packages/framework/src/Console/Commands/MakePublicationCommand.php
@@ -165,7 +165,7 @@ class MakePublicationCommand extends ValidatingCommand
 
         $this->tip('You can enter multiple tags separated by commas');
 
-        $choice = $this->reloadableChoice($this->getReloadableTagValuesArrayClosure(),
+        $choice = $this->reloadableChoice($this->getReloadableTagValuesArrayClosure($tagGroup),
             'Which tag would you like to use?',
             'Reload tags.json',
             true
@@ -211,10 +211,10 @@ class MakePublicationCommand extends ValidatingCommand
     }
 
     /** @return Closure<array<string>> */
-    protected function getReloadableTagValuesArrayClosure(): Closure
+    protected function getReloadableTagValuesArrayClosure(string $tagGroup): Closure
     {
-        return function (): array {
-            return PublicationService::getValuesForTagName($this->publicationType->getIdentifier())->toArray();
+        return function () use ($tagGroup): array {
+            return PublicationService::getValuesForTagName($tagGroup)->toArray();
         };
     }
 }

--- a/packages/framework/src/Console/Commands/MakePublicationCommand.php
+++ b/packages/framework/src/Console/Commands/MakePublicationCommand.php
@@ -155,9 +155,10 @@ class MakePublicationCommand extends ValidatingCommand
 
     protected function captureTagFieldInput(PublicationFieldDefinition $field): ?PublicationFieldValue
     {
-        $this->infoComment('Select a tag for field', $field->name, "from the {$this->publicationType->getIdentifier()} group");
+        $tagGroup = $this->publicationType->getIdentifier();
+        $this->infoComment('Select a tag for field', $field->name, "from the $tagGroup group");
 
-        $options = PublicationService::getValuesForTagName($this->publicationType->getIdentifier());
+        $options = PublicationService::getValuesForTagName($tagGroup);
         if ($options->isEmpty()) {
             return $this->handleEmptyOptionsCollection($field, 'tag', 'No tags for this publication type found in tags.json');
         }

--- a/packages/framework/src/Console/Commands/MakePublicationCommand.php
+++ b/packages/framework/src/Console/Commands/MakePublicationCommand.php
@@ -155,7 +155,7 @@ class MakePublicationCommand extends ValidatingCommand
 
     protected function captureTagFieldInput(PublicationFieldDefinition $field): ?PublicationFieldValue
     {
-        $tagGroup = $field->tagGroup ?? throw new InvalidArgumentException("Tag field $field->name is missing tagGroup property");
+        $tagGroup = $field->tagGroup ?? throw new InvalidArgumentException("Tag field '$field->name' is missing the 'tagGroup' property");
         $this->infoComment('Select a tag for field', $field->name, "from the $tagGroup group");
 
         $options = PublicationService::getValuesForTagName($tagGroup);

--- a/packages/framework/src/Console/Commands/MakePublicationCommand.php
+++ b/packages/framework/src/Console/Commands/MakePublicationCommand.php
@@ -155,7 +155,7 @@ class MakePublicationCommand extends ValidatingCommand
 
     protected function captureTagFieldInput(PublicationFieldDefinition $field): ?PublicationFieldValue
     {
-        $tagGroup = $this->publicationType->getIdentifier();
+        $tagGroup = $field->tagGroup;
         $this->infoComment('Select a tag for field', $field->name, "from the $tagGroup group");
 
         $options = PublicationService::getValuesForTagName($tagGroup);

--- a/packages/framework/src/Console/Commands/MakePublicationTypeCommand.php
+++ b/packages/framework/src/Console/Commands/MakePublicationTypeCommand.php
@@ -103,6 +103,10 @@ class MakePublicationTypeCommand extends ValidatingCommand
 
         // TODO: Here we could collect other data like the "rules" array for the field.
 
+        if ($fieldType === PublicationFieldTypes::Tag) {
+            $tagGroup = $this->getTagGroup();
+        }
+
         return new PublicationFieldDefinition($fieldType, $fieldName);
     }
 
@@ -124,6 +128,13 @@ class MakePublicationTypeCommand extends ValidatingCommand
         $choice = $this->choice("Enter type for field #{$this->getCount()}", $options, 'String');
 
         return PublicationFieldTypes::from(strtolower($choice));
+    }
+
+    protected function getTagGroup(): string
+    {
+        $selected = trim($this->askWithValidation('name', "Enter tag group for field #{$this->getCount()}", ['required']));
+
+        return $selected;
     }
 
     protected function getCanonicalField(): PublicationFieldDefinition

--- a/packages/framework/src/Console/Commands/MakePublicationTypeCommand.php
+++ b/packages/framework/src/Console/Commands/MakePublicationTypeCommand.php
@@ -139,7 +139,9 @@ class MakePublicationTypeCommand extends ValidatingCommand
             $this->error('No tag groups have been added to tags.json');
             if ($this->confirm('Would you like to add some tags now?')) {
                 $this->call('make:publicationTag');
-                $this->comment("\nOkay, we're back on track!");
+
+                $this->newLine();
+                $this->comment("Okay, we're back on track!");
             } else {
                 throw new InvalidArgumentException('Can not create a tag field without any tag groups defined in tags.json');
             }

--- a/packages/framework/src/Console/Commands/MakePublicationTypeCommand.php
+++ b/packages/framework/src/Console/Commands/MakePublicationTypeCommand.php
@@ -135,7 +135,7 @@ class MakePublicationTypeCommand extends ValidatingCommand
 
         $choice = $this->choice("Enter type for field #{$this->getCount()}", $options, 'String');
 
-        if (str_contains($choice, 'no tags defined')) {
+        if (empty(PublicationTags::getTagGroups()) && (str_contains($choice, 'no tags defined') || ($choice === 'Tag'))) {
             throw new InvalidArgumentException('Can not create a tag field without any tag groups defined in tags.json.');
         }
 

--- a/packages/framework/src/Console/Commands/MakePublicationTypeCommand.php
+++ b/packages/framework/src/Console/Commands/MakePublicationTypeCommand.php
@@ -134,16 +134,15 @@ class MakePublicationTypeCommand extends ValidatingCommand
         }
 
         $choice = $this->choice("Enter type for field #{$this->getCount()}", $options, 'String');
-
-        if (empty(PublicationTags::getTagGroups()) && (str_contains($choice, 'no tags defined') || ($choice === 'Tag'))) {
-            throw new InvalidArgumentException('Can not create a tag field without any tag groups defined in tags.json');
-        }
-
         return PublicationFieldTypes::from(strtolower($choice));
     }
 
     protected function getTagGroup(): string
     {
+        if (empty(PublicationTags::getTagGroups())) {
+            throw new InvalidArgumentException('Can not create a tag field without any tag groups defined in tags.json');
+        }
+
         return $this->choice("Enter tag group for field #{$this->getCount()}", PublicationTags::getTagGroups());
     }
 

--- a/packages/framework/src/Console/Commands/MakePublicationTypeCommand.php
+++ b/packages/framework/src/Console/Commands/MakePublicationTypeCommand.php
@@ -135,7 +135,7 @@ class MakePublicationTypeCommand extends ValidatingCommand
 
     protected function getTagGroup(): string
     {
-        return trim($this->anticipate("Enter tag group for field #{$this->getCount()}", PublicationTags::getTagGroups()));
+        return $this->choice("Enter tag group for field #{$this->getCount()}", PublicationTags::getTagGroups());
     }
 
     protected function getCanonicalField(): PublicationFieldDefinition

--- a/packages/framework/src/Console/Commands/MakePublicationTypeCommand.php
+++ b/packages/framework/src/Console/Commands/MakePublicationTypeCommand.php
@@ -128,6 +128,10 @@ class MakePublicationTypeCommand extends ValidatingCommand
     {
         $options = PublicationFieldTypes::names();
 
+        if (empty(PublicationTags::getTagGroups())) {
+            $options[9] = "<fg=gray>\e[9mTag\e[0m</>";
+        }
+
         $choice = $this->choice("Enter type for field #{$this->getCount()}", $options, 'String');
 
         return PublicationFieldTypes::from(strtolower($choice));

--- a/packages/framework/src/Console/Commands/MakePublicationTypeCommand.php
+++ b/packages/framework/src/Console/Commands/MakePublicationTypeCommand.php
@@ -129,12 +129,12 @@ class MakePublicationTypeCommand extends ValidatingCommand
         $options = PublicationFieldTypes::names();
 
         if (empty(PublicationTags::getTagGroups())) {
-            $options[9] = "<fg=gray>\e[9mTag\e[0m</>";
+            $options[9] = "<fg=gray>\e[9mTag\e[0m</> <fg=gray>(no tags defined)</>";
         }
 
         $choice = $this->choice("Enter type for field #{$this->getCount()}", $options, 'String');
 
-        if ($choice === "<fg=gray>\e[9mTag\e[0m</>") {
+        if ($choice === "<fg=gray>\e[9mTag\e[0m</> <fg=gray>(no tags defined)</>") {
             $this->error('Error: Can not create a tag field without any tag groups defined.');
             $this->warn('Please create a tag group first, or choose a different field type.');
             if ($this->confirm('Select another type for this field?', true)) {

--- a/packages/framework/src/Console/Commands/MakePublicationTypeCommand.php
+++ b/packages/framework/src/Console/Commands/MakePublicationTypeCommand.php
@@ -18,7 +18,6 @@ use function is_dir;
 use function is_file;
 use LaravelZero\Framework\Commands\Command;
 use function scandir;
-use function str_contains;
 use function strtolower;
 use function trim;
 
@@ -130,6 +129,7 @@ class MakePublicationTypeCommand extends ValidatingCommand
         $options = PublicationFieldTypes::names();
 
         $choice = $this->choice("Enter type for field #{$this->getCount()}", $options, 'String');
+
         return PublicationFieldTypes::from(strtolower($choice));
     }
 

--- a/packages/framework/src/Console/Commands/MakePublicationTypeCommand.php
+++ b/packages/framework/src/Console/Commands/MakePublicationTypeCommand.php
@@ -132,9 +132,7 @@ class MakePublicationTypeCommand extends ValidatingCommand
 
     protected function getTagGroup(): string
     {
-        $selected = trim($this->askWithValidation('name', "Enter tag group for field #{$this->getCount()}", ['required']));
-
-        return $selected;
+        return trim($this->askWithValidation('name', "Enter tag group for field #{$this->getCount()}", ['required']));
     }
 
     protected function getCanonicalField(): PublicationFieldDefinition

--- a/packages/framework/src/Console/Commands/MakePublicationTypeCommand.php
+++ b/packages/framework/src/Console/Commands/MakePublicationTypeCommand.php
@@ -105,6 +105,7 @@ class MakePublicationTypeCommand extends ValidatingCommand
 
         if ($fieldType === PublicationFieldTypes::Tag) {
             $tagGroup = $this->getTagGroup();
+            return new PublicationFieldDefinition($fieldType, $fieldName, tagGroup: $tagGroup);
         }
 
         return new PublicationFieldDefinition($fieldType, $fieldName);

--- a/packages/framework/src/Console/Commands/MakePublicationTypeCommand.php
+++ b/packages/framework/src/Console/Commands/MakePublicationTypeCommand.php
@@ -18,6 +18,7 @@ use function is_dir;
 use function is_file;
 use LaravelZero\Framework\Commands\Command;
 use function scandir;
+use function str_contains;
 use function strtolower;
 use function trim;
 
@@ -134,14 +135,8 @@ class MakePublicationTypeCommand extends ValidatingCommand
 
         $choice = $this->choice("Enter type for field #{$this->getCount()}", $options, 'String');
 
-        if ($choice === "<fg=gray>\e[9mTag\e[0m</> <fg=gray>(no tags defined)</>") {
-            $this->error('Error: Can not create a tag field without any tag groups defined.');
-            $this->warn('Please create a tag group first, or choose a different field type.');
-            if ($this->confirm('Select another type for this field?', true)) {
-                return $this->getFieldType();
-            } else {
-                throw new InvalidArgumentException('No field type selected');
-            }
+        if (str_contains($choice, 'no tags defined')) {
+            throw new InvalidArgumentException('Can not create a tag field without any tag groups defined in tags.json.');
         }
 
         return PublicationFieldTypes::from(strtolower($choice));

--- a/packages/framework/src/Console/Commands/MakePublicationTypeCommand.php
+++ b/packages/framework/src/Console/Commands/MakePublicationTypeCommand.php
@@ -137,6 +137,11 @@ class MakePublicationTypeCommand extends ValidatingCommand
         if ($choice === "<fg=gray>\e[9mTag\e[0m</>") {
             $this->error('Error: Can not create a tag field without any tag groups defined.');
             $this->warn('Please create a tag group first, or choose a different field type.');
+            if ($this->confirm('Select another type for this field?', true)) {
+                return $this->getFieldType();
+            } else {
+                throw new InvalidArgumentException('No field type selected');
+            }
         }
 
         return PublicationFieldTypes::from(strtolower($choice));

--- a/packages/framework/src/Console/Commands/MakePublicationTypeCommand.php
+++ b/packages/framework/src/Console/Commands/MakePublicationTypeCommand.php
@@ -134,6 +134,11 @@ class MakePublicationTypeCommand extends ValidatingCommand
 
         $choice = $this->choice("Enter type for field #{$this->getCount()}", $options, 'String');
 
+        if ($choice === "<fg=gray>\e[9mTag\e[0m</>") {
+            $this->error('Error: Can not create a tag field without any tag groups defined.');
+            $this->warn('Please create a tag group first, or choose a different field type.');
+        }
+
         return PublicationFieldTypes::from(strtolower($choice));
     }
 

--- a/packages/framework/src/Console/Commands/MakePublicationTypeCommand.php
+++ b/packages/framework/src/Console/Commands/MakePublicationTypeCommand.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Hyde\Console\Commands;
 
+use Hyde\Framework\Features\Publications\Models\PublicationTags;
 use function array_keys;
 use Hyde\Console\Concerns\ValidatingCommand;
 use Hyde\Framework\Actions\CreatesNewPublicationType;
@@ -133,7 +134,7 @@ class MakePublicationTypeCommand extends ValidatingCommand
 
     protected function getTagGroup(): string
     {
-        return trim($this->askWithValidation('name', "Enter tag group for field #{$this->getCount()}", ['required']));
+        return trim($this->anticipate("Enter tag group for field #{$this->getCount()}", PublicationTags::getTagGroups()));
     }
 
     protected function getCanonicalField(): PublicationFieldDefinition

--- a/packages/framework/src/Console/Commands/MakePublicationTypeCommand.php
+++ b/packages/framework/src/Console/Commands/MakePublicationTypeCommand.php
@@ -129,10 +129,6 @@ class MakePublicationTypeCommand extends ValidatingCommand
     {
         $options = PublicationFieldTypes::names();
 
-        if (empty(PublicationTags::getTagGroups())) {
-            $options[9] = "<fg=gray>\e[9mTag\e[0m</> <fg=gray>(no tags defined)</>";
-        }
-
         $choice = $this->choice("Enter type for field #{$this->getCount()}", $options, 'String');
         return PublicationFieldTypes::from(strtolower($choice));
     }

--- a/packages/framework/src/Console/Commands/MakePublicationTypeCommand.php
+++ b/packages/framework/src/Console/Commands/MakePublicationTypeCommand.php
@@ -136,7 +136,7 @@ class MakePublicationTypeCommand extends ValidatingCommand
         $choice = $this->choice("Enter type for field #{$this->getCount()}", $options, 'String');
 
         if (empty(PublicationTags::getTagGroups()) && (str_contains($choice, 'no tags defined') || ($choice === 'Tag'))) {
-            throw new InvalidArgumentException('Can not create a tag field without any tag groups defined in tags.json.');
+            throw new InvalidArgumentException('Can not create a tag field without any tag groups defined in tags.json');
         }
 
         return PublicationFieldTypes::from(strtolower($choice));

--- a/packages/framework/src/Console/Commands/MakePublicationTypeCommand.php
+++ b/packages/framework/src/Console/Commands/MakePublicationTypeCommand.php
@@ -4,11 +4,11 @@ declare(strict_types=1);
 
 namespace Hyde\Console\Commands;
 
-use Hyde\Framework\Features\Publications\Models\PublicationTags;
 use function array_keys;
 use Hyde\Console\Concerns\ValidatingCommand;
 use Hyde\Framework\Actions\CreatesNewPublicationType;
 use Hyde\Framework\Features\Publications\Models\PublicationFieldDefinition;
+use Hyde\Framework\Features\Publications\Models\PublicationTags;
 use Hyde\Framework\Features\Publications\PublicationFieldTypes;
 use Hyde\Hyde;
 use Illuminate\Support\Collection;

--- a/packages/framework/src/Console/Commands/MakePublicationTypeCommand.php
+++ b/packages/framework/src/Console/Commands/MakePublicationTypeCommand.php
@@ -136,7 +136,13 @@ class MakePublicationTypeCommand extends ValidatingCommand
     protected function getTagGroup(): string
     {
         if (empty(PublicationTags::getTagGroups())) {
-            throw new InvalidArgumentException('Can not create a tag field without any tag groups defined in tags.json');
+            $this->error('No tag groups have been added to tags.json');
+            if ($this->confirm('Would you like to add some tags now?')) {
+                $this->call('make:publicationTag');
+                $this->comment("\nOkay, we're back on track!");
+            } else {
+                throw new InvalidArgumentException('Can not create a tag field without any tag groups defined in tags.json');
+            }
         }
 
         return $this->choice("Enter tag group for field #{$this->getCount()}", PublicationTags::getTagGroups());

--- a/packages/framework/src/Console/Commands/ValidatePublicationsCommand.php
+++ b/packages/framework/src/Console/Commands/ValidatePublicationsCommand.php
@@ -67,7 +67,7 @@ class ValidatePublicationsCommand extends ValidatingCommand
                 $this->output->write("\n<fg=cyan>    Validating publication [$publication->title]</>");
                 $publication->matter->forget('__createdAt');
 
-                foreach ($publication->type->fields as $field) {
+                foreach ($publication->type->getFieldData() as $field) {
                     $countFields++;
                     $fieldName = $field['name'];
                     $pubTypeField = new PublicationFieldDefinition($field['type'], $fieldName);

--- a/packages/framework/src/Framework/Actions/SeedsPublicationFiles.php
+++ b/packages/framework/src/Framework/Actions/SeedsPublicationFiles.php
@@ -98,7 +98,7 @@ class SeedsPublicationFiles
             'image' => 'https://picsum.photos/id/'.rand(1, 1000).'/400/400',
             'integer' => rand(-100000, 100000),
             'string' => substr($this->fakeSentence(10), 0, rand(0, 255)),
-            'tag' => $this->getTags($field->tagGroup ?? ''),
+            'tag' => $this->getTags($field->tagGroup),
             'text' => $this->getTextValue(rand(3, 20)),
             'url' => $this->fakeUrl(),
         };

--- a/packages/framework/src/Framework/Actions/SeedsPublicationFiles.php
+++ b/packages/framework/src/Framework/Actions/SeedsPublicationFiles.php
@@ -98,7 +98,7 @@ class SeedsPublicationFiles
             'image' => 'https://picsum.photos/id/'.rand(1, 1000).'/400/400',
             'integer' => rand(-100000, 100000),
             'string' => substr($this->fakeSentence(10), 0, rand(0, 255)),
-            'tag' => $this->getTags($field->tagGroup),
+            'tag' => $this->getTags($field->tagGroup ?? ''),
             'text' => $this->getTextValue(rand(3, 20)),
             'url' => $this->fakeUrl(),
         };

--- a/packages/framework/src/Framework/Actions/SeedsPublicationFiles.php
+++ b/packages/framework/src/Framework/Actions/SeedsPublicationFiles.php
@@ -98,7 +98,7 @@ class SeedsPublicationFiles
             'image' => 'https://picsum.photos/id/'.rand(1, 1000).'/400/400',
             'integer' => rand(-100000, 100000),
             'string' => substr($this->fakeSentence(10), 0, rand(0, 255)),
-            'tag' => $this->getTags(),
+            'tag' => $this->getTags($field->tagGroup),
             'text' => $this->getTextValue(rand(3, 20)),
             'url' => $this->fakeUrl(),
         };
@@ -128,9 +128,9 @@ class SeedsPublicationFiles
         return $arrayItems;
     }
 
-    protected function getTags(): string
+    protected function getTags(string $tagGroup): string
     {
-        $tags = PublicationService::getValuesForTagName($this->pubType->getIdentifier());
+        $tags = PublicationService::getValuesForTagName($tagGroup);
 
         return $tags->isEmpty() ? '' : $tags->random();
     }

--- a/packages/framework/src/Framework/Features/Publications/Models/PublicationFieldDefinition.php
+++ b/packages/framework/src/Framework/Features/Publications/Models/PublicationFieldDefinition.php
@@ -27,17 +27,19 @@ class PublicationFieldDefinition implements SerializableContract
     public readonly PublicationFieldTypes $type;
     public readonly string $name;
     public readonly array $rules;
+    public readonly ?string $tagGroup;
 
     public static function fromArray(array $array): static
     {
         return new static(...$array);
     }
 
-    public function __construct(PublicationFieldTypes|string $type, string $name, array $rules = [])
+    public function __construct(PublicationFieldTypes|string $type, string $name, array $rules = [], ?string $tagGroup = null)
     {
         $this->type = $type instanceof PublicationFieldTypes ? $type : PublicationFieldTypes::from(strtolower($type));
         $this->name = str_starts_with($name, '__') ? $name : Str::kebab($name);
         $this->rules = $rules;
+        $this->tagGroup = $tagGroup;
     }
 
     public function toArray(): array
@@ -46,6 +48,7 @@ class PublicationFieldDefinition implements SerializableContract
             'type' => $this->type->value,
             'name' => $this->name,
             'rules' => $this->rules,
+            'tagGroup' => $this->tagGroup,
         ]);
     }
 

--- a/packages/framework/src/Framework/Features/Publications/Models/PublicationTags.php
+++ b/packages/framework/src/Framework/Features/Publications/Models/PublicationTags.php
@@ -109,6 +109,16 @@ class PublicationTags
     }
 
     /**
+     * Get all tag names.
+     *
+     * @return array<string>
+     */
+    public static function getTagGroups(): array
+    {
+        return self::getAllTags()->keys()->toArray();
+    }
+
+    /**
      * Validate the tags.json file is valid.
      *
      * @internal This method is experimental and may be removed without notice

--- a/packages/framework/src/Framework/Features/Publications/Models/PublicationType.php
+++ b/packages/framework/src/Framework/Features/Publications/Models/PublicationType.php
@@ -99,9 +99,9 @@ class PublicationType implements SerializableContract
     /** @return \Illuminate\Support\Collection<string, \Hyde\Framework\Features\Publications\Models\PublicationFieldDefinition> */
     public function getFields(): Collection
     {
-        return Collection::make(collect($this->fields)->mapWithKeys(function (array $data): array {
+        return Collection::make($this->fields)->mapWithKeys(function (array $data): array {
             return [$data['name'] => new PublicationFieldDefinition(...$data)];
-        }));
+        });
     }
 
     public function getFieldDefinition(string $fieldName): PublicationFieldDefinition

--- a/packages/framework/src/Framework/Features/Publications/Models/PublicationType.php
+++ b/packages/framework/src/Framework/Features/Publications/Models/PublicationType.php
@@ -98,6 +98,8 @@ class PublicationType implements SerializableContract
 
     /**
      * Get the raw field definitions for this publication type.
+     *
+     * @see self::getFields() to get the deserialized field definitions.
      */
     public function getFieldData(): array
     {
@@ -106,6 +108,8 @@ class PublicationType implements SerializableContract
 
     /**
      * Get the publication fields, deserialized to PublicationFieldDefinition objects.
+     *
+     * @see self::getFieldData() to get the raw field definitions.
      *
      * @return \Illuminate\Support\Collection<string, \Hyde\Framework\Features\Publications\Models\PublicationFieldDefinition>
      */

--- a/packages/framework/src/Framework/Features/Publications/Models/PublicationType.php
+++ b/packages/framework/src/Framework/Features/Publications/Models/PublicationType.php
@@ -96,7 +96,11 @@ class PublicationType implements SerializableContract
         return $this->directory;
     }
 
-    /** @return \Illuminate\Support\Collection<string, \Hyde\Framework\Features\Publications\Models\PublicationFieldDefinition> */
+    /**
+     * Get the publication fields, deserialized to PublicationFieldDefinition objects.
+     *
+     * @return \Illuminate\Support\Collection<string, \Hyde\Framework\Features\Publications\Models\PublicationFieldDefinition>
+     */
     public function getFields(): Collection
     {
         return Collection::make($this->fields)->mapWithKeys(function (array $data): array {

--- a/packages/framework/src/Framework/Features/Publications/Models/PublicationType.php
+++ b/packages/framework/src/Framework/Features/Publications/Models/PublicationType.php
@@ -97,6 +97,14 @@ class PublicationType implements SerializableContract
     }
 
     /**
+     * Get the raw field definitions for this publication type.
+     */
+    public function getFieldData(): array
+    {
+        return $this->fields;
+    }
+
+    /**
      * Get the publication fields, deserialized to PublicationFieldDefinition objects.
      *
      * @return \Illuminate\Support\Collection<string, \Hyde\Framework\Features\Publications\Models\PublicationFieldDefinition>

--- a/packages/framework/src/Framework/Features/Publications/Models/PublicationType.php
+++ b/packages/framework/src/Framework/Features/Publications/Models/PublicationType.php
@@ -99,11 +99,9 @@ class PublicationType implements SerializableContract
     /** @return \Illuminate\Support\Collection<string, \Hyde\Framework\Features\Publications\Models\PublicationFieldDefinition> */
     public function getFields(): Collection
     {
-        $result = collect($this->fields)->mapWithKeys(function (array $data): array {
+        return Collection::make(collect($this->fields)->mapWithKeys(function (array $data): array {
             return [$data['name'] => new PublicationFieldDefinition(...$data)];
-        });
-
-        return Collection::make($result);
+        }));
     }
 
     public function getFieldDefinition(string $fieldName): PublicationFieldDefinition

--- a/packages/framework/tests/Feature/Actions/SeedsPublicationFilesTest.php
+++ b/packages/framework/tests/Feature/Actions/SeedsPublicationFilesTest.php
@@ -133,7 +133,10 @@ class SeedsPublicationFilesTest extends TestCase
     {
         $tags = ['test-publication' => ['foo', 'bar', 'baz']];
         $this->file('tags.json', json_encode($tags));
-        $this->updateSchema('tag', 'tag');
+        $this->pubType->fields = [
+            (new PublicationFieldDefinition('tag', 'tag', tagGroup: 'test-publication'))->toArray(),
+        ];
+        $this->pubType->save();
         (new SeedsPublicationFiles($this->pubType))->create();
 
         $publication = $this->firstPublication();

--- a/packages/framework/tests/Feature/Commands/MakePublicationCommandTest.php
+++ b/packages/framework/tests/Feature/Commands/MakePublicationCommandTest.php
@@ -337,6 +337,7 @@ class MakePublicationCommandTest extends TestCase
             'fields'         =>  [[
                 'type' => 'tag',
                 'name' => 'tag',
+                'tagGroup' => 'test-publication',
             ],
             ],
         ]);
@@ -360,6 +361,7 @@ class MakePublicationCommandTest extends TestCase
             'fields'         =>  [[
                 'type' => 'tag',
                 'name' => 'tags',
+                'tagGroup' => 'test-publication',
             ],
             ],
         ]);
@@ -434,6 +436,7 @@ class MakePublicationCommandTest extends TestCase
             'fields'         =>  [[
                 'type' => 'tag',
                 'name' => 'tag',
+                'tagGroup' => 'test-publication',
             ],
             ],
         ]);
@@ -454,6 +457,7 @@ class MakePublicationCommandTest extends TestCase
             'fields'         =>  [[
                 'type' => 'tag',
                 'name' => 'tag',
+                'tagGroup' => 'test-publication',
             ],
             ],
         ]);
@@ -486,6 +490,7 @@ class MakePublicationCommandTest extends TestCase
                 'type' => 'tag',
                 'name' => 'tag',
                 'rules' => ['required'],
+                'tagGroup' => 'test-publication',
             ],
             ],
         ]);

--- a/packages/framework/tests/Feature/Commands/MakePublicationCommandTest.php
+++ b/packages/framework/tests/Feature/Commands/MakePublicationCommandTest.php
@@ -494,7 +494,7 @@ class MakePublicationCommandTest extends TestCase
         ]);
 
         $this->artisan('make:publication test-publication')
-            ->expectsOutput('Error: Tag field tag is missing tagGroup property')
+            ->expectsOutput("Error: Tag field 'tag' is missing the 'tagGroup' property")
             ->assertExitCode(1);
 
         $this->assertFileDoesNotExist(Hyde::path('test-publication/2022-01-01-000000.md'));

--- a/packages/framework/tests/Feature/Commands/MakePublicationCommandTest.php
+++ b/packages/framework/tests/Feature/Commands/MakePublicationCommandTest.php
@@ -481,6 +481,25 @@ class MakePublicationCommandTest extends TestCase
             MARKDOWN, $this->getDatedPublicationContents());
     }
 
+    public function test_tag_input_for_field_without_tagGroup_specified()
+    {
+        config(['app.throw_on_console_exception' => false]);
+        $this->makeSchemaFile([
+            'canonicalField' => '__createdAt',
+            'fields'         =>  [[
+                'type' => 'tag',
+                'name' => 'tag',
+            ],
+            ],
+        ]);
+
+        $this->artisan('make:publication test-publication')
+            ->expectsOutput('Error: Tag field tag is missing tagGroup property')
+            ->assertExitCode(1);
+
+        $this->assertFileDoesNotExist(Hyde::path('test-publication/2022-01-01-000000.md'));
+    }
+
     public function test_handleEmptyOptionsCollection_for_required_field()
     {
         config(['app.throw_on_console_exception' => false]);

--- a/packages/framework/tests/Feature/Commands/MakePublicationTypeCommandTest.php
+++ b/packages/framework/tests/Feature/Commands/MakePublicationTypeCommandTest.php
@@ -207,4 +207,19 @@ class MakePublicationTypeCommandTest extends TestCase
 
         unlink(Hyde::path('tags.json'));
     }
+
+    public function testWithTagFieldInputButNoTags()
+    {
+        config(['app.throw_on_console_exception' => false]);
+        $this->directory('test-publication');
+
+        $this->artisan('make:publicationType "Test Publication" --use-defaults')
+            ->expectsQuestion('Enter name for field #1', 'MyTag')
+            ->expectsChoice('Enter type for field #1', 'Tag',
+                ['String', 'Datetime', 'Boolean', 'Integer', 'Float', 'Image', 'Array', 'Text', 'Url', '<fg=gray>[9mTag[0m</> <fg=gray>(no tags defined)</>'], true)
+            ->expectsOutput('Error: Can not create a tag field without any tag groups defined in tags.json')
+            ->assertExitCode(1);
+
+        $this->assertFileDoesNotExist(Hyde::path('test-publication/schema.json'));
+    }
 }

--- a/packages/framework/tests/Feature/Commands/MakePublicationTypeCommandTest.php
+++ b/packages/framework/tests/Feature/Commands/MakePublicationTypeCommandTest.php
@@ -4,9 +4,8 @@ declare(strict_types=1);
 
 namespace Hyde\Framework\Testing\Feature\Commands;
 
-use Hyde\Console\Commands\Helpers\InputStreamHandler;
-use Hyde\Console\Commands\MakePublicationTagCommand;
 use function config;
+use Hyde\Console\Commands\Helpers\InputStreamHandler;
 use Hyde\Facades\Filesystem;
 use Hyde\Framework\Features\Publications\Models\PublicationTags;
 use Hyde\Framework\Features\Publications\PublicationFieldTypes;
@@ -233,7 +232,7 @@ class MakePublicationTypeCommandTest extends TestCase
         $this->cleanUpWhenDone('tags.json');
         InputStreamHandler::mockInput("foo\nbar\nbaz\n");
 
-       $this->artisan('make:publicationType "Test Publication"')
+        $this->artisan('make:publicationType "Test Publication"')
             ->expectsQuestion('Enter name for field #1', 'MyTag')
             ->expectsChoice('Enter type for field #1', 'Tag',
                 ['String', 'Datetime', 'Boolean', 'Integer', 'Float', 'Image', 'Array', 'Text', 'Url', 'Tag'])
@@ -243,7 +242,7 @@ class MakePublicationTypeCommandTest extends TestCase
             ->expectsChoice('Enter tag group for field #1', 'foo', ['foo'], true)
             ->expectsConfirmation('Field #1 added! Add another field?')
             ->expectsConfirmation('Do you want to configure pagination settings?')
-            ->expectsChoice('Choose a canonical name field (this will be used to generate filenames, so the values need to be unique)', '__createdAt', ['__createdAt',])
+            ->expectsChoice('Choose a canonical name field (this will be used to generate filenames, so the values need to be unique)', '__createdAt', ['__createdAt'])
             ->doesntExpectOutput('Error: Can not create a tag field without any tag groups defined in tags.json')
            ->assertSuccessful();
 

--- a/packages/framework/tests/Feature/Commands/MakePublicationTypeCommandTest.php
+++ b/packages/framework/tests/Feature/Commands/MakePublicationTypeCommandTest.php
@@ -217,6 +217,8 @@ class MakePublicationTypeCommandTest extends TestCase
             ->expectsQuestion('Enter name for field #1', 'MyTag')
             ->expectsChoice('Enter type for field #1', 'Tag',
                 ['String', 'Datetime', 'Boolean', 'Integer', 'Float', 'Image', 'Array', 'Text', 'Url', 'Tag'], true)
+            ->expectsOutput('No tag groups have been added to tags.json')
+            ->expectsConfirmation('Would you like to add some tags now?')
             ->expectsOutput('Error: Can not create a tag field without any tag groups defined in tags.json')
             ->assertExitCode(1);
 

--- a/packages/framework/tests/Feature/Commands/MakePublicationTypeCommandTest.php
+++ b/packages/framework/tests/Feature/Commands/MakePublicationTypeCommandTest.php
@@ -216,7 +216,7 @@ class MakePublicationTypeCommandTest extends TestCase
         $this->artisan('make:publicationType "Test Publication" --use-defaults')
             ->expectsQuestion('Enter name for field #1', 'MyTag')
             ->expectsChoice('Enter type for field #1', 'Tag',
-                ['String', 'Datetime', 'Boolean', 'Integer', 'Float', 'Image', 'Array', 'Text', 'Url', '<fg=gray>[9mTag[0m</> <fg=gray>(no tags defined)</>'], true)
+                ['String', 'Datetime', 'Boolean', 'Integer', 'Float', 'Image', 'Array', 'Text', 'Url', 'Tag'], true)
             ->expectsOutput('Error: Can not create a tag field without any tag groups defined in tags.json')
             ->assertExitCode(1);
 

--- a/packages/framework/tests/Feature/Commands/MakePublicationTypeCommandTest.php
+++ b/packages/framework/tests/Feature/Commands/MakePublicationTypeCommandTest.php
@@ -4,9 +4,9 @@ declare(strict_types=1);
 
 namespace Hyde\Framework\Testing\Feature\Commands;
 
-use Hyde\Framework\Features\Publications\Models\PublicationTags;
 use function config;
 use Hyde\Facades\Filesystem;
+use Hyde\Framework\Features\Publications\Models\PublicationTags;
 use Hyde\Framework\Features\Publications\PublicationFieldTypes;
 use Hyde\Hyde;
 use Hyde\Testing\TestCase;
@@ -166,7 +166,7 @@ class MakePublicationTypeCommandTest extends TestCase
 
         (new PublicationTags())->addTagGroups([
             'foo' => ['bar', 'baz'],
-            'bar' => ['foo', 'baz']
+            'bar' => ['foo', 'baz'],
         ])->save();
 
         $this->artisan('make:publicationType "Test Publication" --use-defaults')

--- a/packages/framework/tests/Feature/Commands/MakePublicationTypeCommandTest.php
+++ b/packages/framework/tests/Feature/Commands/MakePublicationTypeCommandTest.php
@@ -239,7 +239,7 @@ class MakePublicationTypeCommandTest extends TestCase
             ->expectsOutput('No tag groups have been added to tags.json')
             ->expectsConfirmation('Would you like to add some tags now?', 'yes')
             ->expectsQuestion('Tag name', 'foo')
-            ->expectsOutput("\nOkay, we're back on track!")
+            ->expectsOutput("Okay, we're back on track!")
             ->expectsChoice('Enter tag group for field #1', 'foo', ['foo'], true)
             ->expectsConfirmation('Field #1 added! Add another field?')
             ->expectsConfirmation('Do you want to configure pagination settings?')

--- a/packages/framework/tests/Feature/Commands/MakePublicationTypeCommandTest.php
+++ b/packages/framework/tests/Feature/Commands/MakePublicationTypeCommandTest.php
@@ -239,6 +239,7 @@ class MakePublicationTypeCommandTest extends TestCase
             ->expectsOutput('No tag groups have been added to tags.json')
             ->expectsConfirmation('Would you like to add some tags now?', 'yes')
             ->expectsQuestion('Tag name', 'foo')
+            ->expectsOutput("\nOkay, we're back on track!")
             ->expectsChoice('Enter tag group for field #1', 'foo', ['foo'], true)
             ->expectsConfirmation('Field #1 added! Add another field?')
             ->expectsConfirmation('Do you want to configure pagination settings?')

--- a/packages/framework/tests/Feature/PublicationFieldDefinitionTest.php
+++ b/packages/framework/tests/Feature/PublicationFieldDefinitionTest.php
@@ -107,4 +107,22 @@ class PublicationFieldDefinitionTest extends TestCase
         $field = new PublicationFieldDefinition('string', 'test', ['required', 'foo']);
         $this->assertSame(['string', 'required', 'foo'], $field->getRules());
     }
+
+    public function test_can_construct_with_tag_group()
+    {
+        $field = new PublicationFieldDefinition('tag', 'test', [], 'myTags');
+        $this->assertSame('myTags', $field->tagGroup);
+    }
+
+    public function test_can_serialize_tag_group()
+    {
+        $field = new PublicationFieldDefinition('tag', 'test', [], 'myTags');
+        $this->assertSame([
+            'type' => 'tag',
+            'name' => 'test',
+            'tagGroup' => 'myTags',
+        ], $field->toArray());
+
+        $this->assertSame('{"type":"tag","name":"test","tagGroup":"myTags"}', json_encode($field));
+    }
 }

--- a/packages/framework/tests/Feature/PublicationTagsTest.php
+++ b/packages/framework/tests/Feature/PublicationTagsTest.php
@@ -139,11 +139,7 @@ class PublicationTagsTest extends TestCase
 
     public function testGetTagGroupsWithNoTags()
     {
-        $tags = new PublicationTags();
-        $tags->save();
-
         $this->assertSame([], PublicationTags::getTagGroups());
-        unlink(Hyde::path('tags.json'));
     }
 
     public function testCanSaveTagsToDisk()

--- a/packages/framework/tests/Feature/PublicationTagsTest.php
+++ b/packages/framework/tests/Feature/PublicationTagsTest.php
@@ -126,6 +126,26 @@ class PublicationTagsTest extends TestCase
         ]), $tags->getTags());
     }
 
+    public function testGetTagGroups()
+    {
+        $tags = new PublicationTags();
+        $tags->addTagGroup('test', ['foo']);
+        $tags->addTagGroup('test2', ['bar']);
+        $tags->save();
+
+        $this->assertSame(['test', 'test2'], PublicationTags::getTagGroups());
+        unlink(Hyde::path('tags.json'));
+    }
+
+    public function testGetTagGroupsWithNoTags()
+    {
+        $tags = new PublicationTags();
+        $tags->save();
+
+        $this->assertSame([], PublicationTags::getTagGroups());
+        unlink(Hyde::path('tags.json'));
+    }
+
     public function testCanSaveTagsToDisk()
     {
         $tags = new PublicationTags();

--- a/packages/framework/tests/Feature/PublicationTypeTest.php
+++ b/packages/framework/tests/Feature/PublicationTypeTest.php
@@ -206,6 +206,17 @@ class PublicationTypeTest extends TestCase
         ]), $publicationType->getFields());
     }
 
+    public function test_get_field_data_returns_field_data()
+    {
+        $publicationType = new PublicationType(...$this->getTestData());
+
+        $this->assertSame([['name' => 'title', 'type' => 'string']], $publicationType->getFieldData());
+
+        $publicationType->fields = [];
+
+        $this->assertSame([], $publicationType->getFieldData());
+    }
+
     public function test_get_method_can_find_existing_file_on_disk()
     {
         $publicationType = new PublicationType(...$this->getTestDataWithPathInformation());

--- a/packages/testing/src/TestCase.php
+++ b/packages/testing/src/TestCase.php
@@ -4,14 +4,13 @@ declare(strict_types=1);
 
 namespace Hyde\Testing;
 
+use function file_get_contents;
 use Hyde\Facades\Features;
 use Hyde\Facades\Filesystem;
 use Hyde\Hyde;
+use function Hyde\normalize_newlines;
 use Illuminate\View\Component;
 use LaravelZero\Framework\Testing\TestCase as BaseTestCase;
-
-use function file_get_contents;
-use function Hyde\normalize_newlines;
 
 abstract class TestCase extends BaseTestCase
 {


### PR DESCRIPTION
Adds back the tagGroup option for publication tag fields and adds a few tests and minor refactors for the publication type code.