### PR TITLE
Virtual page improvements

### DIFF
--- a/packages/framework/src/Pages/VirtualPage.php
+++ b/packages/framework/src/Pages/VirtualPage.php
@@ -18,6 +18,9 @@ use Illuminate\Support\Facades\View;
  * When used in a package, it's on the package developer to ensure
  * that the virtual page is registered with Hyde, usually within the
  * boot method of the package's service provider so it can be compiled.
+ *
+ * This class is especially useful for one-off pages, but if your usage grows,
+ * you may benefit from creating a custom page class instead to get full control.
  */
 class VirtualPage extends HydePage implements DynamicPage
 {

--- a/packages/framework/src/Pages/VirtualPage.php
+++ b/packages/framework/src/Pages/VirtualPage.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Hyde\Pages;
 
+use Hyde\Framework\Actions\AnonymousViewCompiler;
 use Hyde\Markdown\Models\FrontMatter;
 use Hyde\Pages\Concerns\HydePage;
 use Hyde\Pages\Contracts\DynamicPage;
@@ -73,6 +74,10 @@ class VirtualPage extends HydePage implements DynamicPage
     public function compile(): string
     {
         if (! $this->contents && $this->view) {
+            if (str_ends_with($this->view, '.blade.php')) {
+                return AnonymousViewCompiler::call($this->view, $this->matter->toArray());
+            }
+
             return View::make($this->getBladeView(), $this->matter->toArray())->render();
         }
 

--- a/packages/framework/src/Pages/VirtualPage.php
+++ b/packages/framework/src/Pages/VirtualPage.php
@@ -108,6 +108,6 @@ class VirtualPage extends HydePage implements DynamicPage
             $macro = $macro->bindTo($this, static::class);
         }
 
-        return $macro($this, ...$parameters);
+        return $macro(...$parameters);
     }
 }

--- a/packages/framework/src/Pages/VirtualPage.php
+++ b/packages/framework/src/Pages/VirtualPage.php
@@ -76,6 +76,9 @@ class VirtualPage extends HydePage implements DynamicPage
         return $this->view;
     }
 
+    /**
+     * Get the contents that will be saved to disk for this page.
+     */
     public function compile(): string
     {
         if (! $this->contents && $this->view) {
@@ -89,11 +92,17 @@ class VirtualPage extends HydePage implements DynamicPage
         return $this->getContents();
     }
 
+    /**
+     * Register a macro for the instance.
+     */
     public function macro(string $name, callable $macro): void
     {
         $this->macros[$name] = $macro;
     }
 
+    /**
+     * Dynamically handle calls to the class.
+     */
     public function __call(string $method, array $parameters): mixed
     {
         if (! isset($this->macros[$method])) {

--- a/packages/framework/src/Pages/VirtualPage.php
+++ b/packages/framework/src/Pages/VirtualPage.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Hyde\Pages;
 
+use Closure;
 use Hyde\Framework\Actions\AnonymousViewCompiler;
 use Hyde\Markdown\Models\FrontMatter;
 use Hyde\Pages\Concerns\HydePage;
@@ -31,6 +32,9 @@ class VirtualPage extends HydePage implements DynamicPage
 
     protected string $contents;
     protected string $view;
+
+    /** @var array<string, Closure> */
+    protected array $macros = [];
 
     public static function make(string $identifier = '', FrontMatter|array $matter = [], string $contents = '', string $view = ''): static
     {
@@ -82,5 +86,17 @@ class VirtualPage extends HydePage implements DynamicPage
         }
 
         return $this->getContents();
+    }
+
+    public function macro(string $name, Closure $macro): void
+    {
+        $this->macros[$name] = $macro;
+    }
+
+    public function __call(string $name, array $arguments)
+    {
+        if (isset($this->macros[$name])) {
+            return ($this->macros[$name])($this, ...$arguments);
+        }
     }
 }

--- a/packages/framework/src/Pages/VirtualPage.php
+++ b/packages/framework/src/Pages/VirtualPage.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Hyde\Pages;
 
 use BadMethodCallException;
+use Closure;
 use Hyde\Framework\Actions\AnonymousViewCompiler;
 use Hyde\Markdown\Models\FrontMatter;
 use Hyde\Pages\Concerns\HydePage;
@@ -101,6 +102,12 @@ class VirtualPage extends HydePage implements DynamicPage
             ));
         }
 
-        return ($this->macros[$method])($this, ...$parameters);
+        $macro = $this->macros[$method];
+
+        if ($macro instanceof Closure) {
+            $macro = $macro->bindTo($this, static::class);
+        }
+
+        return $macro($this, ...$parameters);
     }
 }

