### PR TITLE
Set default value of add another field question to yes in make:publicationType command

### DIFF
--- a/packages/publications/src/Commands/MakePublicationTypeCommand.php
+++ b/packages/publications/src/Commands/MakePublicationTypeCommand.php
@@ -88,7 +88,7 @@ class MakePublicationTypeCommand extends ValidatingCommand
         do {
             $this->fields->add($this->captureFieldDefinition());
 
-            $addAnother = $this->confirm(sprintf('Field #%d added! Add another field?', $this->getCount() - 1), true);
+            $addAnother = $this->confirm(sprintf('Field #%d added! Add another field?', $this->getCount() - 1), $this->input->isInteractive());
         } while ($addAnother);
     }
 

--- a/packages/publications/src/Commands/MakePublicationTypeCommand.php
+++ b/packages/publications/src/Commands/MakePublicationTypeCommand.php
@@ -88,7 +88,7 @@ class MakePublicationTypeCommand extends ValidatingCommand
         do {
             $this->fields->add($this->captureFieldDefinition());
 
-            $addAnother = $this->confirm(sprintf('Field #%d added! Add another field?', $this->getCount() - 1));
+            $addAnother = $this->confirm(sprintf('Field #%d added! Add another field?', $this->getCount() - 1), true);
         } while ($addAnother);
     }
 


### PR DESCRIPTION
Resolves the following code review comment:

> Also, when asking if you want another field, I think that "yes" is a better default than "no" because you'll hit yes more times than no (which by definition you'll only hit once)

However, when a terminal is not interactive, it still defaults to no to prevent the program from getting stuck.