### PR TITLE
Breaking: Change default DataCollection directory from `_data` to `resources/collections`

### DIFF
--- a/docs/digging-deeper/collections.md
+++ b/docs/digging-deeper/collections.md
@@ -35,13 +35,13 @@ You may need to enable the module by adding the feature to your Hyde configurati
 
 To make collections easy to use and understand, Hyde makes a few assumptions about the structure of your collections. Follow these conventions and creating dynamic static sites will be a breeze.
 
-1. Collections are stored in the new `_data` directory.
+1. Collections are stored in the new `resources/collections` directory.
 2. Each subdirectory in here can be a collection. 
 3. Data collections are automatically generated when you use the Facade you will learn about below.
 4. When using one of the facades, you need to specify the collection name, this name is the name of the subdirectory.
 5. Each subdirectory should probably only have the same filetype to prevent developer confusion, but this is not enforced.
 6. Unlike Markdown pages, files starting with underscores are not ignored.
-7. You can customize the base `_data` directory through a service provider.
+7. You can customize the base `resources/collections` directory through a service provider.
 
 
 ### Markdown Collections - Hands on Guide
@@ -57,7 +57,7 @@ In it we will place Markdown files. Each file will be a testimonial. The Markdow
 Here is the sample Markdown we will use:
 
 ```blade
-// filepath: _data/testimonials/1.md
+// filepath: resources/collections/testimonials/1.md
 ---
 author: John Doe
 ---
@@ -68,7 +68,7 @@ Lorem ipsum dolor sit amet, consectetur adipiscing elit...
 Let's take a look at our directory structure. I just copied the same file a few times. You can name the files anything you want, I kept it simple and just numbered them.
 
 ```tree
-_data
+resources/collections
 └── testimonials
     ├── 1.md
     ├── 2.md

