### PR TITLE
Refactor kernel booting to defer until all providers have been registered

### DIFF
--- a/packages/framework/src/Foundation/Concerns/BootsHydeKernel.php
+++ b/packages/framework/src/Foundation/Concerns/BootsHydeKernel.php
@@ -37,6 +37,11 @@ trait BootsHydeKernel
     /** @internal */
     public function readyToBoot(): void
     {
+        // To give package developers ample time to register their services,
+        // don't want to boot the kernel until all providers have been registered.
+        // This method is called by the HydeServiceProvider's boot method, indicating
+        // that it's okay to boot the kernel now.
+
         $this->readyToBoot = true;
     }
 }

--- a/packages/framework/src/Foundation/Concerns/BootsHydeKernel.php
+++ b/packages/framework/src/Foundation/Concerns/BootsHydeKernel.php
@@ -39,8 +39,6 @@ trait BootsHydeKernel
     {
         // To give package developers ample time to register their services,
         // don't want to boot the kernel until all providers have been registered.
-        // This method is called by the HydeServiceProvider's boot method, indicating
-        // that it's okay to boot the kernel now.
 
         $this->readyToBoot = true;
     }

--- a/packages/framework/src/Foundation/Concerns/BootsHydeKernel.php
+++ b/packages/framework/src/Foundation/Concerns/BootsHydeKernel.php
@@ -4,6 +4,10 @@ declare(strict_types=1);
 
 namespace Hyde\Foundation\Concerns;
 
+use Hyde\Foundation\FileCollection;
+use Hyde\Foundation\PageCollection;
+use Hyde\Foundation\RouteCollection;
+
 /**
  * @internal Single-use trait for the HydeKernel class.
  *
@@ -11,5 +15,12 @@ namespace Hyde\Foundation\Concerns;
  */
 trait BootsHydeKernel
 {
-    //
+    public function boot(): void
+    {
+        $this->booted = true;
+
+        $this->files = FileCollection::boot($this);
+        $this->pages = PageCollection::boot($this);
+        $this->routes = RouteCollection::boot($this);
+    }
 }

