### PR TITLE
Internal: Update GitHub action to exit more or less gracefully with skipped status instead of fail

### DIFF
--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -7,8 +7,11 @@ on:
 jobs:
 
   psalm:
-    name: Psalm Static Analysis
+    name: Run Analysis
     runs-on: ubuntu-latest
+    continue-on-error: true
+    outputs:
+      exit-code: ${{ steps.analysis.outputs.EXIT_CODE }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v2
@@ -17,4 +20,20 @@ jobs:
         run: composer install --no-ansi --no-interaction --no-scripts --no-progress --prefer-dist
 
       - name: Run Psalm
-        run: vendor/bin/psalm
+        id: analysis
+        run: |
+          vendor/bin/psalm
+          echo EXIT_CODE=$? >> $GITHUB_OUTPUT
+          exit 0;
+
+
+  # Since GitHub Actions for some reason doesn't support exiting with warnings, we work around this by
+  # adding a second job. If the first job fails, this one won't run, thus resulting with a skipped status.
+  report-psalm:
+    name: Psalm Static Analysis
+    runs-on: ubuntu-latest
+    needs: psalm
+    if: needs.psalm.outputs.exit-code == 0
+    steps:
+      - name: Report analysis passed
+        run: exit 0;


### PR DESCRIPTION
Since GitHub Actions for some reason doesn't support exiting with warnings, we work around this by adding a second job. If the first job fails, this one won't run, thus resulting with a skipped status which we can interpret as a "warning".