### PR TITLE
Refactor Markdown service helper for normalizing indentation 

### DIFF
--- a/packages/framework/src/Framework/Services/MarkdownService.php
+++ b/packages/framework/src/Framework/Services/MarkdownService.php
@@ -230,8 +230,6 @@ class MarkdownService
 
     protected static function getIndentationLevelOfFirstLineWithContent(array $lines): array
     {
-        $indentationLevel = 0;
-        $offset = 0;
         foreach ($lines as $index => $line) {
             if (! empty(trim($line))) {
                 $lineLen = strlen($line);
@@ -246,6 +244,6 @@ class MarkdownService
             }
         }
 
-        return [$indentationLevel, $offset];
+        return [0, 0];
     }
 }

--- a/packages/framework/src/Framework/Services/MarkdownService.php
+++ b/packages/framework/src/Framework/Services/MarkdownService.php
@@ -220,18 +220,16 @@ class MarkdownService
 
         // Find the indentation level of the first line that has content
         foreach ($lines as $index => $line) {
-            if (empty(trim($line))) {
-                continue;
-            }
+            if (! empty(trim($line))) {
+                $lineLen = strlen($line);
+                $stripLen = strlen(ltrim($line)); // Length of the line without indentation lets us know its indentation level, and thus how much to strip from each line
 
-            $lineLen = strlen($line);
-            $stripLen = strlen(ltrim($line)); // Length of the line without indentation lets us know its indentation level, and thus how much to strip from each line
+                if ($lineLen !== $stripLen) {
+                    $offset = $index;
+                    $indentationLevel = $lineLen - $stripLen;
 
-            if ($lineLen !== $stripLen) {
-                $offset = $index;
-                $indentationLevel = $lineLen - $stripLen;
-
-                break;
+                    break;
+                }
             }
         }
 

--- a/packages/framework/src/Framework/Services/MarkdownService.php
+++ b/packages/framework/src/Framework/Services/MarkdownService.php
@@ -228,7 +228,7 @@ class MarkdownService
     }
 
 
