### PR TITLE
Improve the public page and route discovery API

### DIFF
--- a/packages/framework/src/Foundation/PageCollection.php
+++ b/packages/framework/src/Foundation/PageCollection.php
@@ -112,7 +112,7 @@ final class PageCollection extends BaseFoundationCollection
 
     protected function discover(HydePage $page): self
     {
-        $this->put($page->getSourcePath(), $page);
+        $this->addPage($page);
 
         return $this;
     }

--- a/packages/framework/src/Foundation/PageCollection.php
+++ b/packages/framework/src/Foundation/PageCollection.php
@@ -41,6 +41,23 @@ final class PageCollection extends BaseFoundationCollection
         });
     }
 
+    /**
+     * This method adds the specified page to the page collection.
+     * It can be used by package developers to add a page that will be compiled.
+     *
+     * When using this method, take notice of the following things:
+     * 1. Be sure to register the page before the HydeKernel boots,
+     *    otherwise it might not be fully processed by Hyde.
+     * 2. Note that all pages will have their routes added to the route index,
+     *    and subsequently be compiled during the build process.
+     */
+    public function addPage(HydePage $page): self
+    {
+        $this->put($page->getSourcePath(), $page);
+
+        return $this;
+    }
+
     protected function runDiscovery(): self
     {
         if (Features::hasHtmlPages()) {

--- a/packages/framework/src/Foundation/PageCollection.php
+++ b/packages/framework/src/Foundation/PageCollection.php
@@ -90,7 +90,7 @@ final class PageCollection extends BaseFoundationCollection
     protected function discoverPagesFor(string $pageClass): void
     {
         $this->parsePagesFor($pageClass)->each(function ($page): void {
-            $this->discover($page);
+            $this->addPage($page);
         });
     }
 
@@ -108,12 +108,5 @@ final class PageCollection extends BaseFoundationCollection
         }
 
         return $collection;
-    }
-
-    protected function discover(HydePage $page): self
-    {
-        $this->addPage($page);
-
-        return $this;
     }
 }

--- a/packages/framework/src/Foundation/PageCollection.php
+++ b/packages/framework/src/Foundation/PageCollection.php
@@ -95,7 +95,6 @@ final class PageCollection extends BaseFoundationCollection
 
     protected function discover(HydePage $page): self
     {
-        // Create a new route for the given page, and add it to the index.
         $this->put($page->getSourcePath(), $page);
 
         return $this;

--- a/packages/framework/src/Foundation/PageCollection.php
+++ b/packages/framework/src/Foundation/PageCollection.php
@@ -45,6 +45,10 @@ final class PageCollection extends BaseFoundationCollection
      * This method adds the specified page to the page collection.
      * It can be used by package developers to add a page that will be compiled.
      *
+     * Note that this method when used outside of this class is only intended to be used for adding on-off pages;
+     * If you are registering multiple pages, you may instead want to register an entire custom page class,
+     * as that will allow you to utilize the full power of the HydePHP autodiscovery.
+     *
      * When using this method, take notice of the following things:
      * 1. Be sure to register the page before the HydeKernel boots,
      *    otherwise it might not be fully processed by Hyde.

--- a/packages/framework/src/Foundation/RouteCollection.php
+++ b/packages/framework/src/Foundation/RouteCollection.php
@@ -46,7 +46,10 @@ final class RouteCollection extends BaseFoundationCollection
     /**
      * This method adds the specified route to the route index.
      * It can be used by package developers to hook into the routing system.
-     * As a package developer, you will need to make sure your route leads to something.
+     *
+     * When using this method, take notice of the following things:
+     * 1. Be sure to register the route before the HydeKernel boots.
+     * 2. Make sure the route leads to something that can be compiled.
      */
     public function addRoute(Route $route): self
     {

--- a/packages/framework/src/Foundation/RouteCollection.php
+++ b/packages/framework/src/Foundation/RouteCollection.php
@@ -46,7 +46,7 @@ final class RouteCollection extends BaseFoundationCollection
     /**
      * This method adds the specified route to the route index.
      * It can be used by package developers to hook into the routing system.
-
+     *
      * Note that this method when used outside of this class is only intended to be used for adding on-off routes;
      * If you are registering multiple routes, you may instead want to register an entire custom page class,
      * as that will allow you to utilize the full power of the HydePHP autodiscovery. In addition,

--- a/packages/framework/src/Foundation/RouteCollection.php
+++ b/packages/framework/src/Foundation/RouteCollection.php
@@ -44,8 +44,8 @@ final class RouteCollection extends BaseFoundationCollection
     }
 
     /**
-     * This internal method adds the specified route to the route index.
-     * It's made public so package developers can hook into the routing system.
+     * This method adds the specified route to the route index.
+     * It can be used by package developers to hook into the routing system.
      * As a package developer, you will need to make sure your route leads to something.
      */
     public function addRoute(Route $route): self

--- a/packages/framework/src/Foundation/RouteCollection.php
+++ b/packages/framework/src/Foundation/RouteCollection.php
@@ -46,6 +46,12 @@ final class RouteCollection extends BaseFoundationCollection
     /**
      * This method adds the specified route to the route index.
      * It can be used by package developers to hook into the routing system.
+
+     * Note that this method when used outside of this class is only intended to be used for adding on-off routes;
+     * If you are registering multiple routes, you may instead want to register an entire custom page class,
+     * as that will allow you to utilize the full power of the HydePHP autodiscovery. In addition,
+     * you might actually rather want to use the page collection's addPage method instead,
+     * as all pages there are automatically also added as routes here as well.
      *
      * When using this method, take notice of the following things:
      * 1. Be sure to register the route before the HydeKernel boots.


### PR DESCRIPTION
Exposes a previously internal method to the PageCollection class, which allows package developers to add pages to the PageCollection.

This is useful for adding on-off pages; if you are registering multiple pages, it's better to register an entire custom page class instead. It also normalizes the API of the matching method in the RouteCollection, and adds/improves package developer documentation for both.