### PR TITLE
Refactor publication types to simplify the code and integrate publication pagination settings

### DIFF
--- a/packages/framework/src/Console/Commands/MakePublicationTypeCommand.php
+++ b/packages/framework/src/Console/Commands/MakePublicationTypeCommand.php
@@ -49,11 +49,11 @@ class MakePublicationTypeCommand extends ValidatingCommand
 
         $this->fields = $this->captureFieldsDefinitions();
 
-        [$sortField, $sortAscending, $prevNextLinks, $pageSize] = ($this->getPaginationSettings());
+        [$sortField, $sortAscending, $pageSize] = ($this->getPaginationSettings());
 
         $canonicalField = $this->getCanonicalField();
 
-        $creator = new CreatesNewPublicationType($title, $this->fields, $canonicalField->name, $sortField, $sortAscending, $prevNextLinks, $pageSize);
+        $creator = new CreatesNewPublicationType($title, $this->fields, $canonicalField->name, $sortField, $sortAscending, $pageSize);
         $this->output->writeln("Saving publication data to [{$creator->getOutputPath()}]");
         $creator->create();
 
@@ -189,12 +189,12 @@ class MakePublicationTypeCommand extends ValidatingCommand
     protected function getPaginationSettings(): array
     {
         if ($this->option('use-defaults') || ! $this->confirm('Would you like to enable pagination?')) {
-            return [null, null, null, null];
+            return [null, null, null];
         }
 
         $this->info("Okay, let's set up pagination! Tip: You can just hit enter to accept the default values.");
 
-        return [$this->getSortField(), $this->getSortDirection(), $this->getPrevNextLinks(), $this->getPageSize()];
+        return [$this->getSortField(), $this->getSortDirection(), $this->getPageSize()];
     }
 
     protected function getSortField(): string
@@ -207,11 +207,6 @@ class MakePublicationTypeCommand extends ValidatingCommand
         $options = ['Ascending' => true, 'Descending' => false];
 
         return $options[$this->choice('Choose the default sort direction', array_keys($options), 'Ascending')];
-    }
-
-    protected function getPrevNextLinks(): bool
-    {
-        return $this->confirm('Generate previous/next links in detail view?', true);
     }
 
     protected function getPageSize(): int

--- a/packages/framework/src/Console/Commands/MakePublicationTypeCommand.php
+++ b/packages/framework/src/Console/Commands/MakePublicationTypeCommand.php
@@ -188,7 +188,7 @@ class MakePublicationTypeCommand extends ValidatingCommand
 
     protected function getPaginationSettings(): array
     {
-        if ($this->option('use-defaults') || ! $this->confirm('Do you want to configure pagination settings?')) {
+        if ($this->option('use-defaults') || ! $this->confirm('Would you like to enable pagination?')) {
             return [null, null, null, null];
         }
 

--- a/packages/framework/src/Console/Commands/MakePublicationTypeCommand.php
+++ b/packages/framework/src/Console/Commands/MakePublicationTypeCommand.php
@@ -197,7 +197,7 @@ class MakePublicationTypeCommand extends ValidatingCommand
 
     protected function getSortField(): string
     {
-        return $this->choice('Choose the default field you wish to sort by', $this->fields->pluck('name')->toArray(), '__dateCreated');
+        return $this->choice('Choose the default field you wish to sort by', $this->fields->pluck('name')->toArray(), 0);
     }
 
     protected function getSortDirection(): bool

--- a/packages/framework/src/Console/Commands/MakePublicationTypeCommand.php
+++ b/packages/framework/src/Console/Commands/MakePublicationTypeCommand.php
@@ -192,6 +192,8 @@ class MakePublicationTypeCommand extends ValidatingCommand
             return [null, null, null, null];
         }
 
+        $this->info("Okay, let's set up pagination! Tip: You can just hit enter to accept the default values.");
+
         return [$this->getSortField(), $this->getSortDirection(), $this->getPrevNextLinks(), $this->getPageSize()];
     }
 

--- a/packages/framework/src/Console/Commands/ValidatePublicationsCommand.php
+++ b/packages/framework/src/Console/Commands/ValidatePublicationsCommand.php
@@ -67,10 +67,10 @@ class ValidatePublicationsCommand extends ValidatingCommand
                 $this->output->write("\n<fg=cyan>    Validating publication [$publication->title]</>");
                 $publication->matter->forget('__createdAt');
 
