### PR TITLE
Extract trait for classes that track execution time

### DIFF
--- a/packages/framework/src/Framework/Concerns/TracksExecutionTime.php
+++ b/packages/framework/src/Framework/Concerns/TracksExecutionTime.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Hyde\Framework\Concerns;
 
 use function microtime;
+use function number_format;
 
 trait TracksExecutionTime
 {
@@ -13,6 +14,11 @@ trait TracksExecutionTime
     protected function startClock(): void
     {
         $this->timeStart = microtime(true);
+    }
+
+    protected function getExecutionTimeString(): string
+    {
+        return number_format($this->getExecutionTimeInMs(), 2).'ms';
     }
 
     protected function getExecutionTimeInMs(): int|float

--- a/packages/framework/src/Framework/Concerns/TracksExecutionTime.php
+++ b/packages/framework/src/Framework/Concerns/TracksExecutionTime.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Hyde\Framework\Concerns;
+
+trait TracksExecutionTime
+{
+    //
+}

--- a/packages/framework/src/Framework/Concerns/TracksExecutionTime.php
+++ b/packages/framework/src/Framework/Concerns/TracksExecutionTime.php
@@ -6,5 +6,5 @@ namespace Hyde\Framework\Concerns;
 
 trait TracksExecutionTime
 {
-    //
+    protected float $timeStart;
 }

--- a/packages/framework/src/Framework/Concerns/TracksExecutionTime.php
+++ b/packages/framework/src/Framework/Concerns/TracksExecutionTime.php
@@ -21,13 +21,13 @@ trait TracksExecutionTime
         return microtime(true) - $this->timeStart;
     }
 
-    protected function getExecutionTimeString(): string
-    {
-        return number_format($this->getExecutionTimeInMs(), 2).'ms';
-    }
-
     protected function getExecutionTimeInMs(): int|float
     {
         return $this->stopClock() * 1000;
+    }
+
+    protected function getExecutionTimeString(): string
+    {
+        return number_format($this->getExecutionTimeInMs(), 2).'ms';
     }
 }

--- a/packages/framework/src/Framework/Concerns/TracksExecutionTime.php
+++ b/packages/framework/src/Framework/Concerns/TracksExecutionTime.php
@@ -4,7 +4,14 @@ declare(strict_types=1);
 
 namespace Hyde\Framework\Concerns;
 
+use function microtime;
+
 trait TracksExecutionTime
 {
     protected float $timeStart;
+
+    protected function startClock(): void
+    {
+        $this->timeStart = microtime(true);
+    }
 }

--- a/packages/framework/src/Framework/Concerns/TracksExecutionTime.php
+++ b/packages/framework/src/Framework/Concerns/TracksExecutionTime.php
@@ -14,4 +14,9 @@ trait TracksExecutionTime
     {
         $this->timeStart = microtime(true);
     }
+
+    protected function getExecutionTimeInMs(): int|float
+    {
+        return (microtime(true) - $this->timeStart) * 1000;
+    }
 }

--- a/packages/framework/src/Framework/Concerns/TracksExecutionTime.php
+++ b/packages/framework/src/Framework/Concerns/TracksExecutionTime.php
@@ -16,6 +16,11 @@ trait TracksExecutionTime
         $this->timeStart = microtime(true);
     }
 
+    protected function stopClock(): float
+    {
+        return microtime(true) - $this->timeStart;
+    }
+
     protected function getExecutionTimeString(): string
     {
         return number_format($this->getExecutionTimeInMs(), 2).'ms';
@@ -23,6 +28,6 @@ trait TracksExecutionTime
 
     protected function getExecutionTimeInMs(): int|float
     {
-        return (microtime(true) - $this->timeStart) * 1000;
+        return $this->stopClock() * 1000;
     }
 }

--- a/packages/framework/src/Framework/Features/BuildTasks/BuildTask.php
+++ b/packages/framework/src/Framework/Features/BuildTasks/BuildTask.php
@@ -8,6 +8,7 @@ use Hyde\Framework\Concerns\TracksExecutionTime;
 use Hyde\Hyde;
 use Illuminate\Console\Concerns\InteractsWithIO;
 use Illuminate\Console\OutputStyle;
