### PR TITLE
Remove search generation guesstimation time as it's so much faster now

### DIFF
--- a/packages/framework/src/Framework/Features/BuildTasks/PostBuildTasks/GenerateSearch.php
+++ b/packages/framework/src/Framework/Features/BuildTasks/PostBuildTasks/GenerateSearch.php
@@ -6,7 +6,6 @@ namespace Hyde\Framework\Features\BuildTasks\PostBuildTasks;
 
 use Hyde\Framework\Concerns\InteractsWithDirectories;
 use Hyde\Framework\Features\BuildTasks\BuildTask;
-use Hyde\Framework\Services\DiscoveryService;
 use Hyde\Framework\Services\DocumentationSearchService;
 
 class GenerateSearch extends BuildTask

--- a/packages/framework/src/Framework/Features/BuildTasks/PostBuildTasks/GenerateSearch.php
+++ b/packages/framework/src/Framework/Features/BuildTasks/PostBuildTasks/GenerateSearch.php
@@ -17,11 +17,6 @@ class GenerateSearch extends BuildTask
 
     public function run(): void
     {
-        $expected = $this->guesstimateGenerationTime();
-        if ($expected >= 1) {
-            $this->line("<fg=gray>This will take an estimated $expected seconds. Terminal may seem non-responsive.</>");
-        }
-
         DocumentationSearchService::generate();
 
         if (config('docs.create_search_page', true)) {
@@ -34,15 +29,5 @@ class GenerateSearch extends BuildTask
     public function then(): void
     {
         $this->createdSiteFile(DocumentationSearchService::getFilePath())->withExecutionTime();
-    }
-
-    /**
-     * Estimated processing time per file in ms.
-     */
-    protected static float $guesstimationFactor = 52.5;
-
-    protected function guesstimateGenerationTime(): int|float
-    {
-        return (int) round(count(DiscoveryService::getDocumentationPageFiles()) * static::$guesstimationFactor) / 1000;
     }
 }

--- a/packages/framework/tests/Feature/Commands/BuildSearchCommandTest.php
+++ b/packages/framework/tests/Feature/Commands/BuildSearchCommandTest.php
@@ -58,20 +58,6 @@ class BuildSearchCommandTest extends TestCase
         Filesystem::unlink('_site/docs/search.html');
     }
 
-    public function test_it_displays_the_estimation_message_when_it_is_greater_than_or_equal_to_1_second()
-    {
-        for ($i = 0; $i < 20; $i++) {
-            $this->file("_docs/$i.md");
-        }
-
-        $this->artisan('build:search')
-            ->expectsOutput('This will take an estimated 1.05 seconds. Terminal may seem non-responsive.')
-            ->assertExitCode(0);
-
-        Filesystem::unlink('_site/docs/search.json');
-        Filesystem::unlink('_site/docs/search.html');
-    }
-
     public function test_search_files_can_be_generated_for_custom_docs_output_directory()
     {
         DocumentationPage::$outputDirectory = 'foo';


### PR DESCRIPTION
This action was made an order of magnitude faster in https://github.com/hydephp/develop/pull/895, and it no longer requires a heads up that the console might seem unresponsive.