### PR TITLE
Add spaces to type annotations in views so they don't get rendered as comments

### DIFF
--- a/packages/framework/resources/views/components/docs/grouped-sidebar-navigation.blade.php
+++ b/packages/framework/resources/views/components/docs/grouped-sidebar-navigation.blade.php
@@ -1,4 +1,4 @@
-@php/** @var \Hyde\Framework\Features\Navigation\DocumentationSidebar $sidebar */@endphp
+@php /** @var \Hyde\Framework\Features\Navigation\DocumentationSidebar $sidebar */ @endphp
 <ul id="sidebar-navigation" role="list">
 	@foreach ($sidebar->getGroups() as $group)
 	<li class="sidebar-group mb-4 mt-4 first:mt-0" role="listitem">

--- a/packages/framework/resources/views/components/docs/sidebar-navigation.blade.php
+++ b/packages/framework/resources/views/components/docs/sidebar-navigation.blade.php
@@ -1,4 +1,4 @@
-@php/** @var \Hyde\Framework\Features\Navigation\DocumentationSidebar $sidebar */@endphp
+@php /** @var \Hyde\Framework\Features\Navigation\DocumentationSidebar $sidebar */ @endphp
 <ul id="sidebar-navigation" role="list">
 	@foreach ($sidebar->items as $item)
 	<li @class(['sidebar-navigation-item -ml-4 pl-4' , 'active bg-black/5 dark:bg-black/10'=> $item->route->getRouteKey() === $currentRoute->getRouteKey()])>

--- a/packages/framework/resources/views/components/pagination-navigation.blade.php
+++ b/packages/framework/resources/views/components/pagination-navigation.blade.php
@@ -1,4 +1,4 @@
-@php/** @var \Hyde\Framework\Features\Paginator $paginator */@endphp
+@php /** @var \Hyde\Framework\Features\Paginator $paginator */ @endphp
 <nav class="flex justify-center mt-4">
     @if($paginator->previous())
         <x-link :href="$paginator->previous()">&#8249;</x-link>


### PR DESCRIPTION
Adds spaces to type annotations in views so they don't get rendered as comments in the compiled HTML source code.