### PR TITLE
Change publication tags to use Yaml instead of Json

### DIFF
--- a/packages/publications/src/Commands/MakePublicationCommand.php
+++ b/packages/publications/src/Commands/MakePublicationCommand.php
@@ -159,14 +159,14 @@ class MakePublicationCommand extends ValidatingCommand
 
         $options = PublicationService::getValuesForTagName($tagGroup);
         if ($options->isEmpty()) {
-            return $this->handleEmptyOptionsCollection($field, 'tag', 'No tags for this publication type found in tags.json');
+            return $this->handleEmptyOptionsCollection($field, 'tag', 'No tags for this publication type found in tags.yml');
         }
 
         $this->tip('You can enter multiple tags separated by commas');
 
         $choice = $this->reloadableChoice($this->getReloadableTagValuesArrayClosure($tagGroup),
             'Which tag would you like to use?',
-            'Reload tags.json',
+            'Reload tags.yml',
             true
         );
 

--- a/packages/publications/src/Commands/MakePublicationTagCommand.php
+++ b/packages/publications/src/Commands/MakePublicationTagCommand.php
@@ -90,7 +90,7 @@ class MakePublicationTagCommand extends ValidatingCommand
     protected function saveTagsToDisk(): void
     {
         $this->infoComment('Saving tag data to',
-            DiscoveryService::createClickableFilepath(Hyde::path('tags.json'))
+            DiscoveryService::createClickableFilepath(Hyde::path('tags.yml'))
         );
 
         app(PublicationTags::class)->addTagGroups($this->tags)->save();

--- a/packages/publications/src/Commands/MakePublicationTypeCommand.php
+++ b/packages/publications/src/Commands/MakePublicationTypeCommand.php
@@ -139,14 +139,14 @@ class MakePublicationTypeCommand extends ValidatingCommand
     protected function getTagGroup(): string
     {
         if (empty(PublicationTags::getTagGroups())) {
-            $this->error('No tag groups have been added to tags.json');
+            $this->error('No tag groups have been added to tags.yml');
             if ($this->confirm('Would you like to add some tags now?')) {
                 $this->call('make:publicationTag');
 
                 $this->newLine();
                 $this->comment("Okay, we're back on track!");
             } else {
-                throw new InvalidArgumentException('Can not create a tag field without any tag groups defined in tags.json');
+                throw new InvalidArgumentException('Can not create a tag field without any tag groups defined in tags.yml');
             }
         }
 

--- a/packages/publications/src/Models/PublicationTags.php
+++ b/packages/publications/src/Models/PublicationTags.php
@@ -9,7 +9,6 @@ use Hyde\Facades\Filesystem;
 use Hyde\Framework\Exceptions\FileNotFoundException;
 use Hyde\Hyde;
 use Illuminate\Support\Collection;
-use function json_encode;
 use Symfony\Component\Yaml\Exception\ParseException;
 use Symfony\Component\Yaml\Yaml;
 
@@ -82,7 +81,7 @@ class PublicationTags
      */
     public function save(): self
     {
-        Filesystem::putContents('tags.yml', json_encode($this->tags, JSON_PRETTY_PRINT));
+        Filesystem::putContents('tags.yml', Yaml::dump($this->tags->toArray()));
 
         return $this;
     }

--- a/packages/publications/src/Models/PublicationTags.php
+++ b/packages/publications/src/Models/PublicationTags.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Hyde\Publications\Models;
 
+use Symfony\Component\Yaml\Exception\ParseException;
 use function file_exists;
 use function file_get_contents;
 use Hyde\Facades\Filesystem;
@@ -132,10 +133,10 @@ class PublicationTags
             throw new FileNotFoundException('tags.yml');
         }
 
-        $tags = json_decode(file_get_contents(Hyde::path('tags.yml')), true);
+        $tags = Yaml::parseFile(Hyde::path('tags.yml'));
 
         if (! is_array($tags) || empty($tags)) {
-            throw new JsonException('Could not decode tags.yml');
+            throw new ParseException('Could not decode tags.yml');
         }
 
         foreach ($tags as $name => $values) {

--- a/packages/publications/src/Models/PublicationTags.php
+++ b/packages/publications/src/Models/PublicationTags.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Hyde\Publications\Models;
 
-use Symfony\Component\Yaml\Yaml;
 use function file_exists;
 use function file_get_contents;
 use Hyde\Facades\Filesystem;
@@ -14,6 +13,7 @@ use Illuminate\Support\Collection;
 use function json_decode;
 use function json_encode;
 use JsonException;
+use Symfony\Component\Yaml\Yaml;
 
 /**
  * Object representation for the tags.json file.

--- a/packages/publications/src/Models/PublicationTags.php
+++ b/packages/publications/src/Models/PublicationTags.php
@@ -4,16 +4,13 @@ declare(strict_types=1);
 
 namespace Hyde\Publications\Models;
 
-use Symfony\Component\Yaml\Exception\ParseException;
 use function file_exists;
-use function file_get_contents;
 use Hyde\Facades\Filesystem;
 use Hyde\Framework\Exceptions\FileNotFoundException;
 use Hyde\Hyde;
 use Illuminate\Support\Collection;
-use function json_decode;
 use function json_encode;
-use JsonException;
+use Symfony\Component\Yaml\Exception\ParseException;
 use Symfony\Component\Yaml\Yaml;
 
 /**

--- a/packages/publications/src/Models/PublicationTags.php
+++ b/packages/publications/src/Models/PublicationTags.php
@@ -123,6 +123,7 @@ class PublicationTags
      * Validate the tags.yml file is valid.
      *
      * @internal This method is experimental and may be removed without notice
+     *
      * @todo Support Yaml
      */
     public static function validateTagsFile(): void

--- a/packages/publications/src/Models/PublicationTags.php
+++ b/packages/publications/src/Models/PublicationTags.php
@@ -123,6 +123,7 @@ class PublicationTags
      * Validate the tags.yml file is valid.
      *
      * @internal This method is experimental and may be removed without notice
+     * @todo Support Yaml
      */
     public static function validateTagsFile(): void
     {

--- a/packages/publications/src/Models/PublicationTags.php
+++ b/packages/publications/src/Models/PublicationTags.php
@@ -16,7 +16,7 @@ use JsonException;
 use Symfony\Component\Yaml\Yaml;
 
 /**
- * Object representation for the tags.json file.
+ * Object representation for the tags.yml file.
  *
  * @see \Hyde\Publications\Testing\Feature\PublicationTagsTest
  */
@@ -84,7 +84,7 @@ class PublicationTags
      */
     public function save(): self
     {
-        Filesystem::putContents('tags.json', json_encode($this->tags, JSON_PRETTY_PRINT));
+        Filesystem::putContents('tags.yml', json_encode($this->tags, JSON_PRETTY_PRINT));
 
         return $this;
     }
@@ -120,20 +120,20 @@ class PublicationTags
     }
 
     /**
-     * Validate the tags.json file is valid.
+     * Validate the tags.yml file is valid.
      *
      * @internal This method is experimental and may be removed without notice
      */
     public static function validateTagsFile(): void
     {
-        if (! file_exists(Hyde::path('tags.json'))) {
-            throw new FileNotFoundException('tags.json');
+        if (! file_exists(Hyde::path('tags.yml'))) {
+            throw new FileNotFoundException('tags.yml');
         }
 
-        $tags = json_decode(file_get_contents(Hyde::path('tags.json')), true);
+        $tags = json_decode(file_get_contents(Hyde::path('tags.yml')), true);
 
         if (! is_array($tags) || empty($tags)) {
-            throw new JsonException('Could not decode tags.json');
+            throw new JsonException('Could not decode tags.yml');
         }
 
         foreach ($tags as $name => $values) {
@@ -149,10 +149,6 @@ class PublicationTags
     /** @return array<string, array<string>> */
     protected function parseTagsFile(): array
     {
-        if (file_exists(Hyde::path('tags.json'))) {
-            return json_decode(file_get_contents(Hyde::path('tags.json')), true);
-        }
-
         if (file_exists(Hyde::path('tags.yml'))) {
             return Yaml::parseFile(Hyde::path('tags.yml'));
         }

--- a/packages/publications/src/Models/PublicationTags.php
+++ b/packages/publications/src/Models/PublicationTags.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Hyde\Publications\Models;
 
+use Symfony\Component\Yaml\Yaml;
 use function file_exists;
 use function file_get_contents;
 use Hyde\Facades\Filesystem;
@@ -150,6 +151,10 @@ class PublicationTags
     {
         if (file_exists(Hyde::path('tags.json'))) {
             return json_decode(file_get_contents(Hyde::path('tags.json')), true);
+        }
+
+        if (file_exists(Hyde::path('tags.yml'))) {
+            return Yaml::parseFile(Hyde::path('tags.yml'));
         }
 
         return [];

--- a/packages/publications/tests/Feature/MakePublicationCommandTest.php
+++ b/packages/publications/tests/Feature/MakePublicationCommandTest.php
@@ -326,7 +326,7 @@ class MakePublicationCommandTest extends TestCase
 
     public function test_command_with_single_tag_input()
     {
-        $this->file('tags.json', json_encode([
+        $this->file('tags.yml', json_encode([
             'test-publication' => ['foo', 'bar', 'baz'],
         ]));
         $this->makeSchemaFile([
@@ -350,7 +350,7 @@ class MakePublicationCommandTest extends TestCase
 
     public function test_command_with_multiple_tag_inputs()
     {
-        $this->file('tags.json', json_encode([
+        $this->file('tags.yml', json_encode([
             'test-publication' => ['foo', 'bar', 'baz'],
         ]));
         $this->makeSchemaFile([
@@ -439,7 +439,7 @@ class MakePublicationCommandTest extends TestCase
         ]);
 
         $this->artisan('make:publication test-publication')
-             ->expectsOutput('Warning: No tags for this publication type found in tags.json')
+             ->expectsOutput('Warning: No tags for this publication type found in tags.yml')
              ->expectsConfirmation('Would you like to skip this field?')
              ->expectsOutput('Error: Unable to locate any tags for this publication type')
              ->assertExitCode(1);
@@ -460,7 +460,7 @@ class MakePublicationCommandTest extends TestCase
         ]);
 
         $this->artisan('make:publication test-publication')
-             ->expectsOutput('Warning: No tags for this publication type found in tags.json')
+             ->expectsOutput('Warning: No tags for this publication type found in tags.yml')
              ->expectsConfirmation('Would you like to skip this field?', 'yes')
              ->doesntExpectOutput('Error: Unable to locate any tags for this publication type')
              ->assertExitCode(0);
@@ -512,8 +512,8 @@ class MakePublicationCommandTest extends TestCase
         ]);
 
         $this->artisan('make:publication test-publication')
-            ->doesntExpectOutput('Warning: No tags for this publication type found in tags.json')
-            ->expectsOutput('Error: Unable to create publication: No tags for this publication type found in tags.json')
+            ->doesntExpectOutput('Warning: No tags for this publication type found in tags.yml')
+            ->expectsOutput('Error: Unable to create publication: No tags for this publication type found in tags.yml')
             ->assertExitCode(1);
     }
 

--- a/packages/publications/tests/Feature/MakePublicationTagCommandTest.php
+++ b/packages/publications/tests/Feature/MakePublicationTagCommandTest.php
@@ -36,7 +36,13 @@ class MakePublicationTagCommandTest extends TestCase
 
         $this->assertFileExists(Hyde::path('tags.yml'));
         $this->assertSame(
-            json_encode(['foo' => ['foo', 'bar', 'baz']], 128),
+            <<<'YAML'
+            foo:
+                - foo
+                - bar
+                - baz
+
+            YAML,
             file_get_contents(Hyde::path('tags.yml'))
         );
     }
@@ -55,7 +61,13 @@ class MakePublicationTagCommandTest extends TestCase
 
         $this->assertFileExists(Hyde::path('tags.yml'));
         $this->assertSame(
-            json_encode(['foo' => ['foo', 'bar', 'baz']], 128),
+            <<<'YAML'
+            foo:
+                - foo
+                - bar
+                - baz
+
+            YAML,
             file_get_contents(Hyde::path('tags.yml'))
         );
     }

--- a/packages/publications/tests/Feature/MakePublicationTagCommandTest.php
+++ b/packages/publications/tests/Feature/MakePublicationTagCommandTest.php
@@ -17,7 +17,7 @@ class MakePublicationTagCommandTest extends TestCase
 {
     protected function tearDown(): void
     {
-        unlink(Hyde::path('tags.json'));
+        unlink(Hyde::path('tags.yml'));
 
         parent::tearDown();
     }
@@ -31,13 +31,13 @@ class MakePublicationTagCommandTest extends TestCase
             ->expectsOutput('Enter the tag values: (end with an empty line)')
             ->expectsOutput('Adding the following tags:')
             ->expectsOutput('  foo: foo, bar, baz')
-            ->expectsOutput('Saving tag data to ['.Hyde::path('tags.json').']')
+            ->expectsOutput('Saving tag data to ['.Hyde::path('tags.yml').']')
             ->assertExitCode(0);
 
-        $this->assertFileExists(Hyde::path('tags.json'));
+        $this->assertFileExists(Hyde::path('tags.yml'));
         $this->assertSame(
             json_encode(['foo' => ['foo', 'bar', 'baz']], 128),
-            file_get_contents(Hyde::path('tags.json'))
+            file_get_contents(Hyde::path('tags.yml'))
         );
     }
 
@@ -50,13 +50,13 @@ class MakePublicationTagCommandTest extends TestCase
             ->expectsOutput('Enter the tag values: (end with an empty line)')
             ->expectsOutput('Adding the following tags:')
             ->expectsOutput('  foo: foo, bar, baz')
-            ->expectsOutput('Saving tag data to ['.Hyde::path('tags.json').']')
+            ->expectsOutput('Saving tag data to ['.Hyde::path('tags.yml').']')
             ->assertExitCode(0);
 
-        $this->assertFileExists(Hyde::path('tags.json'));
+        $this->assertFileExists(Hyde::path('tags.yml'));
         $this->assertSame(
             json_encode(['foo' => ['foo', 'bar', 'baz']], 128),
-            file_get_contents(Hyde::path('tags.json'))
+            file_get_contents(Hyde::path('tags.yml'))
         );
     }
 

--- a/packages/publications/tests/Feature/MakePublicationTypeCommandTest.php
+++ b/packages/publications/tests/Feature/MakePublicationTypeCommandTest.php
@@ -237,7 +237,7 @@ class MakePublicationTypeCommandTest extends TestCase
             JSON,
             'test-publication/schema.json');
 
-        unlink(Hyde::path('tags.json'));
+        unlink(Hyde::path('tags.yml'));
     }
 
     public function testWithTagFieldInputButNoTags()
@@ -249,9 +249,9 @@ class MakePublicationTypeCommandTest extends TestCase
             ->expectsQuestion('Enter name for field #1', 'MyTag')
             ->expectsChoice('Enter type for field #1', 'Tag',
                 self::expectedEnumCases, true)
-            ->expectsOutput('No tag groups have been added to tags.json')
+            ->expectsOutput('No tag groups have been added to tags.yml')
             ->expectsConfirmation('Would you like to add some tags now?')
-            ->expectsOutput('Error: Can not create a tag field without any tag groups defined in tags.json')
+            ->expectsOutput('Error: Can not create a tag field without any tag groups defined in tags.yml')
             ->assertExitCode(1);
 
         $this->assertFileDoesNotExist(Hyde::path('test-publication/schema.json'));
@@ -260,14 +260,14 @@ class MakePublicationTypeCommandTest extends TestCase
     public function testWithTagFieldInputButNoTagsCanPromptToCreateTags()
     {
         $this->directory('test-publication');
-        $this->cleanUpWhenDone('tags.json');
+        $this->cleanUpWhenDone('tags.yml');
         InputStreamHandler::mockInput("foo\nbar\nbaz\n");
 
         $this->artisan('make:publicationType "Test Publication"')
             ->expectsQuestion('Enter name for field #1', 'MyTag')
             ->expectsChoice('Enter type for field #1', 'Tag',
                 self::expectedEnumCases)
-            ->expectsOutput('No tag groups have been added to tags.json')
+            ->expectsOutput('No tag groups have been added to tags.yml')
             ->expectsConfirmation('Would you like to add some tags now?', 'yes')
             ->expectsQuestion('Tag name', 'foo')
             ->expectsOutput("Okay, we're back on track!")
@@ -280,14 +280,14 @@ class MakePublicationTypeCommandTest extends TestCase
             ->expectsChoice('Choose the sort direction', 'Ascending', ['Ascending', 'Descending'])
             ->expectsQuestion(self::selectPageSizeQuestion, 0)
 
-            ->doesntExpectOutput('Error: Can not create a tag field without any tag groups defined in tags.json')
+            ->doesntExpectOutput('Error: Can not create a tag field without any tag groups defined in tags.yml')
            ->assertSuccessful();
 
         $this->assertCommandCalled('make:publicationTag');
-        $this->assertFileExists(Hyde::path('tags.json'));
+        $this->assertFileExists(Hyde::path('tags.yml'));
         $this->assertSame(
             json_encode(['foo' => ['foo', 'bar', 'baz']], 128),
-            file_get_contents(Hyde::path('tags.json'))
+            file_get_contents(Hyde::path('tags.yml'))
         );
     }
 }

--- a/packages/publications/tests/Feature/MakePublicationTypeCommandTest.php
+++ b/packages/publications/tests/Feature/MakePublicationTypeCommandTest.php
@@ -286,7 +286,7 @@ class MakePublicationTypeCommandTest extends TestCase
         $this->assertCommandCalled('make:publicationTag');
         $this->assertFileExists(Hyde::path('tags.yml'));
         $this->assertSame(
-            json_encode(['foo' => ['foo', 'bar', 'baz']], 128),
+            "foo:\n    - foo\n    - bar\n    - baz\n",
             file_get_contents(Hyde::path('tags.yml'))
         );
     }

--- a/packages/publications/tests/Feature/PublicationServiceTest.php
+++ b/packages/publications/tests/Feature/PublicationServiceTest.php
@@ -192,7 +192,7 @@ class PublicationServiceTest extends TestCase
                 'baz',
             ],
         ];
-        $this->file('tags.json', json_encode($tags));
+        $this->file('tags.yml', json_encode($tags));
         $this->assertSame($tags, PublicationService::getAllTags()->toArray());
     }
 
@@ -209,7 +209,7 @@ class PublicationServiceTest extends TestCase
             ],
         ];
 