-                foreach ($publication->type->getFields() as $field) { // FIXME this probably needs fixing as it expected array before
+                foreach ($publication->type->getFields() as $field) {
                     $countFields++;
-                    $fieldName = $field['name'];
-                    $pubTypeField = new PublicationFieldDefinition($field['type'], $fieldName);
+                    $fieldName = $field->name;
+                    $pubTypeField = new PublicationFieldDefinition($field->type, $fieldName);
 
                     try {
                         if ($verbose) {

--- a/packages/framework/src/Console/Commands/ValidatePublicationsCommand.php
+++ b/packages/framework/src/Console/Commands/ValidatePublicationsCommand.php
@@ -67,7 +67,7 @@ class ValidatePublicationsCommand extends ValidatingCommand
                 $this->output->write("\n<fg=cyan>    Validating publication [$publication->title]</>");
                 $publication->matter->forget('__createdAt');
 
-                foreach ($publication->type->getFieldData() as $field) {
+                foreach ($publication->type->getFields() as $field) { // FIXME this probably needs fixing as it expected array before
                     $countFields++;
                     $fieldName = $field['name'];
                     $pubTypeField = new PublicationFieldDefinition($field['type'], $fieldName);

--- a/packages/framework/src/Framework/Actions/CreatesNewPublicationType.php
+++ b/packages/framework/src/Framework/Actions/CreatesNewPublicationType.php
@@ -26,7 +26,6 @@ class CreatesNewPublicationType extends CreateAction implements CreateActionCont
         protected ?string $canonicalField = null,
         protected ?string $sortField = null,
         protected ?bool $sortAscending = null,
-        protected ?bool $prevNextLinks = null,
         protected ?int $pageSize = null,
     ) {
         $this->directoryName = $this->formatStringForStorage($this->name);
@@ -43,7 +42,6 @@ class CreatesNewPublicationType extends CreateAction implements CreateActionCont
             [
                 $this->sortField ?? '__createdAt',
                 $this->sortAscending ?? true,
-                $this->prevNextLinks ?? true,
                 $this->pageSize ?? 25,
             ],
             $this->fields->toArray()

--- a/packages/framework/src/Framework/Features/Publications/Models/PaginationSettings.php
+++ b/packages/framework/src/Framework/Features/Publications/Models/PaginationSettings.php
@@ -13,8 +13,6 @@ class PaginationSettings implements SerializableContract
 
     public string $sortField = '__createdAt';
     public bool $sortAscending = true;
-    /** @deprecated This setting might be deprecated as its unlikely one would enable page size limits without a way to traverse them */
-    public bool $prevNextLinks = true;
     public int $pageSize = 25;
 
     public static function fromArray(array $data): static

--- a/packages/framework/src/Framework/Features/Publications/Models/PaginationSettings.php
+++ b/packages/framework/src/Framework/Features/Publications/Models/PaginationSettings.php
@@ -24,7 +24,6 @@ class PaginationSettings implements SerializableContract
     {
         $this->sortField = $sortField;
         $this->sortAscending = $sortAscending;
-        $this->prevNextLinks = $prevNextLinks;
         $this->pageSize = $pageSize;
     }
 
@@ -33,7 +32,6 @@ class PaginationSettings implements SerializableContract
         return [
             'sortField' => $this->sortField,
             'sortAscending' => $this->sortAscending,
-            'prevNextLinks' => $this->prevNextLinks,
             'pageSize' => $this->pageSize,
         ];
     }

--- a/packages/framework/src/Framework/Features/Publications/Models/PaginationSettings.php
+++ b/packages/framework/src/Framework/Features/Publications/Models/PaginationSettings.php
@@ -20,7 +20,7 @@ class PaginationSettings implements SerializableContract
         return new static(...$data);
     }
 
-    public function __construct(string $sortField = '__createdAt', bool $sortAscending = true, bool $prevNextLinks = true, int $pageSize = 25)
+    public function __construct(string $sortField = '__createdAt', bool $sortAscending = true, int $pageSize = 25)
     {
         $this->sortField = $sortField;
         $this->sortAscending = $sortAscending;

--- a/packages/framework/src/Framework/Features/Publications/Models/PublicationType.php
+++ b/packages/framework/src/Framework/Features/Publications/Models/PublicationType.php
@@ -189,8 +189,10 @@ class PublicationType implements SerializableContract
 
     protected function evaluatePaginationSettings(array|PaginationSettings $pagination): PaginationSettings
     {
-        return $pagination instanceof PaginationSettings
-            ? $pagination
-            : PaginationSettings::fromArray($pagination);
+        if ($pagination instanceof PaginationSettings) {
+            return $pagination;
+        }
+        
+        return PaginationSettings::fromArray($pagination);
     }
 }

--- a/packages/framework/src/Framework/Features/Publications/Models/PublicationType.php
+++ b/packages/framework/src/Framework/Features/Publications/Models/PublicationType.php
@@ -112,6 +112,7 @@ class PublicationType implements SerializableContract
         return json_encode($this->toArray(), $options);
     }
 
+    /** Get the publication type's identifier */
     public function getIdentifier(): string
     {
         return $this->directory ?? Str::slug($this->name);

--- a/packages/framework/src/Framework/Features/Publications/Models/PublicationType.php
+++ b/packages/framework/src/Framework/Features/Publications/Models/PublicationType.php
@@ -76,7 +76,7 @@ class PublicationType implements SerializableContract
             'canonicalField' => $this->canonicalField,
             'detailTemplate' => $this->detailTemplate,
             'listTemplate' => $this->listTemplate,
-            'pagination' => $this->pagination->toArray(),
+            'pagination' => $this->pagination?->toArray(),
             'fields' => $this->fields,
         ];
     }

--- a/packages/framework/src/Framework/Features/Publications/Models/PublicationType.php
+++ b/packages/framework/src/Framework/Features/Publications/Models/PublicationType.php
@@ -33,6 +33,10 @@ class PublicationType implements SerializableContract
     use InteractsWithDirectories;
 
     public PaginationSettings|null $pagination;
+    public string $listTemplate = 'list.blade.php';
+    public string $detailTemplate = 'detail.blade.php';
+    public string $canonicalField = 'identifier';
+    public string $name;
     protected string $directory;
 
     /** @var array<array<string, mixed>> */
@@ -56,14 +60,18 @@ class PublicationType implements SerializableContract
     }
 
     public function __construct(
-        public string $name,
-        public string $canonicalField = 'identifier',
-        public string $detailTemplate = 'detail.blade.php',
-        public string $listTemplate = 'list.blade.php',
+        string $name,
+        string $canonicalField = 'identifier',
+        string $detailTemplate = 'detail.blade.php',
+        string $listTemplate = 'list.blade.php',
         ?array $pagination = [],
         array $fields = [],
         ?string $directory = null
     ) {
+        $this->name = $name;
+        $this->canonicalField = $canonicalField;
+        $this->detailTemplate = $detailTemplate;
+        $this->listTemplate = $listTemplate;
         $this->fields = $fields;
         $this->directory = $directory ?? Str::slug($name);
         $this->pagination = $this->evaluatePaginationSettings($pagination);

--- a/packages/framework/src/Framework/Features/Publications/Models/PublicationType.php
+++ b/packages/framework/src/Framework/Features/Publications/Models/PublicationType.php
@@ -204,6 +204,7 @@ class PublicationType implements SerializableContract
 
     protected function parseFieldData(array $fields): Collection
     {
+        // FIXME check if we actually need the named key, as that adds complexity and the need to call ->values()
         return Collection::make($fields)->mapWithKeys(function (array $data): array {
             return [$data['name'] => new PublicationFieldDefinition(...$data)];
         });

--- a/packages/framework/src/Framework/Features/Publications/Models/PublicationType.php
+++ b/packages/framework/src/Framework/Features/Publications/Models/PublicationType.php
@@ -204,10 +204,6 @@ class PublicationType implements SerializableContract
 
     protected function parseFieldData(array $fields): Collection
     {
-        return Collection::make($fields)->map(function (array $data): PublicationFieldDefinition {
-            return new PublicationFieldDefinition(...$data);
-        });
-
         // FIXME check if we actually need the named key, as that adds complexity and the need to call ->values()
         return Collection::make($fields)->mapWithKeys(function (array $data): array {
             return [$data['name'] => new PublicationFieldDefinition(...$data)];

--- a/packages/framework/src/Framework/Features/Publications/Models/PublicationType.php
+++ b/packages/framework/src/Framework/Features/Publications/Models/PublicationType.php
@@ -130,19 +130,7 @@ class PublicationType implements SerializableContract
     }
 
     /**
-     * Get the raw field definitions for this publication type.
-     *
-     * @deprecated Use getFields() instead
-     */
-    public function getFieldData(): array
-    {
-        return $this->fields;
-    }
-
-    /**
      * Get the publication fields, deserialized to PublicationFieldDefinition objects.
-     *
-     * @see self::getFieldData() to get the raw field definitions.
      *
      * @return \Illuminate\Support\Collection<string, \Hyde\Framework\Features\Publications\Models\PublicationFieldDefinition>
      */

--- a/packages/framework/src/Framework/Features/Publications/Models/PublicationType.php
+++ b/packages/framework/src/Framework/Features/Publications/Models/PublicationType.php
@@ -132,7 +132,7 @@ class PublicationType implements SerializableContract
     /**
      * Get the raw field definitions for this publication type.
      *
-     * @see self::getFields() to get the deserialized field definitions.
+     * @deprecated Use getFields() instead
      */
     public function getFieldData(): array
     {

--- a/packages/framework/src/Framework/Features/Publications/Models/PublicationType.php
+++ b/packages/framework/src/Framework/Features/Publications/Models/PublicationType.php
@@ -32,16 +32,32 @@ class PublicationType implements SerializableContract
     use Serializable;
     use InteractsWithDirectories;
 
+    /** The "pretty" name of the publication type */
     public string $name;
+
+    /**
+     * The field name that is used as the canonical (or identifying) field of publications.
+     * It's used primarily for generating filenames, and the publications must thus be unique by this field.
+     */
     public string $canonicalField = 'identifier';
+
+    /** The Blade filename or view identifier used for rendering a single publication */
     public string $detailTemplate = 'detail.blade.php';
+
+    /** The Blade filename or view identifier used for rendering the index page (or index pages, when using pagination) */
     public string $listTemplate = 'list.blade.php';
 
+    /** The pagination settings. Set to null to disable pagination. Make sure your list view supports it when enabled. */
     public null|PaginationSettings $pagination;
 
-    /** @var array<array<string, mixed>> */
+    /**
+     * The front matter fields used for the publications.
+     *
+     * @var array<array<string, mixed>>
+     */
     public array $fields = [];
 
+    /** The directory of the publication files */
     protected string $directory;
 
     public static function get(string $name): static

--- a/packages/framework/src/Framework/Features/Publications/Models/PublicationType.php
+++ b/packages/framework/src/Framework/Features/Publications/Models/PublicationType.php
@@ -37,6 +37,7 @@ class PublicationType implements SerializableContract
 
     /**
      * The field name that is used as the canonical (or identifying) field of publications.
+     * 
      * It's used primarily for generating filenames, and the publications must thus be unique by this field.
      */
     public string $canonicalField = '__createdAt';

--- a/packages/framework/src/Framework/Features/Publications/Models/PublicationType.php
+++ b/packages/framework/src/Framework/Features/Publications/Models/PublicationType.php
@@ -188,9 +188,13 @@ class PublicationType implements SerializableContract
         }, descending: ! $this->pagination->sortAscending)->values();
     }
 
-    protected function evaluatePaginationSettings(array|PaginationSettings $pagination): PaginationSettings
+    protected function evaluatePaginationSettings(array|PaginationSettings $pagination): ?PaginationSettings
     {
         if (is_array($pagination)) {
+            if (empty($pagination)) {
+                return null;
+            }
+
             return PaginationSettings::fromArray($pagination);
         }
         return $pagination;

--- a/packages/framework/src/Framework/Features/Publications/Models/PublicationType.php
+++ b/packages/framework/src/Framework/Features/Publications/Models/PublicationType.php
@@ -216,11 +216,6 @@ class PublicationType implements SerializableContract
 
     protected function parseFieldData(array $fields): Collection
     {
-        return Collection::make($fields)->map(function (array $data): PublicationFieldDefinition {
-            return new PublicationFieldDefinition(...$data);
-        });
-
-        // FIXME 
         return Collection::make($fields)->mapWithKeys(function (array $data): array {
             return [$data['name'] => new PublicationFieldDefinition(...$data)];
         });

--- a/packages/framework/src/Framework/Features/Publications/Models/PublicationType.php
+++ b/packages/framework/src/Framework/Features/Publications/Models/PublicationType.php
@@ -32,15 +32,17 @@ class PublicationType implements SerializableContract
     use Serializable;
     use InteractsWithDirectories;
 
-    public PaginationSettings|null $pagination;
     public string $name;
     public string $canonicalField = 'identifier';
     public string $detailTemplate = 'detail.blade.php';
     public string $listTemplate = 'list.blade.php';
-    protected string $directory;
+
+    public null|PaginationSettings $pagination;
 
     /** @var array<array<string, mixed>> */
     public array $fields = [];
+
+    protected string $directory;
 
     public static function get(string $name): static
     {

--- a/packages/framework/src/Framework/Features/Publications/Models/PublicationType.php
+++ b/packages/framework/src/Framework/Features/Publications/Models/PublicationType.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Hyde\Framework\Features\Publications\Models;
 
-use function array_filter;
 use function array_merge;
 use function dirname;
 use Exception;
@@ -72,14 +71,14 @@ class PublicationType implements SerializableContract
 
     public function toArray(): array
     {
-        return array_filter([
+        return [
             'name' => $this->name,
             'canonicalField' => $this->canonicalField,
             'detailTemplate' => $this->detailTemplate,
             'listTemplate' => $this->listTemplate,
             'pagination' => $this->pagination?->toArray(),
             'fields' => $this->fields,
-        ]);
+        ];
     }
 
     public function toJson($options = JSON_PRETTY_PRINT): string

--- a/packages/framework/src/Framework/Features/Publications/Models/PublicationType.php
+++ b/packages/framework/src/Framework/Features/Publications/Models/PublicationType.php
@@ -197,6 +197,7 @@ class PublicationType implements SerializableContract
 
             return PaginationSettings::fromArray($pagination);
         }
+
         return $pagination;
     }
 }

--- a/packages/framework/src/Framework/Features/Publications/Models/PublicationType.php
+++ b/packages/framework/src/Framework/Features/Publications/Models/PublicationType.php
@@ -204,9 +204,8 @@ class PublicationType implements SerializableContract
 
     protected function parseFieldData(array $fields): Collection
     {
-        // FIXME check if we actually need the named key, as that adds complexity and the need to call ->values()
-        return Collection::make($fields)->mapWithKeys(function (array $data): array {
-            return [$data['name'] => new PublicationFieldDefinition(...$data)];
+        return Collection::make($fields)->map(function (array $data): PublicationFieldDefinition {
+            return new PublicationFieldDefinition(...$data);
         });
     }
 

--- a/packages/framework/src/Framework/Features/Publications/Models/PublicationType.php
+++ b/packages/framework/src/Framework/Features/Publications/Models/PublicationType.php
@@ -37,7 +37,7 @@ class PublicationType implements SerializableContract
 
     /**
      * The field name that is used as the canonical (or identifying) field of publications.
-     * 
+     *
      * It's used primarily for generating filenames, and the publications must thus be unique by this field.
      */
     public string $canonicalField = '__createdAt';

--- a/packages/framework/src/Framework/Features/Publications/Models/PublicationType.php
+++ b/packages/framework/src/Framework/Features/Publications/Models/PublicationType.php
@@ -61,7 +61,7 @@ class PublicationType implements SerializableContract
         public string $canonicalField = 'identifier',
         public string $detailTemplate = 'detail.blade.php',
         public string $listTemplate = 'list.blade.php',
-        array|PaginationSettings $pagination = [],
+        ?array $pagination = [],
         array $fields = [],
         ?string $directory = null
     ) {
@@ -189,17 +189,13 @@ class PublicationType implements SerializableContract
         }, descending: ! $this->pagination->sortAscending)->values();
     }
 
-    protected function evaluatePaginationSettings(array|PaginationSettings $pagination): ?PaginationSettings
+    protected function evaluatePaginationSettings(array $pagination): ?PaginationSettings
     {
-        if (is_array($pagination)) {
-            if (empty($pagination)) {
-                return null;
-            }
-
-            return PaginationSettings::fromArray($pagination);
+        if (empty($pagination)) {
+            return null;
         }
 
-        return $pagination;
+        return PaginationSettings::fromArray($pagination);
     }
 
     protected function withoutNullValues(array $array): array

--- a/packages/framework/src/Framework/Features/Publications/Models/PublicationType.php
+++ b/packages/framework/src/Framework/Features/Publications/Models/PublicationType.php
@@ -104,7 +104,7 @@ class PublicationType implements SerializableContract
             'detailTemplate' => $this->detailTemplate,
             'listTemplate' => $this->listTemplate,
             'pagination' => $this->pagination?->toArray(),
-            'fields' => $this->fields,
+            'fields' => $this->fields->toArray(),
         ]);
     }
 

