### PR TITLE
Breaking: Make `Site::$outputPath` protected and accessible through setter/getters

### DIFF
--- a/packages/framework/src/Facades/Site.php
+++ b/packages/framework/src/Facades/Site.php
@@ -14,7 +14,7 @@ use Hyde\Hyde;
  */
 final class Site
 {
-    protected static string $outputPath;
+    protected static string $outputPath = '_site';
 
     public static function url(): ?string
     {

--- a/packages/framework/src/Facades/Site.php
+++ b/packages/framework/src/Facades/Site.php
@@ -7,6 +7,8 @@ namespace Hyde\Facades;
 use Hyde\Framework\Features\Metadata\GlobalMetadataBag;
 use Hyde\Hyde;
 
+use function unslash;
+
 /**
  * Object representation for the HydePHP site and its configuration.
  *
@@ -43,6 +45,6 @@ final class Site
 
     public static function setOutputPath(string $outputPath): void
     {
-        self::$outputPath = Hyde::pathToRelative($outputPath);
+        self::$outputPath = Hyde::pathToRelative(unslash($outputPath));
     }
 }

--- a/packages/framework/src/Facades/Site.php
+++ b/packages/framework/src/Facades/Site.php
@@ -13,7 +13,7 @@ use Hyde\Framework\Features\Metadata\GlobalMetadataBag;
  */
 final class Site
 {
-    /** @var string The relative path to the output directory */
+    /** The relative path to the output directory */
     public static string $outputPath;
 
     public static function url(): ?string

--- a/packages/framework/src/Facades/Site.php
+++ b/packages/framework/src/Facades/Site.php
@@ -44,6 +44,6 @@ final class Site
 
     public static function setOutputPath(string $outputPath): void
     {
-        self::$outputPath = Hyde::pathToRelative(unslash($outputPath));
+        self::$outputPath = unslash(Hyde::pathToRelative($outputPath));
     }
 }

--- a/packages/framework/src/Facades/Site.php
+++ b/packages/framework/src/Facades/Site.php
@@ -13,7 +13,11 @@ use Hyde\Framework\Features\Metadata\GlobalMetadataBag;
  */
 final class Site
 {
-    /** The relative path to the output directory */
+    /**
+     * The relative path to the output directory
+     *
+     * @deprecated This property should be made protected, and getter/setter methods should be used instead as that will ensure a consistent and predictable state.
+     */
     public static string $outputPath;
 
     public static function url(): ?string

--- a/packages/framework/src/Facades/Site.php
+++ b/packages/framework/src/Facades/Site.php
@@ -7,7 +7,7 @@ namespace Hyde\Facades;
 use Hyde\Framework\Features\Metadata\GlobalMetadataBag;
 
 /**
- * Object representation for the HydePHP site.
+ * Object representation for the HydePHP site and its configuration.
  *
  * @see \Hyde\Framework\Testing\Feature\SiteTest
  */

--- a/packages/framework/src/Facades/Site.php
+++ b/packages/framework/src/Facades/Site.php
@@ -14,7 +14,7 @@ use Hyde\Framework\Features\Metadata\GlobalMetadataBag;
 final class Site
 {
     /** The relative path to the output directory */
-    public static string $outputPath;
+    protected static string $outputPath;
 
     public static function url(): ?string
     {

--- a/packages/framework/src/Facades/Site.php
+++ b/packages/framework/src/Facades/Site.php
@@ -43,6 +43,6 @@ final class Site
 
     public static function setOutputPath(string $outputPath): void
     {
-        self::$outputPath = \Hyde\unslash(Hyde::pathToRelative($outputPath));
+        self::$outputPath = Hyde::pathToRelative($outputPath);
     }
 }

--- a/packages/framework/src/Facades/Site.php
+++ b/packages/framework/src/Facades/Site.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Hyde\Facades;
 
 use Hyde\Framework\Features\Metadata\GlobalMetadataBag;
-use JetBrains\PhpStorm\Deprecated;
 
 /**
  * Object representation for the HydePHP site and its configuration.
@@ -14,12 +13,7 @@ use JetBrains\PhpStorm\Deprecated;
  */
 final class Site
 {
-    /**
-     * The relative path to the output directory
-     *
-     * @deprecated This property should be made protected, and getter/setter methods should be used instead as that will ensure a consistent and predictable state.
-     */
-    #[Deprecated(reason: 'Use the getter/setter methods instead.', replacement: 'Site::getOutputPath()')]
+    /** The relative path to the output directory */
     public static string $outputPath;
 
     public static function url(): ?string

--- a/packages/framework/src/Facades/Site.php
+++ b/packages/framework/src/Facades/Site.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Hyde\Facades;
 
 use Hyde\Framework\Features\Metadata\GlobalMetadataBag;
+use Hyde\Hyde;
 
 /**
  * Object representation for the HydePHP site and its configuration.
@@ -13,7 +14,6 @@ use Hyde\Framework\Features\Metadata\GlobalMetadataBag;
  */
 final class Site
 {
-    /** The relative path to the output directory */
     protected static string $outputPath;
 
     public static function url(): ?string
@@ -43,6 +43,6 @@ final class Site
 
     public static function setOutputPath(string $outputPath): void
     {
-        self::$outputPath = \Hyde\unslash($outputPath);
+        self::$outputPath = \Hyde\unslash(Hyde::pathToRelative($outputPath));
     }
 }

--- a/packages/framework/src/Facades/Site.php
+++ b/packages/framework/src/Facades/Site.php
@@ -43,6 +43,6 @@ final class Site
 
     public static function setOutputPath(string $outputPath): void
     {
-        self::$outputPath = $outputPath;
+        self::$outputPath = \Hyde\unslash($outputPath);
     }
 }

--- a/packages/framework/src/Facades/Site.php
+++ b/packages/framework/src/Facades/Site.php
@@ -41,4 +41,14 @@ final class Site
     {
         return GlobalMetadataBag::make();
     }
+
+    public static function getOutputPath(): string
+    {
+        return self::$outputPath;
+    }
+
+    public static function setOutputPath(string $outputPath): void
+    {
+        self::$outputPath = $outputPath;
+    }
 }

--- a/packages/framework/src/Facades/Site.php
+++ b/packages/framework/src/Facades/Site.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Hyde\Facades;
 
 use Hyde\Framework\Features\Metadata\GlobalMetadataBag;
+use JetBrains\PhpStorm\Deprecated;
 
 /**
  * Object representation for the HydePHP site and its configuration.
@@ -18,6 +19,7 @@ final class Site
      *
      * @deprecated This property should be made protected, and getter/setter methods should be used instead as that will ensure a consistent and predictable state.
      */
+    #[Deprecated(reason: 'Use the getter/setter methods instead.', replacement: 'Site::getOutputPath()')]
     public static string $outputPath;
 
     public static function url(): ?string

--- a/packages/framework/src/Facades/Site.php
+++ b/packages/framework/src/Facades/Site.php
@@ -6,7 +6,6 @@ namespace Hyde\Facades;
 
 use Hyde\Framework\Features\Metadata\GlobalMetadataBag;
 use Hyde\Hyde;
-
 use function unslash;
 
 /**

--- a/packages/framework/src/Foundation/Filesystem.php
+++ b/packages/framework/src/Foundation/Filesystem.php
@@ -93,12 +93,12 @@ class Filesystem
     public function sitePath(string $path = ''): string
     {
         if (empty($path)) {
-            return Hyde::path(Site::$outputPath);
+            return Hyde::path(Site::getOutputPath());
         }
 
         $path = unslash($path);
 
-        return Hyde::path(Site::$outputPath.DIRECTORY_SEPARATOR.$path);
+        return Hyde::path(Site::getOutputPath().DIRECTORY_SEPARATOR.$path);
     }
 
     /**

--- a/packages/framework/src/Framework/Concerns/RegistersFileLocations.php
+++ b/packages/framework/src/Framework/Concerns/RegistersFileLocations.php
@@ -74,6 +74,6 @@ trait RegistersFileLocations
      */
     protected function storeCompiledSiteIn(string $directory): void
     {
-        Site::setOutputPath(unslash($directory));
+        Site::setOutputPath($directory);
     }
 }

--- a/packages/framework/src/Framework/Concerns/RegistersFileLocations.php
+++ b/packages/framework/src/Framework/Concerns/RegistersFileLocations.php
@@ -74,6 +74,6 @@ trait RegistersFileLocations
      */
     protected function storeCompiledSiteIn(string $directory): void
     {
-        Site::$outputPath = unslash($directory);
+        Site::setOutputPath(unslash($directory));
     }
 }

--- a/packages/framework/src/Framework/Services/BuildService.php
+++ b/packages/framework/src/Framework/Services/BuildService.php
@@ -114,7 +114,7 @@ class BuildService
         return $this->confirm(sprintf(
             'The configured output directory (%s) is potentially unsafe to empty. '.
             'Are you sure you want to continue?',
-            Site::$outputPath
+            Site::getOutputPath()
         ));
     }
 