-        $this->file('tags.json', json_encode($tags));
+        $this->file('tags.yml', json_encode($tags));
 
         $this->assertSame(['bar', 'baz'], PublicationService::getValuesForTagName('foo')->toArray());
     }

--- a/packages/publications/tests/Feature/PublicationTagsTest.php
+++ b/packages/publications/tests/Feature/PublicationTagsTest.php
@@ -206,14 +206,6 @@ class PublicationTagsTest extends TestCase
         ], PublicationTags::getAllTags()->toArray());
     }
 
-    public function testJsonFileIsPreferredOverYaml()
-    {
-        $this->file('tags.yml', '{"json":["foo"]}');
-        $this->file('tags.yml', 'yaml: [foo]');
-
-        $this->assertSame(['json' => ['foo']], PublicationTags::getAllTags()->toArray());
-    }
-
     public function testGetAllTags()
     {
         $tags = [

--- a/packages/publications/tests/Feature/PublicationTagsTest.php
+++ b/packages/publications/tests/Feature/PublicationTagsTest.php
@@ -206,6 +206,14 @@ class PublicationTagsTest extends TestCase
         ], PublicationTags::getAllTags()->toArray());
     }
 
+    public function testJsonFileIsPreferredOverYaml()
+    {
+        $this->file('tags.json', '{"json":["foo"]}');
+        $this->file('tags.yml', 'yaml: [foo]');
+
+        $this->assertSame(['json' => ['foo']], PublicationTags::getAllTags()->toArray());
+    }
+
     public function testGetAllTags()
     {
         $tags = [

--- a/packages/publications/tests/Feature/PublicationTagsTest.php
+++ b/packages/publications/tests/Feature/PublicationTagsTest.php
@@ -24,7 +24,7 @@ class PublicationTagsTest extends TestCase
 
     public function testConstructorAutomaticallyLoadsTagsFile()
     {
-        $this->file('tags.json', json_encode(['foo' => ['bar', 'baz']]));
+        $this->file('tags.yml', json_encode(['foo' => ['bar', 'baz']]));
 
         $this->assertSame(['foo' => ['bar', 'baz']], (new PublicationTags())->getTags()->toArray());
     }
@@ -36,21 +36,21 @@ class PublicationTagsTest extends TestCase
 
     public function testGetTags()
     {
-        $this->file('tags.json', json_encode(['foo' => ['bar', 'baz']]));
+        $this->file('tags.yml', json_encode(['foo' => ['bar', 'baz']]));
 
         $this->assertEquals(new Collection(['foo' => ['bar', 'baz']]), (new PublicationTags())->getTags());
     }
 
     public function testGetTagsInGroup()
     {
-        $this->file('tags.json', json_encode(['foo' => ['bar', 'baz']]));
+        $this->file('tags.yml', json_encode(['foo' => ['bar', 'baz']]));
 
         $this->assertEquals(['bar', 'baz'], (new PublicationTags())->getTagsInGroup('foo'));
     }
 
     public function testGetTagsInGroupOnlyReturnTagsForTheSpecifiedGroup()
     {
-        $this->file('tags.json', json_encode([
+        $this->file('tags.yml', json_encode([
             'foo' => ['bar', 'baz'],
             'bar' => ['foo', 'baz'],
         ]));
@@ -60,7 +60,7 @@ class PublicationTagsTest extends TestCase
 
     public function testGetTagsInGroupReturnsEmptyArrayWhenGroupDoesNotExist()
     {
-        $this->file('tags.json', json_encode(['foo' => ['bar', 'baz']]));
+        $this->file('tags.yml', json_encode(['foo' => ['bar', 'baz']]));
 
         $this->assertEquals([], (new PublicationTags())->getTagsInGroup('bar'));
     }
@@ -134,7 +134,7 @@ class PublicationTagsTest extends TestCase
         $tags->save();
 
         $this->assertSame(['test', 'test2'], PublicationTags::getTagGroups());
-        unlink(Hyde::path('tags.json'));
+        unlink(Hyde::path('tags.yml'));
     }
 
     public function testGetTagGroupsWithNoTags()
@@ -156,15 +156,15 @@ class PublicationTagsTest extends TestCase
                     "test2"
                 ]
             }
-            JSON, file_get_contents(Hyde::path('tags.json'))
+            JSON, file_get_contents(Hyde::path('tags.yml'))
         );
 
-        unlink(Hyde::path('tags.json'));
+        unlink(Hyde::path('tags.yml'));
     }
 
     public function testCanLoadTagsFromJsonFile()
     {
-        $this->file('tags.json', <<<'JSON'
+        $this->file('tags.yml', <<<'JSON'
             {
                 "Foo": [
                     "one",
@@ -208,7 +208,7 @@ class PublicationTagsTest extends TestCase
 
     public function testJsonFileIsPreferredOverYaml()
     {
-        $this->file('tags.json', '{"json":["foo"]}');
+        $this->file('tags.yml', '{"json":["foo"]}');
         $this->file('tags.yml', 'yaml: [foo]');
 
         $this->assertSame(['json' => ['foo']], PublicationTags::getAllTags()->toArray());
@@ -222,7 +222,7 @@ class PublicationTagsTest extends TestCase
                 'baz',
             ],
         ];
-        $this->file('tags.json', json_encode($tags));
+        $this->file('tags.yml', json_encode($tags));
         $this->assertSame($tags, PublicationTags::getAllTags()->toArray());
     }
 
@@ -244,7 +244,7 @@ class PublicationTagsTest extends TestCase
             ],
         ];
 
-        $this->file('tags.json', json_encode($tags));
+        $this->file('tags.yml', json_encode($tags));
 
         $this->assertSame(['bar', 'baz'], PublicationTags::getValuesForTagName('foo'));
     }
@@ -258,7 +258,7 @@ class PublicationTagsTest extends TestCase
             ],
         ];
 