--- a/packages/framework/src/Framework/Features/Publications/Models/PublicationType.php
+++ b/packages/framework/src/Framework/Features/Publications/Models/PublicationType.php
@@ -54,9 +54,9 @@ class PublicationType implements SerializableContract
     /**
      * The front matter fields used for the publications.
      *
-     * @var array<array<string, mixed>>
+     * @var \Illuminate\Support\Collection<string, \Hyde\Framework\Features\Publications\Models\PublicationFieldDefinition>
      */
-    public array $fields = [];
+    public Collection $fields;
 
     /** The directory of the publication files */
     protected string $directory;
@@ -91,7 +91,7 @@ class PublicationType implements SerializableContract
         $this->canonicalField = $canonicalField;
         $this->detailTemplate = $detailTemplate;
         $this->listTemplate = $listTemplate;
-        $this->fields = $fields;
+        $this->fields = $this->parseFieldData($fields);
         $this->directory = $directory ?? Str::slug($name);
         $this->pagination = $this->evaluatePaginationSettings($pagination);
     }
@@ -148,9 +148,7 @@ class PublicationType implements SerializableContract
      */
     public function getFields(): Collection
     {
-        return Collection::make($this->fields)->mapWithKeys(function (array $data): array {
-            return [$data['name'] => new PublicationFieldDefinition(...$data)];
-        });
+        return $this->fields;
     }
 
     public function getFieldDefinition(string $fieldName): PublicationFieldDefinition
@@ -214,6 +212,13 @@ class PublicationType implements SerializableContract
         return $this->getPublications()->sortBy(function (PublicationPage $page): mixed {
             return $page->matter($this->pagination->sortField);
         }, descending: ! $this->pagination->sortAscending)->values();
+    }
+
+    protected function parseFieldData(array $fields): Collection
+    {
+        return Collection::make($fields)->mapWithKeys(function (array $data): array {
+            return [$data['name'] => new PublicationFieldDefinition(...$data)];
+        });
     }
 
     protected function evaluatePaginationSettings(array $pagination): ?PaginationSettings

--- a/packages/framework/src/Framework/Features/Publications/Models/PublicationType.php
+++ b/packages/framework/src/Framework/Features/Publications/Models/PublicationType.php
@@ -18,6 +18,7 @@ use Hyde\Support\Concerns\Serializable;
 use Hyde\Support\Contracts\SerializableContract;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Str;
+use function is_array;
 use function json_decode;
 use function json_encode;
 use RuntimeException;
@@ -189,10 +190,9 @@ class PublicationType implements SerializableContract
 
     protected function evaluatePaginationSettings(array|PaginationSettings $pagination): PaginationSettings
     {
-        if ($pagination instanceof PaginationSettings) {
-            return $pagination;
+        if (is_array($pagination)) {
+            return PaginationSettings::fromArray($pagination);
         }
-        
-        return PaginationSettings::fromArray($pagination);
+        return $pagination;
     }
 }

