### PR TITLE
Remove execution time tracking from the DataCollection class

### DIFF
--- a/packages/framework/src/Framework/Features/DataCollections/DataCollection.php
+++ b/packages/framework/src/Framework/Features/DataCollections/DataCollection.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Hyde\Framework\Features\DataCollections;
 
 use Hyde\Framework\Actions\MarkdownFileParser;
-use Hyde\Framework\Concerns\TracksExecutionTime;
 use Hyde\Hyde;
 use Illuminate\Support\Collection;
 

--- a/packages/framework/src/Framework/Features/DataCollections/DataCollection.php
+++ b/packages/framework/src/Framework/Features/DataCollections/DataCollection.php
@@ -17,18 +17,12 @@ use Illuminate\Support\Collection;
  */
 class DataCollection extends Collection
 {
-    use TracksExecutionTime;
-
     public string $key;
-
-    /** @deprecated as the value added is limited here */
-    public float $parseTimeInMs;
 
     public static string $sourceDirectory = '_data';
 
     public function __construct(string $key)
     {
-        $this->startClock();
         $this->key = $key;
 
         parent::__construct();
@@ -36,9 +30,6 @@ class DataCollection extends Collection
 
     public function getCollection(): static
     {
-        $this->parseTimeInMs = $this->stopClock();
-        unset($this->timeStart);
-
         return $this;
     }
 

--- a/packages/framework/src/Framework/Features/DataCollections/DataCollection.php
+++ b/packages/framework/src/Framework/Features/DataCollections/DataCollection.php
@@ -21,6 +21,7 @@ class DataCollection extends Collection
 
     public string $key;
 
+    /** @deprecated as the value added is limited here */
     public float $parseTimeInMs;
 
     public static string $sourceDirectory = '_data';

--- a/packages/framework/tests/Feature/DataCollectionTest.php
+++ b/packages/framework/tests/Feature/DataCollectionTest.php
@@ -56,13 +56,6 @@ class DataCollectionTest extends TestCase
         $this->assertSame($class, $class->getCollection());
     }
 
-    public function test_get_collection_method_sets_parse_time_in_ms()
-    {
-        $class = new DataCollection('foo');
-        $class->getCollection();
-        $this->assertIsFloat($class->parseTimeInMs);
-    }
-
     public function test_get_markdown_files_method_returns_empty_array_if_the_specified_directory_does_not_exist()
     {
         $class = new DataCollection('foo');


### PR DESCRIPTION
This class acts so fast, so there is virtually no reason to track execution time in it. Here are some results (all rounded to 5 decimals)

```
0ms
0ms
5.0E-5ms
0.00098ms
0.00032ms
3.0E-5ms
2.0E-5ms
```