### PR TITLE
Add method alias to fluently interact with the HydeKernel through the Hyde facade

### DIFF
--- a/packages/framework/src/Hyde.php
+++ b/packages/framework/src/Hyde.php
@@ -79,4 +79,9 @@ class Hyde extends Facade
     {
         return HydeKernel::getInstance();
     }
+
+    public static function kernel(): HydeKernel
+    {
+        return HydeKernel::getInstance();
+    }
 }

--- a/packages/framework/tests/Feature/HydeKernelTest.php
+++ b/packages/framework/tests/Feature/HydeKernelTest.php
@@ -307,4 +307,11 @@ class HydeKernelTest extends TestCase
         Hyde::setSourceRoot('foo');
         $this->assertEquals('foo', Hyde::getSourceRoot());
     }
+
+    public function test_can_access_kernel_fluently_using_the_facade()
+    {
+        $this->assertInstanceOf(HydeKernel::class, Hyde::kernel());
+        $this->assertSame(HydeKernel::getInstance(), Hyde::kernel());
+        $this->assertSame(HydeKernel::VERSION, Hyde::kernel()->version());
+    }
 }


### PR DESCRIPTION
## About

Adds a new shorter alias `Hyde::kernel()` that can be used to fluently call methods on the kernel, but with full IDE support. This because some things in the facade honestly don't feel like they need a method annotation but we still want IDE support without having to use verbose getInstance methods etc.

### Usage

```php
Hyde::kernel(); // Same as HydeKernel::getInstance()
Hyde::kernel()->version(); // Same as HydeKernel::getInstance()->version() and the same as Hyde::version()
```