### PR TITLE
Refactor documentation search to use relative links

### DIFF
--- a/packages/framework/src/Framework/Services/DocumentationSearchService.php
+++ b/packages/framework/src/Framework/Services/DocumentationSearchService.php
@@ -92,13 +92,13 @@ final class DocumentationSearchService
         return (new ConvertsMarkdownToPlainText($page->markdown->body()))->execute();
     }
 
-    public function formatDestination(string $slug): string
+    public function formatDestination(string $page): string
     {
         if (config('site.pretty_urls', false) === true) {
-            return $slug !== 'index' ? $slug : '';
+            return $page !== 'index' ? $page : '';
         }
 
-        return $slug.'.html';
+        return $page.'.html';
     }
 
     public static function getFilePath(): string

--- a/packages/framework/src/Framework/Services/DocumentationSearchService.php
+++ b/packages/framework/src/Framework/Services/DocumentationSearchService.php
@@ -71,7 +71,6 @@ final class DocumentationSearchService
     public function generatePageEntry(DocumentationPage $page): array
     {
         return [
-            // TODO: Slug will be renamed to identifier, paired with the next major HydeSearch version.
             'slug' => basename($page->identifier),
             'title' => $page->title,
             'content' => trim($this->getSearchContentForDocument($page)),

--- a/packages/framework/src/Framework/Services/DocumentationSearchService.php
+++ b/packages/framework/src/Framework/Services/DocumentationSearchService.php
@@ -74,7 +74,7 @@ final class DocumentationSearchService
             'slug' => basename($page->identifier),
             'title' => $page->title,
             'content' => trim($this->getSearchContentForDocument($page)),
-            'destination' => $this->getDestinationForSlug(basename($page->identifier)),
+            'destination' => $this->formatDestination(basename($page->identifier)),
         ];
     }
 
@@ -92,7 +92,7 @@ final class DocumentationSearchService
         return (new ConvertsMarkdownToPlainText($page->markdown->body()))->execute();
     }
 
-    public function getDestinationForSlug(string $slug): string
+    public function formatDestination(string $slug): string
     {
         if (config('site.pretty_urls', false) === true) {
             return $slug !== 'index' ? $slug : '';

--- a/packages/framework/src/Framework/Services/DocumentationSearchService.php
+++ b/packages/framework/src/Framework/Services/DocumentationSearchService.php
@@ -92,7 +92,7 @@ final class DocumentationSearchService
         return (new ConvertsMarkdownToPlainText($page->markdown->body()))->execute();
     }
 
-    public function formatDestination(string $page): string
+    protected function formatDestination(string $page): string
     {
         if ($page === 'index') {
             return DocumentationPage::$outputDirectory . '/' . Hyde::formatLink('index.html');

--- a/packages/framework/src/Framework/Services/DocumentationSearchService.php
+++ b/packages/framework/src/Framework/Services/DocumentationSearchService.php
@@ -96,7 +96,7 @@ final class DocumentationSearchService
 
     protected function getDestination(HydePage $page): string
     {
-        Render::setPage(DocumentationPage::home());
+        Render::share('currentPage', DocumentationPage::$outputDirectory.'/index');
 
         return $page->getRoute()->getLink();
     }

--- a/packages/framework/src/Framework/Services/DocumentationSearchService.php
+++ b/packages/framework/src/Framework/Services/DocumentationSearchService.php
@@ -7,6 +7,7 @@ namespace Hyde\Framework\Services;
 use Hyde\Framework\Actions\ConvertsMarkdownToPlainText;
 use Hyde\Framework\Concerns\InteractsWithDirectories;
 use Hyde\Hyde;
+use Hyde\Pages\Concerns\HydePage;
 use Hyde\Pages\DocumentationPage;
 use Illuminate\Support\Collection;
 
@@ -74,7 +75,7 @@ final class DocumentationSearchService
             'slug' => basename($page->identifier),
             'title' => $page->title,
             'content' => trim($this->getSearchContentForDocument($page)),
-            'destination' => basename($this->formatDestination(DocumentationPage::$outputDirectory."/$page->identifier.html")),
+            'destination' => $this->getDestination($page),
         ];
     }
 
@@ -92,9 +93,9 @@ final class DocumentationSearchService
         return (new ConvertsMarkdownToPlainText($page->markdown->body()))->execute();
     }
 
