### PR TITLE
Add `Hyperlinks::mediaLink()` method

### DIFF
--- a/packages/framework/src/Foundation/Concerns/ForwardsHyperlinks.php
+++ b/packages/framework/src/Foundation/Concerns/ForwardsHyperlinks.php
@@ -21,6 +21,11 @@ trait ForwardsHyperlinks
         return $this->hyperlinks->relativeLink($destination);
     }
 
+    public function mediaLink(string $destination): string
+    {
+        return $this->hyperlinks->mediaLink($destination);
+    }
+
     public function image(string $name, bool $preferQualifiedUrl = false): string
     {
         return $this->hyperlinks->image($name, $preferQualifiedUrl);

--- a/packages/framework/src/Foundation/Hyperlinks.php
+++ b/packages/framework/src/Foundation/Hyperlinks.php
@@ -73,9 +73,9 @@ class Hyperlinks
     /**
      * Gets a relative web link to the given file stored in the _site/media folder.
      */
-    public function mediaLink(string $file): string
+    public function mediaLink(string $destination): string
     {
-        return $this->relativeLink("media/$file");
+        return $this->relativeLink("media/$destination");
     }
 
     /**

--- a/packages/framework/src/Foundation/Hyperlinks.php
+++ b/packages/framework/src/Foundation/Hyperlinks.php
@@ -71,6 +71,14 @@ class Hyperlinks
     }
 
     /**
+     * Gets a relative web link to the given file stored in the _site/media folder.
+     */
+    public function mediaLink(string $file): string
+    {
+        return $this->relativeLink("media/$file");
+    }
+
+    /**
      * Gets a relative web link to the given image stored in the _site/media folder.
      * If the image is remote (starts with http) it will be returned as is.
      *

--- a/packages/framework/src/Foundation/Hyperlinks.php
+++ b/packages/framework/src/Foundation/Hyperlinks.php
@@ -72,6 +72,8 @@ class Hyperlinks
 
     /**
      * Gets a relative web link to the given file stored in the _site/media folder.
+     *
+     * @todo Add default option that throws if file is not present in _site/media (or just) _media?
      */
     public function mediaLink(string $destination): string
     {

--- a/packages/framework/src/Hyde.php
+++ b/packages/framework/src/Hyde.php
@@ -36,6 +36,7 @@ use Illuminate\Support\HtmlString;
  * @method static string sitePath(string $path = '')
  * @method static string formatLink(string $destination)
  * @method static string relativeLink(string $destination)
+ * @method static string mediaLink(string $destination)
  * @method static string image(string $name, bool $preferQualifiedUrl = false)
  * @method static string url(string $path = '')
  * @method static string makeTitle(string $value)

--- a/packages/framework/tests/Feature/Foundation/HyperlinksTest.php
+++ b/packages/framework/tests/Feature/Foundation/HyperlinksTest.php
@@ -66,4 +66,15 @@ class HyperlinksTest extends TestCase
     {
         $this->assertEquals('http://localhost/media/test.jpg', $this->class->image('http://localhost/media/test.jpg', true));
     }
+
+    public function test_media_link_helper()
+    {
+        $this->assertSame('media/foo', $this->class->mediaLink('foo'));
+    }
+
+    public function test_media_link_helper_with_relative_path()
+    {
+        $this->mockCurrentPage('foo/bar');
+        $this->assertSame('../media/foo', $this->class->mediaLink('foo'));
+    }
 }

--- a/packages/framework/tests/Feature/HydeKernelTest.php
+++ b/packages/framework/tests/Feature/HydeKernelTest.php
@@ -154,6 +154,15 @@ class HydeKernelTest extends TestCase
         $this->assertSame('../foo', Hyde::relativeLink('foo'));
     }
 
+    public function test_media_link_helper_returns_relative_link_to_destination()
+    {
+        Render::share('currentPage', 'bar');
+        $this->assertSame('media/foo', Hyde::mediaLink('foo'));
+
+        Render::share('currentPage', 'foo/bar');
+        $this->assertSame('../media/foo', Hyde::mediaLink('foo'));
+    }
+
     public function test_image_helper_returns_image_path_for_given_name()
     {
         Render::share('currentPage', 'foo');


### PR DESCRIPTION
Convenience method that's a Mix between `Hyde::relativeLink()` and `Hyde::image()`.

It's accessible as `Hyde::mediaLink()` and can be used in Blade views to get a resolved relative link to a file in the media directory.