### PR TITLE
Create VirtualPage class to make it easier for package developers to create pages without source files

### DIFF
--- a/packages/framework/src/Pages/Concerns/HydePage.php
+++ b/packages/framework/src/Pages/Concerns/HydePage.php
@@ -144,7 +144,7 @@ abstract class HydePage implements PageSchema
      */
     final public static function fileExtension(): string
     {
-        return '.'.ltrim(static::$fileExtension, '.');
+        return rtrim('.'.ltrim(static::$fileExtension, '.'), '.');
     }
 
     /**

--- a/packages/framework/src/Pages/VirtualPage.php
+++ b/packages/framework/src/Pages/VirtualPage.php
@@ -24,7 +24,7 @@ class VirtualPage extends HydePage
     public static string $outputDirectory = '';
     public static string $fileExtension = '';
 
-    public function __construct(string $identifier, string $contents)
+    public function __construct(string $identifier, string $contents = '')
     {
         parent::__construct($identifier);
 

--- a/packages/framework/src/Pages/VirtualPage.php
+++ b/packages/framework/src/Pages/VirtualPage.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Hyde\Pages;
+
+use Hyde\Pages\Concerns\HydePage;
+
+class VirtualPage extends HydePage
+{
+    public function compile(): string
+    {
+        // TODO: Implement compile() method.
+    }
+}

--- a/packages/framework/src/Pages/VirtualPage.php
+++ b/packages/framework/src/Pages/VirtualPage.php
@@ -25,6 +25,11 @@ class VirtualPage extends HydePage
     public static string $outputDirectory = '';
     public static string $fileExtension = '';
 
+    public static function make(string $identifier = '', FrontMatter|array $matter = []): static
+    {
+        return new static($identifier, matter: $matter);
+    }
+
     public function __construct(string $identifier, string $contents = '', FrontMatter|array $matter = [])
     {
         parent::__construct($identifier, $matter);

--- a/packages/framework/src/Pages/VirtualPage.php
+++ b/packages/framework/src/Pages/VirtualPage.php
@@ -22,6 +22,7 @@ class VirtualPage extends HydePage
 
     public static string $sourceDirectory = '';
     public static string $outputDirectory = '';
+    public static string $fileExtension = '';
 
     public function __construct(string $identifier, string $contents)
     {

--- a/packages/framework/src/Pages/VirtualPage.php
+++ b/packages/framework/src/Pages/VirtualPage.php
@@ -6,6 +6,9 @@ namespace Hyde\Pages;
 
 use Hyde\Pages\Concerns\HydePage;
 
+/**
+ * A virtual page is a page that does not have a source file.
+ */
 class VirtualPage extends HydePage
 {
     public function compile(): string

--- a/packages/framework/src/Pages/VirtualPage.php
+++ b/packages/framework/src/Pages/VirtualPage.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Hyde\Pages;
 
+use Hyde\Markdown\Models\FrontMatter;
 use Hyde\Pages\Concerns\HydePage;
 
 /**
@@ -24,9 +25,9 @@ class VirtualPage extends HydePage
     public static string $outputDirectory = '';
     public static string $fileExtension = '';
 
-    public function __construct(string $identifier, string $contents = '')
+    public function __construct(string $identifier, string $contents = '', FrontMatter|array $matter = [])
     {
-        parent::__construct($identifier);
+        parent::__construct($identifier, $matter);
 
         $this->contents = $contents;
     }

--- a/packages/framework/src/Pages/VirtualPage.php
+++ b/packages/framework/src/Pages/VirtualPage.php
@@ -16,8 +16,22 @@ use Hyde\Pages\Concerns\HydePage;
  */
 class VirtualPage extends HydePage
 {
+    protected string $contents;
+
+    public function __construct(string $identifier, string $contents)
+    {
+        parent::__construct($identifier);
+
+        $this->contents = $contents;
+    }
+
+    public function contents(): string
+    {
+        return $this->contents;
+    }
+
     public function compile(): string
     {
-        // TODO: Implement compile() method.
+        return $this->contents();
     }
 }

--- a/packages/framework/src/Pages/VirtualPage.php
+++ b/packages/framework/src/Pages/VirtualPage.php
@@ -27,7 +27,7 @@ class VirtualPage extends HydePage
 
     public static function make(string $identifier = '', FrontMatter|array $matter = [], string $contents = ''): static
     {
-        return new static($identifier, matter: $matter, contents: $contents);
+        return new static($identifier, $matter, $contents);
     }
 
     public function __construct(string $identifier, FrontMatter|array $matter = [], string $contents = '')

--- a/packages/framework/src/Pages/VirtualPage.php
+++ b/packages/framework/src/Pages/VirtualPage.php
@@ -30,7 +30,7 @@ class VirtualPage extends HydePage
         return new static($identifier, matter: $matter);
     }
 