-    protected function formatDestination(string $page): string
+    protected function getDestination(HydePage $page): string
     {
-        return Hyde::formatLink($page);
+        return $page->getRoute()->getLink();
     }
 
     public static function getFilePath(): string

--- a/packages/framework/src/Framework/Services/DocumentationSearchService.php
+++ b/packages/framework/src/Framework/Services/DocumentationSearchService.php
@@ -74,7 +74,7 @@ final class DocumentationSearchService
             'slug' => basename($page->identifier),
             'title' => $page->title,
             'content' => trim($this->getSearchContentForDocument($page)),
-            'destination' => basename($this->formatDestination(DocumentationPage::$outputDirectory.'/'.$page->identifier)),
+            'destination' => basename($this->formatDestination(DocumentationPage::$outputDirectory."/$page->identifier.html")),
         ];
     }
 
@@ -94,11 +94,7 @@ final class DocumentationSearchService
 
     protected function formatDestination(string $page): string
     {
-        if ($page === 'index') {
-            return DocumentationPage::$outputDirectory . '/' . Hyde::formatLink('index.html');
-        }
-
-        return Hyde::formatLink("$page.html");
+        return Hyde::formatLink($page);
     }
 
     public static function getFilePath(): string

--- a/packages/framework/src/Framework/Services/DocumentationSearchService.php
+++ b/packages/framework/src/Framework/Services/DocumentationSearchService.php
@@ -74,7 +74,7 @@ final class DocumentationSearchService
             'slug' => basename($page->identifier),
             'title' => $page->title,
             'content' => trim($this->getSearchContentForDocument($page)),
-            'destination' => $this->formatDestination(basename($page->identifier)),
+            'destination' => basename($this->formatDestination($page->identifier)),
         ];
     }
 