--- a/packages/framework/src/Framework/Features/Publications/Models/PublicationType.php
+++ b/packages/framework/src/Framework/Features/Publications/Models/PublicationType.php
@@ -216,6 +216,11 @@ class PublicationType implements SerializableContract
 
     protected function parseFieldData(array $fields): Collection
     {
+        return Collection::make($fields)->map(function (array $data): PublicationFieldDefinition {
+            return new PublicationFieldDefinition(...$data);
+        });
+
+        // FIXME 
         return Collection::make($fields)->mapWithKeys(function (array $data): array {
             return [$data['name'] => new PublicationFieldDefinition(...$data)];
         });

--- a/packages/framework/src/Framework/Features/Publications/Models/PublicationType.php
+++ b/packages/framework/src/Framework/Features/Publications/Models/PublicationType.php
@@ -204,6 +204,10 @@ class PublicationType implements SerializableContract
 
     protected function parseFieldData(array $fields): Collection
     {
+        return Collection::make($fields)->map(function (array $data): PublicationFieldDefinition {
+            return new PublicationFieldDefinition(...$data);
+        });
+
         // FIXME check if we actually need the named key, as that adds complexity and the need to call ->values()
         return Collection::make($fields)->mapWithKeys(function (array $data): array {
             return [$data['name'] => new PublicationFieldDefinition(...$data)];

--- a/packages/framework/src/Framework/Features/Publications/Models/PublicationType.php
+++ b/packages/framework/src/Framework/Features/Publications/Models/PublicationType.php
@@ -104,7 +104,7 @@ class PublicationType implements SerializableContract
             'detailTemplate' => $this->detailTemplate,
             'listTemplate' => $this->listTemplate,
             'pagination' => $this->pagination?->toArray(),
-            'fields' => $this->fields->toArray(),
+            'fields' => $this->fields->values()->toArray(),
         ]);
     }
 

--- a/packages/framework/src/Framework/Features/Publications/Models/PublicationType.php
+++ b/packages/framework/src/Framework/Features/Publications/Models/PublicationType.php
@@ -65,9 +65,7 @@ class PublicationType implements SerializableContract
     ) {
         $this->fields = $fields;
         $this->directory = $directory ?? Str::slug($name);
-        $this->pagination = $pagination instanceof PaginationSettings
-            ? $pagination
-            : PaginationSettings::fromArray($pagination);
+        $this->pagination = $this->evaluatePaginationSettings($pagination);
     }
 
     public function toArray(): array
@@ -187,5 +185,12 @@ class PublicationType implements SerializableContract
         return $this->getPublications()->sortBy(function (PublicationPage $page): mixed {
             return $page->matter($this->pagination->sortField);
         }, descending: ! $this->pagination->sortAscending)->values();
+    }
+
+    protected function evaluatePaginationSettings(array|PaginationSettings $pagination): PaginationSettings
+    {
+        return $pagination instanceof PaginationSettings
+            ? $pagination
+            : PaginationSettings::fromArray($pagination);
     }
 }

--- a/packages/framework/src/Framework/Features/Publications/Models/PublicationType.php
+++ b/packages/framework/src/Framework/Features/Publications/Models/PublicationType.php
@@ -104,7 +104,7 @@ class PublicationType implements SerializableContract
             'detailTemplate' => $this->detailTemplate,
             'listTemplate' => $this->listTemplate,
             'pagination' => $this->pagination?->toArray(),
-            'fields' => $this->fields->values()->toArray(),
+            'fields' => $this->fields->toArray(),
         ]);
     }
 

--- a/packages/framework/src/Framework/Features/Publications/Models/PublicationType.php
+++ b/packages/framework/src/Framework/Features/Publications/Models/PublicationType.php
@@ -32,7 +32,7 @@ class PublicationType implements SerializableContract
     use Serializable;
     use InteractsWithDirectories;
 
-    public PaginationSettings $pagination;
+    public ?PaginationSettings $pagination;
     protected string $directory;
 
     /** @var array<array<string, mixed>> */

--- a/packages/framework/src/Framework/Features/Publications/Models/PublicationType.php
+++ b/packages/framework/src/Framework/Features/Publications/Models/PublicationType.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Hyde\Framework\Features\Publications\Models;
 
+use function array_filter;
 use function array_merge;
 use function dirname;
 use Exception;
@@ -71,14 +72,14 @@ class PublicationType implements SerializableContract
 
     public function toArray(): array
     {
-        return [
+        return array_filter([
             'name' => $this->name,
             'canonicalField' => $this->canonicalField,
             'detailTemplate' => $this->detailTemplate,
             'listTemplate' => $this->listTemplate,
             'pagination' => $this->pagination?->toArray(),
             'fields' => $this->fields,
-        ];
+        ]);
     }
 
     public function toJson($options = JSON_PRETTY_PRINT): string

--- a/packages/framework/src/Framework/Features/Publications/Models/PublicationType.php
+++ b/packages/framework/src/Framework/Features/Publications/Models/PublicationType.php
@@ -39,7 +39,7 @@ class PublicationType implements SerializableContract
      * The field name that is used as the canonical (or identifying) field of publications.
      * It's used primarily for generating filenames, and the publications must thus be unique by this field.
      */
-    public string $canonicalField = 'identifier';
+    public string $canonicalField = '__createdAt';
 
     /** The Blade filename or view identifier used for rendering a single publication */
     public string $detailTemplate = 'detail.blade.php';
@@ -79,7 +79,7 @@ class PublicationType implements SerializableContract
 
     public function __construct(
         string $name,
-        string $canonicalField = 'identifier',
+        string $canonicalField = '__createdAt',
         string $detailTemplate = 'detail.blade.php',
         string $listTemplate = 'list.blade.php',
         ?array $pagination = [],

--- a/packages/framework/src/Framework/Features/Publications/Models/PublicationType.php
+++ b/packages/framework/src/Framework/Features/Publications/Models/PublicationType.php
@@ -33,10 +33,10 @@ class PublicationType implements SerializableContract
     use InteractsWithDirectories;
 
     public PaginationSettings|null $pagination;
-    public string $listTemplate = 'list.blade.php';
-    public string $detailTemplate = 'detail.blade.php';
-    public string $canonicalField = 'identifier';
     public string $name;
+    public string $canonicalField = 'identifier';
+    public string $detailTemplate = 'detail.blade.php';
+    public string $listTemplate = 'list.blade.php';
     protected string $directory;
 
     /** @var array<array<string, mixed>> */

--- a/packages/framework/src/Framework/Features/Publications/Models/PublicationType.php
+++ b/packages/framework/src/Framework/Features/Publications/Models/PublicationType.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Hyde\Framework\Features\Publications\Models;
 
+use function array_filter;
 use function array_merge;
 use function dirname;
 use Exception;
@@ -71,14 +72,14 @@ class PublicationType implements SerializableContract
 
     public function toArray(): array
     {
-        return [
+        return $this->withoutNullValues([
             'name' => $this->name,
             'canonicalField' => $this->canonicalField,
             'detailTemplate' => $this->detailTemplate,
             'listTemplate' => $this->listTemplate,
             'pagination' => $this->pagination?->toArray(),
             'fields' => $this->fields,
-        ];
+        ]);
     }
 
     public function toJson($options = JSON_PRETTY_PRINT): string
@@ -199,5 +200,10 @@ class PublicationType implements SerializableContract
         }
 
         return $pagination;
+    }
+
+    protected function withoutNullValues(array $array): array
+    {
+        return array_filter($array, fn (mixed $value): bool => ! is_null($value));
     }
 }

--- a/packages/framework/src/Framework/Features/Publications/Models/PublicationType.php
+++ b/packages/framework/src/Framework/Features/Publications/Models/PublicationType.php
@@ -32,7 +32,7 @@ class PublicationType implements SerializableContract
     use Serializable;
     use InteractsWithDirectories;
 
-    public ?PaginationSettings $pagination;
+    public PaginationSettings|null $pagination;
     protected string $directory;
 
     /** @var array<array<string, mixed>> */