-    public function __construct(string $identifier, string $contents = '', FrontMatter|array $matter = [])
+    public function __construct(string $identifier, FrontMatter|array $matter = [], string $contents = '')
     {
         parent::__construct($identifier, $matter);
 

--- a/packages/framework/src/Pages/VirtualPage.php
+++ b/packages/framework/src/Pages/VirtualPage.php
@@ -25,9 +25,9 @@ class VirtualPage extends HydePage
     public static string $outputDirectory = '';
     public static string $fileExtension = '';
 
-    public static function make(string $identifier = '', FrontMatter|array $matter = []): static
+    public static function make(string $identifier = '', FrontMatter|array $matter = [], string $contents = ''): static
     {
-        return new static($identifier, matter: $matter);
+        return new static($identifier, matter: $matter, contents: $contents);
     }
 
     public function __construct(string $identifier, FrontMatter|array $matter = [], string $contents = '')

--- a/packages/framework/src/Pages/VirtualPage.php
+++ b/packages/framework/src/Pages/VirtualPage.php
@@ -20,6 +20,9 @@ class VirtualPage extends HydePage
 {
     protected string $contents;
 
+    public static string $sourceDirectory = '';
+    public static string $outputDirectory = '';
+
     public function __construct(string $identifier, string $contents)
     {
         parent::__construct($identifier);

--- a/packages/framework/src/Pages/VirtualPage.php
+++ b/packages/framework/src/Pages/VirtualPage.php
@@ -8,6 +8,11 @@ use Hyde\Pages\Concerns\HydePage;
 
 /**
  * A virtual page is a page that does not have a source file.
+ *
+ * This can be useful for creating pagination pages and the like.
+ * When used in a package, it's on the package developer to ensure
+ * that the virtual page is registered with Hyde, usually within the
+ * boot method of the package's service provider so it can be compiled.
  */
 class VirtualPage extends HydePage
 {

--- a/packages/framework/src/Pages/VirtualPage.php
+++ b/packages/framework/src/Pages/VirtualPage.php
@@ -9,6 +9,8 @@ use Hyde\Pages\Concerns\HydePage;
 /**
  * A virtual page is a page that does not have a source file.
  *
+ * @experimental This feature is experimental and may change substantially before the 1.0.0 release.
+ *
  * This can be useful for creating pagination pages and the like.
  * When used in a package, it's on the package developer to ensure
  * that the virtual page is registered with Hyde, usually within the

--- a/packages/framework/tests/Unit/Pages/VirtualPageUnitTest.php
+++ b/packages/framework/tests/Unit/Pages/VirtualPageUnitTest.php
@@ -219,4 +219,25 @@ class VirtualPageUnitTest extends BaseHydePageUnitTest
     {
         $this->assertInstanceOf(FrontMatter::class, (new VirtualPage('404'))->matter());
     }
+
+    public function testConstructWithContentsString()
+    {
+        $this->assertInstanceOf(VirtualPage::class, new VirtualPage('foo', contents: 'bar'));
+    }
+
+    public function testMakeWithContentsString()
+    {
+        $this->assertInstanceOf(VirtualPage::class, VirtualPage::make('foo', contents: 'bar'));
+        $this->assertEquals(VirtualPage::make('foo', contents: 'bar'), new VirtualPage('foo', contents: 'bar'));
+    }
+
+    public function testContentsMethod()
+    {
+        $this->assertSame('bar', (new VirtualPage('foo', contents: 'bar'))->contents());
+    }
+
+    public function testCompileMethodUsesContentsProperty()
+    {
+        $this->assertSame('bar', (new VirtualPage('foo', contents: 'bar'))->compile());
+    }
 }

--- a/packages/framework/tests/Unit/Pages/VirtualPageUnitTest.php
+++ b/packages/framework/tests/Unit/Pages/VirtualPageUnitTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Hyde\Framework\Testing\Unit\Pages;
 
+use Hyde\Foundation\HydeKernel;
 use Hyde\Foundation\PageCollection;
 use Hyde\Framework\Factories\Concerns\CoreDataObject;
 use Hyde\Framework\Features\Metadata\PageMetadataBag;
@@ -141,8 +142,9 @@ class VirtualPageUnitTest extends BaseHydePageUnitTest
 
     public function testGet()
     {
-        $this->file(VirtualPage::sourcePath('foo'));
-        $this->assertEquals(new VirtualPage('foo'), VirtualPage::get('foo'));
+        $page = new VirtualPage('foo');
+        HydeKernel::getInstance()->pages()->put('foo', $page);
+        $this->assertEquals($page, VirtualPage::get('foo'));
     }
 
     public function testParse()

--- a/packages/framework/tests/Unit/Pages/VirtualPageUnitTest.php
+++ b/packages/framework/tests/Unit/Pages/VirtualPageUnitTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Hyde\Framework\Testing\Unit\Pages;
 
+use Error;
 use Hyde\Foundation\HydeKernel;
 use Hyde\Foundation\PageCollection;
 use Hyde\Framework\Factories\Concerns\CoreDataObject;
@@ -127,7 +128,8 @@ class VirtualPageUnitTest extends BaseHydePageUnitTest
 
     public function testGetBladeView()
     {
-        $this->assertSame('foo.html', (new VirtualPage('foo'))->getBladeView());
+        $this->expectException(Error::class);
+        (new VirtualPage('foo'))->getBladeView();
     }
 
     public function testFiles()

--- a/packages/framework/tests/Unit/Pages/VirtualPageUnitTest.php
+++ b/packages/framework/tests/Unit/Pages/VirtualPageUnitTest.php
@@ -1,0 +1,218 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Hyde\Framework\Testing\Unit\Pages;
+
+use Hyde\Foundation\PageCollection;
+use Hyde\Framework\Factories\Concerns\CoreDataObject;
+use Hyde\Framework\Features\Metadata\PageMetadataBag;
+use Hyde\Hyde;
+use Hyde\Markdown\Models\FrontMatter;
+use Hyde\Pages\VirtualPage;
+use Hyde\Support\Models\Route;
+
+require_once __DIR__.'/BaseHydePageUnitTest.php';
+
+/**
+ * @covers \Hyde\Pages\VirtualPage
+ */
+class VirtualPageUnitTest extends BaseHydePageUnitTest
+{
+    public function testSourceDirectory()
+    {
+        $this->assertSame(
+            '_pages',
+            VirtualPage::sourceDirectory()
+        );
+    }
+
+    public function testOutputDirectory()
+    {
+        $this->assertSame(
+            '',
+            VirtualPage::outputDirectory()
+        );
+    }
+
+    public function testFileExtension()
+    {
+        $this->assertSame(
+            '.html',
+            VirtualPage::fileExtension()
+        );
+    }
+
+    public function testSourcePath()
+    {
+        $this->assertSame(
+            '_pages/hello-world.html',
+            VirtualPage::sourcePath('hello-world')
+        );
+    }
+
+    public function testOutputPath()
+    {
+        $this->assertSame(
+            'hello-world.html',
+            VirtualPage::outputPath('hello-world')
+        );
+    }
+
+    public function testPath()
+    {
+        $this->assertSame(
+            Hyde::path('_pages/hello-world.html'),
+            VirtualPage::path('hello-world.html')
+        );
+    }
+
+    public function testGetSourcePath()
+    {
+        $this->assertSame(
+            '_pages/hello-world.html',
+            (new VirtualPage('hello-world'))->getSourcePath()
+        );
+    }
+
+    public function testGetOutputPath()
+    {
+        $this->assertSame(
+            'hello-world.html',
+            (new VirtualPage('hello-world'))->getOutputPath()
+        );
+    }
+
+    public function testGetLink()
+    {
+        $this->assertSame(
+            'hello-world.html',
+            (new VirtualPage('hello-world'))->getLink()
+        );
+    }
+
+    public function testMake()
+    {
+        $this->assertEquals(VirtualPage::make(), new VirtualPage());
+    }
+
+    public function testMakeWithData()
+    {
+        $this->assertEquals(
+            VirtualPage::make('foo', ['foo' => 'bar']),
+            new VirtualPage('foo', ['foo' => 'bar'])
+        );
+    }
+
+    public function testShowInNavigation()
+    {
+        $this->assertTrue((new VirtualPage())->showInNavigation());
+    }
+
+    public function testNavigationMenuPriority()
+    {
+        $this->assertSame(999, (new VirtualPage())->navigationMenuPriority());
+    }
+
+    public function testNavigationMenuLabel()
+    {
+        $this->assertSame('Foo', (new VirtualPage('foo'))->navigationMenuLabel());
+    }
+
+    public function testNavigationMenuGroup()
+    {
+        $this->assertNull((new VirtualPage('foo'))->navigationMenuGroup());
+    }
+
+    public function testGetBladeView()
+    {
+        $this->assertSame('_pages/foo.html', (new VirtualPage('foo'))->getBladeView());
+    }
+
+    public function testFiles()
+    {
+        $this->assertSame([], VirtualPage::files());
+    }
+
+    public function testData()
+    {
+        $this->assertSame('foo', (new VirtualPage('foo'))->data('identifier'));
+    }
+
+    public function testGet()
+    {
+        $this->file(VirtualPage::sourcePath('foo'));
+        $this->assertEquals(new VirtualPage('foo'), VirtualPage::get('foo'));
+    }
+
+    public function testParse()
+    {
+        $this->file(VirtualPage::sourcePath('foo'));
+        $this->assertInstanceOf(VirtualPage::class, VirtualPage::parse('foo'));
+    }
+
+    public function testGetRouteKey()
+    {
+        $this->assertSame('foo', (new VirtualPage('foo'))->getRouteKey());
+    }
+
+    public function testHtmlTitle()
+    {
+        $this->assertSame('HydePHP - Foo', (new VirtualPage('foo'))->htmlTitle());
+    }
+
+    public function testAll()
+    {
+        $this->assertInstanceOf(PageCollection::class, VirtualPage::all());
+    }
+
+    public function testMetadata()
+    {
+        $this->assertInstanceOf(PageMetadataBag::class, (new VirtualPage())->metadata());
+    }
+
+    public function test__construct()
+    {
+        $this->assertInstanceOf(VirtualPage::class, new VirtualPage());
+    }
+
+    public function testGetRoute()
+    {
+        $this->assertInstanceOf(Route::class, (new VirtualPage())->getRoute());
+    }
+
+    public function testGetIdentifier()
+    {
+        $this->assertSame('foo', (new VirtualPage('foo'))->getIdentifier());
+    }
+
+    public function testHas()
+    {
+        $this->assertTrue((new VirtualPage('foo'))->has('identifier'));
+    }
+
+    public function testToCoreDataObject()
+    {
+        $this->assertInstanceOf(CoreDataObject::class, (new VirtualPage('foo'))->toCoreDataObject());
+    }
+
+    public function testConstructFactoryData()
+    {
+        (new VirtualPage())->constructFactoryData($this->mockPageDataFactory());
+        $this->assertTrue(true);
+    }
+
+    public function testCompile()
+    {
+        $this->file('_pages/foo.html');
+
+        $page = new VirtualPage('foo');
+        Hyde::shareViewData($page);
+        $this->assertIsString(VirtualPage::class, $page->compile());
+    }
+
+    public function testMatter()
+    {
+        $this->assertInstanceOf(FrontMatter::class, (new VirtualPage('404'))->matter());
+    }
+}

--- a/packages/framework/tests/Unit/Pages/VirtualPageUnitTest.php
+++ b/packages/framework/tests/Unit/Pages/VirtualPageUnitTest.php
@@ -144,7 +144,7 @@ class VirtualPageUnitTest extends BaseHydePageUnitTest
     {
         $page = new VirtualPage('foo');
         HydeKernel::getInstance()->pages()->put('foo', $page);
-        $this->assertEquals($page, VirtualPage::get('foo'));
+        $this->assertSame($page, VirtualPage::get('foo'));
     }
 
     public function testParse()

--- a/packages/framework/tests/Unit/Pages/VirtualPageUnitTest.php
+++ b/packages/framework/tests/Unit/Pages/VirtualPageUnitTest.php
@@ -22,7 +22,7 @@ class VirtualPageUnitTest extends BaseHydePageUnitTest
     public function testSourceDirectory()
     {
         $this->assertSame(
-            '_pages',
+            '',
             VirtualPage::sourceDirectory()
         );
     }
@@ -38,7 +38,7 @@ class VirtualPageUnitTest extends BaseHydePageUnitTest
     public function testFileExtension()
     {
         $this->assertSame(
-            '.html',
+            '',
             VirtualPage::fileExtension()
         );
     }
@@ -46,7 +46,7 @@ class VirtualPageUnitTest extends BaseHydePageUnitTest
     public function testSourcePath()
     {
         $this->assertSame(
-            '_pages/hello-world.html',
+            'hello-world',
             VirtualPage::sourcePath('hello-world')
         );
     }
@@ -62,15 +62,15 @@ class VirtualPageUnitTest extends BaseHydePageUnitTest
     public function testPath()
     {
         $this->assertSame(
-            Hyde::path('_pages/hello-world.html'),
-            VirtualPage::path('hello-world.html')
+            Hyde::path('hello-world'),
+            VirtualPage::path('hello-world')
         );
     }
 
     public function testGetSourcePath()
     {
         $this->assertSame(
-            '_pages/hello-world.html',
+            'hello-world',
             (new VirtualPage('hello-world'))->getSourcePath()
         );
     }
@@ -93,25 +93,25 @@ class VirtualPageUnitTest extends BaseHydePageUnitTest
 
     public function testMake()
     {
-        $this->assertEquals(VirtualPage::make(), new VirtualPage());
+        $this->assertEquals(VirtualPage::make('foo'), new VirtualPage('foo'));
     }
 
     public function testMakeWithData()
     {
         $this->assertEquals(
             VirtualPage::make('foo', ['foo' => 'bar']),
-            new VirtualPage('foo', ['foo' => 'bar'])
+            new VirtualPage('foo', matter: ['foo' => 'bar'])
         );
     }
 
     public function testShowInNavigation()
     {
-        $this->assertTrue((new VirtualPage())->showInNavigation());
+        $this->assertTrue((new VirtualPage('foo'))->showInNavigation());
     }
 
     public function testNavigationMenuPriority()
     {
-        $this->assertSame(999, (new VirtualPage())->navigationMenuPriority());
+        $this->assertSame(999, (new VirtualPage('foo'))->navigationMenuPriority());
     }
 
     public function testNavigationMenuLabel()
@@ -126,7 +126,7 @@ class VirtualPageUnitTest extends BaseHydePageUnitTest
 
     public function testGetBladeView()
     {
-        $this->assertSame('_pages/foo.html', (new VirtualPage('foo'))->getBladeView());
+        $this->assertSame('foo.html', (new VirtualPage('foo'))->getBladeView());
     }
 
     public function testFiles()
@@ -168,17 +168,17 @@ class VirtualPageUnitTest extends BaseHydePageUnitTest
 
     public function testMetadata()
     {
-        $this->assertInstanceOf(PageMetadataBag::class, (new VirtualPage())->metadata());
+        $this->assertInstanceOf(PageMetadataBag::class, (new VirtualPage('foo'))->metadata());
     }
 
     public function test__construct()
     {
-        $this->assertInstanceOf(VirtualPage::class, new VirtualPage());
+        $this->assertInstanceOf(VirtualPage::class, new VirtualPage('foo'));
     }
 
     public function testGetRoute()
     {
-        $this->assertInstanceOf(Route::class, (new VirtualPage())->getRoute());
+        $this->assertInstanceOf(Route::class, (new VirtualPage('foo'))->getRoute());
     }
 
     public function testGetIdentifier()
@@ -198,7 +198,7 @@ class VirtualPageUnitTest extends BaseHydePageUnitTest
 
     public function testConstructFactoryData()
     {
-        (new VirtualPage())->constructFactoryData($this->mockPageDataFactory());
+        (new VirtualPage('foo'))->constructFactoryData($this->mockPageDataFactory());
         $this->assertTrue(true);
     }
 


### PR DESCRIPTION
While I've been a bit hesitant about this before, since I like having the one-to-one mapping of a source file to a compiled file, I now see use cases where this is helpful.

For example, when generating pagination pages it would be helpful to have those internally represented as `HydePage`s as they'd otherwise require a separate compile process (which could be done in a post-build task but that adds a lot of unnecessary complexity that might not actually be needed).

Those pages could then instead be represented as a `VirtualPage` instance. It's then on the package developer to make sure the page is added to the `HydeKernel`'s `PageCollection` container; usually within the `boot` method of the package's service provider.

The actual class itself is minimal as it's designed to be extended.