--- a/packages/framework/src/Framework/Services/DocumentationSearchService.php
+++ b/packages/framework/src/Framework/Services/DocumentationSearchService.php
@@ -95,7 +95,7 @@ final class DocumentationSearchService
     public function formatDestination(string $page): string
     {
         if ($page === 'index') {
-            return DocumentationPage::home()->getLink();
+            return DocumentationPage::$outputDirectory . '/' . Hyde::formatLink('index.html');
         }
 
         return Hyde::formatLink("$page.html");

--- a/packages/framework/src/Framework/Services/DocumentationSearchService.php
+++ b/packages/framework/src/Framework/Services/DocumentationSearchService.php
@@ -9,6 +9,7 @@ use Hyde\Framework\Concerns\InteractsWithDirectories;
 use Hyde\Hyde;
 use Hyde\Pages\Concerns\HydePage;
 use Hyde\Pages\DocumentationPage;
+use Hyde\Support\Facades\Render;
 use Illuminate\Support\Collection;
 
 /**
@@ -95,6 +96,8 @@ final class DocumentationSearchService
 
     protected function getDestination(HydePage $page): string
     {
+        Render::setPage(DocumentationPage::home());
+
         return $page->getRoute()->getLink();
     }
 

--- a/packages/framework/src/Framework/Services/DocumentationSearchService.php
+++ b/packages/framework/src/Framework/Services/DocumentationSearchService.php
@@ -94,7 +94,7 @@ final class DocumentationSearchService
 
     public function formatDestination(string $page): string
     {
-        return Hyde::formatLink($page);
+        return Hyde::formatLink("$page.html");
     }
 
     public static function getFilePath(): string

--- a/packages/framework/src/Framework/Services/DocumentationSearchService.php
+++ b/packages/framework/src/Framework/Services/DocumentationSearchService.php
@@ -94,11 +94,7 @@ final class DocumentationSearchService
 
     public function formatDestination(string $page): string
     {
-        if (config('site.pretty_urls', false) === true) {
-            return $page !== 'index' ? $page : '';
-        }
-
-        return $page.'.html';
+        return Hyde::formatLink($page);
     }
 
     public static function getFilePath(): string

--- a/packages/framework/src/Framework/Services/DocumentationSearchService.php
+++ b/packages/framework/src/Framework/Services/DocumentationSearchService.php
@@ -74,7 +74,7 @@ final class DocumentationSearchService
             'slug' => basename($page->identifier),
             'title' => $page->title,
             'content' => trim($this->getSearchContentForDocument($page)),
-            'destination' => basename($this->formatDestination($page->identifier)),
+            'destination' => basename($this->formatDestination(DocumentationPage::$outputDirectory.'/'.$page->identifier)),
         ];
     }
 

--- a/packages/framework/src/Framework/Services/DocumentationSearchService.php
+++ b/packages/framework/src/Framework/Services/DocumentationSearchService.php
@@ -94,6 +94,10 @@ final class DocumentationSearchService
 
     public function formatDestination(string $page): string
     {
+        if ($page === 'index') {
+            return DocumentationPage::home()->getLink();
+        }
+
         return Hyde::formatLink("$page.html");
     }
 

--- a/packages/framework/src/Framework/Services/DocumentationSearchService.php
+++ b/packages/framework/src/Framework/Services/DocumentationSearchService.php
@@ -71,6 +71,7 @@ final class DocumentationSearchService
     public function generatePageEntry(DocumentationPage $page): array
     {
         return [
+            // TODO: Slug will be renamed to identifier, paired with the next major HydeSearch version.
             'slug' => basename($page->identifier),
             'title' => $page->title,
             'content' => trim($this->getSearchContentForDocument($page)),

--- a/packages/framework/tests/Feature/Services/DocumentationSearchServiceTest.php
+++ b/packages/framework/tests/Feature/Services/DocumentationSearchServiceTest.php
@@ -93,18 +93,20 @@ class DocumentationSearchServiceTest extends TestCase
     public function test_format_destination_returns_empty_string_for_index_when_pretty_url_is_enabled()
     {
         config(['site.pretty_urls' => true]);
+        $this->file('_docs/index.md');
 
         $this->assertSame('',
-            (new DocumentationSearchService())->formatDestination('index')
+            (new DocumentationSearchService())->run()->searchIndex->toArray()[0]['destination']
         );
     }
 
     public function test_format_destination_returns_pretty_url_when_enabled()
     {
         config(['site.pretty_urls' => true]);
+        $this->file('_docs/foo.md');
 
         $this->assertSame('foo',
-            (new DocumentationSearchService())->formatDestination('foo')
+            (new DocumentationSearchService())->run()->searchIndex->toArray()[0]['destination']
         );
     }
 

--- a/packages/framework/tests/Feature/Services/DocumentationSearchServiceTest.php
+++ b/packages/framework/tests/Feature/Services/DocumentationSearchServiceTest.php
@@ -90,21 +90,21 @@ class DocumentationSearchServiceTest extends TestCase
         );
     }
 
-    public function test_get_destination_for_slug_returns_empty_string_for_index_when_pretty_url_is_enabled()
+    public function test_format_destination_returns_empty_string_for_index_when_pretty_url_is_enabled()
     {
         config(['site.pretty_urls' => true]);
 
         $this->assertSame('',
-            (new DocumentationSearchService())->getDestinationForSlug('index')
+            (new DocumentationSearchService())->formatDestination('index')
         );
     }
 
-    public function test_get_destination_for_slug_returns_pretty_url_when_enabled()
+    public function test_format_destination_returns_pretty_url_when_enabled()
     {
         config(['site.pretty_urls' => true]);
 
         $this->assertSame('foo',
-            (new DocumentationSearchService())->getDestinationForSlug('foo')
+            (new DocumentationSearchService())->formatDestination('foo')
         );
     }
 


### PR DESCRIPTION
Refactors to use the same route resolver as other site links. The current page is set to the documentation home page so links are relative to that.