+use JetBrains\PhpStorm\Deprecated;
 use Throwable;
 
 /**
@@ -64,6 +65,8 @@ abstract class BuildTask
         return static::$description;
     }
 
+    /**  @deprecated Use $this->getExecutionTimeString() instead */
+    #[Deprecated (reason: 'Use getExecutionTimeString() instead', replacement: '$this->getExecutionTimeString()')]
     public function getExecutionTime(): string
     {
         return $this->getExecutionTimeString();

--- a/packages/framework/src/Framework/Features/BuildTasks/BuildTask.php
+++ b/packages/framework/src/Framework/Features/BuildTasks/BuildTask.php
@@ -94,7 +94,7 @@ abstract class BuildTask
 
     public function withExecutionTime(): static
     {
-        $this->write(" in {$this->getExecutionTime()}");
+        $this->write(" in {$this->getExecutionTimeString()}");
 
         return $this;
     }

--- a/packages/framework/src/Framework/Features/BuildTasks/BuildTask.php
+++ b/packages/framework/src/Framework/Features/BuildTasks/BuildTask.php
@@ -66,7 +66,7 @@ abstract class BuildTask
     }
 
     /**  @deprecated Use $this->getExecutionTimeString() instead */
-    #[Deprecated (reason: 'Use getExecutionTimeString() instead', replacement: '$this->getExecutionTimeString()')]
+    #[Deprecated(reason: 'Use getExecutionTimeString() instead', replacement: '$this->getExecutionTimeString()')]
     public function getExecutionTime(): string
     {
         return $this->getExecutionTimeString();

--- a/packages/framework/src/Framework/Features/BuildTasks/BuildTask.php
+++ b/packages/framework/src/Framework/Features/BuildTasks/BuildTask.php
@@ -65,7 +65,7 @@ abstract class BuildTask
         return static::$description;
     }
 