-        $this->file('tags.json', json_encode($tags));
+        $this->file('tags.yml', json_encode($tags));
 
         $this->assertSame([], PublicationTags::getValuesForTagName('bar'));
     }
@@ -270,7 +270,7 @@ class PublicationTagsTest extends TestCase
 
     public function testValidateTagsFileWithValidFile()
     {
-        $this->file('tags.json', json_encode(['foo' => ['bar', 'baz']]));
+        $this->file('tags.yml', json_encode(['foo' => ['bar', 'baz']]));
 
         PublicationTags::validateTagsFile();
         $this->assertTrue(true);
@@ -278,7 +278,7 @@ class PublicationTagsTest extends TestCase
 
     public function testValidateTagsFileWithInvalidFile()
     {
-        $this->file('tags.json', 'invalid json');
+        $this->file('tags.yml', 'invalid json');
 
         $this->expectException(JsonException::class);
         PublicationTags::validateTagsFile();
@@ -292,7 +292,7 @@ class PublicationTagsTest extends TestCase
 
     public function testValidateTagsFileWithEmptyJsonFile()
     {
-        $this->file('tags.json', json_encode([]));
+        $this->file('tags.yml', json_encode([]));
 
         $this->expectException(JsonException::class);
         PublicationTags::validateTagsFile();

--- a/packages/publications/tests/Feature/PublicationTagsTest.php
+++ b/packages/publications/tests/Feature/PublicationTagsTest.php
@@ -9,6 +9,8 @@ use Hyde\Hyde;
 use Hyde\Publications\Models\PublicationTags;
 use Hyde\Testing\TestCase;
 use Illuminate\Support\Collection;
+use Symfony\Component\Yaml\Exception\ParseException;
+use Symfony\Component\Yaml\Yaml;
 use function json_encode;
 use JsonException;
 
@@ -270,9 +272,9 @@ class PublicationTagsTest extends TestCase
 
     public function testValidateTagsFileWithInvalidFile()
     {
-        $this->file('tags.yml', 'invalid json');
+        $this->file('tags.yml', 'invalid yaml');
 
-        $this->expectException(JsonException::class);
+        $this->expectException(ParseException::class);
         PublicationTags::validateTagsFile();
     }
 
@@ -282,11 +284,11 @@ class PublicationTagsTest extends TestCase
         PublicationTags::validateTagsFile();
     }
 
-    public function testValidateTagsFileWithEmptyJsonFile()
+    public function testValidateTagsFileWithEmptyYamlFile()
     {
-        $this->file('tags.yml', json_encode([]));
+        $this->file('tags.yml', Yaml::dump([]));
 
-        $this->expectException(JsonException::class);
+        $this->expectException(ParseException::class);
         PublicationTags::validateTagsFile();
     }
 }

--- a/packages/publications/tests/Feature/PublicationTagsTest.php
+++ b/packages/publications/tests/Feature/PublicationTagsTest.php
@@ -185,6 +185,25 @@ class PublicationTagsTest extends TestCase
         ], PublicationTags::getAllTags()->toArray());
     }
 