--- a/packages/framework/src/Foundation/Concerns/BootsHydeKernel.php
+++ b/packages/framework/src/Foundation/Concerns/BootsHydeKernel.php
@@ -20,6 +20,10 @@ trait BootsHydeKernel
 
     public function boot(): void
     {
+        if ($this->booting) {
+            return;
+        }
+
         $this->booting = true;
 
         $this->files = FileCollection::boot($this);

--- a/packages/framework/src/Foundation/Concerns/BootsHydeKernel.php
+++ b/packages/framework/src/Foundation/Concerns/BootsHydeKernel.php
@@ -20,7 +20,7 @@ trait BootsHydeKernel
 
     public function boot(): void
     {
-        if (! $this->readyToBoot ||  $this->booting) {
+        if (! $this->readyToBoot || $this->booting) {
             return;
         }
 

--- a/packages/framework/src/Foundation/Concerns/BootsHydeKernel.php
+++ b/packages/framework/src/Foundation/Concerns/BootsHydeKernel.php
@@ -20,7 +20,7 @@ trait BootsHydeKernel
 
     public function boot(): void
     {
-        if ($this->booting) {
+        if (! $this->readyToBoot ||  $this->booting) {
             return;
         }
 

--- a/packages/framework/src/Foundation/Concerns/BootsHydeKernel.php
+++ b/packages/framework/src/Foundation/Concerns/BootsHydeKernel.php
@@ -15,6 +15,9 @@ use Hyde\Foundation\RouteCollection;
  */
 trait BootsHydeKernel
 {
+    private bool $readyToBoot = false;
+    private bool $booting = false;
+
     public function boot(): void
     {
         $this->booted = true;

--- a/packages/framework/src/Foundation/Concerns/BootsHydeKernel.php
+++ b/packages/framework/src/Foundation/Concerns/BootsHydeKernel.php
@@ -33,4 +33,10 @@ trait BootsHydeKernel
         $this->booting = false;
         $this->booted = true;
     }
+
+    /** @internal */
+    public function readyToBoot(): void
+    {
+        $this->readyToBoot = true;
+    }
 }

--- a/packages/framework/src/Foundation/Concerns/BootsHydeKernel.php
+++ b/packages/framework/src/Foundation/Concerns/BootsHydeKernel.php
@@ -20,10 +20,13 @@ trait BootsHydeKernel
 
     public function boot(): void
     {
-        $this->booted = true;
+        $this->booting = true;
 
         $this->files = FileCollection::boot($this);
         $this->pages = PageCollection::boot($this);
         $this->routes = RouteCollection::boot($this);
+
+        $this->booting = false;
+        $this->booted = true;
     }
 }

--- a/packages/framework/src/Foundation/Concerns/BootsHydeKernel.php
+++ b/packages/framework/src/Foundation/Concerns/BootsHydeKernel.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Hyde\Foundation\Concerns;
+
+/**
+ * @internal Single-use trait for the HydeKernel class.
+ *
+ * @see \Hyde\Foundation\HydeKernel
+ */
+trait BootsHydeKernel
+{
+    //
+}

--- a/packages/framework/src/Foundation/Concerns/ManagesHydeKernel.php
+++ b/packages/framework/src/Foundation/Concerns/ManagesHydeKernel.php
@@ -5,10 +5,7 @@ declare(strict_types=1);
 namespace Hyde\Foundation\Concerns;
 
 use BadMethodCallException;
-use Hyde\Foundation\FileCollection;
 use Hyde\Foundation\HydeKernel;
-use Hyde\Foundation\PageCollection;
-use Hyde\Foundation\RouteCollection;
 use Hyde\Pages\Concerns\HydePage;
 use Hyde\Pages\Contracts\DynamicPage;
 use function in_array;
@@ -22,15 +19,6 @@ use function is_subclass_of;
  */
 trait ManagesHydeKernel
 {
-    public function boot(): void
-    {
-        $this->booted = true;
-
-        $this->files = FileCollection::boot($this);
-        $this->pages = PageCollection::boot($this);
-        $this->routes = RouteCollection::boot($this);
-    }
-
     public static function getInstance(): HydeKernel
     {
         return static::$instance;

--- a/packages/framework/src/Foundation/HydeKernel.php
+++ b/packages/framework/src/Foundation/HydeKernel.php
@@ -38,6 +38,7 @@ class HydeKernel implements SerializableContract
     use Concerns\ForwardsFilesystem;
     use Concerns\ManagesHydeKernel;
     use Concerns\ManagesViewData;
+    use Concerns\BootsHydeKernel;
 
     use Serializable;
     use Macroable;

--- a/packages/framework/src/Framework/HydeServiceProvider.php
+++ b/packages/framework/src/Framework/HydeServiceProvider.php
@@ -100,7 +100,6 @@ class HydeServiceProvider extends ServiceProvider
         Blade::component('link', LinkComponent::class);
 
         HydeKernel::getInstance()->readyToBoot();
-        HydeKernel::getInstance()->boot();
     }
 
     protected function initializeConfiguration()

--- a/packages/framework/src/Framework/HydeServiceProvider.php
+++ b/packages/framework/src/Framework/HydeServiceProvider.php
@@ -99,6 +99,7 @@ class HydeServiceProvider extends ServiceProvider
 
         Blade::component('link', LinkComponent::class);
 
+        HydeKernel::getInstance()->readyToBoot();
         HydeKernel::getInstance()->boot();
     }
 

--- a/packages/framework/tests/Feature/HydeKernelDynamicPageClassesTest.php
+++ b/packages/framework/tests/Feature/HydeKernelDynamicPageClassesTest.php
@@ -8,7 +8,12 @@ use function app;
 use BadMethodCallException;
 use Hyde\Foundation\Facades;
 use Hyde\Foundation\HydeKernel;
+use Hyde\Pages\BladePage;
 use Hyde\Pages\Concerns\HydePage;
+use Hyde\Pages\DocumentationPage;
+use Hyde\Pages\HtmlPage;
+use Hyde\Pages\MarkdownPage;
+use Hyde\Pages\MarkdownPost;
 use Hyde\Pages\VirtualPage;
 use Hyde\Support\Filesystem\SourceFile;
 use Hyde\Support\Models\Route;
@@ -26,20 +31,40 @@ class HydeKernelDynamicPageClassesTest extends TestCase
 {
     public function test_get_registered_page_classes_method()
     {
-        $this->assertSame([], app(HydeKernel::class)->getRegisteredPageClasses());
+        $this->assertSame([
+            HtmlPage::class,
+            BladePage::class,
+            MarkdownPage::class,
+            MarkdownPost::class,
+            DocumentationPage::class,
+        ], app(HydeKernel::class)->getRegisteredPageClasses());
     }
 
     public function test_register_page_class_method_adds_specified_class_name_to_index()
     {
         app(HydeKernel::class)->registerPageClass(TestPageClass::class);
-        $this->assertSame([TestPageClass::class], app(HydeKernel::class)->getRegisteredPageClasses());
+        $this->assertSame([
+            HtmlPage::class,
+            BladePage::class,
+            MarkdownPage::class,
+            MarkdownPost::class,
+            DocumentationPage::class,
+            TestPageClass::class,
+        ], app(HydeKernel::class)->getRegisteredPageClasses());
     }
 
     public function test_register_page_class_method_does_not_add_already_added_class_names()
     {
         app(HydeKernel::class)->registerPageClass(TestPageClass::class);
         app(HydeKernel::class)->registerPageClass(TestPageClass::class);
-        $this->assertSame([TestPageClass::class], app(HydeKernel::class)->getRegisteredPageClasses());
+        $this->assertSame([
+            HtmlPage::class,
+            BladePage::class,
+            MarkdownPage::class,
+            MarkdownPost::class,
+            DocumentationPage::class,
+            TestPageClass::class,
+        ], app(HydeKernel::class)->getRegisteredPageClasses());
     }
 
     public function test_register_page_class_method_only_accepts_instances_of_hyde_page_class()

--- a/packages/framework/tests/Feature/PageCollectionTest.php
+++ b/packages/framework/tests/Feature/PageCollectionTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Hyde\Framework\Testing\Feature;
 
+use Hyde\Foundation\HydeKernel;
 use Hyde\Foundation\PageCollection;
 use Hyde\Hyde;
 use Hyde\Pages\BladePage;
@@ -128,6 +129,8 @@ class PageCollectionTest extends TestCase
     public function test_pages_are_not_discovered_for_disabled_features()
     {
         config(['hyde.features' => []]);
+
+        HydeKernel::setInstance(new HydeKernel(Hyde::path()));
 
         touch('_pages/blade.blade.php');
         touch('_pages/markdown.md');

--- a/packages/testing/src/CreatesApplication.php
+++ b/packages/testing/src/CreatesApplication.php
@@ -18,9 +18,9 @@ trait CreatesApplication
     {
         $app = require file_exists(__DIR__.'/../../../app/bootstrap.php') ? __DIR__.'/../../../app/bootstrap.php' : getcwd().'/app/bootstrap.php';
 
-        $app->make(Kernel::class)->bootstrap();
-
         HydeKernel::setInstance(new HydeKernel(Hyde::path()));
+
+        $app->make(Kernel::class)->bootstrap();
 
         return $app;
     }


### PR DESCRIPTION
Refactors how and when the Kernel is booted, to allow package developers to register any services before it's too late in the lifecycle.

Integrates working changes from https://github.com/hydephp/develop/pull/822