--- a/packages/framework/tests/Feature/Commands/BuildSearchCommandTest.php
+++ b/packages/framework/tests/Feature/Commands/BuildSearchCommandTest.php
@@ -71,7 +71,7 @@ class BuildSearchCommandTest extends TestCase
 
     public function test_search_files_can_be_generated_for_custom_site_output_directory()
     {
-        Site::$outputPath = 'foo';
+        Site::setOutputPath('foo');
 
         $this->artisan('build:search')->assertExitCode(0);
         $this->assertFileExists(Hyde::path('foo/docs/search.json'));
@@ -82,7 +82,7 @@ class BuildSearchCommandTest extends TestCase
 
     public function test_search_files_can_be_generated_for_custom_site_and_docs_output_directories()
     {
-        Site::$outputPath = 'foo';
+        Site::setOutputPath('foo');
         DocumentationPage::$outputDirectory = 'bar';
 
         $this->artisan('build:search')->assertExitCode(0);
@@ -94,7 +94,7 @@ class BuildSearchCommandTest extends TestCase
 
     public function test_search_files_can_be_generated_for_custom_site_and_nested_docs_output_directories()
     {
-        Site::$outputPath = 'foo/bar';
+        Site::setOutputPath('foo/bar');
         DocumentationPage::$outputDirectory = 'baz';
 
         $this->artisan('build:search')->assertExitCode(0);

--- a/packages/framework/tests/Feature/HydeServiceProviderTest.php
+++ b/packages/framework/tests/Feature/HydeServiceProviderTest.php
@@ -156,13 +156,13 @@ class HydeServiceProviderTest extends TestCase
 
     public function test_provider_registers_site_output_directory()
     {
-        $this->assertEquals('_site', Site::$outputPath);
+        $this->assertEquals('_site', Site::getOutputPath());
 
         config(['site.output_directory' => 'foo']);
 
         $this->provider->register();
 
-        $this->assertEquals('foo', Site::$outputPath);
+        $this->assertEquals('foo', Site::getOutputPath());
     }
 
     public function test_provider_registers_blade_view_discovery_location_for_configured_blade_view_path()

--- a/packages/framework/tests/Feature/StaticPageBuilderTest.php
+++ b/packages/framework/tests/Feature/StaticPageBuilderTest.php
@@ -144,7 +144,7 @@ class StaticPageBuilderTest extends TestCase
 
     public function test_site_directory_can_be_customized()
     {
-        Site::$outputPath = 'foo';
+        Site::setOutputPath('foo');
 
         new StaticPageBuilder(MarkdownPage::make('foo'), true);
 
@@ -156,7 +156,7 @@ class StaticPageBuilderTest extends TestCase
 
     public function test_site_directory_can_be_customized_with_nested_pages()
     {
-        Site::$outputPath = 'foo';
+        Site::setOutputPath('foo');
 
         new StaticPageBuilder(MarkdownPost::make('foo'), true);
 

--- a/packages/framework/tests/Feature/StaticSiteServiceTest.php
+++ b/packages/framework/tests/Feature/StaticSiteServiceTest.php
@@ -230,7 +230,7 @@ class StaticSiteServiceTest extends TestCase
 
     public function test_aborts_when_non_standard_directory_is_emptied()
     {
-        Site::$outputPath = 'foo';
+        Site::setOutputPath('foo');
 
         mkdir(Hyde::path('foo'));
         Hyde::touch('foo/keep.html');

--- a/packages/framework/tests/Unit/BuildOutputDirectoryCanBeChangedTest.php
+++ b/packages/framework/tests/Unit/BuildOutputDirectoryCanBeChangedTest.php
@@ -20,7 +20,7 @@ class BuildOutputDirectoryCanBeChangedTest extends TestCase
     {
         $this->file('_posts/test-post.md');
 
-        Site::$outputPath = '_site/build';
+        Site::setOutputPath('_site/build');
 
         $this->artisan('build');
 
@@ -35,7 +35,7 @@ class BuildOutputDirectoryCanBeChangedTest extends TestCase
     {
         $this->file('_posts/test-post.md');
 
-        Site::$outputPath = '_site/build';
+        Site::setOutputPath('_site/build');
 
         (new RebuildService('_posts/test-post.md'))->execute();
 
@@ -48,7 +48,7 @@ class BuildOutputDirectoryCanBeChangedTest extends TestCase
     {
         $this->file('_posts/test-post.md');
         File::deleteDirectory(Hyde::path('_site/build/foo'));
-        Site::$outputPath = '_site/build/foo';
+        Site::setOutputPath('_site/build/foo');
         (new RebuildService('_posts/test-post.md'))->execute();
 
         $this->assertFileExists(Hyde::path('_site/build/foo/posts/test-post.html'));

--- a/packages/framework/tests/Unit/BuildOutputDirectoryCanBeChangedTest.php
+++ b/packages/framework/tests/Unit/BuildOutputDirectoryCanBeChangedTest.php
@@ -70,4 +70,16 @@ class BuildOutputDirectoryCanBeChangedTest extends TestCase
 
         File::deleteDirectory(Hyde::path('_site/build'));
     }
+
+    public function test_site_output_directory_path_is_normalized_to_be_relative()
+    {
+        Site::setOutputPath(Hyde::path('_site'));
+        $this->assertEquals('_site', Site::getOutputPath());
+    }
+
+    public function test_site_output_directory_path_is_normalized_to_trim_trailing_slashes()
+    {
+        Site::setOutputPath('foo/bar/');
+        $this->assertEquals('foo/bar', Site::getOutputPath());
+    }
 }

--- a/packages/framework/tests/Unit/BuildOutputDirectoryCanBeChangedTest.php
+++ b/packages/framework/tests/Unit/BuildOutputDirectoryCanBeChangedTest.php
@@ -57,12 +57,12 @@ class BuildOutputDirectoryCanBeChangedTest extends TestCase
 
     public function test_site_output_directory_can_be_changed_in_configuration()
     {
-        $this->assertEquals('_site', Site::$outputPath);
+        $this->assertEquals('_site', Site::getOutputPath());
 
         config(['site.output_directory' => '_site/build']);
         (new HydeServiceProvider($this->app))->register();
 
-        $this->assertEquals('_site/build', Site::$outputPath);
+        $this->assertEquals('_site/build', Site::getOutputPath());
 
         $this->file('_posts/test-post.md');
         (new RebuildService('_posts/test-post.md'))->execute();

--- a/packages/framework/tests/Unit/BuildOutputDirectoryCanBeChangedTest.php
+++ b/packages/framework/tests/Unit/BuildOutputDirectoryCanBeChangedTest.php
@@ -75,11 +75,15 @@ class BuildOutputDirectoryCanBeChangedTest extends TestCase
     {
         Site::setOutputPath(Hyde::path('_site'));
         $this->assertEquals('_site', Site::getOutputPath());
+
+        Site::setOutputPath('_site');
     }
 
     public function test_site_output_directory_path_is_normalized_to_trim_trailing_slashes()
     {
         Site::setOutputPath('foo/bar/');
         $this->assertEquals('foo/bar', Site::getOutputPath());
+
+        Site::setOutputPath('_site');
     }
 }


### PR DESCRIPTION
This is intended to force a more consistent internal value state. Now there's no reason to have a bunch of warnings that the path must be relative, we can (and now do) just normalize it before assignment.

To upgrade external code using this class, replace the following:

`Site::$outputPath` => `Site::getOutputPath()` d9ca4a1045df4726aead75963b83b5704aaaf592
`Site::$outputPath = 'foo'` => `Site::setOutputPath('foo')` 50bdc1c517e35d7ffaace655d0944972d803deeb
