### PR TITLE
Publishable code cleanup

### DIFF
--- a/packages/framework/src/Console/Commands/PublishHomepageCommand.php
+++ b/packages/framework/src/Console/Commands/PublishHomepageCommand.php
@@ -18,7 +18,6 @@ use function strstr;
 /**
  * Publish one of the default homepages.
  *
- * @deprecated May be replaced by vendor:publish in the future.
  * @see \Hyde\Framework\Testing\Feature\Commands\PublishHomepageCommandTest
  */
 class PublishHomepageCommand extends Command

--- a/packages/framework/src/Console/Commands/PublishHomepageCommand.php
+++ b/packages/framework/src/Console/Commands/PublishHomepageCommand.php
@@ -18,8 +18,6 @@ use function strstr;
 /**
  * Publish one of the default homepages.
  *
- * @todo Refactor to use vendor:publish and to use code similar to {@see \Hyde\Console\Commands\PublishViewsCommand}
- *
  * @deprecated May be replaced by vendor:publish in the future.
  * @see \Hyde\Framework\Testing\Feature\Commands\PublishHomepageCommandTest
  */

--- a/packages/framework/src/Console/Commands/UpdateConfigsCommand.php
+++ b/packages/framework/src/Console/Commands/UpdateConfigsCommand.php
@@ -23,7 +23,7 @@ class UpdateConfigsCommand extends Command
 
     /** @var bool */
     protected $hidden = true;
-    
+
     public function handle(): int
     {
         Artisan::call('vendor:publish', [

--- a/packages/framework/src/Console/Commands/UpdateConfigsCommand.php
+++ b/packages/framework/src/Console/Commands/UpdateConfigsCommand.php
@@ -21,6 +21,9 @@ class UpdateConfigsCommand extends Command
     /** @var string */
     protected $description = 'Publish the default configuration files';
 
+    /** @var bool */
+    protected $hidden = true;
+    
     public function handle(): int
     {
         Artisan::call('vendor:publish', [

--- a/packages/framework/src/Console/Commands/UpdateConfigsCommand.php
+++ b/packages/framework/src/Console/Commands/UpdateConfigsCommand.php
@@ -11,7 +11,6 @@ use Illuminate\Support\Facades\Artisan;
 /**
  * Publish the Hyde Config Files.
  *
- * @deprecated May be replaced by vendor:publish in the future.
  * @see \Hyde\Framework\Testing\Feature\Commands\UpdateConfigsCommandTest
  */
 class UpdateConfigsCommand extends Command


### PR DESCRIPTION
Cleans up some code related to the publishing commands
- Make the update:config command hidden
- Revert UpdateConfigsCommand deprecation
- Revert PublishHomepageCommand deprecation
- Remove resolved todo