### PR TITLE
Refactor LocalFeaturedImage getSource method to no longer return relative hyperlink

### DIFF
--- a/packages/framework/src/Framework/Features/Blogging/Models/LocalFeaturedImage.php
+++ b/packages/framework/src/Framework/Features/Blogging/Models/LocalFeaturedImage.php
@@ -34,7 +34,7 @@ class LocalFeaturedImage extends FeaturedImage
     public function getSource(): string
     {
         // Return value is relative to the site's root.
-        return Hyde::relativeLink("media/$this->source");
+        return "media/$this->source";
     }
 
     public function getContentLength(): int

--- a/packages/framework/src/Framework/Features/Blogging/Models/LocalFeaturedImage.php
+++ b/packages/framework/src/Framework/Features/Blogging/Models/LocalFeaturedImage.php
@@ -39,18 +39,18 @@ class LocalFeaturedImage extends FeaturedImage
 
     public function getContentLength(): int
     {
-        return filesize($this->validatedStoragePath());
+        return filesize(Hyde::path($this->validatedStoragePath()));
     }
 
     protected function storagePath(): string
     {
-        return Hyde::path("_media/$this->source");
+        return "_media/$this->source";
     }
 
     protected function validatedStoragePath(): string
     {
         if (! file_exists($this->storagePath())) {
-            throw new FileNotFoundException(sprintf('Image at %s does not exist', Hyde::pathToRelative($this->storagePath())));
+            throw new FileNotFoundException(sprintf('Image at %s does not exist', $this->storagePath()));
         }
 
         return $this->storagePath();


### PR DESCRIPTION
Such a dynamic state is better handled when using the value as it makes it more clear where the "magic" happens.

It also makes the code conform a bit more to the existing code comment.

In some cases this change means that you now must use `Hyde::relativeLink($image->source)` instead of just `$image->source`