### PR TITLE
Create vendor:publish command

### DIFF
--- a/packages/framework/src/Console/Commands/PublishHomepageCommand.php
+++ b/packages/framework/src/Console/Commands/PublishHomepageCommand.php
@@ -16,7 +16,6 @@ use LaravelZero\Framework\Commands\Command;
  * Publish one of the default homepages.
  *
  * @deprecated May be replaced by vendor:publish in the future.
- *
  * @see \Hyde\Framework\Testing\Feature\Commands\PublishHomepageCommandTest
  */
 class PublishHomepageCommand extends Command

--- a/packages/framework/src/Console/Commands/PublishHomepageCommand.php
+++ b/packages/framework/src/Console/Commands/PublishHomepageCommand.php
@@ -15,6 +15,8 @@ use LaravelZero\Framework\Commands\Command;
 /**
  * Publish one of the default homepages.
  *
+ * @deprecated May be replaced by vendor:publish in the future.
+ *
  * @see \Hyde\Framework\Testing\Feature\Commands\PublishHomepageCommandTest
  */
 class PublishHomepageCommand extends Command

--- a/packages/framework/src/Console/Commands/PublishViewsCommand.php
+++ b/packages/framework/src/Console/Commands/PublishViewsCommand.php
@@ -10,6 +10,8 @@ use LaravelZero\Framework\Commands\Command;
 
 /**
  * Publish the Hyde Blade views.
+ *
+ * @deprecated May be replaced by vendor:publish in the future.
  */
 class PublishViewsCommand extends Command
 {

--- a/packages/framework/src/Console/Commands/UpdateConfigsCommand.php
+++ b/packages/framework/src/Console/Commands/UpdateConfigsCommand.php
@@ -11,6 +11,8 @@ use LaravelZero\Framework\Commands\Command;
 /**
  * Publish the Hyde Config Files.
  *
+ * @deprecated May be replaced by vendor:publish in the future.
+ *
  * @see \Hyde\Framework\Testing\Feature\Commands\UpdateConfigsCommandTest
  */
 class UpdateConfigsCommand extends Command

--- a/packages/framework/src/Console/Commands/UpdateConfigsCommand.php
+++ b/packages/framework/src/Console/Commands/UpdateConfigsCommand.php
@@ -12,7 +12,6 @@ use LaravelZero\Framework\Commands\Command;
  * Publish the Hyde Config Files.
  *
  * @deprecated May be replaced by vendor:publish in the future.
- *
  * @see \Hyde\Framework\Testing\Feature\Commands\UpdateConfigsCommandTest
  */
 class UpdateConfigsCommand extends Command

--- a/packages/framework/src/Console/Commands/VendorPublishCommand.php
+++ b/packages/framework/src/Console/Commands/VendorPublishCommand.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Hyde\Console\Commands;
+
+use Illuminate\Foundation\Console\VendorPublishCommand as BaseCommand;
+
+class VendorPublishCommand extends BaseCommand
+{
+    //
+}

--- a/packages/framework/src/Console/HydeConsoleServiceProvider.php
+++ b/packages/framework/src/Console/HydeConsoleServiceProvider.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Hyde\Console;
 
+use Illuminate\Foundation\Console\VendorPublishCommand;
 use Illuminate\Support\ServiceProvider;
 
 /**
@@ -38,5 +39,7 @@ class HydeConsoleServiceProvider extends ServiceProvider
 
             Commands\ChangeSourceDirectoryCommand::class,
         ]);
+        
+        $this->commands(VendorPublishCommand::class);
     }
 }

--- a/packages/framework/src/Console/HydeConsoleServiceProvider.php
+++ b/packages/framework/src/Console/HydeConsoleServiceProvider.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Hyde\Console;
 
-use Illuminate\Foundation\Console\VendorPublishCommand;
 use Illuminate\Support\ServiceProvider;
 
 /**
@@ -27,6 +26,7 @@ class HydeConsoleServiceProvider extends ServiceProvider
             Commands\MakePageCommand::class,
             Commands\MakePostCommand::class,
 
+            Commands\VendorPublishCommand::class,
             Commands\PublishHomepageCommand::class,
             Commands\PublishViewsCommand::class,
             Commands\UpdateConfigsCommand::class,
@@ -39,7 +39,5 @@ class HydeConsoleServiceProvider extends ServiceProvider
 
             Commands\ChangeSourceDirectoryCommand::class,
         ]);
-        
-        $this->commands(VendorPublishCommand::class);
     }
 }


### PR DESCRIPTION
Creates a superset implementation of the Illuminate `vendor:publish` command, but edited to stylistically match our commands.

This single command could then replace the following classes:
- PublishHomepageCommand.php
- PublishViewsCommand.php
- UpdateConfigsCommand.php

This also makes it easier to support third party packages, and to provide a more consistent developer experience with Laravel.