### PR TITLE
Update InfoComment command helper to dynamically format output from a single fluent string

### DIFF
--- a/packages/framework/src/Console/Commands/ChangeSourceDirectoryCommand.php
+++ b/packages/framework/src/Console/Commands/ChangeSourceDirectoryCommand.php
@@ -76,7 +76,7 @@ class ChangeSourceDirectoryCommand extends Command
     {
         $this->validateName($name);
         $this->validateDirectoryCanBeUsed($name);
-        $this->dynamicInfoComment("Setting [$name] as the project source directory!");
+        $this->infoComment("Setting [$name] as the project source directory!");
 
         return $name;
     }

--- a/packages/framework/src/Console/Commands/ChangeSourceDirectoryCommand.php
+++ b/packages/framework/src/Console/Commands/ChangeSourceDirectoryCommand.php
@@ -76,7 +76,7 @@ class ChangeSourceDirectoryCommand extends Command
     {
         $this->validateName($name);
         $this->validateDirectoryCanBeUsed($name);
-        $this->infoComment('Setting', $name, 'as the project source directory!');
+        $this->dynamicInfoComment("Setting [$name] as the project source directory!");
 
         return $name;
     }

--- a/packages/framework/src/Console/Concerns/Command.php
+++ b/packages/framework/src/Console/Concerns/Command.php
@@ -25,7 +25,7 @@ abstract class Command extends BaseCommand
      * Write a nicely formatted and consistent message to the console. Using InfoComment for a lack of a better term.
      * @deprecated Use the dynamicInfoComment() method instead
      */