-    /** @return int[] */
+    /** @return int[]  Find the indentation level of the first line that has content */
     protected static function getIndentationLevelOfFirstLineWithContent(array $lines): array
     {
         foreach ($lines as $lineNumber => $line) {

--- a/packages/framework/src/Framework/Services/MarkdownService.php
+++ b/packages/framework/src/Framework/Services/MarkdownService.php
@@ -216,10 +216,10 @@ class MarkdownService
         $string = str_replace("\r\n", "\n", $string);
         $lines = explode("\n", $string);
 
-        [$offset, $indentationLevel] = self::getIndentationLevelOfFirstLineWithContent($lines);
+        [$startNumber, $indentationLevel] = self::getIndentationLevelOfFirstLineWithContent($lines);
 
         foreach ($lines as $lineNumber => $line) {
-            if ($lineNumber >= $offset) {
+            if ($lineNumber >= $startNumber) {
                 $lines[$lineNumber] = substr($line, $indentationLevel);
             }
         }

--- a/packages/framework/src/Framework/Services/MarkdownService.php
+++ b/packages/framework/src/Framework/Services/MarkdownService.php
@@ -216,7 +216,7 @@ class MarkdownService
         $normalizeNewlines = str_replace("\r\n", "\n", $replaceTabs);
         $lines = explode("\n", $normalizeNewlines);
 
-        [$startNumber, $indentationLevel] = self::getIndentationLevelOfFirstLineWithContent($lines);
+        [$startNumber, $indentationLevel] = self::findLineContentPositions($lines);
 
         foreach ($lines as $lineNumber => $line) {
             if ($lineNumber >= $startNumber) {
@@ -229,7 +229,7 @@ class MarkdownService
 
 
     /** @return int[]  Find the indentation level and position of the first line that has content */
-    protected static function getIndentationLevelOfFirstLineWithContent(array $lines): array
+    protected static function findLineContentPositions(array $lines): array
     {
         foreach ($lines as $lineNumber => $line) {
             if (filled(trim($line))) {

--- a/packages/framework/src/Framework/Services/MarkdownService.php
+++ b/packages/framework/src/Framework/Services/MarkdownService.php
@@ -227,8 +227,7 @@ class MarkdownService
 
     protected static function getNormalizedLines(string $string): array
     {
-        $string = str_replace(["\t", "\r\n"], ['    ', "\n"], $string);
-        return explode("\n", $string);
+        return explode("\n", str_replace(["\t", "\r\n"], ['    ', "\n"], $string));
     }
 
     /** @return int[]  Find the indentation level and position of the first line that has content */

--- a/packages/framework/src/Framework/Services/MarkdownService.php
+++ b/packages/framework/src/Framework/Services/MarkdownService.php
@@ -218,9 +218,9 @@ class MarkdownService
 
         [$offset, $indentationLevel] = self::getIndentationLevelOfFirstLineWithContent($lines);
 
-        foreach ($lines as $index => $line) {
-            if ($index >= $offset) {
-                $lines[$index] = substr($line, $indentationLevel);
+        foreach ($lines as $lineNumber => $line) {
+            if ($lineNumber >= $offset) {
+                $lines[$lineNumber] = substr($line, $indentationLevel);
             }
         }
 
@@ -230,13 +230,13 @@ class MarkdownService
 
     protected static function getIndentationLevelOfFirstLineWithContent(array $lines): array
     {
-        foreach ($lines as $index => $line) {
+        foreach ($lines as $lineNumber => $line) {
             if (filled(trim($line))) {
                 $lineLen = strlen($line);
                 $stripLen = strlen(ltrim($line)); // Length of the line without indentation lets us know its indentation level, and thus how much to strip from each line
 
                 if ($lineLen !== $stripLen) {
-                    return [$index, $lineLen - $stripLen];
+                    return [$lineNumber, $lineLen - $stripLen];
                 }
             }
         }

--- a/packages/framework/src/Framework/Services/MarkdownService.php
+++ b/packages/framework/src/Framework/Services/MarkdownService.php
@@ -227,8 +227,7 @@ class MarkdownService
 
     protected static function getNormalizedLines(string $string): array
     {
-        $string = str_replace("\t", '    ', $string);
-        $string = str_replace("\r\n", "\n", $string);
+        $string = str_replace(["\t", "\r\n"], ['    ', "\n"], $string);
         return explode("\n", $string);
     }
 

--- a/packages/framework/src/Framework/Services/MarkdownService.php
+++ b/packages/framework/src/Framework/Services/MarkdownService.php
@@ -227,9 +227,9 @@ class MarkdownService
 
     protected static function getNormalizedLines(string $string): array
     {
-        $replaceTabs = str_replace("\t", '    ', $string);
-        $normalizeNewlines = str_replace("\r\n", "\n", $replaceTabs);
-        return explode("\n", $normalizeNewlines);
+        $string = str_replace("\t", '    ', $string);
+        $string = str_replace("\r\n", "\n", $string);
+        return explode("\n", $string);
     }
 
     /** @return int[]  Find the indentation level and position of the first line that has content */

--- a/packages/framework/src/Framework/Services/MarkdownService.php
+++ b/packages/framework/src/Framework/Services/MarkdownService.php
@@ -225,7 +225,7 @@ class MarkdownService
             }
 
             $lineLen = strlen($line);
-            $stripLen = strlen(ltrim($line)); // Length of the line without indentation lets is know it's indentation level
+            $stripLen = strlen(ltrim($line)); // Length of the line without indentation lets us know its indentation level
 
             if ($lineLen === $stripLen) {
                 continue;

--- a/packages/framework/src/Framework/Services/MarkdownService.php
+++ b/packages/framework/src/Framework/Services/MarkdownService.php
@@ -227,13 +227,12 @@ class MarkdownService
             $lineLen = strlen($line);
             $stripLen = strlen(ltrim($line)); // Length of the line without indentation lets us know its indentation level, and thus how much to strip from each line
 
-            if ($lineLen === $stripLen) {
-                continue;
-            }
+            if ($lineLen !== $stripLen) {
+                $offset = $index;
+                $indentationLevel = $lineLen - $stripLen;
 
-            $offset = $index;
-            $indentationLevel = $lineLen - $stripLen;
-            break;
+                break;
+            }
         }
 
         foreach ($lines as $index => $line) {

--- a/packages/framework/src/Framework/Services/MarkdownService.php
+++ b/packages/framework/src/Framework/Services/MarkdownService.php
@@ -228,6 +228,7 @@ class MarkdownService
     }
 
 
+    /** @return int[] */
     protected static function getIndentationLevelOfFirstLineWithContent(array $lines): array
     {
         foreach ($lines as $lineNumber => $line) {

--- a/packages/framework/src/Framework/Services/MarkdownService.php
+++ b/packages/framework/src/Framework/Services/MarkdownService.php
@@ -237,11 +237,9 @@ class MarkdownService
         }
 
         foreach ($lines as $index => $line) {
-            if ($index < $offset) {
-                continue;
+            if ($index >= $offset) {
+                $lines[$index] = substr($line, $indentationLevel);
             }
-
-            $lines[$index] = substr($line, $indentationLevel);
         }
 
         return implode("\n", $lines);

--- a/packages/framework/src/Framework/Services/MarkdownService.php
+++ b/packages/framework/src/Framework/Services/MarkdownService.php
@@ -241,7 +241,7 @@ class MarkdownService
                     $offset = $index;
                     $indentationLevel = $lineLen - $stripLen;
 
-                    break;
+                    return [$indentationLevel, $offset];
                 }
             }
         }

--- a/packages/framework/src/Framework/Services/MarkdownService.php
+++ b/packages/framework/src/Framework/Services/MarkdownService.php
@@ -216,7 +216,7 @@ class MarkdownService
         $string = str_replace("\r\n", "\n", $string);
         $lines = explode("\n", $string);
 
-        [$indentationLevel, $offset] = self::getIndentationLevelOfFirstLineWithContent($lines);
+        [$offset, $indentationLevel] = self::getIndentationLevelOfFirstLineWithContent($lines);
 
         foreach ($lines as $index => $line) {
             if ($index >= $offset) {
@@ -239,7 +239,7 @@ class MarkdownService
                     $offset = $index;
                     $indentationLevel = $lineLen - $stripLen;
 
-                    return [$indentationLevel, $offset];
+                    return [$offset, $indentationLevel];
                 }
             }
         }

--- a/packages/framework/src/Framework/Services/MarkdownService.php
+++ b/packages/framework/src/Framework/Services/MarkdownService.php
@@ -225,7 +225,7 @@ class MarkdownService
             }
 
             $lineLen = strlen($line);
-            $stripLen = strlen(ltrim($line)); // Length of the line without indentation lets us know its indentation level
+            $stripLen = strlen(ltrim($line)); // Length of the line without indentation lets us know its indentation level, and thus how much to strip from each line
 
             if ($lineLen === $stripLen) {
                 continue;

--- a/packages/framework/src/Framework/Services/MarkdownService.php
+++ b/packages/framework/src/Framework/Services/MarkdownService.php
@@ -228,7 +228,7 @@ class MarkdownService
     }
 
 
-    /** @return int[]  Find the indentation level of the first line that has content */
+    /** @return int[]  Find the indentation level and position of the first line that has content */
     protected static function getIndentationLevelOfFirstLineWithContent(array $lines): array
     {
         foreach ($lines as $lineNumber => $line) {

--- a/packages/framework/src/Framework/Services/MarkdownService.php
+++ b/packages/framework/src/Framework/Services/MarkdownService.php
@@ -231,7 +231,7 @@ class MarkdownService
     protected static function getIndentationLevelOfFirstLineWithContent(array $lines): array
     {
         foreach ($lines as $index => $line) {
-            if (! empty(trim($line))) {
+            if (filled(trim($line))) {
                 $lineLen = strlen($line);
                 $stripLen = strlen(ltrim($line)); // Length of the line without indentation lets us know its indentation level, and thus how much to strip from each line
 

--- a/packages/framework/src/Framework/Services/MarkdownService.php
+++ b/packages/framework/src/Framework/Services/MarkdownService.php
@@ -212,9 +212,7 @@ class MarkdownService
      */
     public static function normalizeIndentationLevel(string $string): string
     {
-        $replaceTabs = str_replace("\t", '    ', $string);
-        $normalizeNewlines = str_replace("\r\n", "\n", $replaceTabs);
-        $lines = explode("\n", $normalizeNewlines);
+        $lines = self::getNormalizedLines($string);
 
         [$startNumber, $indentationLevel] = self::findLineContentPositions($lines);
 
@@ -227,6 +225,12 @@ class MarkdownService
         return implode("\n", $lines);
     }
 
+    protected static function getNormalizedLines(string $string): array
+    {
+        $replaceTabs = str_replace("\t", '    ', $string);
+        $normalizeNewlines = str_replace("\r\n", "\n", $replaceTabs);
+        return explode("\n", $normalizeNewlines);
+    }
 
     /** @return int[]  Find the indentation level and position of the first line that has content */
     protected static function findLineContentPositions(array $lines): array

--- a/packages/framework/src/Framework/Services/MarkdownService.php
+++ b/packages/framework/src/Framework/Services/MarkdownService.php
@@ -212,9 +212,9 @@ class MarkdownService
      */
     public static function normalizeIndentationLevel(string $string): string
     {
-        $string = str_replace("\t", '    ', $string);
-        $string = str_replace("\r\n", "\n", $string);
-        $lines = explode("\n", $string);
+        $replaceTabs = str_replace("\t", '    ', $string);
+        $normalizeNewlines = str_replace("\r\n", "\n", $replaceTabs);
+        $lines = explode("\n", $normalizeNewlines);
 
         [$startNumber, $indentationLevel] = self::getIndentationLevelOfFirstLineWithContent($lines);
 

--- a/packages/framework/src/Framework/Services/MarkdownService.php
+++ b/packages/framework/src/Framework/Services/MarkdownService.php
@@ -215,10 +215,23 @@ class MarkdownService
         $string = str_replace("\t", '    ', $string);
         $string = str_replace("\r\n", "\n", $string);
         $lines = explode("\n", $string);
+
+        [$indentationLevel, $offset] = self::getIndentationLevelOfFirstLineWithContent($lines);
+
+        foreach ($lines as $index => $line) {
+            if ($index >= $offset) {
+                $lines[$index] = substr($line, $indentationLevel);
+            }
+        }
+
+        return implode("\n", $lines);
+    }
+
+
+    protected static function getIndentationLevelOfFirstLineWithContent(array $lines): array
+    {
         $indentationLevel = 0;
         $offset = 0;
-
-        // Find the indentation level of the first line that has content
         foreach ($lines as $index => $line) {
             if (! empty(trim($line))) {
                 $lineLen = strlen($line);
@@ -233,12 +246,6 @@ class MarkdownService
             }
         }
 
-        foreach ($lines as $index => $line) {
-            if ($index >= $offset) {
-                $lines[$index] = substr($line, $indentationLevel);
-            }
-        }
-
-        return implode("\n", $lines);
+        return [$indentationLevel, $offset];
     }
 }

--- a/packages/framework/src/Framework/Services/MarkdownService.php
+++ b/packages/framework/src/Framework/Services/MarkdownService.php
@@ -236,10 +236,7 @@ class MarkdownService
                 $stripLen = strlen(ltrim($line)); // Length of the line without indentation lets us know its indentation level, and thus how much to strip from each line
 
                 if ($lineLen !== $stripLen) {
-                    $offset = $index;
-                    $indentationLevel = $lineLen - $stripLen;
-
-                    return [$offset, $indentationLevel];
+                    return [$index, $lineLen - $stripLen];
                 }
             }
         }


### PR DESCRIPTION
Refactors `MarkdownService::normalizeIndentationLevel()` to simplify control flow handling, and extracts some helper methods.