### PR TITLE
Refactor internal data store of LocalFeaturedImage $source property to not include directory information

### DIFF
--- a/packages/framework/src/Framework/Features/Blogging/Models/FeaturedImage.php
+++ b/packages/framework/src/Framework/Features/Blogging/Models/FeaturedImage.php
@@ -46,6 +46,7 @@ abstract class FeaturedImage implements Stringable
      */
     abstract public function getSource(): string;
 
+    /** Called from constructor to allow child classes to validate and transform the value as needed before assignment. */
     protected function setSource(string $source): string
     {
         return $source;

--- a/packages/framework/src/Framework/Features/Blogging/Models/LocalFeaturedImage.php
+++ b/packages/framework/src/Framework/Features/Blogging/Models/LocalFeaturedImage.php
@@ -55,7 +55,7 @@ class LocalFeaturedImage extends FeaturedImage
     protected function validatedStoragePath(): string
     {
         if (! file_exists($this->storagePath())) {
-            throw new FileNotFoundException(sprintf("Image at _media/%s does not exist", $this->source));
+            throw new FileNotFoundException(sprintf("Image at %s does not exist", Hyde::pathToRelative($this->storagePath())));
         }
 
         return $this->storagePath();

--- a/packages/framework/src/Framework/Features/Blogging/Models/LocalFeaturedImage.php
+++ b/packages/framework/src/Framework/Features/Blogging/Models/LocalFeaturedImage.php
@@ -26,10 +26,6 @@ class LocalFeaturedImage extends FeaturedImage
             $source = substr($source, 7);
         }
 
-        if (str_starts_with($source, '_site/media/')) {
-            $source = substr($source, 12);
-        }
-
         // We could also validate the file exists here if we want. We might also want to just send a warning.
 
         return $source;

--- a/packages/framework/src/Framework/Features/Blogging/Models/LocalFeaturedImage.php
+++ b/packages/framework/src/Framework/Features/Blogging/Models/LocalFeaturedImage.php
@@ -39,7 +39,7 @@ class LocalFeaturedImage extends FeaturedImage
     public function getSource(): string
     {
         // Return value is relative to the site's root.
-        return Hyde::relativeLink(substr($this->source, 1));
+        return Hyde::relativeLink($this->source);
     }
 
     public function getContentLength(): int

--- a/packages/framework/src/Framework/Features/Blogging/Models/LocalFeaturedImage.php
+++ b/packages/framework/src/Framework/Features/Blogging/Models/LocalFeaturedImage.php
@@ -23,8 +23,8 @@ class LocalFeaturedImage extends FeaturedImage
 {
     protected function setSource(string $source): string
     {
-        if (! str_starts_with($source, '_media/')) {
-            //
+        if (str_starts_with($source, '_media/')) {
+            $source = substr($source, 7);
         }
 
         // We could also validate the file exists here if we want. We might also want to just send a warning.

--- a/packages/framework/src/Framework/Features/Blogging/Models/LocalFeaturedImage.php
+++ b/packages/framework/src/Framework/Features/Blogging/Models/LocalFeaturedImage.php
@@ -55,7 +55,7 @@ class LocalFeaturedImage extends FeaturedImage
     protected function validatedStoragePath(): string
     {
         if (! file_exists($this->storagePath())) {
-            throw new FileNotFoundException("Image at $this->source does not exist");
+            throw new FileNotFoundException("Image at _media/$this->source does not exist");
         }
 
         return $this->storagePath();

--- a/packages/framework/src/Framework/Features/Blogging/Models/LocalFeaturedImage.php
+++ b/packages/framework/src/Framework/Features/Blogging/Models/LocalFeaturedImage.php
@@ -38,7 +38,7 @@ class LocalFeaturedImage extends FeaturedImage
 
     public function getSource(): string
     {
-        // Return value must be relative to the site's root.
+        // Return value is relative to the site's root.
         return Hyde::relativeLink(substr($this->source, 1));
     }
 

--- a/packages/framework/src/Framework/Features/Blogging/Models/LocalFeaturedImage.php
+++ b/packages/framework/src/Framework/Features/Blogging/Models/LocalFeaturedImage.php
@@ -24,8 +24,7 @@ class LocalFeaturedImage extends FeaturedImage
     protected function setSource(string $source): string
     {
         if (! str_starts_with($source, '_media/')) {
-            // Throwing an exception here ensures we have a super predictable state.
-            throw new InvalidArgumentException('LocalFeaturedImage source must start with _media/');
+            //
         }
 
         // We could also validate the file exists here if we want. We might also want to just send a warning.

--- a/packages/framework/src/Framework/Features/Blogging/Models/LocalFeaturedImage.php
+++ b/packages/framework/src/Framework/Features/Blogging/Models/LocalFeaturedImage.php
@@ -49,7 +49,7 @@ class LocalFeaturedImage extends FeaturedImage
 
     protected function storagePath(): string
     {
-        return Hyde::path($this->source);
+        return Hyde::path("_media/$this->source");
     }
 
     protected function validatedStoragePath(): string

--- a/packages/framework/src/Framework/Features/Blogging/Models/LocalFeaturedImage.php
+++ b/packages/framework/src/Framework/Features/Blogging/Models/LocalFeaturedImage.php
@@ -16,6 +16,8 @@ use function substr;
  * The internal data structure forces the image source to reference a file in the _media directory,
  * and thus that is what is required for the input. However, when outputting data, the data will
  * be used for the _site/media directory, so it will provide data relative to the site root.
+ *
+ * The source information is stored in $this->source, which is a file in the _media directory.
  */
 class LocalFeaturedImage extends FeaturedImage
 {

--- a/packages/framework/src/Framework/Features/Blogging/Models/LocalFeaturedImage.php
+++ b/packages/framework/src/Framework/Features/Blogging/Models/LocalFeaturedImage.php
@@ -55,7 +55,7 @@ class LocalFeaturedImage extends FeaturedImage
     protected function validatedStoragePath(): string
     {
         if (! file_exists($this->storagePath())) {
-            throw new FileNotFoundException("Image at _media/$this->source does not exist");
+            throw new FileNotFoundException(sprintf("Image at _media/%s does not exist", $this->source));
         }
 
         return $this->storagePath();

--- a/packages/framework/src/Framework/Features/Blogging/Models/LocalFeaturedImage.php
+++ b/packages/framework/src/Framework/Features/Blogging/Models/LocalFeaturedImage.php
@@ -44,7 +44,7 @@ class LocalFeaturedImage extends FeaturedImage
 
     public function getContentLength(): int
     {
-        return filesize($this->storageValidatedPath());
+        return filesize($this->validatedStoragePath());
     }
 
     protected function storagePath(): string
@@ -52,7 +52,7 @@ class LocalFeaturedImage extends FeaturedImage
         return Hyde::path($this->source);
     }
 
-    protected function storageValidatedPath(): string
+    protected function validatedStoragePath(): string
     {
         if (! file_exists($this->storagePath())) {
             throw new FileNotFoundException("Image at $this->source does not exist");

--- a/packages/framework/src/Framework/Features/Blogging/Models/LocalFeaturedImage.php
+++ b/packages/framework/src/Framework/Features/Blogging/Models/LocalFeaturedImage.php
@@ -27,6 +27,10 @@ class LocalFeaturedImage extends FeaturedImage
             $source = substr($source, 7);
         }
 
+        if (str_starts_with($source, '_site/media/')) {
+            $source = substr($source, 12);
+        }
+
         // We could also validate the file exists here if we want. We might also want to just send a warning.
 
         return $source;

--- a/packages/framework/src/Framework/Features/Blogging/Models/LocalFeaturedImage.php
+++ b/packages/framework/src/Framework/Features/Blogging/Models/LocalFeaturedImage.php
@@ -6,7 +6,6 @@ namespace Hyde\Framework\Features\Blogging\Models;
 
 use Hyde\Framework\Exceptions\FileNotFoundException;
 use Hyde\Hyde;
-use InvalidArgumentException;
 use function str_starts_with;
 use function substr;
 
@@ -55,7 +54,7 @@ class LocalFeaturedImage extends FeaturedImage
     protected function validatedStoragePath(): string
     {
         if (! file_exists($this->storagePath())) {
-            throw new FileNotFoundException(sprintf("Image at %s does not exist", Hyde::pathToRelative($this->storagePath())));
+            throw new FileNotFoundException(sprintf('Image at %s does not exist', Hyde::pathToRelative($this->storagePath())));
         }
 
         return $this->storagePath();

--- a/packages/framework/src/Framework/Features/Blogging/Models/LocalFeaturedImage.php
+++ b/packages/framework/src/Framework/Features/Blogging/Models/LocalFeaturedImage.php
@@ -39,7 +39,7 @@ class LocalFeaturedImage extends FeaturedImage
     public function getSource(): string
     {
         // Return value is relative to the site's root.
-        return Hyde::relativeLink($this->source);
+        return Hyde::relativeLink("media/$this->source");
     }
 
     public function getContentLength(): int

--- a/packages/framework/tests/Feature/FeaturedImageTest.php
+++ b/packages/framework/tests/Feature/FeaturedImageTest.php
@@ -12,7 +12,6 @@ use Hyde\Framework\Features\Blogging\Models\RemoteFeaturedImage;
 use Hyde\Markdown\Models\FrontMatter;
 use Hyde\Testing\TestCase;
 use Illuminate\Support\Facades\Http;
-use InvalidArgumentException;
 
 /**
  * @covers \Hyde\Framework\Features\Blogging\Models\FeaturedImage

--- a/packages/framework/tests/Feature/FeaturedImageTest.php
+++ b/packages/framework/tests/Feature/FeaturedImageTest.php
@@ -135,14 +135,6 @@ class FeaturedImageTest extends TestCase
         $this->assertEquals('media/foo', $image->getSource());
     }
 
-    public function testCannotConstructLocalFeaturedImageWithInvalidSource()
-    {
-        $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('LocalFeaturedImage source must start with _media/');
-
-        new LocalFeaturedImage('foo', ...$this->defaultArguments());
-    }
-
     public function testFeaturedImageGetContentLength()
     {
         $this->file('_media/foo', 'image');


### PR DESCRIPTION
Prior to this refactor, the `$source` property of `LocalFeaturedImage` classes was forced to start with `_media/`, and threw an exception if it did not. The value was then normalized to the desired format upon accessing the value.

This PR changes so that the internal data value no longer contain the path information, as it is instead prepended when accessing the value. To keep the internal state consistent, any leading `_media/` prefixes are removed. Thus this change is entirely unbreaking as no usage outside the class is affected since the public accessors still function the same.

This change is important from an internal perspective however, as is more compatible with [customizable media directories #920](https://github.com/hydephp/develop/pull/920)