+    public function testCanLoadTagsFromYamlFile()
+    {
+        $this->file('tags.yml', <<<'YAML'
+            Foo:
+                - one
+                - two
+                - three
+            Second:
+                - foo
+                - bar
+                - baz
+            YAML);
+
+        $this->assertSame([
+            'Foo' => ['one', 'two', 'three'],
+            'Second' => ['foo', 'bar', 'baz'],
+        ], PublicationTags::getAllTags()->toArray());
+    }
+
     public function testGetAllTags()
     {
         $tags = [

--- a/packages/publications/tests/Feature/PublicationTagsTest.php
+++ b/packages/publications/tests/Feature/PublicationTagsTest.php
@@ -177,7 +177,8 @@ class PublicationTagsTest extends TestCase
                     "baz"
                 ]
             }
-            JSON);
+            JSON
+        );
 
         $this->assertSame([
             'Foo' => ['one', 'two', 'three'],
@@ -196,7 +197,8 @@ class PublicationTagsTest extends TestCase
                 - foo
                 - bar
                 - baz
-            YAML);
+            YAML
+        );
 
         $this->assertSame([
             'Foo' => ['one', 'two', 'three'],

--- a/packages/publications/tests/Feature/PublicationTagsTest.php
+++ b/packages/publications/tests/Feature/PublicationTagsTest.php
@@ -150,14 +150,12 @@ class PublicationTagsTest extends TestCase
         $tags->save();
 
         $this->assertSame(
-            <<<'JSON'
-            {
-                "test": [
-                    "test1",
-                    "test2"
-                ]
-            }
-            JSON, file_get_contents(Hyde::path('tags.yml'))
+            <<<'YAML'
+            test:
+                - test1
+                - test2
+
+            YAML, file_get_contents(Hyde::path('tags.yml'))
         );
 
         unlink(Hyde::path('tags.yml'));

--- a/packages/publications/tests/Feature/PublicationTagsTest.php
+++ b/packages/publications/tests/Feature/PublicationTagsTest.php
@@ -162,6 +162,29 @@ class PublicationTagsTest extends TestCase
         unlink(Hyde::path('tags.json'));
     }
 
+    public function testCanLoadTagsFromJsonFile()
+    {
+        $this->file('tags.json', <<<'JSON'
+            {
+                "Foo": [
+                    "one",
+                    "two",
+                    "three"
+                ],
+                "Second": [
+                    "foo",
+                    "bar",
+                    "baz"
+                ]
+            }
+            JSON);
+
+        $this->assertSame([
+            'Foo' => ['one', 'two', 'three'],
+            'Second' => ['foo', 'bar', 'baz'],
+        ], PublicationTags::getAllTags()->toArray());
+    }
+
     public function testGetAllTags()
     {
         $tags = [

--- a/packages/publications/tests/Feature/PublicationTagsTest.php
+++ b/packages/publications/tests/Feature/PublicationTagsTest.php
@@ -9,10 +9,9 @@ use Hyde\Hyde;
 use Hyde\Publications\Models\PublicationTags;
 use Hyde\Testing\TestCase;
 use Illuminate\Support\Collection;
+use function json_encode;
 use Symfony\Component\Yaml\Exception\ParseException;
 use Symfony\Component\Yaml\Yaml;
-use function json_encode;
-use JsonException;
 
 /**
  * @covers \Hyde\Publications\Models\PublicationTags

--- a/packages/publications/tests/Feature/SeedsPublicationFilesTest.php
+++ b/packages/publications/tests/Feature/SeedsPublicationFilesTest.php
@@ -131,7 +131,7 @@ class SeedsPublicationFilesTest extends TestCase
     public function testWithTagType()
     {
         $tags = ['test-publication' => ['foo', 'bar', 'baz']];
-        $this->file('tags.json', json_encode($tags));
+        $this->file('tags.yml', json_encode($tags));
         $this->pubType->fields = collect([
             (new PublicationFieldDefinition('tag', 'tag', tagGroup: 'test-publication')),
         ]);


### PR DESCRIPTION
Since Yaml is a superset of Json, all Json will still validate. To migrate existing tag files, simply change the `.json` extension to `.yml` (example in https://github.com/hydephp/develop/commit/2c16bcd274871e90f45c40ac9f91b8d0277c3c82)