### PR TITLE
Update HydePage::fileExtension() getter to trim trailing periods to support extension-less page types

### DIFF
--- a/packages/framework/src/Pages/Concerns/HydePage.php
+++ b/packages/framework/src/Pages/Concerns/HydePage.php
@@ -144,7 +144,7 @@ abstract class HydePage implements PageSchema
      */
     final public static function fileExtension(): string
     {
-        return '.'.ltrim(static::$fileExtension, '.');
+        return rtrim('.'.ltrim(static::$fileExtension, '.'), '.');
     }
 
     /**

--- a/packages/framework/tests/Feature/HydePageTest.php
+++ b/packages/framework/tests/Feature/HydePageTest.php
@@ -203,6 +203,13 @@ class HydePageTest extends TestCase
         $this->resetDirectoryConfiguration();
     }
 
+    public function test_get_file_extension_removes_trailing_period()
+    {
+        MarkdownPage::$fileExtension = 'foo.';
+        $this->assertEquals('.foo', MarkdownPage::fileExtension());
+        $this->resetDirectoryConfiguration();
+    }
+
     public function test_get_identifier_returns_identifier_property()
     {
         $page = new MarkdownPage('foo');


### PR DESCRIPTION
This getter currently normalizes periods so there is always a leading period, but for page types without extensions (like https://github.com/hydephp/develop/pull/809) this would cause a trailing period to be added. This adds an additional normalization to trim those.