### PR TITLE
Refactor the RebuildStaticSiteCommand class

### DIFF
--- a/packages/framework/src/Console/Commands/RebuildStaticPageCommand.php
+++ b/packages/framework/src/Console/Commands/RebuildStaticPageCommand.php
@@ -26,8 +26,7 @@ use function unslash;
 class RebuildStaticPageCommand extends Command
 {
     /** @var string */
-    protected $signature = 'rebuild
-        {path : The relative file path (example: _posts/hello-world.md)}';
+    protected $signature = 'rebuild {path : The relative file path (example: _posts/hello-world.md)}';
 
     /** @var string */
     protected $description = 'Run the static site builder for a single file';

--- a/packages/framework/src/Console/Commands/RebuildStaticPageCommand.php
+++ b/packages/framework/src/Console/Commands/RebuildStaticPageCommand.php
@@ -22,9 +22,6 @@ use function unslash;
  * Hyde Command to build a single static site file.
  *
  * @see \Hyde\Framework\Testing\Feature\Commands\RebuildStaticSiteCommandTest
- *
- * @todo Refactor to use newer helpers
- * @todo Rename to RebuildStaticPageCommand since it only rebuilds a single page?
  */
 class RebuildStaticPageCommand extends Command
 {

--- a/packages/framework/src/Console/Commands/RebuildStaticPageCommand.php
+++ b/packages/framework/src/Console/Commands/RebuildStaticPageCommand.php
@@ -26,7 +26,7 @@ use function unslash;
  * @todo Refactor to use newer helpers
  * @todo Rename to RebuildStaticPageCommand since it only rebuilds a single page?
  */
-class RebuildStaticSiteCommand extends Command
+class RebuildStaticPageCommand extends Command
 {
     /** @var string */
     protected $signature = 'rebuild

--- a/packages/framework/src/Console/Commands/RebuildStaticSiteCommand.php
+++ b/packages/framework/src/Console/Commands/RebuildStaticSiteCommand.php
@@ -40,9 +40,7 @@ class RebuildStaticSiteCommand extends Command
             return Command::SUCCESS;
         }
 
-        $path = $this->normalizePathString($this->argument('path'));
-
-        return $this->makeBuildTask($this->output, $path)->handle() ?? Command::SUCCESS;
+        return $this->makeBuildTask($this->output, $this->normalizePathString($this->argument('path')))->handle() ?? Command::SUCCESS;
     }
 
     protected function normalizePathString(string $path): string

--- a/packages/framework/src/Console/Commands/RebuildStaticSiteCommand.php
+++ b/packages/framework/src/Console/Commands/RebuildStaticSiteCommand.php
@@ -17,6 +17,7 @@ use Hyde\Hyde;
  * @see \Hyde\Framework\Testing\Feature\Commands\RebuildStaticSiteCommandTest
  *
  * @todo Refactor to use newer helpers
+ * @todo Rename to RebuildStaticPageCommand since it only rebuilds a single page?
  */
 class RebuildStaticSiteCommand extends Command
 {

--- a/packages/framework/src/Console/Commands/RebuildStaticSiteCommand.php
+++ b/packages/framework/src/Console/Commands/RebuildStaticSiteCommand.php
@@ -37,8 +37,6 @@ class RebuildStaticSiteCommand extends Command
 
     public function handle(): int
     {
-        $this->startClock();
-
         if ($this->argument('path') === Hyde::getMediaDirectory()) {
             (new BuildService($this->getOutput()))->transferMediaAssets();
 

--- a/packages/framework/src/Console/Commands/RebuildStaticSiteCommand.php
+++ b/packages/framework/src/Console/Commands/RebuildStaticSiteCommand.php
@@ -45,15 +45,15 @@ class RebuildStaticSiteCommand extends Command
             return Command::SUCCESS;
         }
 
-        $this->path = $this->sanitizePathString($this->argument('path'));
+        $this->path = $this->normalizePathString($this->argument('path'));
 
         return $this->makeBuildTask($this->output, $this->path)->handle() ?? Command::SUCCESS;
     }
 
     /**
-     * Perform a basic sanitation to strip trailing characters.
+     * Perform a basic normalization to strip trailing characters.
      */
-    public function sanitizePathString(string $path): string
+    public function normalizePathString(string $path): string
     {
         return str_replace('\\', '/', trim($path, '.\\/'));
     }

--- a/packages/framework/src/Console/Commands/RebuildStaticSiteCommand.php
+++ b/packages/framework/src/Console/Commands/RebuildStaticSiteCommand.php
@@ -36,7 +36,7 @@ class RebuildStaticSiteCommand extends Command
     /**
      * The source path.
      */
-    public string $path;
+    protected string $path;
 
     public function handle(): int
     {

--- a/packages/framework/src/Console/Commands/RebuildStaticSiteCommand.php
+++ b/packages/framework/src/Console/Commands/RebuildStaticSiteCommand.php
@@ -57,12 +57,8 @@ class RebuildStaticSiteCommand extends Command
         (new RebuildService($this->path))->execute();
 
         $this->infoComment(sprintf(
-            'Created [%s] in [%s] seconds. (%s)',
+            'Created [%s] in %s.',
             static::createClickableFilepath(PageCollection::getPage($this->path)->getOutputPath()),
-            number_format(
-                $this->getExecutionTimeInMs() / 1000,
-                2
-            ),
             $this->getExecutionTimeString()
         ));
 

--- a/packages/framework/src/Console/Commands/RebuildStaticSiteCommand.php
+++ b/packages/framework/src/Console/Commands/RebuildStaticSiteCommand.php
@@ -38,7 +38,7 @@ class RebuildStaticSiteCommand extends Command
 
     public function handle(): int
     {
-        $time_start = microtime(true);
+        $this->startClock();
 
         if ($this->argument('path') === Hyde::getMediaDirectory()) {
             (new BuildService($this->getOutput()))->transferMediaAssets();
@@ -56,17 +56,14 @@ class RebuildStaticSiteCommand extends Command
 
         (new RebuildService($this->path))->execute();
 
-        $time_end = microtime(true);
-        $execution_time = ($time_end - $time_start);
-
         $this->info(sprintf(
-            'Created %s in %s seconds. (%sms)',
+            'Created %s in %s seconds. (%s)',
             static::createClickableFilepath(PageCollection::getPage($this->path)->getOutputPath()),
             number_format(
-                $execution_time,
+                $this->getExecutionTimeInMs() / 1000,
                 2
             ),
-            number_format(($execution_time * 1000), 2)
+            $this->getExecutionTimeString()
         ));
 
         return Command::SUCCESS;

--- a/packages/framework/src/Console/Commands/RebuildStaticSiteCommand.php
+++ b/packages/framework/src/Console/Commands/RebuildStaticSiteCommand.php
@@ -12,7 +12,6 @@ use Hyde\Framework\Services\BuildService;
 use Hyde\Framework\Services\RebuildService;
 use Hyde\Hyde;
 use Illuminate\Console\OutputStyle;
-
 use function dirname;
 use function file_exists;
 use function in_array;

--- a/packages/framework/src/Console/Commands/RebuildStaticSiteCommand.php
+++ b/packages/framework/src/Console/Commands/RebuildStaticSiteCommand.php
@@ -13,7 +13,9 @@ use Hyde\Framework\Services\RebuildService;
 use Hyde\Hyde;
 use Illuminate\Console\OutputStyle;
 
+use function dirname;
 use function file_exists;
+use function in_array;
 use function str_replace;
 use function unslash;
 
@@ -82,12 +84,17 @@ class RebuildStaticSiteCommand extends Command
 
             protected function validate(): void
             {
-                if (! (
-                    str_starts_with($this->path, Hyde::pathToRelative(Hyde::getBladePagePath())) ||
-                    str_starts_with($this->path, Hyde::pathToRelative(Hyde::getMarkdownPagePath())) ||
-                    str_starts_with($this->path, Hyde::pathToRelative(Hyde::getMarkdownPostPath())) ||
-                    str_starts_with($this->path, Hyde::pathToRelative(Hyde::getDocumentationPagePath()))
-                )) {
+                $directory = Hyde::pathToRelative(dirname($this->path));
+
+                $directories = [
+                    Hyde::pathToRelative(Hyde::getBladePagePath()),
+                    Hyde::pathToRelative(Hyde::getBladePagePath()),
+                    Hyde::pathToRelative(Hyde::getMarkdownPagePath()),
+                    Hyde::pathToRelative(Hyde::getMarkdownPostPath()),
+                    Hyde::pathToRelative(Hyde::getDocumentationPagePath()),
+                ];
+
+                if (! in_array($directory, $directories)) {
                     throw new Exception("Path [$this->path] is not in a valid source directory.", 400);
                 }
 

--- a/packages/framework/src/Console/Commands/RebuildStaticSiteCommand.php
+++ b/packages/framework/src/Console/Commands/RebuildStaticSiteCommand.php
@@ -50,9 +50,6 @@ class RebuildStaticSiteCommand extends Command
         return $this->makeBuildTask($this->output, $this->path)->handle() ?? Command::SUCCESS;
     }
 
-    /**
-     * Perform a basic normalization to strip trailing characters.
-     */
     protected function normalizePathString(string $path): string
     {
         return str_replace('\\', '/', trim($path, '.\\/'));

--- a/packages/framework/src/Console/Commands/RebuildStaticSiteCommand.php
+++ b/packages/framework/src/Console/Commands/RebuildStaticSiteCommand.php
@@ -41,13 +41,13 @@ class RebuildStaticSiteCommand extends Command
         }
 
         return $this->makeBuildTask($this->output,
-            $this->normalizePathString($this->argument('path'))
+            $this->getNormalizePathString()
         )->handle() ?? Command::SUCCESS;
     }
 
-    protected function normalizePathString(string $path): string
+    protected function getNormalizePathString(): string
     {
-        return str_replace('\\', '/', trim($path, '.\\/'));
+        return str_replace('\\', '/', trim($this->argument('path'), '.\\/'));
     }
 
     protected function makeBuildTask(OutputStyle $output, string $path): BuildTask

--- a/packages/framework/src/Console/Commands/RebuildStaticSiteCommand.php
+++ b/packages/framework/src/Console/Commands/RebuildStaticSiteCommand.php
@@ -45,7 +45,7 @@ class RebuildStaticSiteCommand extends Command
 
     protected function getNormalizedPathString(): string
     {
-        return str_replace('\\', '/', trim($this->argument('path'), '.\\/'));
+        return str_replace('\\', '/', trim($this->argument('path'), '\\/'));
     }
 
     protected function makeBuildTask(OutputStyle $output, string $path): BuildTask

--- a/packages/framework/src/Console/Commands/RebuildStaticSiteCommand.php
+++ b/packages/framework/src/Console/Commands/RebuildStaticSiteCommand.php
@@ -53,7 +53,7 @@ class RebuildStaticSiteCommand extends Command
     /**
      * Perform a basic normalization to strip trailing characters.
      */
-    public function normalizePathString(string $path): string
+    protected function normalizePathString(string $path): string
     {
         return str_replace('\\', '/', trim($path, '.\\/'));
     }

--- a/packages/framework/src/Console/Commands/RebuildStaticSiteCommand.php
+++ b/packages/framework/src/Console/Commands/RebuildStaticSiteCommand.php
@@ -57,13 +57,13 @@ class RebuildStaticSiteCommand extends Command
         (new RebuildService($this->path))->execute();
 
         $this->infoComment(sprintf(
-            'Created [%s] in [%s] seconds. ',
+            'Created [%s] in [%s] seconds. (%s)',
             static::createClickableFilepath(PageCollection::getPage($this->path)->getOutputPath()),
             number_format(
                 $this->getExecutionTimeInMs() / 1000,
                 2
-            ))
-            . $this->inlineGray("({$this->getExecutionTimeString()})"
+            ),
+            $this->getExecutionTimeString()
         ));
 
         return Command::SUCCESS;

--- a/packages/framework/src/Console/Commands/RebuildStaticSiteCommand.php
+++ b/packages/framework/src/Console/Commands/RebuildStaticSiteCommand.php
@@ -7,6 +7,7 @@ namespace Hyde\Console\Commands;
 use Exception;
 use Hyde\Console\Concerns\Command;
 use Hyde\Foundation\Facades\PageCollection;
+use Hyde\Framework\Concerns\TracksExecutionTime;
 use Hyde\Framework\Services\BuildService;
 use Hyde\Framework\Services\RebuildService;
 use Hyde\Hyde;
@@ -21,6 +22,8 @@ use Hyde\Hyde;
  */
 class RebuildStaticSiteCommand extends Command
 {
+    use TracksExecutionTime;
+
     /** @var string */
     protected $signature = 'rebuild
         {path : The relative file path (example: _posts/hello-world.md)}';

--- a/packages/framework/src/Console/Commands/RebuildStaticSiteCommand.php
+++ b/packages/framework/src/Console/Commands/RebuildStaticSiteCommand.php
@@ -13,6 +13,10 @@ use Hyde\Framework\Services\RebuildService;
 use Hyde\Hyde;
 use Illuminate\Console\OutputStyle;
 
+use function file_exists;
+use function str_replace;
+use function unslash;
+
 /**
  * Hyde Command to build a single static site file.
  *

--- a/packages/framework/src/Console/Commands/RebuildStaticSiteCommand.php
+++ b/packages/framework/src/Console/Commands/RebuildStaticSiteCommand.php
@@ -40,7 +40,9 @@ class RebuildStaticSiteCommand extends Command
             return Command::SUCCESS;
         }
 
-        return $this->makeBuildTask($this->output, $this->normalizePathString($this->argument('path')))->handle() ?? Command::SUCCESS;
+        return $this->makeBuildTask($this->output,
+            $this->normalizePathString($this->argument('path'))
+        )->handle() ?? Command::SUCCESS;
     }
 
     protected function normalizePathString(string $path): string

--- a/packages/framework/src/Console/Commands/RebuildStaticSiteCommand.php
+++ b/packages/framework/src/Console/Commands/RebuildStaticSiteCommand.php
@@ -30,11 +30,6 @@ class RebuildStaticSiteCommand extends Command
     /** @var string */
     protected $description = 'Run the static site builder for a single file';
 
-    /**
-     * The source path.
-     */
-    protected string $path;
-
     public function handle(): int
     {
         if ($this->argument('path') === Hyde::getMediaDirectory()) {
@@ -45,9 +40,9 @@ class RebuildStaticSiteCommand extends Command
             return Command::SUCCESS;
         }
 
-        $this->path = $this->normalizePathString($this->argument('path'));
+        $path = $this->normalizePathString($this->argument('path'));
 
-        return $this->makeBuildTask($this->output, $this->path)->handle() ?? Command::SUCCESS;
+        return $this->makeBuildTask($this->output, $path)->handle() ?? Command::SUCCESS;
     }
 
     protected function normalizePathString(string $path): string

--- a/packages/framework/src/Console/Commands/RebuildStaticSiteCommand.php
+++ b/packages/framework/src/Console/Commands/RebuildStaticSiteCommand.php
@@ -57,13 +57,13 @@ class RebuildStaticSiteCommand extends Command
         (new RebuildService($this->path))->execute();
 
         $this->infoComment(sprintf(
-            'Created [%s] in [%s] seconds. (%s)',
+            'Created [%s] in [%s] seconds. ',
             static::createClickableFilepath(PageCollection::getPage($this->path)->getOutputPath()),
             number_format(
                 $this->getExecutionTimeInMs() / 1000,
                 2
-            ),
-            $this->getExecutionTimeString()
+            ))
+            . $this->inlineGray("({$this->getExecutionTimeString()})"
         ));
 
         return Command::SUCCESS;

--- a/packages/framework/src/Console/Commands/RebuildStaticSiteCommand.php
+++ b/packages/framework/src/Console/Commands/RebuildStaticSiteCommand.php
@@ -40,6 +40,8 @@ class RebuildStaticSiteCommand extends Command
         if ($this->argument('path') === Hyde::getMediaDirectory()) {
             (new BuildService($this->getOutput()))->transferMediaAssets();
 
+            $this->info('All done!');
+
             return Command::SUCCESS;
         }
 

--- a/packages/framework/src/Console/Commands/RebuildStaticSiteCommand.php
+++ b/packages/framework/src/Console/Commands/RebuildStaticSiteCommand.php
@@ -45,7 +45,7 @@ class RebuildStaticSiteCommand extends Command
 
     protected function getNormalizedPathString(): string
     {
-        return str_replace('\\', '/', trim($this->argument('path'), '\\/'));
+        return str_replace('\\', '/', unslash($this->argument('path')));
     }
 
     protected function makeBuildTask(OutputStyle $output, string $path): BuildTask

--- a/packages/framework/src/Console/Commands/RebuildStaticSiteCommand.php
+++ b/packages/framework/src/Console/Commands/RebuildStaticSiteCommand.php
@@ -40,9 +40,7 @@ class RebuildStaticSiteCommand extends Command
             return Command::SUCCESS;
         }
 
-        return $this->makeBuildTask($this->output,
-            $this->getNormalizePathString()
-        )->handle() ?? Command::SUCCESS;
+        return $this->makeBuildTask($this->output, $this->getNormalizePathString())->handle() ?? Command::SUCCESS;
     }
 
     protected function getNormalizePathString(): string

--- a/packages/framework/src/Console/Commands/RebuildStaticSiteCommand.php
+++ b/packages/framework/src/Console/Commands/RebuildStaticSiteCommand.php
@@ -40,10 +40,10 @@ class RebuildStaticSiteCommand extends Command
             return Command::SUCCESS;
         }
 
-        return $this->makeBuildTask($this->output, $this->getNormalizePathString())->handle() ?? Command::SUCCESS;
+        return $this->makeBuildTask($this->output, $this->getNormalizedPathString())->handle() ?? Command::SUCCESS;
     }
 