--- a/packages/framework/src/Framework/Features/Publications/Models/PublicationType.php
+++ b/packages/framework/src/Framework/Features/Publications/Models/PublicationType.php
@@ -19,7 +19,6 @@ use Hyde\Support\Concerns\Serializable;
 use Hyde\Support\Contracts\SerializableContract;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Str;
-use function is_array;
 use function json_decode;
 use function json_encode;
 use RuntimeException;

--- a/packages/framework/tests/Feature/Actions/CreatesNewPublicationTypeTest.php
+++ b/packages/framework/tests/Feature/Actions/CreatesNewPublicationTypeTest.php
@@ -48,7 +48,6 @@ class CreatesNewPublicationTypeTest extends TestCase
                 "pagination": {
                     "sortField": "sort",
                     "sortAscending": false,
-                    "prevNextLinks": false,
                     "pageSize": 10
                 },
                 "fields": []
@@ -75,7 +74,6 @@ class CreatesNewPublicationTypeTest extends TestCase
                 "pagination": {
                     "sortField": "__createdAt",
                     "sortAscending": true,
-                    "prevNextLinks": true,
                     "pageSize": 25
                 },
                 "fields": []

--- a/packages/framework/tests/Feature/Actions/CreatesNewPublicationTypeTest.php
+++ b/packages/framework/tests/Feature/Actions/CreatesNewPublicationTypeTest.php
@@ -33,7 +33,6 @@ class CreatesNewPublicationTypeTest extends TestCase
             'canonical',
             'sort',
             false,
-            false,
             10
         );
         $creator->create();

--- a/packages/framework/tests/Feature/Actions/SeedsPublicationFilesTest.php
+++ b/packages/framework/tests/Feature/Actions/SeedsPublicationFilesTest.php
@@ -133,9 +133,9 @@ class SeedsPublicationFilesTest extends TestCase
     {
         $tags = ['test-publication' => ['foo', 'bar', 'baz']];
         $this->file('tags.json', json_encode($tags));
-        $this->pubType->fields = [
-            (new PublicationFieldDefinition('tag', 'tag', tagGroup: 'test-publication'))->toArray(),
-        ];
+        $this->pubType->fields = collect([
+            (new PublicationFieldDefinition('tag', 'tag', tagGroup: 'test-publication')),
+        ]);
         $this->pubType->save();
         (new SeedsPublicationFiles($this->pubType))->create();
 
@@ -187,9 +187,9 @@ class SeedsPublicationFilesTest extends TestCase
 
     protected function updateSchema(string $type, string $name): void
     {
-        $this->pubType->fields = [
-            (new PublicationFieldDefinition($type, $name))->toArray(),
-        ];
+        $this->pubType->fields = collect([
+            (new PublicationFieldDefinition($type, $name)),
+        ]);
         $this->pubType->save();
     }
 

--- a/packages/framework/tests/Feature/Commands/MakePublicationCommandTest.php
+++ b/packages/framework/tests/Feature/Commands/MakePublicationCommandTest.php
@@ -77,7 +77,6 @@ class MakePublicationCommandTest extends TestCase
                 'listTemplate'   => 'list',
                 'pagination' => [
                     'pageSize'       => 10,
-                    'prevNextLinks'  => true,
                     'sortField'      => '__createdAt',
                     'sortAscending'  => true,
                 ],
@@ -584,7 +583,6 @@ class MakePublicationCommandTest extends TestCase
                 'listTemplate'   => 'list',
                 'pagination' => [
                     'pageSize'       => 10,
-                    'prevNextLinks'  => true,
                     'sortField'      => '__createdAt',
                     'sortAscending'  => true,
                 ],

--- a/packages/framework/tests/Feature/Commands/MakePublicationTypeCommandTest.php
+++ b/packages/framework/tests/Feature/Commands/MakePublicationTypeCommandTest.php
@@ -80,7 +80,6 @@ class MakePublicationTypeCommandTest extends TestCase
                 "pagination": {
                     "sortField": "__createdAt",
                     "sortAscending": true,
-                    "prevNextLinks": true,
                     "pageSize": 10
                 },
                 "fields": [
@@ -187,7 +186,6 @@ class MakePublicationTypeCommandTest extends TestCase
                 "pagination": {
                     "sortField": "__createdAt",
                     "sortAscending": true,
-                    "prevNextLinks": true,
                     "pageSize": 25
                 },
                 "fields": [

--- a/packages/framework/tests/Feature/Commands/MakePublicationTypeCommandTest.php
+++ b/packages/framework/tests/Feature/Commands/MakePublicationTypeCommandTest.php
@@ -59,7 +59,6 @@ class MakePublicationTypeCommandTest extends TestCase
                 'Ascending',
                 'Descending',
             ])
-            ->expectsConfirmation('Generate previous/next links in detail view?', 'yes')
             ->expectsQuestion('Enter the page size (0 for no limit)', 10)
             ->expectsChoice('Choose a canonical name field (this will be used to generate filenames, so the values need to be unique)', 'publication-title', [
                 '__createdAt',

--- a/packages/framework/tests/Feature/Commands/MakePublicationTypeCommandTest.php
+++ b/packages/framework/tests/Feature/Commands/MakePublicationTypeCommandTest.php
@@ -50,7 +50,7 @@ class MakePublicationTypeCommandTest extends TestCase
                 'Tag',
             ], true)
             ->expectsConfirmation('Field #1 added! Add another field?')
-            ->expectsConfirmation('Do you want to configure pagination settings?', 'yes')
+            ->expectsConfirmation('Would you like to enable pagination?', 'yes')
             ->expectsChoice('Choose the default field you wish to sort by', '__createdAt', [
                 '__createdAt',
                 'publication-title',
@@ -129,7 +129,7 @@ class MakePublicationTypeCommandTest extends TestCase
 
             ->expectsConfirmation('Field #2 added! Add another field?')
 
-            ->expectsConfirmation('Do you want to configure pagination settings?')
+            ->expectsConfirmation('Would you like to enable pagination?')
             ->expectsChoice('Choose a canonical name field (this will be used to generate filenames, so the values need to be unique)', 'foo', [
                 '__createdAt',
                 'bar',
@@ -242,7 +242,7 @@ class MakePublicationTypeCommandTest extends TestCase
             ->expectsOutput("Okay, we're back on track!")
             ->expectsChoice('Enter tag group for field #1', 'foo', ['foo'], true)
             ->expectsConfirmation('Field #1 added! Add another field?')
-            ->expectsConfirmation('Do you want to configure pagination settings?')
+            ->expectsConfirmation('Would you like to enable pagination?')
             ->expectsChoice('Choose a canonical name field (this will be used to generate filenames, so the values need to be unique)', '__createdAt', ['__createdAt'])
             ->doesntExpectOutput('Error: Can not create a tag field without any tag groups defined in tags.json')
            ->assertSuccessful();

--- a/packages/framework/tests/Feature/PublicationListPageTest.php
+++ b/packages/framework/tests/Feature/PublicationListPageTest.php
@@ -76,7 +76,10 @@ Hello World!
                 'pageSize'       => 10,
             ],
             'fields'         => [
-                'foo' => 'bar',
+                [
+                    'type' => 'string',
+                    'name' => 'Foo',
+                ]
             ],
         ];
     }

--- a/packages/framework/tests/Feature/PublicationListPageTest.php
+++ b/packages/framework/tests/Feature/PublicationListPageTest.php
@@ -79,7 +79,7 @@ Hello World!
                 [
                     'type' => 'string',
                     'name' => 'Foo',
-                ]
+                ],
             ],
         ];
     }

--- a/packages/framework/tests/Feature/PublicationListPageTest.php
+++ b/packages/framework/tests/Feature/PublicationListPageTest.php
@@ -74,7 +74,6 @@ Hello World!
                 'sortField'      => 'sort',
                 'sortAscending'  => true,
                 'pageSize'       => 10,
