### PR TITLE
Clean up the documentation search service class

### DIFF
--- a/packages/framework/src/Framework/Features/BuildTasks/PostBuildTasks/GenerateSearch.php
+++ b/packages/framework/src/Framework/Features/BuildTasks/PostBuildTasks/GenerateSearch.php
@@ -33,7 +33,7 @@ class GenerateSearch extends BuildTask
 
     public function then(): void
     {
-        $this->createdSiteFile(DocumentationSearchService::$filePath)->withExecutionTime();
+        $this->createdSiteFile(DocumentationSearchService::getFilePath())->withExecutionTime();
     }
 
     /**

--- a/packages/framework/src/Framework/Services/DocumentationSearchService.php
+++ b/packages/framework/src/Framework/Services/DocumentationSearchService.php
@@ -20,6 +20,7 @@ final class DocumentationSearchService
     use InteractsWithDirectories;
 
     public Collection $searchIndex;
+    /** @deprecated Not sure what value this adds from being a static property */
     public static string $filePath;
 
     public static function generate(): self

--- a/packages/framework/src/Framework/Services/DocumentationSearchService.php
+++ b/packages/framework/src/Framework/Services/DocumentationSearchService.php
@@ -45,9 +45,7 @@ final class DocumentationSearchService
     {
         $this->searchIndex = new Collection();
         if (! isset(self::$filePath)) {
-            self::$filePath = Hyde::pathToRelative(Hyde::sitePath(
-                DocumentationPage::outputDirectory().'/search.json'
-            ));
+            self::$filePath = $this->getFilePath();
         }
     }
 
@@ -104,5 +102,12 @@ final class DocumentationSearchService
         }
 
         return $slug.'.html';
+    }
+
+    public static function getFilePath(): string
+    {
+        return Hyde::pathToRelative(Hyde::sitePath(
+            DocumentationPage::outputDirectory().'/search.json'
+        ));
     }
 }

--- a/packages/framework/src/Framework/Services/DocumentationSearchService.php
+++ b/packages/framework/src/Framework/Services/DocumentationSearchService.php
@@ -20,8 +20,7 @@ final class DocumentationSearchService
     use InteractsWithDirectories;
 
     public Collection $searchIndex;
-    /** @deprecated Not sure what value this adds from being a static property */
-    public static string $filePath;
+    protected string $filePath;
 
     public static function generate(): self
     {
@@ -44,9 +43,7 @@ final class DocumentationSearchService
     public function __construct()
     {
         $this->searchIndex = new Collection();
-        if (! isset(self::$filePath)) {
-            self::$filePath = $this->getFilePath();
-        }
+        $this->filePath = $this->getFilePath();
     }
 
     public function execute(): self
@@ -83,9 +80,9 @@ final class DocumentationSearchService
 
     protected function save(): self
     {
-        $this->needsParentDirectory(Hyde::path(self::$filePath));
+        $this->needsParentDirectory(Hyde::path($this->filePath));
 
-        file_put_contents(Hyde::path(self::$filePath), $this->searchIndex->toJson());
+        file_put_contents(Hyde::path($this->filePath), $this->searchIndex->toJson());
 
         return $this;
     }

--- a/packages/framework/src/Framework/Services/DocumentationSearchService.php
+++ b/packages/framework/src/Framework/Services/DocumentationSearchService.php
@@ -89,26 +89,6 @@ final class DocumentationSearchService
         return $this;
     }
 