--- a/packages/framework/src/Framework/Features/DataCollections/DataCollection.php
+++ b/packages/framework/src/Framework/Features/DataCollections/DataCollection.php
@@ -18,7 +18,7 @@ class DataCollection extends Collection
 {
     public string $key;
 
-    public static string $sourceDirectory = '_data';
+    public static string $sourceDirectory = 'resources/collections';
 
     public function __construct(string $key)
     {
@@ -40,10 +40,10 @@ class DataCollection extends Collection
     }
 
     /**
-     * Get a collection of Markdown documents in the _data/<$key> directory.
+     * Get a collection of Markdown documents in the resources/collections/<$key> directory.
      * Each Markdown file will be parsed into a MarkdownDocument with front matter.
      *
-     * @param  string  $key  for a subdirectory of the _data directory
+     * @param  string  $key  for a subdirectory of the resources/collections directory
      * @return DataCollection<\Hyde\Markdown\Models\MarkdownDocument>
      */
     public static function markdown(string $key): static

--- a/packages/framework/src/Framework/Features/DataCollections/DataCollectionServiceProvider.php
+++ b/packages/framework/src/Framework/Features/DataCollections/DataCollectionServiceProvider.php
@@ -27,9 +27,9 @@ class DataCollectionServiceProvider extends ServiceProvider
     public function boot(): void
     {
         if (Features::hasDataCollections()) {
-            // Create the _data directory if it doesn't exist
-            if (! is_dir(Hyde::path('_data'))) {
-                mkdir(Hyde::path('_data'));
+            // Create the resources/collections directory if it doesn't exist
+            if (! is_dir(Hyde::path('resources/collections'))) {
+                mkdir(Hyde::path('resources/collections'));
             }
         }
     }

--- a/packages/framework/tests/Feature/DataCollectionTest.php
+++ b/packages/framework/tests/Feature/DataCollectionTest.php
@@ -65,59 +65,59 @@ class DataCollectionTest extends TestCase
 
     public function test_get_markdown_files_method_returns_empty_array_if_no_files_are_found_in_specified_directory()
     {
-        mkdir(Hyde::path('_data/foo'));
+        mkdir(Hyde::path('resources/collections/foo'));
         $class = new DataCollection('foo');
         $this->assertIsArray($class->getMarkdownFiles());
         $this->assertEmpty($class->getMarkdownFiles());
-        rmdir(Hyde::path('_data/foo'));
+        rmdir(Hyde::path('resources/collections/foo'));
     }
 
     public function test_get_markdown_files_method_returns_an_array_of_markdown_files_in_the_specified_directory()
     {
-        mkdir(Hyde::path('_data/foo'));
-        Hyde::touch('_data/foo/foo.md');
-        Hyde::touch('_data/foo/bar.md');
+        mkdir(Hyde::path('resources/collections/foo'));
+        Hyde::touch('resources/collections/foo/foo.md');
+        Hyde::touch('resources/collections/foo/bar.md');
 
         $this->assertEquals([
-            Hyde::path('_data/foo/bar.md'),
-            Hyde::path('_data/foo/foo.md'),
+            Hyde::path('resources/collections/foo/bar.md'),
+            Hyde::path('resources/collections/foo/foo.md'),
         ], (new DataCollection('foo'))->getMarkdownFiles());
 
-        File::deleteDirectory(Hyde::path('_data/foo'));
+        File::deleteDirectory(Hyde::path('resources/collections/foo'));
     }
 
     public function test_get_markdown_files_method_does_not_include_files_in_subdirectories()
     {
-        mkdir(Hyde::path('_data/foo'));
-        mkdir(Hyde::path('_data/foo/bar'));
-        Hyde::touch('_data/foo/foo.md');
-        Hyde::touch('_data/foo/bar/bar.md');
+        mkdir(Hyde::path('resources/collections/foo'));
+        mkdir(Hyde::path('resources/collections/foo/bar'));
+        Hyde::touch('resources/collections/foo/foo.md');
+        Hyde::touch('resources/collections/foo/bar/bar.md');
         $this->assertEquals([
-            Hyde::path('_data/foo/foo.md'),
+            Hyde::path('resources/collections/foo/foo.md'),
         ], (new DataCollection('foo'))->getMarkdownFiles());
-        File::deleteDirectory(Hyde::path('_data/foo'));
+        File::deleteDirectory(Hyde::path('resources/collections/foo'));
     }
 
     public function test_get_markdown_files_method_does_not_include_files_with_extensions_other_than_md()
     {
-        mkdir(Hyde::path('_data/foo'));
-        Hyde::touch('_data/foo/foo.md');
-        Hyde::touch('_data/foo/bar.txt');
+        mkdir(Hyde::path('resources/collections/foo'));
+        Hyde::touch('resources/collections/foo/foo.md');
+        Hyde::touch('resources/collections/foo/bar.txt');
         $this->assertEquals([
-            Hyde::path('_data/foo/foo.md'),
+            Hyde::path('resources/collections/foo/foo.md'),
         ], (new DataCollection('foo'))->getMarkdownFiles());
-        File::deleteDirectory(Hyde::path('_data/foo'));
+        File::deleteDirectory(Hyde::path('resources/collections/foo'));
     }
 
     public function test_get_markdown_files_method_does_not_remove_files_starting_with_an_underscore()
     {
-        mkdir(Hyde::path('_data/foo'));
-        Hyde::touch('_data/foo/_foo.md');
+        mkdir(Hyde::path('resources/collections/foo'));
+        Hyde::touch('resources/collections/foo/_foo.md');
 
         $this->assertEquals([
-            Hyde::path('_data/foo/_foo.md'),
+            Hyde::path('resources/collections/foo/_foo.md'),
         ], (new DataCollection('foo'))->getMarkdownFiles());
-        File::deleteDirectory(Hyde::path('_data/foo'));
+        File::deleteDirectory(Hyde::path('resources/collections/foo'));
     }
 
     public function test_static_markdown_helper_returns_new_data_collection_instance()
@@ -127,24 +127,24 @@ class DataCollectionTest extends TestCase
 
     public function test_static_markdown_helper_discovers_and_parses_markdown_files_in_the_specified_directory()
     {
-        mkdir(Hyde::path('_data/foo'));
-        Hyde::touch('_data/foo/foo.md');
-        Hyde::touch('_data/foo/bar.md');
+        mkdir(Hyde::path('resources/collections/foo'));
+        Hyde::touch('resources/collections/foo/foo.md');
+        Hyde::touch('resources/collections/foo/bar.md');
 
         $collection = DataCollection::markdown('foo');
 
         $this->assertContainsOnlyInstancesOf(MarkdownDocument::class, $collection);
 
-        File::deleteDirectory(Hyde::path('_data/foo'));
+        File::deleteDirectory(Hyde::path('resources/collections/foo'));
     }
 
     public function test_static_markdown_helper_doest_not_ignore_files_starting_with_an_underscore()
     {
-        mkdir(Hyde::path('_data/foo'));
-        Hyde::touch('_data/foo/foo.md');
-        Hyde::touch('_data/foo/_bar.md');
+        mkdir(Hyde::path('resources/collections/foo'));
+        Hyde::touch('resources/collections/foo/foo.md');
+        Hyde::touch('resources/collections/foo/_bar.md');
         $this->assertCount(2, DataCollection::markdown('foo'));
-        File::deleteDirectory(Hyde::path('_data/foo'));
+        File::deleteDirectory(Hyde::path('resources/collections/foo'));
     }
 
     public function test_markdown_facade_returns_same_result_as_static_markdown_helper()
@@ -166,29 +166,29 @@ class DataCollectionTest extends TestCase
     {
         config(['hyde.features' => [Features::dataCollections()]]);
 
-        File::deleteDirectory(Hyde::path('_data'));
-        $this->assertFileDoesNotExist(Hyde::path('_data'));
+        File::deleteDirectory(Hyde::path('resources/collections'));
+        $this->assertFileDoesNotExist(Hyde::path('resources/collections'));
 
         (new DataCollectionServiceProvider($this->app))->boot();
 
-        $this->assertFileExists(Hyde::path('_data'));
+        $this->assertFileExists(Hyde::path('resources/collections'));
     }
 
     public function test_data_collection_service_provider_does_not_create_the__data_directory_feature_is_disabled()
     {
-        File::deleteDirectory(Hyde::path('_data'));
-        $this->assertFileDoesNotExist(Hyde::path('_data'));
+        File::deleteDirectory(Hyde::path('resources/collections'));
+        $this->assertFileDoesNotExist(Hyde::path('resources/collections'));
 
         config(['hyde.features' => []]);
         $this->app['config']->set('hyde.data_collection.enabled', false);
         (new DataCollectionServiceProvider($this->app))->boot();
 
-        $this->assertFileDoesNotExist(Hyde::path('_data'));
+        $this->assertFileDoesNotExist(Hyde::path('resources/collections'));
     }
 
     public function test_class_has_static_source_directory_property()
     {
-        $this->assertEquals('_data', DataCollection::$sourceDirectory);
+        $this->assertEquals('resources/collections', DataCollection::$sourceDirectory);
     }
 
     public function test_source_directory_can_be_changed()


### PR DESCRIPTION
Moving the (default) `_data` directory to `resources/collections` accomplishes two things:

1. Makes the top level directory structure leaner (which also distinguishes it from page directories.
2. The name collections makes more semantic sense for the usage, and I think the kind of data used fits within the resources domain too.
The directory is configurable, so this is just the defaults.

Any existing sites will need to move their data before upgrading. This is as easy as `mv -r _data resources/collections`

Tracked in [#877](https://github.com/hydephp/develop/issues/877)