-                'prevNextLinks'  => true,
             ],
             'fields'         => [
                 'foo' => 'bar',

--- a/packages/framework/tests/Feature/PublicationPageTest.php
+++ b/packages/framework/tests/Feature/PublicationPageTest.php
@@ -121,8 +121,7 @@ class PublicationPageTest extends TestCase
   "pagination": {
       "sortField": "__createdAt",
       "sortAscending": true,
-      "pageSize": 0,
-      "prevNextLinks": true
+      "pageSize": 0
   },
   "fields": [
     {

--- a/packages/framework/tests/Feature/PublicationTypeTest.php
+++ b/packages/framework/tests/Feature/PublicationTypeTest.php
@@ -47,11 +47,7 @@ class PublicationTypeTest extends TestCase
         $this->assertEquals('detail.blade.php', $publicationType->detailTemplate);
         $this->assertEquals('list.blade.php', $publicationType->listTemplate);
         $this->assertEquals([], $publicationType->fields);
-        $this->assertEquals(PaginationSettings::fromArray([
-            'sortField' => '__createdAt',
-            'sortAscending' => true,
-            'pageSize' => 25,
-        ]), $publicationType->pagination);
+        $this->assertNull($publicationType->pagination);
 
         $this->assertEquals('test-publication', $publicationType->getDirectory());
     }

--- a/packages/framework/tests/Feature/PublicationTypeTest.php
+++ b/packages/framework/tests/Feature/PublicationTypeTest.php
@@ -204,17 +204,6 @@ class PublicationTypeTest extends TestCase
         ]), $publicationType->getFields());
     }
 
-    public function test_get_field_data_returns_field_data()
-    {
-        $publicationType = new PublicationType(...$this->getTestData());
-
-        $this->assertSame([['name' => 'title', 'type' => 'string']], $publicationType->getFieldData());
-
-        $publicationType->fields = [];
-
-        $this->assertSame([], $publicationType->getFieldData());
-    }
-
     public function test_get_method_can_find_existing_file_on_disk()
     {
         $publicationType = new PublicationType(...$this->getTestDataWithPathInformation());

--- a/packages/framework/tests/Feature/PublicationTypeTest.php
+++ b/packages/framework/tests/Feature/PublicationTypeTest.php
@@ -33,7 +33,11 @@ class PublicationTypeTest extends TestCase
             if ($key === 'pagination') {
                 $this->assertEquals($property, $publicationType->$key->toArray());
             } else {
-                $this->assertEquals($property, $publicationType->$key);
+                if ($key === 'fields') {
+                    $this->assertEquals($property, $publicationType->$key->values()->toArray());
+                } else {
+                    $this->assertEquals($property, $publicationType->$key);
+                }
             }
         }
     }
@@ -46,7 +50,7 @@ class PublicationTypeTest extends TestCase
         $this->assertEquals('__createdAt', $publicationType->canonicalField);
         $this->assertEquals('detail.blade.php', $publicationType->detailTemplate);
         $this->assertEquals('list.blade.php', $publicationType->listTemplate);
-        $this->assertEquals([], $publicationType->fields);
+        $this->assertEquals(collect([]), $publicationType->fields);
         $this->assertNull($publicationType->pagination);
 
         $this->assertEquals('test-publication', $publicationType->getDirectory());

--- a/packages/framework/tests/Feature/PublicationTypeTest.php
+++ b/packages/framework/tests/Feature/PublicationTypeTest.php
@@ -404,7 +404,6 @@ class PublicationTypeTest extends TestCase
             'canonicalField' => 'identifier',
             'detailTemplate' => 'detail.blade.php',
             'listTemplate' => 'list.blade.php',
-            'pagination' => null,
             'fields' => [],
         ], $publicationType->toArray());
     }
@@ -419,7 +418,6 @@ class PublicationTypeTest extends TestCase
                 "canonicalField": "identifier",
                 "detailTemplate": "detail.blade.php",
                 "listTemplate": "list.blade.php",
-                "pagination": null,
                 "fields": []
             }
             JSON, $publicationType->toJson());

--- a/packages/framework/tests/Feature/PublicationTypeTest.php
+++ b/packages/framework/tests/Feature/PublicationTypeTest.php
@@ -52,15 +52,15 @@ class PublicationTypeTest extends TestCase
         $this->assertEquals('test-publication', $publicationType->getDirectory());
     }
 
-    public function test_construct_with_pagination_object()
+    public function test_construct_with_pagination_settings()
     {
-        $paginationSettings = PaginationSettings::fromArray([
+        $paginationSettings = [
             'sortField'     => 'title',
             'sortAscending' => false,
             'pageSize'      => 10,
-        ]);
+        ];
         $publicationType = new PublicationType('Test Publication', pagination: $paginationSettings);
-        $this->assertSame($paginationSettings, $publicationType->pagination);
+        $this->assertSame($paginationSettings, $publicationType->pagination->toArray());
     }
 
     public function test_class_is_arrayable()
@@ -310,7 +310,7 @@ class PublicationTypeTest extends TestCase
         $paginationSettings = new PaginationSettings('myNumber');
         $fields = [['name' => 'myNumber', 'type' => 'integer']];
 
-        $publicationType = new PublicationType('test-publication', 'myNumber', pagination: $paginationSettings, fields: $fields);
+        $publicationType = new PublicationType('test-publication', 'myNumber', pagination: $paginationSettings->toArray(), fields: $fields);
         $publicationType->save();
 
         $pages[0] = (new PublicationPage('test-publication/page-1', ['myNumber' => 5], type: $publicationType))->save();
@@ -332,7 +332,7 @@ class PublicationTypeTest extends TestCase
         $paginationSettings = new PaginationSettings('myNumber', false);
         $fields = [['name' => 'myNumber', 'type' => 'integer']];
 
-        $publicationType = new PublicationType('test-publication', 'myNumber', pagination: $paginationSettings, fields: $fields);
+        $publicationType = new PublicationType('test-publication', 'myNumber', pagination: $paginationSettings->toArray(), fields: $fields);
         $publicationType->save();
 
         $pages[0] = (new PublicationPage('test-publication/page-1', ['myNumber' => 5], type: $publicationType))->save();