--- a/packages/framework/src/Pages/VirtualPage.php
+++ b/packages/framework/src/Pages/VirtualPage.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Hyde\Pages;
 
-use Closure;
 use Hyde\Framework\Actions\AnonymousViewCompiler;
 use Hyde\Markdown\Models\FrontMatter;
 use Hyde\Pages\Concerns\HydePage;
@@ -33,7 +32,7 @@ class VirtualPage extends HydePage implements DynamicPage
     protected string $contents;
     protected string $view;
 
-    /** @var array<string, Closure> */
+    /** @var array<string, callable> */
     protected array $macros = [];
 
     public static function make(string $identifier = '', FrontMatter|array $matter = [], string $contents = '', string $view = ''): static
@@ -88,7 +87,7 @@ class VirtualPage extends HydePage implements DynamicPage
         return $this->getContents();
     }
 
-    public function macro(string $name, Closure $macro): void
+    public function macro(string $name, callable $macro): void
     {
         $this->macros[$name] = $macro;
     }

--- a/packages/framework/src/Pages/VirtualPage.php
+++ b/packages/framework/src/Pages/VirtualPage.php
@@ -93,16 +93,16 @@ class VirtualPage extends HydePage implements DynamicPage
         $this->macros[$name] = $macro;
     }
 
-    public function __call(string $name, array $arguments)
+    public function __call(string $method, array $parameters)
     {
-        if (! isset($this->macros[$name])) {
+        if (! isset($this->macros[$method])) {
             throw new BadMethodCallException(sprintf(
-                'Method %s::%s does not exist.', static::class, $name
+                'Method %s::%s does not exist.', static::class, $method
             ));
         }
 
-        if (isset($this->macros[$name])) {
-            return ($this->macros[$name])($this, ...$arguments);
+        if (isset($this->macros[$method])) {
+            return ($this->macros[$method])($this, ...$parameters);
         }
     }
 }

--- a/packages/framework/src/Pages/VirtualPage.php
+++ b/packages/framework/src/Pages/VirtualPage.php
@@ -53,6 +53,7 @@ class VirtualPage extends HydePage implements DynamicPage
      * and Hyde will use that view to render the page contents with the supplied front matter during the static site build process.
      *
      * Note that $contents take precedence over $view, so if you pass both, only $contents will be used.
+     * You can also register a macro with the name 'compile' to overload the default compile method.
      *
      * @param  string  $identifier  The identifier of the page. This is used to generate the route key which is used to create the output filename.
      *                              If the identifier for a virtual page is "foo/bar" the page will be saved to "_site/foo/bar.html".

--- a/packages/framework/src/Pages/VirtualPage.php
+++ b/packages/framework/src/Pages/VirtualPage.php
@@ -101,8 +101,6 @@ class VirtualPage extends HydePage implements DynamicPage
             ));
         }
 
-        if (isset($this->macros[$method])) {
-            return ($this->macros[$method])($this, ...$parameters);
-        }
+        return ($this->macros[$method])($this, ...$parameters);
     }
 }

--- a/packages/framework/src/Pages/VirtualPage.php
+++ b/packages/framework/src/Pages/VirtualPage.php
@@ -93,7 +93,7 @@ class VirtualPage extends HydePage implements DynamicPage
         $this->macros[$name] = $macro;
     }
 
