### PR TITLE
Add a command to automatically change source directories

### DIFF
--- a/docs/digging-deeper/advanced-customization.md
+++ b/docs/digging-deeper/advanced-customization.md
@@ -52,6 +52,18 @@ public function register(): void
 }
 ```
 
+## Custom source root directory 🧪
+
+HydePHP will by default look for the underscored source directories in the root of your project.
+If you're not happy with this, it's easy to change! For example, you might want everything in a 'src'
+subdirectory. That's easy enough, just set the value of the `source_root` setting in config/hyde.php to `'src'`!
+
+### Automatic change 🧪
+You can even make this change automatically with the `php hyde change:sourceDirectory` command!
+
+When run, Hyde will update the source directory setting in the config file, then create the directory if it doesn't exist, then move all source directories into it.
+
+
 ## Customizing the output directory ⚠
 
 >danger Hyde deletes all files in the output directory before compiling the site. Don't set this path to a directory that contains important files!

--- a/packages/framework/src/Console/Commands/ChangeSourceDirectoryCommand.php
+++ b/packages/framework/src/Console/Commands/ChangeSourceDirectoryCommand.php
@@ -66,8 +66,8 @@ class ChangeSourceDirectoryCommand extends Command
     {
         $this->comment('Updating configuration file');
 
-        // We could also inject the current source root value and check if the setting is even present, but we're keeping it simple for now
-        $search = "'source_root' => '',";
+        $current = config('hyde.source_root', '');
+        $search = "'source_root' => '$current',";
 
         $config = Filesystem::getContents('config/hyde.php');
         if (! str_contains($config, $search)) {

--- a/packages/framework/src/Console/Commands/ChangeSourceDirectoryCommand.php
+++ b/packages/framework/src/Console/Commands/ChangeSourceDirectoryCommand.php
@@ -49,7 +49,7 @@ class ChangeSourceDirectoryCommand extends Command
         $this->comment('Moving source directories');
 
         foreach ($directories as $directory) {
-            Filesystem::moveDirectory($directory, "$name/$directory");
+            Filesystem::moveDirectory($directory, "$name/".basename($directory));
         }
 
         

--- a/packages/framework/src/Console/Commands/ChangeSourceDirectoryCommand.php
+++ b/packages/framework/src/Console/Commands/ChangeSourceDirectoryCommand.php
@@ -30,6 +30,7 @@ class ChangeSourceDirectoryCommand extends Command
             return Command::FAILED;
         }
 
+        $this->comment('Creating directory');
         Filesystem::ensureDirectoryExists($name);
 
         return Command::SUCCESS;

--- a/packages/framework/src/Console/Commands/ChangeSourceDirectoryCommand.php
+++ b/packages/framework/src/Console/Commands/ChangeSourceDirectoryCommand.php
@@ -59,17 +59,6 @@ class ChangeSourceDirectoryCommand extends Command
         }
 
         
-        $this->updateConfigurationFile($name);
-
-        // We could also check if there are any more page classes (from packages) and add a note that they may need manual attention
-
-        $this->info('All done!');
-
-        return Command::SUCCESS;
-    }
-
-    protected function updateConfigurationFile(string $name): void
-    {
         $this->comment('Updating configuration file');
 
         $current = config('hyde.source_root', '');
@@ -82,5 +71,11 @@ class ChangeSourceDirectoryCommand extends Command
             $config = str_replace($search, "'source_root' => '$name',", $config);
             Filesystem::putContents('config/hyde.php', $config);
         }
+
+        // We could also check if there are any more page classes (from packages) and add a note that they may need manual attention
+
+        $this->info('All done!');
+
+        return Command::SUCCESS;
     }
 }

--- a/packages/framework/src/Console/Commands/ChangeSourceDirectoryCommand.php
+++ b/packages/framework/src/Console/Commands/ChangeSourceDirectoryCommand.php
@@ -40,8 +40,8 @@ class ChangeSourceDirectoryCommand extends Command
 
         if (Filesystem::isDirectory($name) && ! Filesystem::isEmptyDirectory($name)) {
             foreach ($directories as $directory) {
-                if (Filesystem::isDirectory($directory) && ! Filesystem::isEmptyDirectory($directory)) {
                 $directory = "$name/".basename($directory);
+                if (self::isNonEmptyDirectory(Hyde::path($directory))) {
                     $this->error('Directory already exists!');
                     return Command::FAILURE;
                 }
@@ -77,5 +77,13 @@ class ChangeSourceDirectoryCommand extends Command
         $this->info('All done!');
 
         return Command::SUCCESS;
+    }
+
+    protected static function isNonEmptyDirectory(string $directory): bool
+    {
+        if (is_file($directory)) {
+            return false;
+        }
+        return ((is_dir($directory) && (count(scandir($directory)) > 2)));
     }
 }

--- a/packages/framework/src/Console/Commands/ChangeSourceDirectoryCommand.php
+++ b/packages/framework/src/Console/Commands/ChangeSourceDirectoryCommand.php
@@ -45,8 +45,12 @@ class ChangeSourceDirectoryCommand extends Command
         $this->comment('Updating configuration file');
 
         $config = Filesystem::getContents('config/hyde.php');
-        $config = str_replace("'source_root' => '',", "'source_root' => '$name',", $config);
-        Filesystem::putContents('config/hyde.php', $config);
+        if (! str_contains($config, "'source_root' => '',")) {
+            $this->error('Automatic configuration update failed, to finalize the change, please set the `source_root` setting to '. "'$name'". ' in `config/hyde.php`');
+        } else {
+            $config = str_replace("'source_root' => '',", "'source_root' => '$name',", $config);
+            Filesystem::putContents('config/hyde.php', $config);
+        }
 
         return Command::SUCCESS;
     }

--- a/packages/framework/src/Console/Commands/ChangeSourceDirectoryCommand.php
+++ b/packages/framework/src/Console/Commands/ChangeSourceDirectoryCommand.php
@@ -26,9 +26,10 @@ class ChangeSourceDirectoryCommand extends Command
         $name = $this->argument('name');
         if (realpath(Hyde::path($name)) === realpath(Hyde::path(config('hyde.source_root', '')))) {
             $this->error("The directory '$name' is already set as the project source root!");
+
             return 409;
         }
-        $this->infoComment("Setting", $name, "as the project source directory!");
+        $this->infoComment('Setting', $name, 'as the project source directory!');
 
         $directories = array_unique([
             \Hyde\Pages\HtmlPage::$sourceDirectory,
@@ -43,6 +44,7 @@ class ChangeSourceDirectoryCommand extends Command
                 $directory = "$name/".basename($directory);
                 if (self::isNonEmptyDirectory(Hyde::path($directory))) {
                     $this->error('Directory already exists!');
+
                     return Command::FAILURE;
                 }
             }
@@ -51,14 +53,12 @@ class ChangeSourceDirectoryCommand extends Command
         $this->comment('Creating directory');
         Filesystem::ensureDirectoryExists($name);
 
-
         $this->comment('Moving source directories');
 
         foreach ($directories as $directory) {
             Filesystem::moveDirectory($directory, "$name/".basename($directory));
         }
 
-        
         $this->comment('Updating configuration file');
 
         $current = config('hyde.source_root', '');
@@ -66,7 +66,7 @@ class ChangeSourceDirectoryCommand extends Command
 
         $config = Filesystem::getContents('config/hyde.php');
         if (! str_contains($config, $search)) {
-            $this->error('Automatic configuration update failed, to finalize the change, please set the `source_root` setting to '. "'$name'". ' in `config/hyde.php`');
+            $this->error('Automatic configuration update failed, to finalize the change, please set the `source_root` setting to '."'$name'".' in `config/hyde.php`');
         } else {
             $config = str_replace($search, "'source_root' => '$name',", $config);
             Filesystem::putContents('config/hyde.php', $config);
@@ -84,6 +84,7 @@ class ChangeSourceDirectoryCommand extends Command
         if (is_file($directory)) {
             return false;
         }
-        return (is_dir($directory) && (count(scandir($directory)) > 2));
+
+        return is_dir($directory) && (count(scandir($directory)) > 2);
     }
 }

--- a/packages/framework/src/Console/Commands/ChangeSourceDirectoryCommand.php
+++ b/packages/framework/src/Console/Commands/ChangeSourceDirectoryCommand.php
@@ -27,7 +27,7 @@ class ChangeSourceDirectoryCommand extends Command
 
         if (Filesystem::isDirectory($name) && ! Filesystem::isEmptyDirectory($name)) {
             $this->error('Directory already exists!');
-            return Command::FAILED;
+            return Command::FAILURE;
         }
 
         $this->comment('Creating directory');

--- a/packages/framework/src/Console/Commands/ChangeSourceDirectoryCommand.php
+++ b/packages/framework/src/Console/Commands/ChangeSourceDirectoryCommand.php
@@ -64,6 +64,7 @@ class ChangeSourceDirectoryCommand extends Command
             Filesystem::putContents('config/hyde.php', $config);
         }
 
+        // We could also check if there are any more page classes (from packages) and add a note that they may need manual attention
 
         $this->info('All done!');
 

--- a/packages/framework/src/Console/Commands/ChangeSourceDirectoryCommand.php
+++ b/packages/framework/src/Console/Commands/ChangeSourceDirectoryCommand.php
@@ -46,6 +46,7 @@ class ChangeSourceDirectoryCommand extends Command
 
         $config = Filesystem::getContents('config/hyde.php');
         if (! str_contains($config, "'source_root' => '',")) {
+            // We could also inject the current source root value and check if the setting is even present, but we're keeping it simple for now
             $this->error('Automatic configuration update failed, to finalize the change, please set the `source_root` setting to '. "'$name'". ' in `config/hyde.php`');
         } else {
             $config = str_replace("'source_root' => '',", "'source_root' => '$name',", $config);

--- a/packages/framework/src/Console/Commands/ChangeSourceDirectoryCommand.php
+++ b/packages/framework/src/Console/Commands/ChangeSourceDirectoryCommand.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Hyde\Console\Commands;
+
+use LaravelZero\Framework\Commands\Command;
+
+/**
+ * @see \Hyde\Framework\Testing\Feature\Commands\ChangeSourceDirectoryCommandTest
+ */
+class ChangeSourceDirectoryCommand extends Command
+{
+    /** @var string */
+    protected $signature = 'change:sourceDirectory';
+
+    /** @var string */
+    protected $description = 'Change the source directory for your project.';
+
+    public function handle(): int
+    {
+        //
+
+        return Command::SUCCESS;
+    }
+}

--- a/packages/framework/src/Console/Commands/ChangeSourceDirectoryCommand.php
+++ b/packages/framework/src/Console/Commands/ChangeSourceDirectoryCommand.php
@@ -82,7 +82,7 @@ class ChangeSourceDirectoryCommand extends Command
     protected static function isNonEmptyDirectory(string $directory): bool
     {
         if (is_file($directory)) {
-            return false;
+            return true;
         }
 
         return is_dir($directory) && (count(scandir($directory)) > 2);

--- a/packages/framework/src/Console/Commands/ChangeSourceDirectoryCommand.php
+++ b/packages/framework/src/Console/Commands/ChangeSourceDirectoryCommand.php
@@ -23,7 +23,7 @@ class ChangeSourceDirectoryCommand extends Command
 
     public function handle(): int
     {
-        $name = $this->argument('name');
+        $name = (string) $this->argument('name');
         if (realpath(Hyde::path($name)) === realpath(Hyde::path(config('hyde.source_root', '')))) {
             $this->error("The directory '$name' is already set as the project source root!");
 

--- a/packages/framework/src/Console/Commands/ChangeSourceDirectoryCommand.php
+++ b/packages/framework/src/Console/Commands/ChangeSourceDirectoryCommand.php
@@ -61,7 +61,7 @@ class ChangeSourceDirectoryCommand extends Command
 
         $this->comment('Updating configuration file');
 
-        $current = config('hyde.source_root', '');
+        $current = (string) config('hyde.source_root', '');
         $search = "'source_root' => '$current',";
 
         $config = Filesystem::getContents('config/hyde.php');

--- a/packages/framework/src/Console/Commands/ChangeSourceDirectoryCommand.php
+++ b/packages/framework/src/Console/Commands/ChangeSourceDirectoryCommand.php
@@ -66,12 +66,14 @@ class ChangeSourceDirectoryCommand extends Command
     {
         $this->comment('Updating configuration file');
 
+        // We could also inject the current source root value and check if the setting is even present, but we're keeping it simple for now
+        $search = "'source_root' => '',";
+
         $config = Filesystem::getContents('config/hyde.php');
-        if (! str_contains($config, "'source_root' => '',")) {
-            // We could also inject the current source root value and check if the setting is even present, but we're keeping it simple for now
+        if (! str_contains($config, $search)) {
             $this->error('Automatic configuration update failed, to finalize the change, please set the `source_root` setting to '. "'$name'". ' in `config/hyde.php`');
         } else {
-            $config = str_replace("'source_root' => '',", "'source_root' => '$name',", $config);
+            $config = str_replace($search, "'source_root' => '$name',", $config);
             Filesystem::putContents('config/hyde.php', $config);
         }
     }

--- a/packages/framework/src/Console/Commands/ChangeSourceDirectoryCommand.php
+++ b/packages/framework/src/Console/Commands/ChangeSourceDirectoryCommand.php
@@ -23,6 +23,7 @@ class ChangeSourceDirectoryCommand extends Command
     public function handle(): int
     {
         $name = $this->argument('name');
+        $this->info("Setting $name as the project source directory!");
 
         if (Filesystem::isDirectory($name) && ! Filesystem::isEmptyDirectory($name)) {
             $this->error('Directory already exists!');

--- a/packages/framework/src/Console/Commands/ChangeSourceDirectoryCommand.php
+++ b/packages/framework/src/Console/Commands/ChangeSourceDirectoryCommand.php
@@ -25,6 +25,8 @@ class ChangeSourceDirectoryCommand extends Command
         $name = $this->argument('name');
         $this->infoComment("Setting", $name, "as the project source directory!");
 
+        $directories = ['_pages', '_posts', '_docs'];
+
         if (Filesystem::isDirectory($name) && ! Filesystem::isEmptyDirectory($name)) {
             $this->error('Directory already exists!');
             return Command::FAILURE;
@@ -36,7 +38,6 @@ class ChangeSourceDirectoryCommand extends Command
 
         $this->comment('Moving source directories');
 
-        $directories = ['_pages', '_posts', '_docs'];
         foreach ($directories as $directory) {
             Filesystem::moveDirectory($directory, "$name/$directory");
         }

--- a/packages/framework/src/Console/Commands/ChangeSourceDirectoryCommand.php
+++ b/packages/framework/src/Console/Commands/ChangeSourceDirectoryCommand.php
@@ -65,11 +65,11 @@ class ChangeSourceDirectoryCommand extends Command
         $search = "'source_root' => '$current',";
 
         $config = Filesystem::getContents('config/hyde.php');
-        if (! str_contains($config, $search)) {
-            $this->error('Automatic configuration update failed, to finalize the change, please set the `source_root` setting to '."'$name'".' in `config/hyde.php`');
-        } else {
+        if (str_contains($config, $search)) {
             $config = str_replace($search, "'source_root' => '$name',", $config);
             Filesystem::putContents('config/hyde.php', $config);
+        } else {
+            $this->error('Automatic configuration update failed, to finalize the change, please set the `source_root` setting to '."'$name'".' in `config/hyde.php`');
         }
 
         // We could also check if there are any more page classes (from packages) and add a note that they may need manual attention

--- a/packages/framework/src/Console/Commands/ChangeSourceDirectoryCommand.php
+++ b/packages/framework/src/Console/Commands/ChangeSourceDirectoryCommand.php
@@ -40,8 +40,8 @@ class ChangeSourceDirectoryCommand extends Command
 
         if (Filesystem::isDirectory($name) && ! Filesystem::isEmptyDirectory($name)) {
             foreach ($directories as $directory) {
-                $directory = basename($directory);
                 if (Filesystem::isDirectory($directory) && ! Filesystem::isEmptyDirectory($directory)) {
+                $directory = "$name/".basename($directory);
                     $this->error('Directory already exists!');
                     return Command::FAILURE;
                 }

--- a/packages/framework/src/Console/Commands/ChangeSourceDirectoryCommand.php
+++ b/packages/framework/src/Console/Commands/ChangeSourceDirectoryCommand.php
@@ -6,6 +6,7 @@ namespace Hyde\Console\Commands;
 
 use Hyde\Console\Concerns\Command;
 use Hyde\Facades\Filesystem;
+use Hyde\Hyde;
 
 /**
  * @see \Hyde\Framework\Testing\Feature\Commands\ChangeSourceDirectoryCommandTest
@@ -23,7 +24,7 @@ class ChangeSourceDirectoryCommand extends Command
     public function handle(): int
     {
         $name = $this->argument('name');
-        if ($name === config('hyde.source_root', '')) {
+        if (realpath(Hyde::path($name)) === realpath(Hyde::path(config('hyde.source_root', '')))) {
             $this->error("The directory '$name' is already set as the project source root!");
             return 409;
         }

--- a/packages/framework/src/Console/Commands/ChangeSourceDirectoryCommand.php
+++ b/packages/framework/src/Console/Commands/ChangeSourceDirectoryCommand.php
@@ -34,8 +34,12 @@ class ChangeSourceDirectoryCommand extends Command
         ]);
 
         if (Filesystem::isDirectory($name) && ! Filesystem::isEmptyDirectory($name)) {
-            $this->error('Directory already exists!');
-            return Command::FAILURE;
+            foreach ($directories as $directory) {
+                if (Filesystem::isDirectory($directory) && ! Filesystem::isEmptyDirectory($directory)) {
+                    $this->error('Directory already exists!');
+                    return Command::FAILURE;
+                }
+            }
         }
 
         $this->comment('Creating directory');

--- a/packages/framework/src/Console/Commands/ChangeSourceDirectoryCommand.php
+++ b/packages/framework/src/Console/Commands/ChangeSourceDirectoryCommand.php
@@ -22,8 +22,7 @@ class ChangeSourceDirectoryCommand extends Command
 
     public function handle(): int
     {
-        $name = $this->argument('name');
-        $this->infoComment("Setting", $name, "as the project source directory!");
+        $name = $this->getDirectoryName();
 
         $directories = array_unique([
             \Hyde\Pages\HtmlPage::$sourceDirectory,
@@ -61,6 +60,13 @@ class ChangeSourceDirectoryCommand extends Command
         $this->info('All done!');
 
         return Command::SUCCESS;
+    }
+
+    protected function getDirectoryName(): string
+    {
+        $name = $this->argument('name');
+        $this->infoComment("Setting", $name, "as the project source directory!");
+        return $name;
     }
 
     protected function updateConfigurationFile(string $name): void

--- a/packages/framework/src/Console/Commands/ChangeSourceDirectoryCommand.php
+++ b/packages/framework/src/Console/Commands/ChangeSourceDirectoryCommand.php
@@ -33,6 +33,14 @@ class ChangeSourceDirectoryCommand extends Command
         $this->comment('Creating directory');
         Filesystem::ensureDirectoryExists($name);
 
+
+        $this->comment('Moving source directories');
+
+        $directories = ['_pages', '_posts', '_docs'];
+        foreach ($directories as $directory) {
+            Filesystem::moveDirectory($directory, "$name/$directory");
+        }
+
         return Command::SUCCESS;
     }
 }

--- a/packages/framework/src/Console/Commands/ChangeSourceDirectoryCommand.php
+++ b/packages/framework/src/Console/Commands/ChangeSourceDirectoryCommand.php
@@ -53,6 +53,17 @@ class ChangeSourceDirectoryCommand extends Command
         }
 
         
+        $this->updateConfigurationFile($name);
+
+        // We could also check if there are any more page classes (from packages) and add a note that they may need manual attention
+
+        $this->info('All done!');
+
+        return Command::SUCCESS;
+    }
+
+    protected function updateConfigurationFile(string $name): void
+    {
         $this->comment('Updating configuration file');
 
         $config = Filesystem::getContents('config/hyde.php');
@@ -63,11 +74,5 @@ class ChangeSourceDirectoryCommand extends Command
             $config = str_replace("'source_root' => '',", "'source_root' => '$name',", $config);
             Filesystem::putContents('config/hyde.php', $config);
         }
-
-        // We could also check if there are any more page classes (from packages) and add a note that they may need manual attention
-
-        $this->info('All done!');
-
-        return Command::SUCCESS;
     }
 }

--- a/packages/framework/src/Console/Commands/ChangeSourceDirectoryCommand.php
+++ b/packages/framework/src/Console/Commands/ChangeSourceDirectoryCommand.php
@@ -23,7 +23,7 @@ class ChangeSourceDirectoryCommand extends Command
     public function handle(): int
     {
         $name = $this->argument('name');
-        $this->info("Setting $name as the project source directory!");
+        $this->infoComment("Setting", $name, "as the project source directory!");
 
         if (Filesystem::isDirectory($name) && ! Filesystem::isEmptyDirectory($name)) {
             $this->error('Directory already exists!');

--- a/packages/framework/src/Console/Commands/ChangeSourceDirectoryCommand.php
+++ b/packages/framework/src/Console/Commands/ChangeSourceDirectoryCommand.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Hyde\Console\Commands;
 
-use LaravelZero\Framework\Commands\Command;
+use Hyde\Console\Concerns\Command;
 use Hyde\Facades\Filesystem;
 
 /**

--- a/packages/framework/src/Console/Commands/ChangeSourceDirectoryCommand.php
+++ b/packages/framework/src/Console/Commands/ChangeSourceDirectoryCommand.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Hyde\Console\Commands;
 
 use LaravelZero\Framework\Commands\Command;
+use Hyde\Facades\Filesystem;
 
 /**
  * @see \Hyde\Framework\Testing\Feature\Commands\ChangeSourceDirectoryCommandTest
@@ -21,7 +22,14 @@ class ChangeSourceDirectoryCommand extends Command
 
     public function handle(): int
     {
-        //
+        $name = $this->argument('name');
+
+        if (Filesystem::isDirectory($name)) {
+            $this->error('Directory already exists!');
+            return Command::FAILED;
+        }
+
+        Filesystem::ensureDirectoryExists($name);
 
         return Command::SUCCESS;
     }

--- a/packages/framework/src/Console/Commands/ChangeSourceDirectoryCommand.php
+++ b/packages/framework/src/Console/Commands/ChangeSourceDirectoryCommand.php
@@ -17,6 +17,8 @@ class ChangeSourceDirectoryCommand extends Command
     /** @var string */
     protected $description = 'Change the source directory for your project.';
 
+    protected $hidden = true;
+
     public function handle(): int
     {
         //

--- a/packages/framework/src/Console/Commands/ChangeSourceDirectoryCommand.php
+++ b/packages/framework/src/Console/Commands/ChangeSourceDirectoryCommand.php
@@ -24,7 +24,7 @@ class ChangeSourceDirectoryCommand extends Command
     {
         $name = $this->argument('name');
 
-        if (Filesystem::isDirectory($name)) {
+        if (Filesystem::isDirectory($name) && ! Filesystem::isEmptyDirectory($name)) {
             $this->error('Directory already exists!');
             return Command::FAILED;
         }

--- a/packages/framework/src/Console/Commands/ChangeSourceDirectoryCommand.php
+++ b/packages/framework/src/Console/Commands/ChangeSourceDirectoryCommand.php
@@ -41,6 +41,13 @@ class ChangeSourceDirectoryCommand extends Command
             Filesystem::moveDirectory($directory, "$name/$directory");
         }
 
+        
+        $this->comment('Updating configuration file');
+
+        $config = Filesystem::getContents('config/hyde.php');
+        $config = str_replace("'source_root' => '',", "'source_root' => '$name',", $config);
+        Filesystem::putContents('config/hyde.php', $config);
+
         return Command::SUCCESS;
     }
 }

--- a/packages/framework/src/Console/Commands/ChangeSourceDirectoryCommand.php
+++ b/packages/framework/src/Console/Commands/ChangeSourceDirectoryCommand.php
@@ -45,7 +45,7 @@ class ChangeSourceDirectoryCommand extends Command
                 if (self::isNonEmptyDirectory(Hyde::path($directory))) {
                     $this->error('Directory already exists!');
 
-                    return Command::FAILURE;
+                    return 409;
                 }
             }
         }

--- a/packages/framework/src/Console/Commands/ChangeSourceDirectoryCommand.php
+++ b/packages/framework/src/Console/Commands/ChangeSourceDirectoryCommand.php
@@ -53,6 +53,9 @@ class ChangeSourceDirectoryCommand extends Command
             Filesystem::putContents('config/hyde.php', $config);
         }
 
+
+        $this->info('All done!');
+
         return Command::SUCCESS;
     }
 }

--- a/packages/framework/src/Console/Commands/ChangeSourceDirectoryCommand.php
+++ b/packages/framework/src/Console/Commands/ChangeSourceDirectoryCommand.php
@@ -84,6 +84,6 @@ class ChangeSourceDirectoryCommand extends Command
         if (is_file($directory)) {
             return false;
         }
-        return ((is_dir($directory) && (count(scandir($directory)) > 2)));
+        return (is_dir($directory) && (count(scandir($directory)) > 2));
     }
 }

--- a/packages/framework/src/Console/Commands/ChangeSourceDirectoryCommand.php
+++ b/packages/framework/src/Console/Commands/ChangeSourceDirectoryCommand.php
@@ -22,7 +22,8 @@ class ChangeSourceDirectoryCommand extends Command
 
     public function handle(): int
     {
-        $name = $this->getDirectoryName();
+        $name = $this->argument('name');
+        $this->infoComment("Setting", $name, "as the project source directory!");
 
         $directories = array_unique([
             \Hyde\Pages\HtmlPage::$sourceDirectory,
@@ -60,13 +61,6 @@ class ChangeSourceDirectoryCommand extends Command
         $this->info('All done!');
 
         return Command::SUCCESS;
-    }
-
-    protected function getDirectoryName(): string
-    {
-        $name = $this->argument('name');
-        $this->infoComment("Setting", $name, "as the project source directory!");
-        return $name;
     }
 
     protected function updateConfigurationFile(string $name): void

--- a/packages/framework/src/Console/Commands/ChangeSourceDirectoryCommand.php
+++ b/packages/framework/src/Console/Commands/ChangeSourceDirectoryCommand.php
@@ -25,7 +25,13 @@ class ChangeSourceDirectoryCommand extends Command
         $name = $this->argument('name');
         $this->infoComment("Setting", $name, "as the project source directory!");
 
-        $directories = ['_pages', '_posts', '_docs'];
+        $directories = array_unique([
+            \Hyde\Pages\HtmlPage::$sourceDirectory,
+            \Hyde\Pages\BladePage::$sourceDirectory,
+            \Hyde\Pages\MarkdownPage::$sourceDirectory,
+            \Hyde\Pages\MarkdownPost::$sourceDirectory,
+            \Hyde\Pages\DocumentationPage::$sourceDirectory,
+        ]);
 
         if (Filesystem::isDirectory($name) && ! Filesystem::isEmptyDirectory($name)) {
             $this->error('Directory already exists!');

--- a/packages/framework/src/Console/Commands/ChangeSourceDirectoryCommand.php
+++ b/packages/framework/src/Console/Commands/ChangeSourceDirectoryCommand.php
@@ -23,6 +23,10 @@ class ChangeSourceDirectoryCommand extends Command
     public function handle(): int
     {
         $name = $this->argument('name');
+        if ($name === config('hyde.source_root', '')) {
+            $this->error("The directory '$name' is already set as the project source root!");
+            return 409;
+        }
         $this->infoComment("Setting", $name, "as the project source directory!");
 
         $directories = array_unique([

--- a/packages/framework/src/Console/Commands/ChangeSourceDirectoryCommand.php
+++ b/packages/framework/src/Console/Commands/ChangeSourceDirectoryCommand.php
@@ -35,6 +35,7 @@ class ChangeSourceDirectoryCommand extends Command
 
         if (Filesystem::isDirectory($name) && ! Filesystem::isEmptyDirectory($name)) {
             foreach ($directories as $directory) {
+                $directory = basename($directory);
                 if (Filesystem::isDirectory($directory) && ! Filesystem::isEmptyDirectory($directory)) {
                     $this->error('Directory already exists!');
                     return Command::FAILURE;

--- a/packages/framework/src/Console/Commands/ChangeSourceDirectoryCommand.php
+++ b/packages/framework/src/Console/Commands/ChangeSourceDirectoryCommand.php
@@ -12,7 +12,7 @@ use LaravelZero\Framework\Commands\Command;
 class ChangeSourceDirectoryCommand extends Command
 {
     /** @var string */
-    protected $signature = 'change:sourceDirectory';
+    protected $signature = 'change:sourceDirectory {name : The new source directory name }';
 
     /** @var string */
     protected $description = 'Change the source directory for your project.';

--- a/packages/framework/src/Console/HydeConsoleServiceProvider.php
+++ b/packages/framework/src/Console/HydeConsoleServiceProvider.php
@@ -35,6 +35,8 @@ class HydeConsoleServiceProvider extends ServiceProvider
             Commands\ValidateCommand::class,
             Commands\ServeCommand::class,
             Commands\DebugCommand::class,
+
+            Commands\ChangeSourceDirectoryCommand::class,
         ]);
     }
 }

--- a/packages/framework/tests/Feature/Commands/ChangeSourceDirectoryCommandTest.php
+++ b/packages/framework/tests/Feature/Commands/ChangeSourceDirectoryCommandTest.php
@@ -33,6 +33,8 @@ class ChangeSourceDirectoryCommandTest extends TestCase
         $this->assertDirectoryExists(Hyde::path('test/_docs'));
 
         $this->assertFileExists(Hyde::path('test/_pages/tracker.txt'));
-        $this->assertSame('This should be moved to the new location', file_get_contents(Hyde::path('test/_pages/tracker.txt')));
+        $this->assertSame('This should be moved to the new location',
+            file_get_contents(Hyde::path('test/_pages/tracker.txt'))
+        );
     }
 }

--- a/packages/framework/tests/Feature/Commands/ChangeSourceDirectoryCommandTest.php
+++ b/packages/framework/tests/Feature/Commands/ChangeSourceDirectoryCommandTest.php
@@ -4,9 +4,9 @@ declare(strict_types=1);
 
 namespace Hyde\Framework\Testing\Feature\Commands;
 
-use Hyde\Testing\TestCase;
 use Hyde\Facades\Filesystem;
 use Hyde\Hyde;
+use Hyde\Testing\TestCase;
 
 /**
  * @covers \Hyde\Console\Commands\ChangeSourceDirectoryCommand

--- a/packages/framework/tests/Feature/Commands/ChangeSourceDirectoryCommandTest.php
+++ b/packages/framework/tests/Feature/Commands/ChangeSourceDirectoryCommandTest.php
@@ -50,4 +50,11 @@ class ChangeSourceDirectoryCommandTest extends TestCase
         $config = str_replace("'source_root' => 'test',", "'source_root' => '',", $config);
         Filesystem::putContents('config/hyde.php', $config);
     }
+
+    public function test_with_name_matching_current_value()
+    {
+        $this->artisan('change:sourceDirectory /')
+            ->expectsOutput("The directory '/' is already set as the project source root!")
+            ->assertExitCode(409);
+    }
 }

--- a/packages/framework/tests/Feature/Commands/ChangeSourceDirectoryCommandTest.php
+++ b/packages/framework/tests/Feature/Commands/ChangeSourceDirectoryCommandTest.php
@@ -36,5 +36,9 @@ class ChangeSourceDirectoryCommandTest extends TestCase
         $this->assertSame('This should be moved to the new location',
             file_get_contents(Hyde::path('test/_pages/tracker.txt'))
         );
+
+        $this->assertStringContainsString("'source_root' => 'test',",
+            file_get_contents(Hyde::path('config/hyde.php'))
+        );
     }
 }

--- a/packages/framework/tests/Feature/Commands/ChangeSourceDirectoryCommandTest.php
+++ b/packages/framework/tests/Feature/Commands/ChangeSourceDirectoryCommandTest.php
@@ -67,6 +67,6 @@ class ChangeSourceDirectoryCommandTest extends TestCase
         $this->artisan('change:sourceDirectory test')
             ->expectsOutput('Setting [test] as the project source directory!')
             ->expectsOutput('Directory already exists!')
-            ->assertExitCode(1);
+            ->assertExitCode(409);
     }
 }

--- a/packages/framework/tests/Feature/Commands/ChangeSourceDirectoryCommandTest.php
+++ b/packages/framework/tests/Feature/Commands/ChangeSourceDirectoryCommandTest.php
@@ -14,6 +14,8 @@ class ChangeSourceDirectoryCommandTest extends TestCase
 {
     public function test_command_moves_source_directories_to_new_supplied_directory_and_updates_the_configuration_file()
     {
+        $this->file('_pages/tracker.txt', 'This should be moved to the new location');
+
         $this->artisan('change:sourceDirectory test')
             ->expectsOutput('Setting [test] as the project source directory!')
             ->expectsOutput('Creating directory')
@@ -29,5 +31,8 @@ class ChangeSourceDirectoryCommandTest extends TestCase
         $this->assertDirectoryExists(Hyde::path('test/_pages'));
         $this->assertDirectoryExists(Hyde::path('test/_posts'));
         $this->assertDirectoryExists(Hyde::path('test/_docs'));
+
+        $this->assertFileExists(Hyde::path('test/_pages/tracker.txt'));
+        $this->assertSame('This should be moved to the new location', file_get_contents(Hyde::path('test/_pages/tracker.txt')));
     }
 }

--- a/packages/framework/tests/Feature/Commands/ChangeSourceDirectoryCommandTest.php
+++ b/packages/framework/tests/Feature/Commands/ChangeSourceDirectoryCommandTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Hyde\Framework\Testing\Feature\Commands;
 
 use Hyde\Testing\TestCase;
+use Hyde\Facades\Filesystem;
 use Hyde\Hyde;
 
 /**
@@ -40,5 +41,13 @@ class ChangeSourceDirectoryCommandTest extends TestCase
         $this->assertStringContainsString("'source_root' => 'test',",
             file_get_contents(Hyde::path('config/hyde.php'))
         );
+
+        Filesystem::moveDirectory('test/_pages', '_pages');
+        Filesystem::moveDirectory('test/_posts', '_posts');
+        Filesystem::moveDirectory('test/_docs', '_docs');
+
+        $config = Filesystem::getContents('config/hyde.php');
+        $config = str_replace("'source_root' => 'test',", "'source_root' => '',", $config);
+        Filesystem::putContents('config/hyde.php', $config);
     }
 }

--- a/packages/framework/tests/Feature/Commands/ChangeSourceDirectoryCommandTest.php
+++ b/packages/framework/tests/Feature/Commands/ChangeSourceDirectoryCommandTest.php
@@ -51,6 +51,45 @@ class ChangeSourceDirectoryCommandTest extends TestCase
         Filesystem::putContents('config/hyde.php', $config);
     }
 
+    public function test_with_missing_config_search_string()
+    {
+        $this->file('_pages/tracker.txt', 'This should be moved to the new location');
+
+        $config = Filesystem::getContents('config/hyde.php');
+        $config = str_replace("'source_root' => '',", "'no_source_root' => '',", $config);
+        Filesystem::putContents('config/hyde.php', $config);
+
+        $this->artisan('change:sourceDirectory test')
+            ->expectsOutput('Setting [test] as the project source directory!')
+            ->expectsOutput('Creating directory')
+            ->expectsOutput('Moving source directories')
+            ->expectsOutput('Updating configuration file')
+            ->expectsOutput("Automatic configuration update failed, to finalize the change, please set the `source_root` setting to 'test' in `config/hyde.php`")
+            ->expectsOutput('All done!')
+            ->assertExitCode(0);
+
+        $this->assertDirectoryDoesNotExist(Hyde::path('_pages'));
+        $this->assertDirectoryDoesNotExist(Hyde::path('_posts'));
+        $this->assertDirectoryDoesNotExist(Hyde::path('_docs'));
+
+        $this->assertDirectoryExists(Hyde::path('test/_pages'));
+        $this->assertDirectoryExists(Hyde::path('test/_posts'));
+        $this->assertDirectoryExists(Hyde::path('test/_docs'));
+
+        $this->assertFileExists(Hyde::path('test/_pages/tracker.txt'));
+        $this->assertSame('This should be moved to the new location',
+            file_get_contents(Hyde::path('test/_pages/tracker.txt'))
+        );
+
+        Filesystem::moveDirectory('test/_pages', '_pages');
+        Filesystem::moveDirectory('test/_posts', '_posts');
+        Filesystem::moveDirectory('test/_docs', '_docs');
+
+        $config = Filesystem::getContents('config/hyde.php');
+        $config = str_replace("'no_source_root' => '',", "'source_root' => '',", $config);
+        Filesystem::putContents('config/hyde.php', $config);
+    }
+
     public function test_with_name_matching_current_value()
     {
         $this->artisan('change:sourceDirectory /')

--- a/packages/framework/tests/Feature/Commands/ChangeSourceDirectoryCommandTest.php
+++ b/packages/framework/tests/Feature/Commands/ChangeSourceDirectoryCommandTest.php
@@ -57,4 +57,16 @@ class ChangeSourceDirectoryCommandTest extends TestCase
             ->expectsOutput("The directory '/' is already set as the project source root!")
             ->assertExitCode(409);
     }
+
+    public function test_with_existing_directory()
+    {
+        $this->directory('test');
+        $this->directory('test/_pages');
+        $this->file('test/_pages/foo');
+
+        $this->artisan('change:sourceDirectory test')
+            ->expectsOutput('Setting [test] as the project source directory!')
+            ->expectsOutput('Directory already exists!')
+            ->assertExitCode(1);
+    }
 }

--- a/packages/framework/tests/Feature/Commands/ChangeSourceDirectoryCommandTest.php
+++ b/packages/framework/tests/Feature/Commands/ChangeSourceDirectoryCommandTest.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Hyde\Framework\Testing\Feature\Commands;
+
+use Hyde\Testing\TestCase;
+
+/**
+ * @covers \Hyde\Console\Commands\ChangeSourceDirectoryCommand
+ */
+class ChangeSourceDirectoryCommandTest extends TestCase
+{
+    //
+}

--- a/packages/framework/tests/Feature/Commands/ChangeSourceDirectoryCommandTest.php
+++ b/packages/framework/tests/Feature/Commands/ChangeSourceDirectoryCommandTest.php
@@ -11,5 +11,14 @@ use Hyde\Testing\TestCase;
  */
 class ChangeSourceDirectoryCommandTest extends TestCase
 {
-    //
+    public function test_command_moves_source_directories_to_new_supplied_directory_and_updates_the_configuration_file()
+    {
+        $this->artisan('change:sourceDirectory test')
+            ->expectsOutput('Setting [test] as the project source directory!')
+            ->expectsOutput('Creating directory')
+            ->expectsOutput('Moving source directories')
+            ->expectsOutput('Updating configuration file')
+            ->expectsOutput('All done!')
+            ->assertExitCode(0);
+    }
 }

--- a/packages/framework/tests/Feature/Commands/ChangeSourceDirectoryCommandTest.php
+++ b/packages/framework/tests/Feature/Commands/ChangeSourceDirectoryCommandTest.php
@@ -69,4 +69,15 @@ class ChangeSourceDirectoryCommandTest extends TestCase
             ->expectsOutput('Directory already exists!')
             ->assertExitCode(409);
     }
+
+    public function test_with_target_being_file()
+    {
+        $this->directory('test');
+        $this->file('test/_pages');
+
+        $this->artisan('change:sourceDirectory test')
+            ->expectsOutput('Setting [test] as the project source directory!')
+            ->expectsOutput('Directory already exists!')
+            ->assertExitCode(409);
+    }
 }

--- a/packages/framework/tests/Feature/Commands/ChangeSourceDirectoryCommandTest.php
+++ b/packages/framework/tests/Feature/Commands/ChangeSourceDirectoryCommandTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Hyde\Framework\Testing\Feature\Commands;
 
 use Hyde\Testing\TestCase;
+use Hyde\Hyde;
 
 /**
  * @covers \Hyde\Console\Commands\ChangeSourceDirectoryCommand
@@ -20,5 +21,13 @@ class ChangeSourceDirectoryCommandTest extends TestCase
             ->expectsOutput('Updating configuration file')
             ->expectsOutput('All done!')
             ->assertExitCode(0);
+
+        $this->assertDirectoryDoesNotExist(Hyde::path('_pages'));
+        $this->assertDirectoryDoesNotExist(Hyde::path('_posts'));
+        $this->assertDirectoryDoesNotExist(Hyde::path('_docs'));
+
+        $this->assertDirectoryExists(Hyde::path('test/_pages'));
+        $this->assertDirectoryExists(Hyde::path('test/_posts'));
+        $this->assertDirectoryExists(Hyde::path('test/_docs'));
     }
 }


### PR DESCRIPTION
Adds a command that can be used to quickly change source directories. When run, Hyde will update the source directory setting in the config file, then create the directory if it doesn't exist, then move all source directories into it.