@@ -425,7 +425,7 @@ class PublicationTypeTest extends TestCase
 
     public function testArrayRepresentationWithPaginationSettings()
     {
-        $publicationType = new PublicationType('test-publication', pagination: new PaginationSettings());
+        $publicationType = new PublicationType('test-publication', pagination: (new PaginationSettings())->toArray());
 
         $this->assertSame([
             'name' => 'test-publication',
@@ -443,7 +443,7 @@ class PublicationTypeTest extends TestCase
 
     public function testJsonRepresentationWithPaginationSettings()
     {
-        $publicationType = new PublicationType('test-publication', pagination: new PaginationSettings());
+        $publicationType = new PublicationType('test-publication', pagination: (new PaginationSettings())->toArray());
 
         $this->assertSame(<<<'JSON'
             {

--- a/packages/framework/tests/Feature/PublicationTypeTest.php
+++ b/packages/framework/tests/Feature/PublicationTypeTest.php
@@ -435,6 +435,46 @@ class PublicationTypeTest extends TestCase
             JSON, $publicationType->toJson());
     }
 
+    public function testArrayRepresentationWithPaginationSettings()
+    {
+        $publicationType = new PublicationType('test-publication');
+
+        $this->assertSame([
+            'name' => 'test-publication',
+            'canonicalField' => 'identifier',
+            'fields' => [],
+            'pagination' => [
+                'pageSize' => 25,
+                'sortField' => '__createdAt',
+                'sortAscending' => true,
+                'prevNextLinks' => true,
+            ],
+            'detailTemplate' => 'detail.blade.php',
+            'listTemplate' => 'list.blade.php',
+        ], $publicationType->toArray());
+    }
+
+    public function testJsonRepresentationWithPaginationSettings()
+    {
+        $publicationType = new PublicationType('test-publication');
+
+        $this->assertSame(<<<'JSON'
+            {
+                "name": "test-publication",
+                "canonicalField": "identifier",
+                "detailTemplate": "detail.blade.php",
+                "listTemplate": "list.blade.php",
+                "pagination": {
+                    "sortField": "__createdAt",
+                    "sortAscending": true,
+                    "prevNextLinks": true,
+                    "pageSize": 25
+                },
+                "fields": []
+            }
+            JSON, $publicationType->toJson());
+    }
+
     protected function getTestData(array $mergeData = []): array
     {
         return array_merge([

--- a/packages/framework/tests/Feature/PublicationTypeTest.php
+++ b/packages/framework/tests/Feature/PublicationTypeTest.php
@@ -43,7 +43,7 @@ class PublicationTypeTest extends TestCase
         $publicationType = new PublicationType('Test Publication');
 
         $this->assertEquals('Test Publication', $publicationType->name);
-        $this->assertEquals('identifier', $publicationType->canonicalField);
+        $this->assertEquals('__createdAt', $publicationType->canonicalField);
         $this->assertEquals('detail.blade.php', $publicationType->detailTemplate);
         $this->assertEquals('list.blade.php', $publicationType->listTemplate);
         $this->assertEquals([], $publicationType->fields);
@@ -401,7 +401,7 @@ class PublicationTypeTest extends TestCase
 
         $this->assertSame([
             'name' => 'test-publication',
-            'canonicalField' => 'identifier',
+            'canonicalField' => '__createdAt',
             'detailTemplate' => 'detail.blade.php',
             'listTemplate' => 'list.blade.php',
             'fields' => [],
@@ -415,7 +415,7 @@ class PublicationTypeTest extends TestCase
         $this->assertSame(<<<'JSON'
             {
                 "name": "test-publication",
-                "canonicalField": "identifier",
+                "canonicalField": "__createdAt",
                 "detailTemplate": "detail.blade.php",
                 "listTemplate": "list.blade.php",
                 "fields": []
@@ -429,7 +429,7 @@ class PublicationTypeTest extends TestCase
 
         $this->assertSame([
             'name' => 'test-publication',
-            'canonicalField' => 'identifier',
+            'canonicalField' => '__createdAt',
             'detailTemplate' => 'detail.blade.php',
             'listTemplate' => 'list.blade.php',
             'pagination' => [
@@ -448,7 +448,7 @@ class PublicationTypeTest extends TestCase
         $this->assertSame(<<<'JSON'
             {
                 "name": "test-publication",
-                "canonicalField": "identifier",
+                "canonicalField": "__createdAt",
                 "detailTemplate": "detail.blade.php",
                 "listTemplate": "list.blade.php",
                 "pagination": {

--- a/packages/framework/tests/Feature/PublicationTypeTest.php
+++ b/packages/framework/tests/Feature/PublicationTypeTest.php
@@ -442,14 +442,14 @@ class PublicationTypeTest extends TestCase
         $this->assertSame([
             'name' => 'test-publication',
             'canonicalField' => 'identifier',
-            'fields' => [],
-            'pagination' => [
-                'pageSize' => 25,
-                'sortField' => '__createdAt',
-                'sortAscending' => true,
-            ],
             'detailTemplate' => 'detail.blade.php',
             'listTemplate' => 'list.blade.php',
+            'pagination' => [
+                'sortField' => '__createdAt',
+                'sortAscending' => true,
+                'pageSize' => 25,
+            ],
+            'fields' => [],
         ], $publicationType->toArray());
     }
 

--- a/packages/framework/tests/Feature/PublicationTypeTest.php
+++ b/packages/framework/tests/Feature/PublicationTypeTest.php
@@ -404,12 +404,7 @@ class PublicationTypeTest extends TestCase
             'canonicalField' => 'identifier',
             'detailTemplate' => 'detail.blade.php',
             'listTemplate' => 'list.blade.php',
-            'pagination' => [
-                'sortField' => '__createdAt',
-                'sortAscending' => true,
-                'prevNextLinks' => true,
-                'pageSize' => 25,
-            ],
+            'pagination' => null,
             'fields' => [],
         ], $publicationType->toArray());
     }
@@ -424,12 +419,7 @@ class PublicationTypeTest extends TestCase
                 "canonicalField": "identifier",
                 "detailTemplate": "detail.blade.php",
                 "listTemplate": "list.blade.php",
-                "pagination": {
-                    "sortField": "__createdAt",
-                    "sortAscending": true,
-                    "prevNextLinks": true,
-                    "pageSize": 25
-                },
+                "pagination": null,
                 "fields": []
             }
             JSON, $publicationType->toJson());

--- a/packages/framework/tests/Feature/PublicationTypeTest.php
+++ b/packages/framework/tests/Feature/PublicationTypeTest.php
@@ -161,7 +161,7 @@ class PublicationTypeTest extends TestCase
         $this->assertInstanceOf(Collection::class, $collection);
         $this->assertInstanceOf(PublicationFieldDefinition::class, $collection->first());
         $this->assertEquals(new Collection([
-            'title' => new PublicationFieldDefinition('string', 'title'),
+            new PublicationFieldDefinition('string', 'title'),
         ]), $collection);
     }
 
@@ -178,8 +178,8 @@ class PublicationTypeTest extends TestCase
 
         $publicationType = PublicationType::fromFile('test-publication/schema.json');
         $this->assertEquals(new Collection([
-            'title' => new PublicationFieldDefinition('string', 'title'),
-            'number' => new PublicationFieldDefinition('integer', 'number'),
+            new PublicationFieldDefinition('string', 'title'),
+            new PublicationFieldDefinition('integer', 'number'),
         ]), $publicationType->getFields());
     }
 
@@ -196,8 +196,8 @@ class PublicationTypeTest extends TestCase
 
         $publicationType = PublicationType::fromFile('test-publication/schema.json');
         $this->assertEquals(new Collection([
-            'title' => new PublicationFieldDefinition('string', 'title', ['foo', 'bar']),
-            'tags' => new PublicationFieldDefinition('tag', 'tags', tagGroup: 'myTags'),
+            new PublicationFieldDefinition('string', 'title', ['foo', 'bar']),
+            new PublicationFieldDefinition('tag', 'tags', tagGroup: 'myTags'),
         ]), $publicationType->getFields());
     }
 

--- a/packages/framework/tests/Feature/PublicationTypeTest.php
+++ b/packages/framework/tests/Feature/PublicationTypeTest.php
@@ -134,32 +134,6 @@ class PublicationTypeTest extends TestCase
         $this->assertEquals($publicationType, PublicationType::fromFile(('tests/fixtures/test-publication-schema.json')));
     }
 
-    public function test_it_loads_arbitrary_publication_fields_from_schema_file()
-    {
-        $this->directory('test-publication');
-        $fields = [
-            [
-                'name' => 'Title',
-                'type' => 'text',
-                'identifier' => 'title',
-                'required' => true,
-            ],
-            [
-                'name' => 'Body',
-                'type' => 'markdown',
-                'identifier' => 'body',
-                'required' => true,
-            ],
-        ];
-        $this->file('test-publication/schema.json', json_encode([
-            'name' => 'Test Publication',
-            'fields' => $fields,
-        ]));
-
-        $publicationType = PublicationType::fromFile('test-publication/schema.json');
-        $this->assertSame($fields, $publicationType->fields);
-    }
-
     public function test_get_fields_method_returns_collection_of_field_objects()
     {
         $publicationType = new PublicationType(...$this->getTestDataWithPathInformation());

--- a/packages/framework/tests/Feature/PublicationTypeTest.php
+++ b/packages/framework/tests/Feature/PublicationTypeTest.php
@@ -51,7 +51,6 @@ class PublicationTypeTest extends TestCase
             'sortField' => '__createdAt',
             'sortAscending' => true,
             'pageSize' => 25,
-            'prevNextLinks' => true,
         ]), $publicationType->pagination);
 
         $this->assertEquals('test-publication', $publicationType->getDirectory());
@@ -63,7 +62,6 @@ class PublicationTypeTest extends TestCase
             'sortField'     => 'title',
             'sortAscending' => false,
             'pageSize'      => 10,
-            'prevNextLinks' => false,
         ]);
         $publicationType = new PublicationType('Test Publication', pagination: $paginationSettings);
         $this->assertSame($paginationSettings, $publicationType->pagination);
@@ -411,7 +409,6 @@ class PublicationTypeTest extends TestCase
             'pagination' => [
                 'sortField' => '__createdAt',
                 'sortAscending' => true,
-                'prevNextLinks' => true,
                 'pageSize' => 25,
             ],
             'fields' => [

--- a/packages/framework/tests/Feature/PublicationTypeTest.php
+++ b/packages/framework/tests/Feature/PublicationTypeTest.php
@@ -475,8 +475,8 @@ class PublicationTypeTest extends TestCase
             ],
             'fields' => [
                 [
-                    'name' => 'title',
                     'type' => 'string',
+                    'name' => 'title',
                 ],
             ],
         ], $mergeData);

--- a/packages/framework/tests/Feature/PublicationTypeTest.php
+++ b/packages/framework/tests/Feature/PublicationTypeTest.php
@@ -34,7 +34,7 @@ class PublicationTypeTest extends TestCase
                 $this->assertEquals($property, $publicationType->$key->toArray());
             } else {
                 if ($key === 'fields') {
-                    $this->assertEquals($property, $publicationType->$key->values()->toArray());
+                    $this->assertEquals($property, $publicationType->$key->toArray());
                 } else {
                     $this->assertEquals($property, $publicationType->$key);
                 }
@@ -150,7 +150,7 @@ class PublicationTypeTest extends TestCase
         ]));
 
         $publicationType = PublicationType::fromFile('test-publication/schema.json');
