### PR TITLE
Add yaml helper functions

### DIFF
--- a/packages/framework/src/helpers.php
+++ b/packages/framework/src/helpers.php
@@ -29,7 +29,6 @@ namespace {
 namespace Hyde {
     use Hyde\Foundation\HydeKernel;
     use Illuminate\Contracts\Support\Arrayable;
-
     use Symfony\Component\Yaml\Yaml;
 
     if (! function_exists('\Hyde\hyde')) {

--- a/packages/framework/src/helpers.php
+++ b/packages/framework/src/helpers.php
@@ -30,6 +30,8 @@ namespace Hyde {
     use Hyde\Foundation\HydeKernel;
     use Illuminate\Contracts\Support\Arrayable;
 
+    use Symfony\Component\Yaml\Yaml;
+
     if (! function_exists('\Hyde\hyde')) {
         /**
          * Get the available HydeKernel instance.
@@ -82,6 +84,13 @@ namespace Hyde {
         function evaluate_arrayable(array|Arrayable $array): array
         {
             return $array instanceof Arrayable ? $array->toArray() : $array;
+        }
+    }
+
+    if (! function_exists('\Hyde\yaml_encode')) {
+        function yaml_encode(mixed $input): string
+        {
+            return Yaml::dump($input);
         }
     }
 }

--- a/packages/framework/src/helpers.php
+++ b/packages/framework/src/helpers.php
@@ -90,7 +90,7 @@ namespace Hyde {
     if (! function_exists('\Hyde\yaml_encode')) {
         function yaml_encode(mixed $input): string
         {
-            return Yaml::dump($input);
+            return Yaml::dump($input instanceof Arrayable ? $input->toArray() : $input);
         }
     }
 

--- a/packages/framework/src/helpers.php
+++ b/packages/framework/src/helpers.php
@@ -93,4 +93,11 @@ namespace Hyde {
             return Yaml::dump($input);
         }
     }
+
+    if (! function_exists('\Hyde\yaml_decode')) {
+        function yaml_decode(string $input): mixed
+        {
+            return Yaml::parse($input);
+        }
+    }
 }

--- a/packages/framework/tests/Feature/HelpersTest.php
+++ b/packages/framework/tests/Feature/HelpersTest.php
@@ -118,4 +118,10 @@ class HelpersTest extends TestCase
     {
         $this->assertSame("foo: bar\n", \Hyde\yaml_encode(['foo' => 'bar']));
     }
+
+    /** @covers ::\Hyde\yaml_decode */
+    public function test_hyde_yaml_decode_function()
+    {
+        $this->assertSame(['foo' => 'bar'], \Hyde\yaml_decode("foo: bar\n"));
+    }
 }

--- a/packages/framework/tests/Feature/HelpersTest.php
+++ b/packages/framework/tests/Feature/HelpersTest.php
@@ -119,6 +119,12 @@ class HelpersTest extends TestCase
         $this->assertSame("foo: bar\n", \Hyde\yaml_encode(['foo' => 'bar']));
     }
 
+    /** @covers ::\Hyde\yaml_encode */
+    public function test_hyde_yaml_encode_function_encodes_arrayables()
+    {
+        $this->assertSame("foo: bar\n", \Hyde\yaml_encode(collect(['foo' => 'bar'])));
+    }
+
     /** @covers ::\Hyde\yaml_decode */
     public function test_hyde_yaml_decode_function()
     {

--- a/packages/framework/tests/Feature/HelpersTest.php
+++ b/packages/framework/tests/Feature/HelpersTest.php
@@ -112,4 +112,10 @@ class HelpersTest extends TestCase
         $this->assertSame(['foo'], \Hyde\evaluate_arrayable(['foo']));
         $this->assertSame(['foo'], \Hyde\evaluate_arrayable(collect(['foo'])));
     }
+
+    /** @covers ::\Hyde\yaml_encode */
+    public function test_hyde_yaml_encode_function()
+    {
+        $this->assertSame("foo: bar\n", \Hyde\yaml_encode(['foo' => 'bar']));
+    }
 }


### PR DESCRIPTION
Adds two new helper functions under the `\hyde\` function namespace that are intended to function as drop-in equivalents of json_encode and json_decode, but for YAML instead of JSON.

- `\hyde\yaml_encode($data)`
- `\hyde\yaml_decode($data)`

The encoder also evaluates arrayables to support direct encoding of collections as the Symfony dumper otherwise serializes collections to null.
