### PR TITLE
Remove the $sourceRoot constructor parameter from the HydeKernel

### DIFF
--- a/packages/framework/src/Foundation/HydeKernel.php
+++ b/packages/framework/src/Foundation/HydeKernel.php
@@ -64,10 +64,9 @@ class HydeKernel implements SerializableContract
     protected array $pageClasses = [];
     protected array $extensions = [];
 
-    public function __construct(?string $basePath = null, #[Deprecated(reason: 'This does not seem to be used anywhere, use the setter instead')]string $sourceRoot = '')
+    public function __construct(?string $basePath = null)
     {
         $this->setBasePath($basePath ?? getcwd());
-        $this->setSourceRoot($sourceRoot);
         $this->filesystem = new Filesystem($this);
         $this->hyperlinks = new Hyperlinks($this);
     }

--- a/packages/framework/src/Foundation/HydeKernel.php
+++ b/packages/framework/src/Foundation/HydeKernel.php
@@ -8,7 +8,6 @@ use Hyde\Facades\Features;
 use Hyde\Support\Concerns\Serializable;
 use Hyde\Support\Contracts\SerializableContract;
 use Illuminate\Support\Traits\Macroable;
-use JetBrains\PhpStorm\Deprecated;
 
 /**
  * Encapsulates a HydePHP project, providing helpful methods for interacting with it.


### PR DESCRIPTION
As far as I can see, this is unused within the codebase, and is simple enough to assign in a service provider using the setter. It also makes little sense that this is the only setting assignable in the constructor.