-    protected function getNormalizePathString(): string
+    protected function getNormalizedPathString(): string
     {
         return str_replace('\\', '/', trim($this->argument('path'), '.\\/'));
     }

--- a/packages/framework/src/Console/Commands/RebuildStaticSiteCommand.php
+++ b/packages/framework/src/Console/Commands/RebuildStaticSiteCommand.php
@@ -7,7 +7,6 @@ namespace Hyde\Console\Commands;
 use Exception;
 use Hyde\Console\Concerns\Command;
 use Hyde\Foundation\Facades\PageCollection;
-use Hyde\Framework\Concerns\TracksExecutionTime;
 use Hyde\Framework\Features\BuildTasks\BuildTask;
 use Hyde\Framework\Services\BuildService;
 use Hyde\Framework\Services\RebuildService;
@@ -24,8 +23,6 @@ use Illuminate\Console\OutputStyle;
  */
 class RebuildStaticSiteCommand extends Command
 {
-    use TracksExecutionTime;
-
     /** @var string */
     protected $signature = 'rebuild
         {path : The relative file path (example: _posts/hello-world.md)}';

--- a/packages/framework/src/Console/Commands/RebuildStaticSiteCommand.php
+++ b/packages/framework/src/Console/Commands/RebuildStaticSiteCommand.php
@@ -56,8 +56,8 @@ class RebuildStaticSiteCommand extends Command
 
         (new RebuildService($this->path))->execute();
 
-        $this->info(sprintf(
-            'Created %s in %s seconds. (%s)',
+        $this->infoComment(sprintf(
+            'Created [%s] in [%s] seconds. (%s)',
             static::createClickableFilepath(PageCollection::getPage($this->path)->getOutputPath()),
             number_format(
                 $this->getExecutionTimeInMs() / 1000,

--- a/packages/framework/src/Console/Commands/RebuildStaticSiteCommand.php
+++ b/packages/framework/src/Console/Commands/RebuildStaticSiteCommand.php
@@ -60,6 +60,7 @@ class RebuildStaticSiteCommand extends Command
         return new class($output, $path) extends BuildTask
         {
             public static string $description = 'Rebuilding page';
+
             protected string $path;
 
             public function __construct(OutputStyle $output, string $path)

--- a/packages/framework/src/Console/HydeConsoleServiceProvider.php
+++ b/packages/framework/src/Console/HydeConsoleServiceProvider.php
@@ -21,7 +21,7 @@ class HydeConsoleServiceProvider extends ServiceProvider
             Commands\BuildSearchCommand::class,
             Commands\BuildSiteCommand::class,
             Commands\BuildSitemapCommand::class,
-            Commands\RebuildStaticSiteCommand::class,
+            Commands\RebuildStaticPageCommand::class,
 
             Commands\MakePageCommand::class,
             Commands\MakePostCommand::class,

--- a/packages/framework/tests/Feature/Commands/RebuildStaticPageCommandTest.php
+++ b/packages/framework/tests/Feature/Commands/RebuildStaticPageCommandTest.php
@@ -10,7 +10,7 @@ use Hyde\Testing\TestCase;
 /**
  * @covers \Hyde\Console\Commands\RebuildStaticPageCommand
  */
-class RebuildStaticSiteCommandTest extends TestCase
+class RebuildStaticPageCommandTest extends TestCase
 {
     public function test_handle_is_successful_with_valid_path()
     {

--- a/packages/framework/tests/Feature/Commands/RebuildStaticSiteCommandTest.php
+++ b/packages/framework/tests/Feature/Commands/RebuildStaticSiteCommandTest.php
@@ -8,7 +8,7 @@ use Hyde\Hyde;
 use Hyde\Testing\TestCase;
 
 /**
- * @covers \Hyde\Console\Commands\RebuildStaticSiteCommand
+ * @covers \Hyde\Console\Commands\RebuildStaticPageCommand
  */
 class RebuildStaticSiteCommandTest extends TestCase
 {

--- a/packages/framework/tests/Feature/Commands/RebuildStaticSiteCommandTest.php
+++ b/packages/framework/tests/Feature/Commands/RebuildStaticSiteCommandTest.php
@@ -16,7 +16,7 @@ class RebuildStaticSiteCommandTest extends TestCase
     {
         $this->file('_pages/test-page.md', 'foo');
 
-        $this->artisan('rebuild '.'_pages/test-page.md')->assertExitCode(0);
+        $this->artisan('rebuild _pages/test-page.md')->assertExitCode(0);
 
         $this->assertFileExists(Hyde::path('_site/test-page.html'));
 


### PR DESCRIPTION
Refactors the `RebuildStaticSiteCommand `class to use newer helpers to reduce repeated code and to utilize an anonymous build task to keep a consistent output. Also renames the command to `RebuildStaticPageCommand` since it only rebuilds a single page.