-    /**
-     * There are a few ways we could go about this. The goal is to allow the user
-     * to run a free-text search to find relevant documentation pages.
-     *
-     * The easiest way to do this is by adding the Markdown body to the search index.
-     * But this is of course not ideal as it may take an incredible amount of space
-     * for large documentation sites. The Hyde docs weight around 80kb of JSON.
-     *
-     * Another option is to assemble all the headings in a document and use that
-     * for the search basis. A truncated version of the body could also be included.
-     *
-     * A third option which might be the most space efficient (besides from just
-     * adding titles, which doesn't offer much help to the user since it is just
-     * a filterable sidebar at that point), would be to search for keywords
-     * in the document. This would however add complexity as well as extra
-     * computing time.
-     *
-     * The current function is benchmarked on the official Hyde docs and takes
-     * around 140ms to generate the search index for all page files.
-     */
     protected function getSearchContentForDocument(DocumentationPage $page): string
     {
         return (new ConvertsMarkdownToPlainText($page->markdown->body()))->execute();

--- a/packages/framework/src/Framework/Services/DocumentationSearchService.php
+++ b/packages/framework/src/Framework/Services/DocumentationSearchService.php
@@ -82,7 +82,7 @@ final class DocumentationSearchService
 
     protected function save(): self
     {
-        $this->needsDirectory(Hyde::path(str_replace('/search.json', '', self::$filePath)));
+        $this->needsDirectory(Hyde::path(dirname(self::$filePath)));
 
         file_put_contents(Hyde::path(self::$filePath), $this->searchIndex->toJson());
 

--- a/packages/framework/src/Framework/Services/DocumentationSearchService.php
+++ b/packages/framework/src/Framework/Services/DocumentationSearchService.php
@@ -82,7 +82,7 @@ final class DocumentationSearchService
 
     protected function save(): self
     {
-        $this->needsDirectory(Hyde::path(dirname(self::$filePath)));
+        $this->needsParentDirectory(Hyde::path(self::$filePath));
 
         file_put_contents(Hyde::path(self::$filePath), $this->searchIndex->toJson());
 

--- a/packages/framework/src/Framework/Services/DocumentationSearchService.php
+++ b/packages/framework/src/Framework/Services/DocumentationSearchService.php
@@ -43,9 +43,11 @@ final class DocumentationSearchService
     public function __construct()
     {
         $this->searchIndex = new Collection();
-        self::$filePath = Hyde::pathToRelative(Hyde::sitePath(
-            DocumentationPage::outputDirectory().'/search.json'
-        ));
+        if (! isset(self::$filePath)) {
+            self::$filePath = Hyde::pathToRelative(Hyde::sitePath(
+                DocumentationPage::outputDirectory().'/search.json'
+            ));
+        }
     }
 
     public function execute(): self

--- a/packages/framework/src/Framework/Services/DocumentationSearchService.php
+++ b/packages/framework/src/Framework/Services/DocumentationSearchService.php
@@ -30,7 +30,7 @@ final class DocumentationSearchService
     public static function generateSearchPage(): string
     {
         $outputDirectory = Hyde::sitePath(DocumentationPage::outputDirectory());
-        self::needsDirectory(($outputDirectory));
+        self::needsDirectory($outputDirectory);
 
         file_put_contents(
             "$outputDirectory/search.html",

--- a/packages/framework/src/Framework/Services/DocumentationSearchService.php
+++ b/packages/framework/src/Framework/Services/DocumentationSearchService.php
@@ -20,7 +20,7 @@ final class DocumentationSearchService
     use InteractsWithDirectories;
 
     public Collection $searchIndex;
-    public static string $filePath = '_site/docs/search.json';
+    public static string $filePath;
 
     public static function generate(): self
     {

--- a/packages/framework/tests/Feature/Services/DocumentationSearchServiceTest.php
+++ b/packages/framework/tests/Feature/Services/DocumentationSearchServiceTest.php
@@ -26,7 +26,7 @@ class DocumentationSearchServiceTest extends TestCase
             'title' => 'Foo',
             'content' => '',
             'destination' => 'foo.html',
-        ]]), file_get_contents(DocumentationSearchService::$filePath));
+        ]]), file_get_contents('_site/docs/search.json'));
 
         Filesystem::unlink('_docs/foo.md');
         Filesystem::unlink('_site/docs/search.json');
@@ -49,7 +49,7 @@ class DocumentationSearchServiceTest extends TestCase
     {
         DocumentationSearchService::generate();
 
-        $this->assertSame('[]', file_get_contents(DocumentationSearchService::$filePath));
+        $this->assertSame('[]', file_get_contents('_site/docs/search.json'));
 
         Filesystem::unlink('_site/docs/search.json');
     }

--- a/packages/framework/tests/Feature/Services/DocumentationSearchServiceTest.php
+++ b/packages/framework/tests/Feature/Services/DocumentationSearchServiceTest.php
@@ -17,7 +17,7 @@ class DocumentationSearchServiceTest extends TestCase
 {
     public function test_it_generates_a_json_file_with_a_search_index()
     {
-        Filesystem::touch('_docs/foo.md');
+        $this->file('_docs/foo.md');
 
         DocumentationSearchService::generate();
 
@@ -27,22 +27,15 @@ class DocumentationSearchServiceTest extends TestCase
             'content' => '',
             'destination' => 'foo.html',
         ]]), file_get_contents('_site/docs/search.json'));