-    public function __call(string $method, array $parameters)
+    public function __call(string $method, array $parameters): mixed
     {
         if (! isset($this->macros[$method])) {
             throw new BadMethodCallException(sprintf(

--- a/packages/framework/src/Pages/VirtualPage.php
+++ b/packages/framework/src/Pages/VirtualPage.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Hyde\Pages;
 
+use BadMethodCallException;
 use Hyde\Framework\Actions\AnonymousViewCompiler;
 use Hyde\Markdown\Models\FrontMatter;
 use Hyde\Pages\Concerns\HydePage;
@@ -94,6 +95,12 @@ class VirtualPage extends HydePage implements DynamicPage
 
     public function __call(string $name, array $arguments)
     {
+        if (! isset($this->macros[$name])) {
+            throw new BadMethodCallException(sprintf(
+                'Method %s::%s does not exist.', static::class, $name
+            ));
+        }
+
         if (isset($this->macros[$name])) {
             return ($this->macros[$name])($this, ...$arguments);
         }

--- a/packages/framework/src/Pages/VirtualPage.php
+++ b/packages/framework/src/Pages/VirtualPage.php
@@ -84,6 +84,10 @@ class VirtualPage extends HydePage implements DynamicPage
      */
     public function compile(): string
     {
+        if (isset($this->macros['compile'])) {
+            return $this->__call('compile', []);
+        }
+
         if (! $this->contents && $this->view) {
             if (str_ends_with($this->view, '.blade.php')) {
                 return AnonymousViewCompiler::call($this->view, $this->matter->toArray());

--- a/packages/framework/src/Pages/VirtualPage.php
+++ b/packages/framework/src/Pages/VirtualPage.php
@@ -37,6 +37,9 @@ class VirtualPage extends HydePage implements DynamicPage
     /** @var array<string, callable> */
     protected array $macros = [];
 
+    /**
+     * Static alias for the constructor.
+     */
     public static function make(string $identifier = '', FrontMatter|array $matter = [], string $contents = '', string $view = ''): static
     {
         return new static($identifier, $matter, $contents, $view);

--- a/packages/framework/tests/Unit/VirtualPageTest.php
+++ b/packages/framework/tests/Unit/VirtualPageTest.php
@@ -106,7 +106,7 @@ class VirtualPageTest extends TestCase
         });
 
         /** @noinspection PhpUndefinedMethodInspection */
-        $this->assertSame([$page, 'bar'], $page->foo('bar'));
+        $this->assertSame(['bar'], $page->foo('bar'));
     }
 
     public function testCallingUndefinedMacro()

--- a/packages/framework/tests/Unit/VirtualPageTest.php
+++ b/packages/framework/tests/Unit/VirtualPageTest.php
@@ -111,6 +111,17 @@ class VirtualPageTest extends TestCase
         $this->assertSame(['bar'], $page->foo('bar'));
     }
 
+    public function testCanUseMacrosToOverloadClassCompileMethod()
+    {
+        $page = VirtualPage::make('foo');
+
+        $page->macro('compile', function () {
+            return 'bar';
+        });
+
+        $this->assertSame('bar', $page->compile());
+    }
+
     public function testCallingUndefinedMacro()
     {
         $this->expectException(BadMethodCallException::class);

--- a/packages/framework/tests/Unit/VirtualPageTest.php
+++ b/packages/framework/tests/Unit/VirtualPageTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Hyde\Framework\Testing\Unit;
 
+use BadMethodCallException;
 use Hyde\Pages\VirtualPage;
 use Hyde\Testing\TestCase;
 
@@ -111,7 +112,7 @@ class VirtualPageTest extends TestCase
 
     public function testCallingUndefinedMacro()
     {
-        $this->expectException(\BadMethodCallException::class);
+        $this->expectException(BadMethodCallException::class);
         $this->expectExceptionMessage('Method Hyde\Pages\VirtualPage::foo does not exist.');
 
         $page = VirtualPage::make('foo');

--- a/packages/framework/tests/Unit/VirtualPageTest.php
+++ b/packages/framework/tests/Unit/VirtualPageTest.php
@@ -80,4 +80,14 @@ class VirtualPageTest extends TestCase
 
         $this->assertSame('bar', $page->foo());
     }
+
+    public function testCallingUndefinedMacro()
+    {
+        $this->expectException(\BadMethodCallException::class);
+        $this->expectExceptionMessage('Method Hyde\Pages\VirtualPage::foo does not exist.');
+
+        $page = VirtualPage::make('foo');
+
+        $page->foo();
+    }
 }

--- a/packages/framework/tests/Unit/VirtualPageTest.php
+++ b/packages/framework/tests/Unit/VirtualPageTest.php
@@ -51,4 +51,10 @@ class VirtualPageTest extends TestCase
         $this->file('_pages/foo.blade.php', 'blade');
         $this->assertSame('contents', (new VirtualPage('foo', contents: 'contents', view: 'foo'))->compile());
     }
+
+    public function testCompileMethodCanCompileAnonymousViewFiles()
+    {
+        $this->file('_pages/foo.blade.php', 'blade');
+        $this->assertSame('blade', (new VirtualPage('foo', view: '_pages/foo.blade.php'))->compile());
+    }
 }

--- a/packages/framework/tests/Unit/VirtualPageTest.php
+++ b/packages/framework/tests/Unit/VirtualPageTest.php
@@ -69,4 +69,15 @@ class VirtualPageTest extends TestCase
         $this->file('_pages/foo.blade.php', 'blade {{ $foo }}');
         $this->assertSame('blade bar', (new VirtualPage('foo', ['foo' => 'bar'], view: '_pages/foo.blade.php'))->compile());
     }
+
+    public function testCanCreateInstanceMacros()
+    {
+        $page = VirtualPage::make('foo');
+
+        $page->macro('foo', function () {
+            return 'bar';
+        });
+
+        $this->assertSame('bar', $page->foo());
+    }
 }

--- a/packages/framework/tests/Unit/VirtualPageTest.php
+++ b/packages/framework/tests/Unit/VirtualPageTest.php
@@ -78,6 +78,7 @@ class VirtualPageTest extends TestCase
             return 'bar';
         });
 
