### PR TITLE
Deprecate base class InvokableAction

### DIFF
--- a/packages/framework/src/Framework/Concerns/InvokableAction.php
+++ b/packages/framework/src/Framework/Concerns/InvokableAction.php
@@ -11,7 +11,6 @@ use JetBrains\PhpStorm\Deprecated;
  *
  * @deprecated None of these child classes are ever used invokably used.
  *             A better alternative is to simply use a static `handle` method as that offers full type and IDE support.
- *
  * @see \Hyde\Framework\Testing\Feature\InvokableActionTest
  */
 abstract class InvokableAction

--- a/packages/framework/src/Framework/Concerns/InvokableAction.php
+++ b/packages/framework/src/Framework/Concerns/InvokableAction.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Hyde\Framework\Concerns;
 
+use JetBrains\PhpStorm\Deprecated;
+
 /**
  * Base class for invokable actions. Provides a helper to invoke the action statically.
  *
@@ -16,6 +18,7 @@ abstract class InvokableAction
 {
     abstract public function __invoke(): mixed;
 
+    #[Deprecated(replacement: '%class%::handle(%parametersList%)')]
     public static function call(mixed ...$args): mixed
     {
         return (new static(...$args))->__invoke();

--- a/packages/framework/src/Framework/Concerns/InvokableAction.php
+++ b/packages/framework/src/Framework/Concerns/InvokableAction.php
@@ -7,6 +7,9 @@ namespace Hyde\Framework\Concerns;
 /**
  * Base class for invokable actions. Provides a helper to invoke the action statically.
  *
+ * @deprecated None of these child classes are ever used invokably used.
+ *             A better alternative is to simply use a static `handle` method as that offers full type and IDE support.
+ *
  * @see \Hyde\Framework\Testing\Feature\InvokableActionTest
  */
 abstract class InvokableAction


### PR DESCRIPTION
None of these child classes are ever used invokably used. A better alternative is to simply use a static `handle` method as that offers full type and IDE support.