-    /**  @deprecated Use $this->getExecutionTimeString() instead */
+    /**  @deprecated Will be removed before 1.0.0 - Use $this->getExecutionTimeString() instead */
     #[Deprecated(reason: 'Use getExecutionTimeString() instead', replacement: '$this->getExecutionTimeString()')]
     public function getExecutionTime(): string
     {

--- a/packages/framework/src/Framework/Features/BuildTasks/BuildTask.php
+++ b/packages/framework/src/Framework/Features/BuildTasks/BuildTask.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Hyde\Framework\Features\BuildTasks;
 
+use Hyde\Framework\Concerns\TracksExecutionTime;
 use Hyde\Hyde;
 use Illuminate\Console\Concerns\InteractsWithIO;
 use Illuminate\Console\OutputStyle;
@@ -15,10 +16,9 @@ use Throwable;
 abstract class BuildTask
 {
     use InteractsWithIO;
+    use TracksExecutionTime;
 
     protected static string $description = 'Generic build task';
-
-    protected float $timeStart;
 
     /**
      * @todo Consider setting default value to 0
@@ -30,7 +30,7 @@ abstract class BuildTask
 
     public function __construct(?OutputStyle $output = null)
     {
-        $this->timeStart = microtime(true);
+        $this->startClock();
         $this->output = $output;
     }
 
@@ -66,7 +66,7 @@ abstract class BuildTask
 
     public function getExecutionTime(): string
     {
-        return number_format((microtime(true) - $this->timeStart) * 1000, 2).'ms';
+        return $this->getExecutionTimeString();
     }
 
     public function write(string $message): void

--- a/packages/framework/src/Framework/Features/DataCollections/DataCollection.php
+++ b/packages/framework/src/Framework/Features/DataCollections/DataCollection.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Hyde\Framework\Features\DataCollections;
 
 use Hyde\Framework\Actions\MarkdownFileParser;
+use Hyde\Framework\Concerns\TracksExecutionTime;
 use Hyde\Hyde;
 use Illuminate\Support\Collection;
 
@@ -16,16 +17,17 @@ use Illuminate\Support\Collection;
  */
 class DataCollection extends Collection
 {
+    use TracksExecutionTime;
+
     public string $key;
 
-    protected float $timeStart;
     public float $parseTimeInMs;
 
     public static string $sourceDirectory = '_data';
 
     public function __construct(string $key)
     {
-        $this->timeStart = microtime(true);
+        $this->startClock();
         $this->key = $key;
 
         parent::__construct();
@@ -33,7 +35,7 @@ class DataCollection extends Collection
 
     public function getCollection(): static
     {
-        $this->parseTimeInMs = round((microtime(true) - $this->timeStart) * 1000, 2);
+        $this->parseTimeInMs = $this->stopClock();
         unset($this->timeStart);
 
         return $this;

--- a/packages/framework/src/Framework/Features/XmlGenerators/SitemapGenerator.php
+++ b/packages/framework/src/Framework/Features/XmlGenerators/SitemapGenerator.php
@@ -9,6 +9,7 @@ namespace Hyde\Framework\Features\XmlGenerators;
 use function config;
 use function date;
 use function filemtime;
+use Hyde\Framework\Concerns\TracksExecutionTime;
 use Hyde\Hyde;
 use Hyde\Pages\BladePage;
 use Hyde\Pages\DocumentationPage;
@@ -16,8 +17,6 @@ use Hyde\Pages\MarkdownPage;
 use Hyde\Pages\MarkdownPost;
 use Hyde\Support\Models\Route;
 use function in_array;
-use function microtime;
-use function round;
 use SimpleXMLElement;
 
 /**
@@ -26,7 +25,7 @@ use SimpleXMLElement;
  */
 class SitemapGenerator extends BaseXmlGenerator
 {
-    protected float $timeStart;
+    use TracksExecutionTime;
 
     public function generate(): static
     {
@@ -46,7 +45,7 @@ class SitemapGenerator extends BaseXmlGenerator
 
     protected function constructBaseElement(): void
     {
-        $this->timeStart = microtime(true);
+        $this->startClock();
 
         $this->xmlElement = new SimpleXMLElement('<?xml version="1.0" encoding="UTF-8"?><urlset xmlns="https://www.sitemaps.org/schemas/sitemap/0.9"></urlset>');
         $this->xmlElement->addAttribute('generator', 'HydePHP '.Hyde::version());
@@ -100,6 +99,6 @@ class SitemapGenerator extends BaseXmlGenerator
     /** @return numeric-string */
     protected function getFormattedProcessingTime(): string
     {
-        return (string) round((microtime(true) - $this->timeStart) * 1000, 2);
+        return (string) $this->getExecutionTimeInMs();
     }
 }

--- a/packages/framework/tests/Feature/TracksExecutionTimeTest.php
+++ b/packages/framework/tests/Feature/TracksExecutionTimeTest.php
@@ -12,7 +12,40 @@ use Hyde\Testing\TestCase;
  */
 class TracksExecutionTimeTest extends TestCase
 {
-    //
+    public function test_startClock()
+    {
+        $class = new TracksExecutionTimeTestClass();
+
+        $this->assertFalse($class->isset('timeStart'));
+        $class->startClock();
+
+        $this->assertTrue($class->isset('timeStart'));
+        $this->assertIsFloat($class->timeStart);
+    }
+
+    public function test_stopClock()
+    {
+        $class = new TracksExecutionTimeTestClass();
+        $class->startClock();
+
+        $this->assertIsFloat($class->stopClock());
+    }
+
+    public function test_getExecutionTimeString()
+    {
+        $class = new TracksExecutionTimeTestClass();
+        $class->startClock();
+
+        $this->assertIsString($class->getExecutionTimeString());
+    }
+
+    public function test_getExecutionTimeInMs()
+    {
+        $class = new TracksExecutionTimeTestClass();
+        $class->startClock();
+
+        $this->assertIsFloat($class->getExecutionTimeInMs());
+    }
 }
 
 class TracksExecutionTimeTestClass {

--- a/packages/framework/tests/Feature/TracksExecutionTimeTest.php
+++ b/packages/framework/tests/Feature/TracksExecutionTimeTest.php
@@ -48,7 +48,7 @@ class TracksExecutionTimeTest extends TestCase
         $class->startClock();
 
         $this->assertIsString($class->getExecutionTimeString());
-        $this->assertTrue(str_starts_with($class->getExecutionTimeString(), '0.0'));
+        $this->assertTrue(str_starts_with($class->getExecutionTimeString(), '0'));
         $this->assertTrue(str_ends_with($class->getExecutionTimeString(), 'ms'));
     }
 }

--- a/packages/framework/tests/Feature/TracksExecutionTimeTest.php
+++ b/packages/framework/tests/Feature/TracksExecutionTimeTest.php
@@ -33,6 +33,15 @@ class TracksExecutionTimeTest extends TestCase
         $this->assertSame(0.0, round($class->stopClock()));
     }
 
+    public function test_getExecutionTimeInMs()
+    {
+        $class = new TracksExecutionTimeTestClass();
+        $class->startClock();
+
+        $this->assertIsFloat($class->getExecutionTimeInMs());
+        $this->assertSame(0.0, round($class->getExecutionTimeInMs()));
+    }
+
     public function test_getExecutionTimeString()
     {
         $class = new TracksExecutionTimeTestClass();
@@ -41,15 +50,6 @@ class TracksExecutionTimeTest extends TestCase
         $this->assertIsString($class->getExecutionTimeString());
         $this->assertTrue(str_starts_with($class->getExecutionTimeString(), '0.0'));
         $this->assertTrue(str_ends_with( $class->getExecutionTimeString(), 'ms'));
-    }
-
-    public function test_getExecutionTimeInMs()
-    {
-        $class = new TracksExecutionTimeTestClass();
-        $class->startClock();
-
-        $this->assertIsFloat($class->getExecutionTimeInMs());
-        $this->assertSame(0.0, round($class->getExecutionTimeInMs()));
     }
 }
 

--- a/packages/framework/tests/Feature/TracksExecutionTimeTest.php
+++ b/packages/framework/tests/Feature/TracksExecutionTimeTest.php
@@ -14,3 +14,22 @@ class TracksExecutionTimeTest extends TestCase
 {
     //
 }
+
+class TracksExecutionTimeTestClass {
+    use TracksExecutionTime;
+
+    public function __call(string $name, array $arguments)
+    {
+        return $this->$name(...$arguments);
+    }
+
+    public function __get(string $name)
+    {
+        return $this->$name;
+    }
+
+    public function isset(string $name): bool
+    {
+        return isset($this->$name);
+    }
+}

--- a/packages/framework/tests/Feature/TracksExecutionTimeTest.php
+++ b/packages/framework/tests/Feature/TracksExecutionTimeTest.php
@@ -21,6 +21,7 @@ class TracksExecutionTimeTest extends TestCase
 
         $this->assertTrue($class->isset('timeStart'));
         $this->assertIsFloat($class->timeStart);
+        $this->assertSame(round(microtime(true)), round($class->timeStart));
     }
 
     public function test_stopClock()
@@ -29,6 +30,7 @@ class TracksExecutionTimeTest extends TestCase
         $class->startClock();
 
         $this->assertIsFloat($class->stopClock());
+        $this->assertSame(0.0, round($class->stopClock()));
     }
 
     public function test_getExecutionTimeString()
@@ -37,6 +39,8 @@ class TracksExecutionTimeTest extends TestCase
         $class->startClock();
 
         $this->assertIsString($class->getExecutionTimeString());
+        $this->assertTrue(str_starts_with($class->getExecutionTimeString(), '0.0'));
+        $this->assertTrue(str_ends_with( $class->getExecutionTimeString(), 'ms'));
     }
 
     public function test_getExecutionTimeInMs()
@@ -45,6 +49,7 @@ class TracksExecutionTimeTest extends TestCase
         $class->startClock();
 
         $this->assertIsFloat($class->getExecutionTimeInMs());
+        $this->assertSame(0.0, round($class->getExecutionTimeInMs()));
     }
 }
 