-    #[Deprecated('Use the dynamicInfoComment() method instead', replacement: '$this->dynamicInfoComment("$info [$comment] $moreInfo")' )]
+    #[Deprecated('Use the dynamicInfoComment() method instead', replacement: '$this->dynamicInfoComment("%parameter0% [%parameter1%] %parameter2%")' )]
     public function infoComment(string $info, string $comment, ?string $moreInfo = null): void
     {
         $this->line("<info>$info</info> [<comment>$comment</comment>]".($moreInfo ? " <info>$moreInfo</info>" : ''));

--- a/packages/framework/src/Console/Concerns/Command.php
+++ b/packages/framework/src/Console/Concerns/Command.php
@@ -24,18 +24,9 @@ abstract class Command extends BaseCommand
     /**
      * Write a nicely formatted and consistent message to the console. Using InfoComment for a lack of a better term.
      *
-     * @deprecated Use the dynamicInfoComment() method instead
+     * Text in [brackets] will automatically be wrapped in <comment> tags.
      */
-    #[Deprecated('Use the dynamicInfoComment() method instead', replacement: '$this->dynamicInfoComment(%parameter0%." [".%parameter1%."] ".%parameter2%)')]
-    public function infoComment(string $info, string $comment, ?string $moreInfo = null): void
-    {
-        $moreInfo ? $this->dynamicInfoComment("$info [$comment] $moreInfo") : $this->dynamicInfoComment("$info [$comment]");
-    }
-
-    /**
-     * Dynamically create an infoComment from a single string.
-     */
-    public function dynamicInfoComment(string $string): void
+    public function infoComment(string $string): void
     {
         $replacements = [
             '[' => '</info>[<comment>',

--- a/packages/framework/src/Console/Concerns/Command.php
+++ b/packages/framework/src/Console/Concerns/Command.php
@@ -28,7 +28,7 @@ abstract class Command extends BaseCommand
     #[Deprecated('Use the dynamicInfoComment() method instead', replacement: '$this->dynamicInfoComment("%parameter0% [%parameter1%] %parameter2%")' )]
     public function infoComment(string $info, string $comment, ?string $moreInfo = null): void
     {
-        $this->line("<info>$info</info> [<comment>$comment</comment>]".($moreInfo ? " <info>$moreInfo</info>" : ''));
+        $moreInfo ? $this->dynamicInfoComment("$info [$comment] $moreInfo") : $this->dynamicInfoComment("$info [$comment]");
     }
 
     /**

--- a/packages/framework/src/Console/Concerns/Command.php
+++ b/packages/framework/src/Console/Concerns/Command.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Hyde\Console\Concerns;
 
 use Hyde\Hyde;
-use JetBrains\PhpStorm\Deprecated;
 use LaravelZero\Framework\Commands\Command as BaseCommand;
 
 /**

--- a/packages/framework/src/Console/Concerns/Command.php
+++ b/packages/framework/src/Console/Concerns/Command.php
@@ -28,6 +28,21 @@ abstract class Command extends BaseCommand
         $this->line("<info>$info</info> [<comment>$comment</comment>]".($moreInfo ? " <info>$moreInfo</info>" : ''));
     }
 
+    /**
+     * Dynamically create an infoComment from a single string.
+     */
+    public function dynamicInfoComment(string $string): void
+    {
+        $replacements = [
+            '[' => '</info>[<comment>',
+            ']' => '</comment>]<info>',
+        ];
+
+        $string = str_replace(array_keys($replacements), array_values($replacements), $string);
+
+        $this->line("<info>$string</info>");
+    }
+
     /** @experimental This method may change (or be removed) before the 1.0.0 release */
     public function gray(string $string): void
     {

--- a/packages/framework/src/Console/Concerns/Command.php
+++ b/packages/framework/src/Console/Concerns/Command.php
@@ -25,7 +25,7 @@ abstract class Command extends BaseCommand
      * Write a nicely formatted and consistent message to the console. Using InfoComment for a lack of a better term.
      * @deprecated Use the dynamicInfoComment() method instead
      */
-    #[Deprecated('Use the dynamicInfoComment() method instead', replacement: '$this->dynamicInfoComment("%parameter0% [%parameter1%] %parameter2%")' )]
+    #[Deprecated('Use the dynamicInfoComment() method instead', replacement: '$this->dynamicInfoComment(%parameter0%." [".%parameter1%."] ".%parameter2%)' )]
     public function infoComment(string $info, string $comment, ?string $moreInfo = null): void
     {
         $moreInfo ? $this->dynamicInfoComment("$info [$comment] $moreInfo") : $this->dynamicInfoComment("$info [$comment]");

--- a/packages/framework/src/Console/Concerns/Command.php
+++ b/packages/framework/src/Console/Concerns/Command.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Hyde\Console\Concerns;
 
 use Hyde\Hyde;
+use JetBrains\PhpStorm\Deprecated;
 use LaravelZero\Framework\Commands\Command as BaseCommand;
 
 /**
@@ -24,6 +25,7 @@ abstract class Command extends BaseCommand
      * Write a nicely formatted and consistent message to the console. Using InfoComment for a lack of a better term.
      * @deprecated Use the dynamicInfoComment() method instead
      */
+    #[Deprecated('Use the dynamicInfoComment() method instead', replacement: '$this->dynamicInfoComment("$info [$comment] $moreInfo")' )]
     public function infoComment(string $info, string $comment, ?string $moreInfo = null): void
     {
         $this->line("<info>$info</info> [<comment>$comment</comment>]".($moreInfo ? " <info>$moreInfo</info>" : ''));

--- a/packages/framework/src/Console/Concerns/Command.php
+++ b/packages/framework/src/Console/Concerns/Command.php
@@ -22,6 +22,7 @@ abstract class Command extends BaseCommand
 
     /**
      * Write a nicely formatted and consistent message to the console. Using InfoComment for a lack of a better term.
+     * @deprecated Use the dynamicInfoComment() method instead
      */
     public function infoComment(string $info, string $comment, ?string $moreInfo = null): void
     {

--- a/packages/framework/tests/Feature/CommandTest.php
+++ b/packages/framework/tests/Feature/CommandTest.php
@@ -65,6 +65,22 @@ class CommandTest extends TestCase
         $command->handle();
     }
 
+    public function testInfoCommentWithExtraInfoAndComments()
+    {
+        $command = new MockableTestCommand();
+        $command->closure = function (Command $command) {
+            $command->infoComment('foo [bar] baz [qux]');
+        };
+
+        $output = $this->mock(OutputStyle::class);
+        $output->shouldReceive('writeln')->once()->withArgs(function (string $message): bool {
+            return $message === '<info>foo </info>[<comment>bar</comment>]<info> baz </info>[<comment>qux</comment>]<info></info>';
+        });
+
+        $command->setMockedOutput($output);
+        $command->handle();
+    }
+
     public function testGray()
     {
         $command = new MockableTestCommand();

--- a/packages/framework/tests/Feature/CommandTest.php
+++ b/packages/framework/tests/Feature/CommandTest.php
@@ -42,7 +42,7 @@ class CommandTest extends TestCase
 
         $output = $this->mock(OutputStyle::class);
         $output->shouldReceive('writeln')->once()->withArgs(function (string $message): bool {
-            return $message === '<info>foo</info> [<comment>bar</comment>]';
+            return $message === '<info>foo </info>[<comment>bar</comment>]<info></info>';
         });
 
         $command->setMockedOutput($output);
@@ -58,7 +58,7 @@ class CommandTest extends TestCase
 
         $output = $this->mock(OutputStyle::class);
         $output->shouldReceive('writeln')->once()->withArgs(function (string $message): bool {
-            return $message === '<info>foo</info> [<comment>bar</comment>] <info>baz</info>';
+            return $message === '<info>foo </info>[<comment>bar</comment>]<info> baz</info>';
         });
 
         $command->setMockedOutput($output);

--- a/packages/framework/tests/Feature/CommandTest.php
+++ b/packages/framework/tests/Feature/CommandTest.php
@@ -8,7 +8,6 @@ use Closure;
 use Hyde\Console\Concerns\Command;
 use Hyde\Hyde;
 use Hyde\Testing\TestCase;
-use JetBrains\PhpStorm\Deprecated;
 use Symfony\Component\Console\Style\OutputStyle;
 
 /**
@@ -38,7 +37,7 @@ class CommandTest extends TestCase
     {
         $command = new MockableTestCommand();
         $command->closure = function (Command $command) {
-            $command->infoComment("foo [bar]");
+            $command->infoComment('foo [bar]');
         };
 
         $output = $this->mock(OutputStyle::class);
@@ -54,7 +53,7 @@ class CommandTest extends TestCase
     {
         $command = new MockableTestCommand();
         $command->closure = function (Command $command) {
-            $command->infoComment("foo [bar] baz");
+            $command->infoComment('foo [bar] baz');
         };
 
         $output = $this->mock(OutputStyle::class);

--- a/packages/framework/tests/Feature/CommandTest.php
+++ b/packages/framework/tests/Feature/CommandTest.php
@@ -8,6 +8,7 @@ use Closure;
 use Hyde\Console\Concerns\Command;
 use Hyde\Hyde;
 use Hyde\Testing\TestCase;
+use JetBrains\PhpStorm\Deprecated;
 use Symfony\Component\Console\Style\OutputStyle;
 
 /**
@@ -37,7 +38,7 @@ class CommandTest extends TestCase
     {
         $command = new MockableTestCommand();
         $command->closure = function (Command $command) {
-            $command->infoComment('foo', 'bar');
+            $command->infoComment("foo [bar]");
         };
 
         $output = $this->mock(OutputStyle::class);
@@ -53,7 +54,7 @@ class CommandTest extends TestCase
     {
         $command = new MockableTestCommand();
         $command->closure = function (Command $command) {
-            $command->infoComment('foo', 'bar', 'baz');
+            $command->infoComment("foo [bar] baz");
         };
 
         $output = $this->mock(OutputStyle::class);


### PR DESCRIPTION
Allows you to use this:
```php
$this->dynamicInfoComment('info [comment] moreInfo');
```
Instead of this:
```php
$this->infoComment('info', 'comment', 'moreInfo');
```

Both render the same thing:

![image](https://user-images.githubusercontent.com/95144705/215449694-6add0119-4cd4-45b2-a02c-cfa9cb9f382f.png)
