### PR TITLE
Show publication list pages in navigation

### DIFF
--- a/packages/publications/src/Models/PublicationListPage.php
+++ b/packages/publications/src/Models/PublicationListPage.php
@@ -28,4 +28,9 @@ class PublicationListPage extends VirtualPage
     {
         return PublicationPageCompiler::call($this);
     }
+
+    public function showInNavigation(): bool
+    {
+        return true;
+    }
 }

--- a/packages/publications/src/Models/PublicationListPage.php
+++ b/packages/publications/src/Models/PublicationListPage.php
@@ -31,6 +31,6 @@ class PublicationListPage extends VirtualPage
 
     public function showInNavigation(): bool
     {
-        return true;
+        return ! in_array($this->type->getDirectory(), config('hyde.navigation.exclude', []));
     }
 }

--- a/packages/publications/tests/Feature/PublicationListPageTest.php
+++ b/packages/publications/tests/Feature/PublicationListPageTest.php
@@ -52,6 +52,19 @@ class PublicationListPageTest extends TestCase
         File::deleteDirectory(Hyde::path('test-publication'));
     }
 
+    public function test_list_page_is_not_added_to_navigation_when_publication_identifier_is_set_in_config()
+    {
+        config(['hyde.navigation.exclude' => ['test-publication']]);
+
+        $this->createPublicationFiles();
+
+        $page = new PublicationListPage($this->getPublicationType());
+
+        $this->assertFalse($page->showInNavigation());
+
+        File::deleteDirectory(Hyde::path('test-publication'));
+    }
+
     protected function createPublicationFiles(): void
     {
         mkdir(Hyde::path('test-publication'));

--- a/packages/publications/tests/Feature/PublicationListPageTest.php
+++ b/packages/publications/tests/Feature/PublicationListPageTest.php
@@ -48,6 +48,8 @@ class PublicationListPageTest extends TestCase
         $page = new PublicationListPage($this->getPublicationType());
 
         $this->assertTrue($page->showInNavigation());
+
+        File::deleteDirectory(Hyde::path('test-publication'));
     }
 
     protected function createPublicationFiles(): void

--- a/packages/publications/tests/Feature/PublicationListPageTest.php
+++ b/packages/publications/tests/Feature/PublicationListPageTest.php
@@ -41,6 +41,15 @@ class PublicationListPageTest extends TestCase
         File::deleteDirectory(Hyde::path('test-publication'));
     }
 
+    public function test_list_page_can_show_up_in_navigation()
+    {
+        $this->createPublicationFiles();
+
+        $page = new PublicationListPage($this->getPublicationType());
+
+        $this->assertTrue($page->showInNavigation());
+    }
+
     protected function createPublicationFiles(): void
     {
         mkdir(Hyde::path('test-publication'));


### PR DESCRIPTION
Publication list (index) pages now automatically show up in the navigation menu using the publication type's name as a label.

This can be disabled by adding the publication type's identifier (directory name) to the `hyde.navigation.exclude` config array settings. This is something that could be done in the schema, but frankly I think the config option is so easy it's not worth the added complexity of a schema change.