### PR TITLE
Move internal data store for the site output directory to the HydeKernel

### DIFF
--- a/packages/framework/src/Facades/Site.php
+++ b/packages/framework/src/Facades/Site.php
@@ -6,6 +6,7 @@ namespace Hyde\Facades;
 
 use Hyde\Foundation\HydeKernel;
 use Hyde\Framework\Features\Metadata\GlobalMetadataBag;
+use JetBrains\PhpStorm\Deprecated;
 
 /**
  * Object representation for the HydePHP site and its configuration.
@@ -39,6 +40,8 @@ final class Site
         return HydeKernel::getInstance()->getOutputPath();
     }
 
+    /** @deprecated Call the Kernel method directly instead */
+    #[Deprecated(reason: 'Call the Kernel method directly instead', replacement: 'Hyde::setOutputPath(%parameter0%)')]
     public static function setOutputPath(string $outputPath): void
     {
         HydeKernel::getInstance()->setOutputPath($outputPath);

--- a/packages/framework/src/Facades/Site.php
+++ b/packages/framework/src/Facades/Site.php
@@ -4,9 +4,8 @@ declare(strict_types=1);
 
 namespace Hyde\Facades;
 
+use Hyde\Foundation\HydeKernel;
 use Hyde\Framework\Features\Metadata\GlobalMetadataBag;
-use Hyde\Hyde;
-use function unslash;
 
 /**
  * Object representation for the HydePHP site and its configuration.
@@ -15,8 +14,6 @@ use function unslash;
  */
 final class Site
 {
-    protected static string $outputPath = '_site';
-
     public static function url(): ?string
     {
         return config('site.url');
@@ -39,11 +36,11 @@ final class Site
 
     public static function getOutputPath(): string
     {
-        return self::$outputPath;
+        return HydeKernel::getInstance()->getOutputPath();
     }
 
     public static function setOutputPath(string $outputPath): void
     {
-        self::$outputPath = unslash(Hyde::pathToRelative($outputPath));
+        HydeKernel::getInstance()->setOutputPath($outputPath);
     }
 }

--- a/packages/framework/src/Facades/Site.php
+++ b/packages/framework/src/Facades/Site.php
@@ -6,7 +6,6 @@ namespace Hyde\Facades;
 
 use Hyde\Framework\Features\Metadata\GlobalMetadataBag;
 use Hyde\Hyde;
-use JetBrains\PhpStorm\Deprecated;
 
 /**
  * Object representation for the HydePHP site and its configuration.
@@ -40,8 +39,6 @@ final class Site
         return Hyde::kernel()->getOutputPath();
     }
 
-    /** @deprecated Call the Kernel method directly instead */
-    #[Deprecated(reason: 'Call the Kernel method directly instead', replacement: 'Hyde::setOutputPath(%parameter0%)')]
     public static function setOutputPath(string $outputPath): void
     {
         Hyde::kernel()->setOutputPath($outputPath);

--- a/packages/framework/src/Facades/Site.php
+++ b/packages/framework/src/Facades/Site.php
@@ -38,13 +38,13 @@ final class Site
 
     public static function getOutputPath(): string
     {
-        return Hyde::getOutputPath();
+        return Hyde::kernel()->getOutputPath();
     }
 
     /** @deprecated Call the Kernel method directly instead */
     #[Deprecated(reason: 'Call the Kernel method directly instead', replacement: 'Hyde::setOutputPath(%parameter0%)')]
     public static function setOutputPath(string $outputPath): void
     {
-        Hyde::setOutputPath($outputPath);
+        Hyde::kernel()->setOutputPath($outputPath);
     }
 }

--- a/packages/framework/src/Facades/Site.php
+++ b/packages/framework/src/Facades/Site.php
@@ -6,6 +6,7 @@ namespace Hyde\Facades;
 
 use Hyde\Foundation\HydeKernel;
 use Hyde\Framework\Features\Metadata\GlobalMetadataBag;
+use Hyde\Hyde;
 use JetBrains\PhpStorm\Deprecated;
 
 /**
@@ -37,13 +38,13 @@ final class Site
 
     public static function getOutputPath(): string
     {
-        return HydeKernel::getInstance()->getOutputPath();
+        return Hyde::getOutputPath();
     }
 
     /** @deprecated Call the Kernel method directly instead */
     #[Deprecated(reason: 'Call the Kernel method directly instead', replacement: 'Hyde::setOutputPath(%parameter0%)')]
     public static function setOutputPath(string $outputPath): void
     {
-        HydeKernel::getInstance()->setOutputPath($outputPath);
+        Hyde::setOutputPath($outputPath);
     }
 }

--- a/packages/framework/src/Facades/Site.php
+++ b/packages/framework/src/Facades/Site.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Hyde\Facades;
 
-use Hyde\Foundation\HydeKernel;
 use Hyde\Framework\Features\Metadata\GlobalMetadataBag;
 use Hyde\Hyde;
 use JetBrains\PhpStorm\Deprecated;

--- a/packages/framework/src/Foundation/Concerns/ManagesHydeKernel.php
+++ b/packages/framework/src/Foundation/Concerns/ManagesHydeKernel.php
@@ -49,6 +49,16 @@ trait ManagesHydeKernel
         return $this->sourceRoot;
     }
 