+        /** @noinspection PhpUndefinedMethodInspection */
         $this->assertSame('bar', $page->foo());
     }
 
@@ -88,6 +89,7 @@ class VirtualPageTest extends TestCase
 
         $page = VirtualPage::make('foo');
 
+        /** @noinspection PhpUndefinedMethodInspection */
         $page->foo();
     }
 }

--- a/packages/framework/tests/Unit/VirtualPageTest.php
+++ b/packages/framework/tests/Unit/VirtualPageTest.php
@@ -46,6 +46,12 @@ class VirtualPageTest extends TestCase
         $this->assertSame('bar', (new VirtualPage('foo', view: 'foo'))->compile());
     }
 
+    public function testCompileMethodUsingViewCompileAndFrontMatter()
+    {
+        $this->file('_pages/foo.blade.php', 'foo {{ $bar }}');
+        $this->assertSame('foo baz', (new VirtualPage('foo', ['bar' => 'baz'], view: 'foo'))->compile());
+    }
+
     public function testCompileMethodPrefersContentsPropertyOverView()
     {
         $this->file('_pages/foo.blade.php', 'blade');
@@ -56,5 +62,11 @@ class VirtualPageTest extends TestCase
     {
         $this->file('_pages/foo.blade.php', 'blade');
         $this->assertSame('blade', (new VirtualPage('foo', view: '_pages/foo.blade.php'))->compile());
+    }
+
+    public function testCompileMethodCanCompileAnonymousViewFilesWithFrontMatter()
+    {
+        $this->file('_pages/foo.blade.php', 'blade {{ $foo }}');
+        $this->assertSame('blade bar', (new VirtualPage('foo', ['foo' => 'bar'], view: '_pages/foo.blade.php'))->compile());
     }
 }

--- a/packages/framework/tests/Unit/VirtualPageTest.php
+++ b/packages/framework/tests/Unit/VirtualPageTest.php
@@ -82,6 +82,21 @@ class VirtualPageTest extends TestCase
         $this->assertSame('bar', $page->foo());
     }
 
+    public function testCanCreateInstanceMacrosUsingCallableObject()
+    {
+        $page = VirtualPage::make('foo');
+
+        $page->macro('foo', new class {
+            public function __invoke(): string
+            {
+                return 'bar';
+            }
+        });
+
+        /** @noinspection PhpUndefinedMethodInspection */
+        $this->assertSame('bar', $page->foo());
+    }
+
     public function testCallingUndefinedMacro()
     {
         $this->expectException(\BadMethodCallException::class);

--- a/packages/framework/tests/Unit/VirtualPageTest.php
+++ b/packages/framework/tests/Unit/VirtualPageTest.php
@@ -97,6 +97,18 @@ class VirtualPageTest extends TestCase
         $this->assertSame('bar', $page->foo());
     }
 
+    public function testCallingMacroWithArguments()
+    {
+        $page = VirtualPage::make('foo');
+
+        $page->macro('foo', function (...$args) {
+            return $args;
+        });
+
+        /** @noinspection PhpUndefinedMethodInspection */
+        $this->assertSame([$page, 'bar'], $page->foo('bar'));
+    }
+
     public function testCallingUndefinedMacro()
     {
         $this->expectException(\BadMethodCallException::class);

--- a/packages/framework/tests/Unit/VirtualPageTest.php
+++ b/packages/framework/tests/Unit/VirtualPageTest.php
@@ -87,7 +87,8 @@ class VirtualPageTest extends TestCase
     {
         $page = VirtualPage::make('foo');
 
-        $page->macro('foo', new class {
+        $page->macro('foo', new class
+        {
             public function __invoke(): string
             {
                 return 'bar';


### PR DESCRIPTION
Makes improvements to `VirtualPage.php`, such as

- Support Blade rendering of anonymous view files (any arbitrary project file path)
- Custom instance macros (more or less based on the Illuminate Macroable trait (MIT) but refactored to work on the instance not static class. The idea is that there will be very few virtual page instances around, if there are many it might be better to create a dedicated page class)