--- a/packages/framework/tests/Feature/TracksExecutionTimeTest.php
+++ b/packages/framework/tests/Feature/TracksExecutionTimeTest.php
@@ -49,11 +49,12 @@ class TracksExecutionTimeTest extends TestCase
 
         $this->assertIsString($class->getExecutionTimeString());
         $this->assertTrue(str_starts_with($class->getExecutionTimeString(), '0.0'));
-        $this->assertTrue(str_ends_with( $class->getExecutionTimeString(), 'ms'));
+        $this->assertTrue(str_ends_with($class->getExecutionTimeString(), 'ms'));
     }
 }
 
-class TracksExecutionTimeTestClass {
+class TracksExecutionTimeTestClass
+{
     use TracksExecutionTime;
 
     public function __call(string $name, array $arguments)

--- a/packages/framework/tests/Feature/TracksExecutionTimeTest.php
+++ b/packages/framework/tests/Feature/TracksExecutionTimeTest.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Hyde\Framework\Testing\Feature;
+
+use Hyde\Framework\Concerns\TracksExecutionTime;
+use Hyde\Testing\TestCase;
+
+/**
+ * @covers \Hyde\Framework\Concerns\TracksExecutionTime
+ */
+class TracksExecutionTimeTest extends TestCase
+{
+    //
+}


### PR DESCRIPTION
Since a few classes track execution time, we might as well extract all those helpers for reduced repeated code and consistency. 