### PR TITLE
Add method Site::path() to match similar model helper methods

### DIFF
--- a/packages/framework/src/Facades/Site.php
+++ b/packages/framework/src/Facades/Site.php
@@ -34,6 +34,11 @@ final class Site
         return GlobalMetadataBag::make();
     }
 
+    public static function path(string $path = ''): string
+    {
+        return Hyde::kernel()->sitePath($path);
+    }
+
     public static function getOutputDirectory(): string
     {
         return Hyde::kernel()->getOutputDirectory();

--- a/packages/framework/tests/Feature/SiteTest.php
+++ b/packages/framework/tests/Feature/SiteTest.php
@@ -6,6 +6,7 @@ namespace Hyde\Framework\Testing\Feature;
 
 use Hyde\Facades\Site;
 use Hyde\Framework\Features\Metadata\GlobalMetadataBag;
+use Hyde\Hyde;
 use Hyde\Testing\TestCase;
 
 /**
@@ -49,5 +50,11 @@ class SiteTest extends TestCase
     public function testMetadata()
     {
         $this->assertEquals(GlobalMetadataBag::make(), Site::metadata());
+    }
+
+    public function testPath()
+    {
+        $this->assertSame(Hyde::sitePath(), Site::path());
+        $this->assertSame(Hyde::sitePath('foo'), Site::path('foo'));
     }
 }


### PR DESCRIPTION
This alias allows you to get the absolute path to where the site is compiled to, or a file therein. This matches the `HydePage::path()` and `Hyde::path()` helpers.