### PR TITLE
Refactor the InteractsWithDirectories trait to use absolute paths for filesystem interactions

### DIFF
--- a/packages/framework/src/Framework/Concerns/InteractsWithDirectories.php
+++ b/packages/framework/src/Framework/Concerns/InteractsWithDirectories.php
@@ -14,7 +14,7 @@ trait InteractsWithDirectories
     /**
      * Ensure the supplied directory exist by creating it if it does not.
      *
-     * @param  string  $directory  absolute file path to the directory
+     * @param  string  $directory  relative file path to the directory
      */
     public static function needsDirectory(string $directory): void
     {
@@ -26,7 +26,7 @@ trait InteractsWithDirectories
     /**
      * Ensure the supplied directories exist by creating them if they don't.
      *
-     * @param  array<string>  $directories  array with absolute file paths to the directories
+     * @param  array<string>  $directories  array with relative file paths to the directories
      */
     public static function needsDirectories(array $directories): void
     {

--- a/packages/framework/src/Framework/Concerns/InteractsWithDirectories.php
+++ b/packages/framework/src/Framework/Concerns/InteractsWithDirectories.php
@@ -16,7 +16,7 @@ trait InteractsWithDirectories
      *
      * @param  string  $directory  relative file path to the directory
      */
-    public static function needsDirectory(string $directory): void
+    public function needsDirectory(string $directory): void
     {
         if (! Filesystem::exists($directory)) {
             Filesystem::makeDirectory($directory, recursive: true);
@@ -28,18 +28,18 @@ trait InteractsWithDirectories
      *
      * @param  array<string>  $directories  array with relative file paths to the directories
      */
-    public static function needsDirectories(array $directories): void
+    public function needsDirectories(array $directories): void
     {
         foreach ($directories as $directory) {
-            static::needsDirectory($directory);
+            $this->needsDirectory($directory);
         }
     }
 
     /**
      * Ensure the supplied file's parent directory exists by creating it if it does not.
      */
-    public static function needsParentDirectory(string $file, int $levels = 1): void
+    public function needsParentDirectory(string $file, int $levels = 1): void
     {
-        static::needsDirectory(dirname($file, $levels));
+        $this->needsDirectory(dirname($file, $levels));
     }
 }

--- a/packages/framework/src/Framework/Concerns/InteractsWithDirectories.php
+++ b/packages/framework/src/Framework/Concerns/InteractsWithDirectories.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Hyde\Framework\Concerns;
 
+use Hyde\Facades\Filesystem;
+
 /**
  * @see \Hyde\Framework\Testing\Unit\InteractsWithDirectoriesConcernTest
  */
@@ -16,8 +18,8 @@ trait InteractsWithDirectories
      */
     public static function needsDirectory(string $directory): void
     {
-        if (! file_exists($directory)) {
-            mkdir($directory, recursive: true);
+        if (! Filesystem::exists($directory)) {
+            Filesystem::makeDirectory($directory, recursive: true);
         }
     }
 

--- a/packages/framework/src/Framework/Concerns/InteractsWithDirectories.php
+++ b/packages/framework/src/Framework/Concerns/InteractsWithDirectories.php
@@ -16,7 +16,7 @@ trait InteractsWithDirectories
      *
      * @param  string  $directory  relative file path to the directory
      */
-    public function needsDirectory(string $directory): void
+    public static function needsDirectory(string $directory): void
     {
         if (! Filesystem::exists($directory)) {
             Filesystem::makeDirectory($directory, recursive: true);
@@ -28,18 +28,18 @@ trait InteractsWithDirectories
      *
      * @param  array<string>  $directories  array with relative file paths to the directories
      */
-    public function needsDirectories(array $directories): void
+    public static function needsDirectories(array $directories): void
     {
         foreach ($directories as $directory) {
-            $this->needsDirectory($directory);
+            static::needsDirectory($directory);
         }
     }
 
     /**
      * Ensure the supplied file's parent directory exists by creating it if it does not.
      */
-    public function needsParentDirectory(string $file, int $levels = 1): void
+    public static function needsParentDirectory(string $file, int $levels = 1): void
     {
-        $this->needsDirectory(dirname($file, $levels));
+        static::needsDirectory(dirname($file, $levels));
     }
 }

--- a/packages/framework/tests/Unit/InteractsWithDirectoriesConcernTest.php
+++ b/packages/framework/tests/Unit/InteractsWithDirectoriesConcernTest.php
@@ -34,41 +34,41 @@ class InteractsWithDirectoriesConcernTest extends TestCase
 
     public function test_methods_can_be_called_statically()
     {
-        static::needsDirectory(Hyde::path('foo'));
+        static::needsDirectory('foo');
         $this->assertDirectoryExists(Hyde::path('foo'));
 
-        static::needsDirectories([Hyde::path('foo')]);
+        static::needsDirectories(['foo']);
         $this->assertDirectoryExists(Hyde::path('foo'));
     }
 
     public function test_needs_directory_creates_the_directory()
     {
-        $this->needsDirectory(Hyde::path('foo'));
+        $this->needsDirectory('foo');
         $this->assertDirectoryExists(Hyde::path('foo'));
     }
 
     public function test_needs_directory_creates_the_directory_recursively()
     {
-        $this->needsDirectory(Hyde::path('foo/bar/baz'));
+        $this->needsDirectory('foo/bar/baz');
         $this->assertDirectoryExists(Hyde::path('foo/bar/baz'));
     }
 
     public function test_needs_directory_handles_existing_directory()
     {
-        $this->needsDirectory(Hyde::path('foo'));
-        $this->needsDirectory(Hyde::path('foo'));
+        $this->needsDirectory('foo');
+        $this->needsDirectory('foo');
         $this->assertDirectoryExists(Hyde::path('foo'));
     }
 
     public function test_needs_directories_creates_single_directory()
     {
-        $this->needsDirectories([Hyde::path('foo')]);
+        $this->needsDirectories(['foo']);
         $this->assertDirectoryExists(Hyde::path('foo'));
     }
 
     public function test_needs_directories_creates_multiple_directories()
     {
-        $this->needsDirectories([Hyde::path('foo'), Hyde::path('bar')]);
+        $this->needsDirectories(['foo', 'bar']);
         $this->assertDirectoryExists(Hyde::path('foo'));
         $this->assertDirectoryExists(Hyde::path('bar'));
 

--- a/packages/framework/tests/Unit/InteractsWithDirectoriesConcernTest.php
+++ b/packages/framework/tests/Unit/InteractsWithDirectoriesConcernTest.php
@@ -32,15 +32,6 @@ class InteractsWithDirectoriesConcernTest extends TestCase
         parent::tearDown();
     }
 
-    public function test_methods_can_be_called_statically()
-    {
-        static::needsDirectory('foo');
-        $this->assertDirectoryExists(Hyde::path('foo'));
-
-        static::needsDirectories(['foo']);
-        $this->assertDirectoryExists(Hyde::path('foo'));
-    }
-
     public function test_needs_directory_creates_the_directory()
     {
         $this->needsDirectory('foo');

--- a/packages/framework/tests/Unit/InteractsWithDirectoriesConcernTest.php
+++ b/packages/framework/tests/Unit/InteractsWithDirectoriesConcernTest.php
@@ -32,6 +32,15 @@ class InteractsWithDirectoriesConcernTest extends TestCase
         parent::tearDown();
     }
 
+    public function test_methods_can_be_called_statically()
+    {
+        static::needsDirectory('foo');
+        $this->assertDirectoryExists(Hyde::path('foo'));
+
+        static::needsDirectories(['foo']);
+        $this->assertDirectoryExists(Hyde::path('foo'));
+    }
+
     public function test_needs_directory_creates_the_directory()
     {
         $this->needsDirectory('foo');


### PR DESCRIPTION
Refactor InteractsWithDirectories to use absolute paths using the filesystem helpers