+    public function setOutputPath(string $outputPath): void
+    {
+        $this->outputPath = rtrim($outputPath, '/\\');
+    }
+
+    public function getOutputPath(): string
+    {
+        return $this->outputPath;
+    }
+
     /**
      * Developer Information.
      *

--- a/packages/framework/src/Foundation/HydeKernel.php
+++ b/packages/framework/src/Foundation/HydeKernel.php
@@ -47,6 +47,7 @@ class HydeKernel implements SerializableContract
 
     protected string $basePath;
     protected string $sourceRoot;
+    protected string $outputPath;
 
     protected Filesystem $filesystem;
     protected Hyperlinks $hyperlinks;

--- a/packages/framework/src/Foundation/HydeKernel.php
+++ b/packages/framework/src/Foundation/HydeKernel.php
@@ -48,7 +48,7 @@ class HydeKernel implements SerializableContract
 
     protected string $basePath;
     protected string $sourceRoot = '';
-    protected string $outputPath;
+    protected string $outputPath = '_site';
 
     protected Filesystem $filesystem;
     protected Hyperlinks $hyperlinks;

--- a/packages/framework/tests/Feature/HydeKernelTest.php
+++ b/packages/framework/tests/Feature/HydeKernelTest.php
@@ -308,6 +308,17 @@ class HydeKernelTest extends TestCase
         $this->assertEquals('foo', Hyde::getSourceRoot());
     }
 
+    public function test_can_get_output_path()
+    {
+        $this->assertEquals('_site', Hyde::getOutputPath());
+    }
+
+    public function test_can_set_output_path()
+    {
+        Hyde::setOutputPath('foo');
+        $this->assertEquals('foo', Hyde::getOutputPath());
+    }
+
     public function test_can_access_kernel_fluently_using_the_facade()
     {
         $this->assertInstanceOf(HydeKernel::class, Hyde::kernel());

--- a/packages/framework/tests/Unit/BuildOutputDirectoryCanBeChangedTest.php
+++ b/packages/framework/tests/Unit/BuildOutputDirectoryCanBeChangedTest.php
@@ -71,14 +71,6 @@ class BuildOutputDirectoryCanBeChangedTest extends TestCase
         File::deleteDirectory(Hyde::path('_site/build'));
     }
 
-    public function test_site_output_directory_path_is_normalized_to_be_relative()
-    {
-        Site::setOutputPath(Hyde::path('_site'));
-        $this->assertEquals('_site', Site::getOutputPath());
-
-        Site::setOutputPath('_site');
-    }
-
     public function test_site_output_directory_path_is_normalized_to_trim_trailing_slashes()
     {
         Site::setOutputPath('foo/bar/');

--- a/packages/framework/tests/Unit/BuildOutputDirectoryCanBeChangedTest.php
+++ b/packages/framework/tests/Unit/BuildOutputDirectoryCanBeChangedTest.php
@@ -75,7 +75,5 @@ class BuildOutputDirectoryCanBeChangedTest extends TestCase
     {
         Site::setOutputPath('foo/bar/');
         $this->assertEquals('foo/bar', Site::getOutputPath());
-
-        Site::setOutputPath('_site');
     }
 }


### PR DESCRIPTION
The variable location determining which directory the site is compiled to is moved from the Site facade to the HydeKernel.

Thanks to the accessors added in https://github.com/hydephp/develop/pull/902, this doesn't mess with the API (not that anyone has had time to use the new methods in the two hours since, but still)

I did not move the normalization forcing relative paths, as anyone messing with the HydeKernel should know what they're doing, but I might port the warning that the directory will be emptied (though I should double check if we need it since I'm pretty sure we warn if the directory seems unsafe) Edit: yeah there's a warning so all good. No need to add extra warnings IMO.