### PR TITLE
Documentation page navigation bugfixes

### DIFF
--- a/packages/framework/src/Framework/Factories/NavigationDataFactory.php
+++ b/packages/framework/src/Framework/Factories/NavigationDataFactory.php
@@ -93,7 +93,7 @@ class NavigationDataFactory extends Concerns\PageDataFactory implements Navigati
         return $this->isInstanceOf(MarkdownPost::class)
             || $this->searchForHiddenInFrontMatter()
             || in_array($this->routeKey, config('hyde.navigation.exclude', ['404']))
-            || ! $this->isInstanceOf(DocumentationPage::class) && $this->pageIsInSubdirectory() && ($this->getSubdirectoryConfiguration() === 'hidden');
+            || ($this->isInstanceOf(DocumentationPage::class) && $this->determineIfDocumentationPageIsHidden());
     }
 
     protected function makePriority(): int
@@ -185,6 +185,11 @@ class NavigationDataFactory extends Concerns\PageDataFactory implements Navigati
     protected function getSubdirectoryConfiguration(): string
     {
         return config('hyde.navigation.subdirectories', 'hidden');
+    }
+
+    protected function determineIfDocumentationPageIsHidden(): bool
+    {
+        return $this->pageIsInSubdirectory() && ($this->getSubdirectoryConfiguration() === 'hidden');
     }
 
     protected function isInstanceOf(string $class): bool

--- a/packages/framework/src/Framework/Factories/NavigationDataFactory.php
+++ b/packages/framework/src/Framework/Factories/NavigationDataFactory.php
@@ -93,7 +93,7 @@ class NavigationDataFactory extends Concerns\PageDataFactory implements Navigati
         return $this->isInstanceOf(MarkdownPost::class)
             || $this->searchForHiddenInFrontMatter()
             || in_array($this->routeKey, config('hyde.navigation.exclude', ['404']))
-            || ($this->isInstanceOf(DocumentationPage::class) && $this->determineIfDocumentationPageIsHiddenFromSidebar());
+            || ($this->determineIfDocumentationPageIsHiddenFromSidebar());
     }
 
     protected function makePriority(): int
@@ -182,14 +182,14 @@ class NavigationDataFactory extends Concerns\PageDataFactory implements Navigati
         return Str::before($this->identifier, '/');
     }
 
+    private function determineIfDocumentationPageIsHiddenFromSidebar(): bool
+    {
+        return ! $this->isInstanceOf(DocumentationPage::class) && $this->pageIsInSubdirectory() && ($this->getSubdirectoryConfiguration() === 'hidden');
+    }
+
     protected function getSubdirectoryConfiguration(): string
     {
         return config('hyde.navigation.subdirectories', 'hidden');
-    }
-
-    protected function determineIfDocumentationPageIsHiddenFromSidebar(): bool
-    {
-        return $this->pageIsInSubdirectory() && ($this->getSubdirectoryConfiguration() === 'hidden');
     }
 
     protected function isInstanceOf(string $class): bool

--- a/packages/framework/src/Framework/Factories/NavigationDataFactory.php
+++ b/packages/framework/src/Framework/Factories/NavigationDataFactory.php
@@ -93,7 +93,7 @@ class NavigationDataFactory extends Concerns\PageDataFactory implements Navigati
         return $this->isInstanceOf(MarkdownPost::class)
             || $this->searchForHiddenInFrontMatter()
             || in_array($this->routeKey, config('hyde.navigation.exclude', ['404']))
-            || ($this->isInstanceOf(DocumentationPage::class) && $this->determineIfDocumentationPageIsHidden());
+            || ($this->isInstanceOf(DocumentationPage::class) && $this->determineIfDocumentationPageIsHiddenFromSidebar());
     }
 
     protected function makePriority(): int
@@ -187,7 +187,7 @@ class NavigationDataFactory extends Concerns\PageDataFactory implements Navigati
         return config('hyde.navigation.subdirectories', 'hidden');
     }
 
-    protected function determineIfDocumentationPageIsHidden(): bool
+    protected function determineIfDocumentationPageIsHiddenFromSidebar(): bool
     {
         return $this->pageIsInSubdirectory() && ($this->getSubdirectoryConfiguration() === 'hidden');
     }

--- a/packages/framework/src/Framework/Factories/NavigationDataFactory.php
+++ b/packages/framework/src/Framework/Factories/NavigationDataFactory.php
@@ -184,7 +184,7 @@ class NavigationDataFactory extends Concerns\PageDataFactory implements Navigati
 
     private function determineIfDocumentationPageIsHiddenFromSidebar(): bool
     {
-        if ($this->isInstanceOf(DocumentationPage::class) && $this->page->identifier === 'docs/index') {
+        if ($this->isInstanceOf(DocumentationPage::class) && $this->identifier === 'docs/index') {
             return true;
         }
 

--- a/packages/framework/src/Framework/Factories/NavigationDataFactory.php
+++ b/packages/framework/src/Framework/Factories/NavigationDataFactory.php
@@ -184,6 +184,10 @@ class NavigationDataFactory extends Concerns\PageDataFactory implements Navigati
 
     private function determineIfDocumentationPageIsHiddenFromSidebar(): bool
     {
+        if ($this->isInstanceOf(DocumentationPage::class) && $this->page->identifier === 'docs/index') {
+            return true;
+        }
+
         return ! $this->isInstanceOf(DocumentationPage::class) && $this->pageIsInSubdirectory() && ($this->getSubdirectoryConfiguration() === 'hidden');
     }
 


### PR DESCRIPTION
Fixes additional problems found in https://github.com/hydephp/develop/issues/867 regarding functionalities lost during previous refactors. This should fix the last issues and will now match the behaviour of the latest release.

The upcoming documentation site has the index page in the sidebar, this should not be.

![image](https://user-images.githubusercontent.com/95144705/215273548-c035c335-d405-4a87-bece-45aa88cf0a06.png)