-        $this->assertSame($fields, $publicationType->getFields()->values()->toArray());
+        $this->assertSame($fields, $publicationType->getFields()->toArray());
     }
 
     public function test_get_fields_method_returns_collection_of_field_objects()

--- a/packages/framework/tests/Feature/PublicationTypeTest.php
+++ b/packages/framework/tests/Feature/PublicationTypeTest.php
@@ -437,7 +437,7 @@ class PublicationTypeTest extends TestCase
 
     public function testArrayRepresentationWithPaginationSettings()
     {
-        $publicationType = new PublicationType('test-publication');
+        $publicationType = new PublicationType('test-publication', pagination: new PaginationSettings());
 
         $this->assertSame([
             'name' => 'test-publication',
@@ -447,7 +447,6 @@ class PublicationTypeTest extends TestCase
                 'pageSize' => 25,
                 'sortField' => '__createdAt',
                 'sortAscending' => true,
-                'prevNextLinks' => true,
             ],
             'detailTemplate' => 'detail.blade.php',
             'listTemplate' => 'list.blade.php',
@@ -456,7 +455,7 @@ class PublicationTypeTest extends TestCase
 
     public function testJsonRepresentationWithPaginationSettings()
     {
-        $publicationType = new PublicationType('test-publication');
+        $publicationType = new PublicationType('test-publication', pagination: new PaginationSettings());
 
         $this->assertSame(<<<'JSON'
             {
@@ -467,7 +466,6 @@ class PublicationTypeTest extends TestCase
                 "pagination": {
                     "sortField": "__createdAt",
                     "sortAscending": true,
-                    "prevNextLinks": true,
                     "pageSize": 25
                 },
                 "fields": []

--- a/packages/framework/tests/Feature/PublicationTypeTest.php
+++ b/packages/framework/tests/Feature/PublicationTypeTest.php
@@ -134,6 +134,25 @@ class PublicationTypeTest extends TestCase
         $this->assertEquals($publicationType, PublicationType::fromFile(('tests/fixtures/test-publication-schema.json')));
     }
 
+    public function test_can_load_fields_with_validation_rules()
+    {
+        $this->directory('test-publication');
+        $fields = [
+            [
+                'type' => 'text',
+                'name' => 'title',
+                'rules' => ['required'],
+            ],
+        ];
+        $this->file('test-publication/schema.json', json_encode([
+            'name' => 'Test Publication',
+            'fields' => $fields,
+        ]));
+
+        $publicationType = PublicationType::fromFile('test-publication/schema.json');
+        $this->assertSame($fields, $publicationType->getFields()->values()->toArray());
+    }
+
     public function test_get_fields_method_returns_collection_of_field_objects()
     {
         $publicationType = new PublicationType(...$this->getTestDataWithPathInformation());

--- a/packages/framework/tests/Unit/Pages/PublicationPageUnitTest.php
+++ b/packages/framework/tests/Unit/Pages/PublicationPageUnitTest.php
@@ -244,7 +244,7 @@ class PublicationPageUnitTest extends BaseMarkdownPageUnitTest
             'canonicalField',
             'detail.blade.php',
             'list.blade.php',
-            ['sortField', true, true, 1],
+            ['sortField', true, 1],
             [],
             'directory'
         );

--- a/packages/framework/tests/Unit/PaginationSettingsTest.php
+++ b/packages/framework/tests/Unit/PaginationSettingsTest.php
@@ -24,7 +24,7 @@ class PaginationSettingsTest extends TestCase
 
     public function testConstruct()
     {
-        $paginationSettings = new PaginationSettings('foo', false, false, 10);
+        $paginationSettings = new PaginationSettings('foo', false, 10);
 
         $this->assertSame('foo', $paginationSettings->sortField);
         $this->assertFalse($paginationSettings->sortAscending);

--- a/packages/framework/tests/Unit/PaginationSettingsTest.php
+++ b/packages/framework/tests/Unit/PaginationSettingsTest.php
@@ -19,7 +19,6 @@ class PaginationSettingsTest extends TestCase
         $this->assertSame('__createdAt', $paginationSettings->sortField);
         $this->assertSame(true, $paginationSettings->sortAscending);
         $this->assertSame(25, $paginationSettings->pageSize);
-        $this->assertSame(true, $paginationSettings->prevNextLinks);
     }
 
     public function testConstruct()
@@ -29,7 +28,6 @@ class PaginationSettingsTest extends TestCase
         $this->assertSame('foo', $paginationSettings->sortField);
         $this->assertFalse($paginationSettings->sortAscending);
         $this->assertSame(10, $paginationSettings->pageSize);
-        $this->assertFalse($paginationSettings->prevNextLinks);
     }
 
     public function testFromArray()
@@ -38,13 +36,11 @@ class PaginationSettingsTest extends TestCase
             'sortField' => 'foo',
             'sortAscending' => false,
             'pageSize' => 10,
-            'prevNextLinks' => false,
         ]);
 
         $this->assertSame('foo', $paginationSettings->sortField);
         $this->assertSame(false, $paginationSettings->sortAscending);
         $this->assertSame(10, $paginationSettings->pageSize);
-        $this->assertSame(false, $paginationSettings->prevNextLinks);
     }
 
     public function testToArray()
@@ -54,7 +50,6 @@ class PaginationSettingsTest extends TestCase
         $this->assertSame([
             'sortField' => '__createdAt',
             'sortAscending' => true,
-            'prevNextLinks' => true,
             'pageSize' => 25,
         ], $paginationSettings->toArray());
     }
@@ -63,7 +58,7 @@ class PaginationSettingsTest extends TestCase
     {
         $paginationSettings = new PaginationSettings();
 
-        $this->assertSame('{"sortField":"__createdAt","sortAscending":true,"prevNextLinks":true,"pageSize":25}', $paginationSettings->toJson());
+        $this->assertSame('{"sortField":"__createdAt","sortAscending":true,"pageSize":25}', $paginationSettings->toJson());
     }
 
     public function testJsonSerialize()

--- a/packages/testing/src/TestCase.php
+++ b/packages/testing/src/TestCase.php
@@ -48,6 +48,7 @@ abstract class TestCase extends BaseTestCase
         parent::tearDown();
     }
 
+    /** @deprecated as it's probably better to do this via the object constructor */
     protected function setupTestPublication(string $directory = 'test-publication')
     {
         Filesystem::copy('tests/fixtures/test-publication-schema.json', "$directory/schema.json");

--- a/tests/fixtures/test-publication-schema.json
+++ b/tests/fixtures/test-publication-schema.json
@@ -6,8 +6,7 @@
     "pagination": {
         "sortField": "__createdAt",
         "sortAscending": true,
-        "pageSize": 25,
-        "prevNextLinks": true
+        "pageSize": 25
     },
     "fields": [
         {


### PR DESCRIPTION
- Improves the publication type create command to better integrate pagination settings
- Removes the prevNextLinks setting as it's unlikely one would enable page size limits without a way to traverse them
- Makes the pagination settings property of publication types nullable, whilst also making pagination not be the default
- The publication type constructor now only accepts arrays for the publication setting (to keeps things simple, and since all other arguments are primitive PHP types)
- Change default publication type canonicalField value from identifier to __createdAt as this is what is being null coalesced to in the creator action, plus it matches the pagination defaults
- Refactor internal field data state to be parsed as this makes it impossible to create an invalid schema only to not realize it until later. Also removes the duplicate getters which is just confusing.