### PR TITLE
Update monorepo `.styleci.yml` configuration to disable the `alpha_ordered_imports` rule

### DIFF
--- a/.styleci.yml
+++ b/.styleci.yml
@@ -1,1 +1,4 @@
 preset: laravel
+
+disabled:
+    - alpha_ordered_imports


### PR DESCRIPTION
As I strongly dislike the default ordering that mixes function and class imports I'm going to try to disable it, and let PhpStorm manually sort imports when needed.