-
-        Filesystem::unlink('_docs/foo.md');
-        Filesystem::unlink('_site/docs/search.json');
     }
 
     public function test_it_adds_all_files_to_search_index()
     {
-        Filesystem::touch('_docs/foo.md');
-        Filesystem::touch('_docs/bar.md');
-        Filesystem::touch('_docs/baz.md');
+        $this->file('_docs/foo.md');
+        $this->file('_docs/bar.md');
+        $this->file('_docs/baz.md');
 
         $this->assertCount(3, (new DocumentationSearchService())->run()->searchIndex);
-
-        Filesystem::unlink('_docs/foo.md');
-        Filesystem::unlink('_docs/bar.md');
-        Filesystem::unlink('_docs/baz.md');
     }
 
     public function test_it_handles_generation_even_when_there_are_no_pages()
@@ -65,7 +58,7 @@ class DocumentationSearchServiceTest extends TestCase
 
     public function test_generate_page_entry_method_generates_a_page_entry()
     {
-        Filesystem::putContents('_docs/foo.md', "# Bar\nHello World");
+        $this->file('_docs/foo.md', "# Bar\nHello World");
 
         $this->assertSame([
             'slug' => 'foo',
@@ -73,35 +66,28 @@ class DocumentationSearchServiceTest extends TestCase
             'content' => "Bar\nHello World",
             'destination' => 'foo.html',
         ], (new DocumentationSearchService())->generatePageEntry(DocumentationPage::parse('foo')));
-
-        Filesystem::unlink('_docs/foo.md');
     }
 
     public function test_it_generates_a_valid_JSON()
     {
-        Filesystem::putContents('_docs/foo.md', "# Bar\nHello World");
-        Filesystem::putContents('_docs/bar.md', "# Foo\n\nHello World");
+        $this->file('_docs/foo.md', "# Bar\nHello World");
+        $this->file('_docs/bar.md', "# Foo\n\nHello World");
 
         $this->assertSame(
             '[{"slug":"bar","title":"Foo","content":"Foo\n\nHello World","destination":"bar.html"},'.
             '{"slug":"foo","title":"Bar","content":"Bar\nHello World","destination":"foo.html"}]',
             json_encode((new DocumentationSearchService())->run()->searchIndex->toArray())
         );
-
-        Filesystem::unlink('_docs/foo.md');
-        Filesystem::unlink('_docs/bar.md');
     }
 
     public function test_it_strips_markdown()
     {
-        Filesystem::putContents('_docs/foo.md', "# Foo Bar\n**Hello** _World_");
+        $this->file('_docs/foo.md', "# Foo Bar\n**Hello** _World_");
 
         $this->assertSame(
             "Foo Bar\nHello World",
             ((new DocumentationSearchService())->run()->searchIndex->toArray())[0]['content']
         );
-
-        Filesystem::unlink('_docs/foo.md');
     }
 
     public function test_get_destination_for_slug_returns_empty_string_for_index_when_pretty_url_is_enabled()
@@ -124,25 +110,21 @@ class DocumentationSearchServiceTest extends TestCase
 
     public function test_excluded_pages_are_not_present_in_the_search_index()
     {
-        Filesystem::touch('_docs/excluded.md');
+        $this->file('_docs/excluded.md');
         config(['docs.exclude_from_search' => ['excluded']]);
 
         $this->assertStringNotContainsString('excluded',
             json_encode((new DocumentationSearchService())->run()->searchIndex->toArray())
         );
-
-        Filesystem::unlink('_docs/excluded.md');
     }
 
     public function test_nested_source_files_do_not_retain_directory_name_in_search_index()
     {
-        Filesystem::makeDirectory(Hyde::path('_docs/foo'));
-        Filesystem::touch('_docs/foo/bar.md');
+        $this->directory(Hyde::path('_docs/foo'));
+        $this->file('_docs/foo/bar.md');
 
         $this->assertStringNotContainsString('foo',
             json_encode((new DocumentationSearchService())->run()->searchIndex->toArray())
         );
-
-        Filesystem::deleteDirectory('_docs/foo');
     }
 }


### PR DESCRIPTION
Cleans up `DocumentationSearchService.php`. The class is marked as internal, so nothing here is considered breaking.