### PR TITLE
Refactor Filesystem to use Unix directory separators

### DIFF
--- a/packages/framework/src/Foundation/Filesystem.php
+++ b/packages/framework/src/Foundation/Filesystem.php
@@ -103,7 +103,7 @@ class Filesystem
 
         $path = unslash($path);
 
-        return Hyde::path(Hyde::getMediaDirectory().DIRECTORY_SEPARATOR.$path);
+        return Hyde::path(Hyde::getMediaDirectory().self::DIRECTORY_SEPARATOR.$path);
     }
 
     /**
@@ -117,7 +117,7 @@ class Filesystem
 
         $path = unslash($path);
 
-        return Hyde::path(Site::getOutputDirectory().DIRECTORY_SEPARATOR.$path);
+        return Hyde::path(Site::getOutputDirectory().self::DIRECTORY_SEPARATOR.$path);
     }
 
     /**
@@ -131,7 +131,7 @@ class Filesystem
 
         $path = unslash($path);
 
-        return Hyde::sitePath(Hyde::getMediaOutputDirectory().DIRECTORY_SEPARATOR.$path);
+        return Hyde::sitePath(Hyde::getMediaOutputDirectory().self::DIRECTORY_SEPARATOR.$path);
     }
 
     /**

--- a/packages/framework/src/Foundation/Filesystem.php
+++ b/packages/framework/src/Foundation/Filesystem.php
@@ -35,8 +35,6 @@ class Filesystem
 {
     protected HydeKernel $kernel;
 
-    const DIRECTORY_SEPARATOR = '/';
-
     public function __construct(HydeKernel $kernel)
     {
         $this->kernel = $kernel;
@@ -103,7 +101,7 @@ class Filesystem
 
         $path = unslash($path);
 
-        return Hyde::path(Hyde::getMediaDirectory().self::DIRECTORY_SEPARATOR.$path);
+        return Hyde::path(Hyde::getMediaDirectory().'/'.$path);
     }
 
     /**
@@ -117,7 +115,7 @@ class Filesystem
 
         $path = unslash($path);
 
-        return Hyde::path(Site::getOutputDirectory().self::DIRECTORY_SEPARATOR.$path);
+        return Hyde::path(Site::getOutputDirectory().'/'.$path);
     }
 
     /**
@@ -131,7 +129,7 @@ class Filesystem
 
         $path = unslash($path);
 
-        return Hyde::sitePath(Hyde::getMediaOutputDirectory().self::DIRECTORY_SEPARATOR.$path);
+        return Hyde::sitePath(Hyde::getMediaOutputDirectory().'/'.$path);
     }
 
     /**

--- a/packages/framework/src/Foundation/Filesystem.php
+++ b/packages/framework/src/Foundation/Filesystem.php
@@ -100,7 +100,7 @@ class Filesystem
 
         $path = unslash($path);
 
-        return Hyde::path(Hyde::getMediaDirectory().'/'.$path);
+        return Hyde::path(Hyde::getMediaDirectory()."/$path");
     }
 
     /**
@@ -114,7 +114,7 @@ class Filesystem
 
         $path = unslash($path);
 
-        return Hyde::path(Site::getOutputDirectory().'/'.$path);
+        return Hyde::path(Site::getOutputDirectory()."/$path");
     }
 
     /**
@@ -128,7 +128,7 @@ class Filesystem
 
         $path = unslash($path);
 
-        return Hyde::sitePath(Hyde::getMediaOutputDirectory().'/'.$path);
+        return Hyde::sitePath(Hyde::getMediaOutputDirectory()."/$path");
     }
 
     /**

--- a/packages/framework/src/Foundation/Filesystem.php
+++ b/packages/framework/src/Foundation/Filesystem.php
@@ -15,6 +15,7 @@ use Hyde\Pages\DocumentationPage;
 use Hyde\Pages\MarkdownPage;
 use Hyde\Pages\MarkdownPost;
 use Illuminate\Support\Collection;
+use function Hyde\normalize_slashes;
 use function Hyde\path_join;
 use function is_array;
 use function is_string;
@@ -80,14 +81,12 @@ class Filesystem
 
     /**
      * Decode an absolute path created with a Hyde::path() helper into its relative counterpart.
-     *
-     * @todo Normalize slashes to forward slashes?
      */
     public function pathToRelative(string $path): string
     {
-        return str_starts_with($path, $this->path())
+        return normalize_slashes(str_starts_with($path, $this->path())
             ? unslash(str_replace($this->path(), '', $path))
-            : $path;
+            : $path);
     }
 
     /**

--- a/packages/framework/src/Foundation/Filesystem.php
+++ b/packages/framework/src/Foundation/Filesystem.php
@@ -100,7 +100,7 @@ class Filesystem
 
         $path = unslash($path);
 
-        return Hyde::path(Hyde::getMediaDirectory().'/'.$path);
+        return Hyde::path(path_join(Hyde::getMediaDirectory(), $path));
     }
 
     /**

--- a/packages/framework/src/Foundation/Filesystem.php
+++ b/packages/framework/src/Foundation/Filesystem.php
@@ -15,7 +15,7 @@ use Hyde\Pages\DocumentationPage;
 use Hyde\Pages\MarkdownPage;
 use Hyde\Pages\MarkdownPost;
 use Illuminate\Support\Collection;
-use function Hyde\system_path_join;
+use function Hyde\path_join;
 use function is_array;
 use function is_string;
 use function str_replace;
@@ -61,7 +61,7 @@ class Filesystem
 
         $path = unslash($path);
 
-        return system_path_join($this->getBasePath(), $path);
+        return path_join($this->getBasePath(), $path);
     }
 
     /**
@@ -209,7 +209,7 @@ class Filesystem
 
         $path = unslash($path);
 
-        return $this->path(system_path_join(DiscoveryService::getModelSourceDirectory($model), $path));
+        return $this->path(path_join(DiscoveryService::getModelSourceDirectory($model), $path));
     }
 
     public function getBladePagePath(string $path = ''): string

--- a/packages/framework/src/Foundation/Filesystem.php
+++ b/packages/framework/src/Foundation/Filesystem.php
@@ -95,12 +95,12 @@ class Filesystem
     public function mediaPath(string $path = ''): string
     {
         if (empty($path)) {
-            return Hyde::path(Hyde::getMediaDirectory());
+            return $this->path(Hyde::getMediaDirectory());
         }
 
         $path = unslash($path);
 
-        return Hyde::path(Hyde::getMediaDirectory()."/$path");
+        return $this->path(Hyde::getMediaDirectory()."/$path");
     }
 
     /**
@@ -109,12 +109,12 @@ class Filesystem
     public function sitePath(string $path = ''): string
     {
         if (empty($path)) {
-            return Hyde::path(Site::getOutputDirectory());
+            return $this->path(Site::getOutputDirectory());
         }
 
         $path = unslash($path);
 
-        return Hyde::path(Site::getOutputDirectory()."/$path");
+        return $this->path(Site::getOutputDirectory()."/$path");
     }
 
     /**

--- a/packages/framework/src/Foundation/Filesystem.php
+++ b/packages/framework/src/Foundation/Filesystem.php
@@ -35,6 +35,8 @@ class Filesystem
 {
     protected HydeKernel $kernel;
 
+    const DIRECTORY_SEPARATOR = '/';
+
     public function __construct(HydeKernel $kernel)
     {
         $this->kernel = $kernel;

--- a/packages/framework/src/Foundation/Filesystem.php
+++ b/packages/framework/src/Foundation/Filesystem.php
@@ -206,9 +206,7 @@ class Filesystem
             return $this->path(DiscoveryService::getModelSourceDirectory($model));
         }
 
-        $path = unslash($path);
-
-        return $this->path(path_join(DiscoveryService::getModelSourceDirectory($model), $path));
+        return $this->path(path_join(DiscoveryService::getModelSourceDirectory($model), unslash($path)));
     }
 
     public function getBladePagePath(string $path = ''): string

--- a/packages/framework/src/Foundation/Filesystem.php
+++ b/packages/framework/src/Foundation/Filesystem.php
@@ -23,10 +23,6 @@ use function touch;
 use function unlink;
 use function unslash;
 
-const UNIX_DIRECTORY_SEPARATOR = '/';
-
-use const Hyde\Foundation\UNIX_DIRECTORY_SEPARATOR as DIRECTORY_SEPARATOR;
-
 /**
  * File helper methods, bound to the HydeKernel instance, and is an integral part of the framework.
  *
@@ -38,6 +34,8 @@ use const Hyde\Foundation\UNIX_DIRECTORY_SEPARATOR as DIRECTORY_SEPARATOR;
 class Filesystem
 {
     protected HydeKernel $kernel;
+
+    const DIRECTORY_SEPARATOR = '/';
 
     public function __construct(HydeKernel $kernel)
     {
@@ -105,7 +103,7 @@ class Filesystem
 
         $path = unslash($path);
 
-        return Hyde::path(Hyde::getMediaDirectory().DIRECTORY_SEPARATOR.$path);
+        return Hyde::path(Hyde::getMediaDirectory().self::DIRECTORY_SEPARATOR.$path);
     }
 
     /**
@@ -119,7 +117,7 @@ class Filesystem
 
         $path = unslash($path);
 
-        return Hyde::path(Site::getOutputDirectory().DIRECTORY_SEPARATOR.$path);
+        return Hyde::path(Site::getOutputDirectory().self::DIRECTORY_SEPARATOR.$path);
     }
 
     /**
@@ -133,7 +131,7 @@ class Filesystem
 
         $path = unslash($path);
 
-        return Hyde::sitePath(Hyde::getMediaOutputDirectory().DIRECTORY_SEPARATOR.$path);
+        return Hyde::sitePath(Hyde::getMediaOutputDirectory().self::DIRECTORY_SEPARATOR.$path);
     }
 
     /**

--- a/packages/framework/src/Foundation/Filesystem.php
+++ b/packages/framework/src/Foundation/Filesystem.php
@@ -123,12 +123,12 @@ class Filesystem
     public function siteMediaPath(string $path = ''): string
     {
         if (empty($path)) {
-            return Hyde::sitePath(Hyde::getMediaOutputDirectory());
+            return $this->sitePath(Hyde::getMediaOutputDirectory());
         }
 
         $path = unslash($path);
 
-        return Hyde::sitePath(Hyde::getMediaOutputDirectory()."/$path");
+        return $this->sitePath(Hyde::getMediaOutputDirectory()."/$path");
     }
 
     /**

--- a/packages/framework/src/Foundation/Filesystem.php
+++ b/packages/framework/src/Foundation/Filesystem.php
@@ -100,7 +100,7 @@ class Filesystem
 
         $path = unslash($path);
 
-        return Hyde::path(path_join(Hyde::getMediaDirectory(), $path));
+        return Hyde::path(Hyde::getMediaDirectory().'/'.$path);
     }
 
     /**

--- a/packages/framework/src/Foundation/Filesystem.php
+++ b/packages/framework/src/Foundation/Filesystem.php
@@ -23,6 +23,10 @@ use function touch;
 use function unlink;
 use function unslash;
 
+const UNIX_DIRECTORY_SEPARATOR = '/';
+
+use const Hyde\Foundation\UNIX_DIRECTORY_SEPARATOR as DIRECTORY_SEPARATOR;
+
 /**
  * File helper methods, bound to the HydeKernel instance, and is an integral part of the framework.
  *
@@ -34,8 +38,6 @@ use function unslash;
 class Filesystem
 {
     protected HydeKernel $kernel;
-
-    const DIRECTORY_SEPARATOR = '/';
 
     public function __construct(HydeKernel $kernel)
     {
@@ -103,7 +105,7 @@ class Filesystem
 
         $path = unslash($path);
 
-        return Hyde::path(Hyde::getMediaDirectory().self::DIRECTORY_SEPARATOR.$path);
+        return Hyde::path(Hyde::getMediaDirectory().DIRECTORY_SEPARATOR.$path);
     }
 
     /**
@@ -117,7 +119,7 @@ class Filesystem
 
         $path = unslash($path);
 
-        return Hyde::path(Site::getOutputDirectory().self::DIRECTORY_SEPARATOR.$path);
+        return Hyde::path(Site::getOutputDirectory().DIRECTORY_SEPARATOR.$path);
     }
 
     /**
@@ -131,7 +133,7 @@ class Filesystem
 
         $path = unslash($path);
 
-        return Hyde::sitePath(Hyde::getMediaOutputDirectory().self::DIRECTORY_SEPARATOR.$path);
+        return Hyde::sitePath(Hyde::getMediaOutputDirectory().DIRECTORY_SEPARATOR.$path);
     }
 
     /**

--- a/packages/framework/src/helpers.php
+++ b/packages/framework/src/helpers.php
@@ -108,15 +108,6 @@ namespace Hyde {
         }
     }
 
-    if (! function_exists('\Hyde\system_path_join')) {
-        /** @deprecated Use Unix directory separators */
-        #[Deprecated(reason: 'Use Unix directory separators', replacement: '\Hyde\path_join(%parametersList%)')]
-        function system_path_join(string $directory, string ...$paths): string
-        {
-            return implode(DIRECTORY_SEPARATOR, array_merge([$directory], $paths));
-        }
-    }
-
     if (! function_exists('\Hyde\normalize_slashes')) {
         function normalize_slashes(string $string): string
         {

--- a/packages/framework/src/helpers.php
+++ b/packages/framework/src/helpers.php
@@ -29,7 +29,6 @@ namespace {
 namespace Hyde {
     use Hyde\Foundation\HydeKernel;
     use Illuminate\Contracts\Support\Arrayable;
-    use JetBrains\PhpStorm\Deprecated;
     use Symfony\Component\Yaml\Yaml;
 
     if (! function_exists('\Hyde\hyde')) {

--- a/packages/framework/src/helpers.php
+++ b/packages/framework/src/helpers.php
@@ -29,6 +29,7 @@ namespace {
 namespace Hyde {
     use Hyde\Foundation\HydeKernel;
     use Illuminate\Contracts\Support\Arrayable;
+    use JetBrains\PhpStorm\Deprecated;
     use Symfony\Component\Yaml\Yaml;
 
     if (! function_exists('\Hyde\hyde')) {
@@ -109,6 +110,7 @@ namespace Hyde {
 
     if (! function_exists('\Hyde\system_path_join')) {
         /** @deprecated Use Unix directory separators */
+        #[Deprecated(reason: 'Use Unix directory separators', replacement: '\Hyde\path_join(%parametersList%)')]
         function system_path_join(string $directory, string ...$paths): string
         {
             return implode(DIRECTORY_SEPARATOR, array_merge([$directory], $paths));

--- a/packages/framework/src/helpers.php
+++ b/packages/framework/src/helpers.php
@@ -108,6 +108,7 @@ namespace Hyde {
     }
 
     if (! function_exists('\Hyde\system_path_join')) {
+        /** @deprecated Use Unix directory separators */
         function system_path_join(string $directory, string ...$paths): string
         {
             return implode(DIRECTORY_SEPARATOR, array_merge([$directory], $paths));

--- a/packages/framework/tests/Feature/Foundation/FilesystemTest.php
+++ b/packages/framework/tests/Feature/Foundation/FilesystemTest.php
@@ -349,12 +349,11 @@ class FilesystemTest extends TestCase
 
     public function test_path_to_relative_helper_decodes_hyde_path_into_relative()
     {
-        $s = '/';
         $this->assertEquals('foo', Hyde::pathToRelative(Hyde::path('foo')));
         $this->assertEquals('foo', Hyde::pathToRelative(Hyde::path('/foo/')));
         $this->assertEquals('foo.md', Hyde::pathToRelative(Hyde::path('foo.md')));
-        $this->assertEquals("foo{$s}bar", Hyde::pathToRelative(Hyde::path("foo{$s}bar")));
-        $this->assertEquals("foo{$s}bar.md", Hyde::pathToRelative(Hyde::path("foo{$s}bar.md")));
+        $this->assertEquals('foo/bar', Hyde::pathToRelative(Hyde::path('foo/bar')));
+        $this->assertEquals('foo/bar.md', Hyde::pathToRelative(Hyde::path('foo/bar.md')));
     }
 
     public function test_path_to_relative_helper_does_not_modify_already_relative_paths()

--- a/packages/framework/tests/Feature/Foundation/FilesystemTest.php
+++ b/packages/framework/tests/Feature/Foundation/FilesystemTest.php
@@ -11,7 +11,6 @@ use Hyde\Pages\DocumentationPage;
 use Hyde\Pages\MarkdownPage;
 use Hyde\Pages\MarkdownPost;
 use Hyde\Testing\TestCase;
-
 use function Hyde\normalize_slashes;
 
 /**

--- a/packages/framework/tests/Feature/Foundation/FilesystemTest.php
+++ b/packages/framework/tests/Feature/Foundation/FilesystemTest.php
@@ -62,31 +62,31 @@ class FilesystemTest extends TestCase
     public function test_path_method_returns_path_relative_to_base_path_when_supplied_with_argument()
     {
         Hyde::getInstance()->setBasePath('/foo');
-        $this->assertEquals('/foo'.DIRECTORY_SEPARATOR.'foo/bar.php', $this->filesystem->path('foo/bar.php'));
+        $this->assertEquals('/foo'.'/'.'foo/bar.php', $this->filesystem->path('foo/bar.php'));
     }
 
     public function test_path_method_returns_qualified_file_path_when_supplied_with_argument()
     {
         Hyde::getInstance()->setBasePath('/foo');
-        $this->assertEquals('/foo'.DIRECTORY_SEPARATOR.'file.php', $this->filesystem->path('file.php'));
+        $this->assertEquals('/foo'.'/'.'file.php', $this->filesystem->path('file.php'));
     }
 
     public function test_path_method_returns_expected_value_for_nested_path_arguments()
     {
         Hyde::getInstance()->setBasePath('/foo');
-        $this->assertEquals('/foo'.DIRECTORY_SEPARATOR.'directory/file.php', $this->filesystem->path('directory/file.php'));
+        $this->assertEquals('/foo'.'/'.'directory/file.php', $this->filesystem->path('directory/file.php'));
     }
 
     public function test_path_method_strips_trailing_directory_separators_from_argument()
     {
         Hyde::getInstance()->setBasePath('/foo');
-        $this->assertEquals('/foo'.DIRECTORY_SEPARATOR.'file.php', $this->filesystem->path('\\/file.php/'));
+        $this->assertEquals('/foo'.'/'.'file.php', $this->filesystem->path('\\/file.php/'));
     }
 
     public function test_path_method_returns_expected_value_regardless_of_trailing_directory_separators_in_argument()
     {
         Hyde::getInstance()->setBasePath('/foo');
-        $this->assertEquals('/foo'.DIRECTORY_SEPARATOR.'bar/file.php', $this->filesystem->path('\\/bar/file.php/'));
+        $this->assertEquals('/foo'.'/'.'bar/file.php', $this->filesystem->path('\\/bar/file.php/'));
     }
 
     public function test_vendor_path_method_exists()
@@ -107,7 +107,7 @@ class FilesystemTest extends TestCase
     public function test_vendor_path_method_returns_expected_value_regardless_of_trailing_directory_separators_in_argument()
     {
         Hyde::getInstance()->setBasePath('/foo');
-        $this->assertEquals('/foo'.DIRECTORY_SEPARATOR.'vendor/hyde/framework/file.php', $this->filesystem->vendorPath('\\//file.php/'));
+        $this->assertEquals('/foo'.'/'.'vendor/hyde/framework/file.php', $this->filesystem->vendorPath('\\//file.php/'));
     }
 
     public function test_copy_method()
@@ -190,22 +190,22 @@ class FilesystemTest extends TestCase
     public function test_get_model_source_path_method_returns_path_to_file_for_model_classes()
     {
         $this->assertEquals(
-            Hyde::path('_posts'.DIRECTORY_SEPARATOR.'foo.md'),
+            Hyde::path('_posts'.'/'.'foo.md'),
             Hyde::getModelSourcePath(MarkdownPost::class, 'foo.md')
         );
 
         $this->assertEquals(
-            Hyde::path('_pages'.DIRECTORY_SEPARATOR.'foo.md'),
+            Hyde::path('_pages'.'/'.'foo.md'),
             Hyde::getModelSourcePath(MarkdownPage::class, 'foo.md')
         );
 
         $this->assertEquals(
-            Hyde::path('_docs'.DIRECTORY_SEPARATOR.'foo.md'),
+            Hyde::path('_docs'.'/'.'foo.md'),
             Hyde::getModelSourcePath(DocumentationPage::class, 'foo.md')
         );
 
         $this->assertEquals(
-            Hyde::path('_pages'.DIRECTORY_SEPARATOR.'foo.md'),
+            Hyde::path('_pages'.'/'.'foo.md'),
             Hyde::getModelSourcePath(BladePage::class, 'foo.md')
         );
     }
@@ -253,7 +253,7 @@ class FilesystemTest extends TestCase
     public function test_helper_for_media_path_returns_path_to_file_within_the_directory()
     {
         $this->assertEquals(
-            Hyde::path('_media'.DIRECTORY_SEPARATOR.'foo.css'),
+            Hyde::path('_media'.'/'.'foo.css'),
             Hyde::mediaPath('foo.css')
         );
     }
@@ -269,7 +269,7 @@ class FilesystemTest extends TestCase
     public function test_helper_for_media_output_path()
     {
         $this->assertEquals(
-            Hyde::path('_site'.DIRECTORY_SEPARATOR.'media'),
+            Hyde::path('_site'.'/'.'media'),
             Hyde::siteMediaPath()
         );
     }
@@ -277,7 +277,7 @@ class FilesystemTest extends TestCase
     public function test_helper_for_media_output_path_returns_path_to_file_within_the_directory()
     {
         $this->assertEquals(
-            Hyde::path('_site'.DIRECTORY_SEPARATOR.'media'.DIRECTORY_SEPARATOR.'foo.css'),
+            Hyde::path('_site'.'/'.'media'.'/'.'foo.css'),
             Hyde::siteMediaPath('foo.css')
         );
     }
@@ -285,7 +285,7 @@ class FilesystemTest extends TestCase
     public function test_get_media_output_path_returns_absolute_path()
     {
         $this->assertEquals(
-            Hyde::path('_site'.DIRECTORY_SEPARATOR.'media'),
+            Hyde::path('_site'.'/'.'media'),
             Hyde::siteMediaPath()
         );
     }
@@ -301,7 +301,7 @@ class FilesystemTest extends TestCase
     public function test_helper_for_site_output_path_returns_path_to_file_within_the_directory()
     {
         $this->assertEquals(
-            Hyde::path('_site'.DIRECTORY_SEPARATOR.'foo.html'),
+            Hyde::path('_site'.'/'.'foo.html'),
             Hyde::sitePath('foo.html')
         );
     }
@@ -317,7 +317,7 @@ class FilesystemTest extends TestCase
     public function test_site_output_path_helper_ignores_trailing_slashes()
     {
         $this->assertEquals(
-            Hyde::path('_site'.DIRECTORY_SEPARATOR.'foo.html'),
+            Hyde::path('_site'.'/'.'foo.html'),
             Hyde::sitePath('/foo.html/')
         );
     }
@@ -348,7 +348,7 @@ class FilesystemTest extends TestCase
 
     public function test_path_to_relative_helper_decodes_hyde_path_into_relative()
     {
-        $s = DIRECTORY_SEPARATOR;
+        $s = '/';
         $this->assertEquals('foo', Hyde::pathToRelative(Hyde::path('foo')));
         $this->assertEquals('foo', Hyde::pathToRelative(Hyde::path('/foo/')));
         $this->assertEquals('foo.md', Hyde::pathToRelative(Hyde::path('foo.md')));
@@ -392,6 +392,6 @@ class FilesystemTest extends TestCase
 
     protected function systemPath(string $path): string
     {
-        return str_replace('/', DIRECTORY_SEPARATOR, $path);
+        return str_replace('/', '/', $path);
     }
 }

--- a/packages/framework/tests/Feature/Foundation/FilesystemTest.php
+++ b/packages/framework/tests/Feature/Foundation/FilesystemTest.php
@@ -12,6 +12,8 @@ use Hyde\Pages\MarkdownPage;
 use Hyde\Pages\MarkdownPost;
 use Hyde\Testing\TestCase;
 
+use function Hyde\normalize_slashes;
+
 /**
  * @covers \Hyde\Foundation\HydeKernel
  * @covers \Hyde\Foundation\Filesystem
@@ -381,7 +383,7 @@ class FilesystemTest extends TestCase
         ];
 
         foreach ($testStrings as $testString) {
-            $this->assertEquals($testString, Hyde::pathToRelative($testString));
+            $this->assertEquals(normalize_slashes($testString), Hyde::pathToRelative($testString));
         }
     }
 }

--- a/packages/framework/tests/Feature/Foundation/FilesystemTest.php
+++ b/packages/framework/tests/Feature/Foundation/FilesystemTest.php
@@ -382,16 +382,11 @@ class FilesystemTest extends TestCase
 
         foreach ($testStrings as $testString) {
             $this->assertEquals(
-                $this->systemPath($testString),
+                $testString,
                 Hyde::pathToRelative(
-                    $this->systemPath($testString)
+                    $testString
                 )
             );
         }
-    }
-
-    protected function systemPath(string $path): string
-    {
-        return str_replace('/', '/', $path);
     }
 }

--- a/packages/framework/tests/Feature/Foundation/FilesystemTest.php
+++ b/packages/framework/tests/Feature/Foundation/FilesystemTest.php
@@ -381,12 +381,7 @@ class FilesystemTest extends TestCase
         ];
 
         foreach ($testStrings as $testString) {
-            $this->assertEquals(
-                $testString,
-                Hyde::pathToRelative(
-                    $testString
-                )
-            );
+            $this->assertEquals($testString, Hyde::pathToRelative($testString));
         }
     }
 }

--- a/packages/framework/tests/Feature/Foundation/FilesystemTest.php
+++ b/packages/framework/tests/Feature/Foundation/FilesystemTest.php
@@ -62,31 +62,31 @@ class FilesystemTest extends TestCase
     public function test_path_method_returns_path_relative_to_base_path_when_supplied_with_argument()
     {
         Hyde::getInstance()->setBasePath('/foo');
-        $this->assertEquals('/foo'.'/'.'foo/bar.php', $this->filesystem->path('foo/bar.php'));
+        $this->assertEquals('/foo/foo/bar.php', $this->filesystem->path('foo/bar.php'));
     }
 
     public function test_path_method_returns_qualified_file_path_when_supplied_with_argument()
     {
         Hyde::getInstance()->setBasePath('/foo');
-        $this->assertEquals('/foo'.'/'.'file.php', $this->filesystem->path('file.php'));
+        $this->assertEquals('/foo/file.php', $this->filesystem->path('file.php'));
     }
 
     public function test_path_method_returns_expected_value_for_nested_path_arguments()
     {
         Hyde::getInstance()->setBasePath('/foo');
-        $this->assertEquals('/foo'.'/'.'directory/file.php', $this->filesystem->path('directory/file.php'));
+        $this->assertEquals('/foo/directory/file.php', $this->filesystem->path('directory/file.php'));
     }
 
     public function test_path_method_strips_trailing_directory_separators_from_argument()
     {
         Hyde::getInstance()->setBasePath('/foo');
-        $this->assertEquals('/foo'.'/'.'file.php', $this->filesystem->path('\\/file.php/'));
+        $this->assertEquals('/foo/file.php', $this->filesystem->path('\\/file.php/'));
     }
 
     public function test_path_method_returns_expected_value_regardless_of_trailing_directory_separators_in_argument()
     {
         Hyde::getInstance()->setBasePath('/foo');
-        $this->assertEquals('/foo'.'/'.'bar/file.php', $this->filesystem->path('\\/bar/file.php/'));
+        $this->assertEquals('/foo/bar/file.php', $this->filesystem->path('\\/bar/file.php/'));
     }
 
     public function test_vendor_path_method_exists()
@@ -107,7 +107,7 @@ class FilesystemTest extends TestCase
     public function test_vendor_path_method_returns_expected_value_regardless_of_trailing_directory_separators_in_argument()
     {
         Hyde::getInstance()->setBasePath('/foo');
-        $this->assertEquals('/foo'.'/'.'vendor/hyde/framework/file.php', $this->filesystem->vendorPath('\\//file.php/'));
+        $this->assertEquals('/foo/vendor/hyde/framework/file.php', $this->filesystem->vendorPath('\\//file.php/'));
     }
 
     public function test_copy_method()
@@ -190,22 +190,22 @@ class FilesystemTest extends TestCase
     public function test_get_model_source_path_method_returns_path_to_file_for_model_classes()
     {
         $this->assertEquals(
-            Hyde::path('_posts'.'/'.'foo.md'),
+            Hyde::path('_posts/foo.md'),
             Hyde::getModelSourcePath(MarkdownPost::class, 'foo.md')
         );
 
         $this->assertEquals(
-            Hyde::path('_pages'.'/'.'foo.md'),
+            Hyde::path('_pages/foo.md'),
             Hyde::getModelSourcePath(MarkdownPage::class, 'foo.md')
         );
 
         $this->assertEquals(
-            Hyde::path('_docs'.'/'.'foo.md'),
+            Hyde::path('_docs/foo.md'),
             Hyde::getModelSourcePath(DocumentationPage::class, 'foo.md')
         );
 
         $this->assertEquals(
-            Hyde::path('_pages'.'/'.'foo.md'),
+            Hyde::path('_pages/foo.md'),
             Hyde::getModelSourcePath(BladePage::class, 'foo.md')
         );
     }
@@ -253,7 +253,7 @@ class FilesystemTest extends TestCase
     public function test_helper_for_media_path_returns_path_to_file_within_the_directory()
     {
         $this->assertEquals(
-            Hyde::path('_media'.'/'.'foo.css'),
+            Hyde::path('_media/foo.css'),
             Hyde::mediaPath('foo.css')
         );
     }
@@ -269,7 +269,7 @@ class FilesystemTest extends TestCase
     public function test_helper_for_media_output_path()
     {
         $this->assertEquals(
-            Hyde::path('_site'.'/'.'media'),
+            Hyde::path('_site/media'),
             Hyde::siteMediaPath()
         );
     }
@@ -277,7 +277,7 @@ class FilesystemTest extends TestCase
     public function test_helper_for_media_output_path_returns_path_to_file_within_the_directory()
     {
         $this->assertEquals(
-            Hyde::path('_site'.'/'.'media'.'/'.'foo.css'),
+            Hyde::path('_site/media/foo.css'),
             Hyde::siteMediaPath('foo.css')
         );
     }
@@ -285,7 +285,7 @@ class FilesystemTest extends TestCase
     public function test_get_media_output_path_returns_absolute_path()
     {
         $this->assertEquals(
-            Hyde::path('_site'.'/'.'media'),
+            Hyde::path('_site/media'),
             Hyde::siteMediaPath()
         );
     }
@@ -301,7 +301,7 @@ class FilesystemTest extends TestCase
     public function test_helper_for_site_output_path_returns_path_to_file_within_the_directory()
     {
         $this->assertEquals(
-            Hyde::path('_site'.'/'.'foo.html'),
+            Hyde::path('_site/foo.html'),
             Hyde::sitePath('foo.html')
         );
     }
@@ -317,7 +317,7 @@ class FilesystemTest extends TestCase
     public function test_site_output_path_helper_ignores_trailing_slashes()
     {
         $this->assertEquals(
-            Hyde::path('_site'.'/'.'foo.html'),
+            Hyde::path('_site/foo.html'),
             Hyde::sitePath('/foo.html/')
         );
     }

--- a/packages/framework/tests/Feature/HelpersTest.php
+++ b/packages/framework/tests/Feature/HelpersTest.php
@@ -162,18 +162,6 @@ class HelpersTest extends TestCase
         $this->assertSame('foo/bar/baz', \Hyde\path_join('foo', 'bar', 'baz'));
     }
 
-    /** @covers ::\Hyde\system_path_join */
-    public function test_hyde_system_path_join_function()
-    {
-        $this->assertSame('foo'.DIRECTORY_SEPARATOR.'bar', \Hyde\system_path_join('foo', 'bar'));
-    }
-
-    /** @covers ::\Hyde\system_path_join */
-    public function test_hyde_system_path_join_function_with_multiple_paths()
-    {
-        $this->assertSame('foo'.DIRECTORY_SEPARATOR.'bar'.DIRECTORY_SEPARATOR.'baz', \Hyde\system_path_join('foo', 'bar', 'baz'));
-    }
-
     /** @covers ::\Hyde\normalize_slashes */
     public function test_hyde_normalize_slashes_function()
     {

--- a/packages/framework/tests/Feature/HelpersTest.php
+++ b/packages/framework/tests/Feature/HelpersTest.php
@@ -165,7 +165,6 @@ class HelpersTest extends TestCase
     /** @covers ::\Hyde\normalize_slashes */
     public function test_hyde_normalize_slashes_function()
     {
-        $this->assertSame('foo/bar', \Hyde\normalize_slashes('foo'.DIRECTORY_SEPARATOR.'bar'));
         $this->assertSame('foo/bar', \Hyde\normalize_slashes('foo\\bar'));
         $this->assertSame('foo/bar', \Hyde\normalize_slashes('foo/bar'));
     }

--- a/packages/framework/tests/Feature/HydeKernelTest.php
+++ b/packages/framework/tests/Feature/HydeKernelTest.php
@@ -218,13 +218,13 @@ class HydeKernelTest extends TestCase
     public function test_path_returns_qualified_path_for_given_path()
     {
         $this->assertSame(Hyde::getBasePath(), Hyde::path());
-        $this->assertSame(Hyde::getBasePath().'/'.'foo', Hyde::path('foo'));
+        $this->assertSame(Hyde::getBasePath().'/foo', Hyde::path('foo'));
     }
 
     public function test_vendor_path_returns_qualified_path_for_given_path()
     {
-        $this->assertSame(Hyde::getBasePath().'/'.'vendor/hyde/framework', Hyde::vendorPath());
-        $this->assertSame(Hyde::getBasePath().'/'.'vendor/hyde/framework/foo', Hyde::vendorPath('foo'));
+        $this->assertSame(Hyde::getBasePath().'/vendor/hyde/framework', Hyde::vendorPath());
+        $this->assertSame(Hyde::getBasePath().'/vendor/hyde/framework/foo', Hyde::vendorPath('foo'));
     }
 
     public function test_copy_helper_copies_file_from_given_path_to_given_path()
@@ -263,7 +263,7 @@ class HydeKernelTest extends TestCase
         $this->assertSame(Hyde::path('_posts'), Hyde::getMarkdownPostPath());
         $this->assertSame(Hyde::path('_docs'), Hyde::getDocumentationPagePath());
         $this->assertSame(Hyde::path('_site'), Hyde::sitePath());
-        $this->assertSame(Hyde::path('_site'.'/'.'media'), Hyde::siteMediaPath());
+        $this->assertSame(Hyde::path('_site/media'), Hyde::siteMediaPath());
     }
 
     public function test_path_to_relative_helper_returns_relative_path_for_given_path()
@@ -394,20 +394,20 @@ class HydeKernelTest extends TestCase
 
     public function test_can_get_site_media_output_directory()
     {
-        $this->assertSame(Hyde::path('_site'.'/'.'media'), Hyde::siteMediaPath());
+        $this->assertSame(Hyde::path('_site/media'), Hyde::siteMediaPath());
     }
 
     public function test_get_site_media_output_directory_uses_trimmed_version_of_media_source_directory()
     {
         Hyde::setMediaDirectory('_foo');
-        $this->assertSame(Hyde::path('_site'.'/'.'foo'), Hyde::siteMediaPath());
+        $this->assertSame(Hyde::path('_site/foo'), Hyde::siteMediaPath());
     }
 
     public function test_get_site_media_output_directory_uses_configured_site_output_directory()
     {
         Hyde::setOutputDirectory(Hyde::path('foo'));
         Hyde::setMediaDirectory('bar');
-        $this->assertSame(Hyde::path('foo'.'/'.'bar'), Hyde::siteMediaPath());
+        $this->assertSame(Hyde::path('foo/bar'), Hyde::siteMediaPath());
     }
 
     public function test_media_output_directory_can_be_changed_in_configuration()

--- a/packages/framework/tests/Feature/HydeKernelTest.php
+++ b/packages/framework/tests/Feature/HydeKernelTest.php
@@ -218,13 +218,13 @@ class HydeKernelTest extends TestCase
     public function test_path_returns_qualified_path_for_given_path()
     {
         $this->assertSame(Hyde::getBasePath(), Hyde::path());
-        $this->assertSame(Hyde::getBasePath().DIRECTORY_SEPARATOR.'foo', Hyde::path('foo'));
+        $this->assertSame(Hyde::getBasePath().Filesystem::DIRECTORY_SEPARATOR.'foo', Hyde::path('foo'));
     }
 
     public function test_vendor_path_returns_qualified_path_for_given_path()
     {
-        $this->assertSame(Hyde::getBasePath().DIRECTORY_SEPARATOR.'vendor/hyde/framework', Hyde::vendorPath());
-        $this->assertSame(Hyde::getBasePath().DIRECTORY_SEPARATOR.'vendor/hyde/framework/foo', Hyde::vendorPath('foo'));
+        $this->assertSame(Hyde::getBasePath().Filesystem::DIRECTORY_SEPARATOR.'vendor/hyde/framework', Hyde::vendorPath());
+        $this->assertSame(Hyde::getBasePath().Filesystem::DIRECTORY_SEPARATOR.'vendor/hyde/framework/foo', Hyde::vendorPath('foo'));
     }
 
     public function test_copy_helper_copies_file_from_given_path_to_given_path()
@@ -263,7 +263,7 @@ class HydeKernelTest extends TestCase
         $this->assertSame(Hyde::path('_posts'), Hyde::getMarkdownPostPath());
         $this->assertSame(Hyde::path('_docs'), Hyde::getDocumentationPagePath());
         $this->assertSame(Hyde::path('_site'), Hyde::sitePath());
-        $this->assertSame(Hyde::path('_site'.DIRECTORY_SEPARATOR.'media'), Hyde::siteMediaPath());
+        $this->assertSame(Hyde::path('_site'.Filesystem::DIRECTORY_SEPARATOR.'media'), Hyde::siteMediaPath());
     }
 
     public function test_path_to_relative_helper_returns_relative_path_for_given_path()
@@ -394,20 +394,20 @@ class HydeKernelTest extends TestCase
 
     public function test_can_get_site_media_output_directory()
     {
-        $this->assertSame(Hyde::path('_site'.DIRECTORY_SEPARATOR.'media'), Hyde::siteMediaPath());
+        $this->assertSame(Hyde::path('_site'.Filesystem::DIRECTORY_SEPARATOR.'media'), Hyde::siteMediaPath());
     }
 
     public function test_get_site_media_output_directory_uses_trimmed_version_of_media_source_directory()
     {
         Hyde::setMediaDirectory('_foo');
-        $this->assertSame(Hyde::path('_site'.DIRECTORY_SEPARATOR.'foo'), Hyde::siteMediaPath());
+        $this->assertSame(Hyde::path('_site'.Filesystem::DIRECTORY_SEPARATOR.'foo'), Hyde::siteMediaPath());
     }
 
     public function test_get_site_media_output_directory_uses_configured_site_output_directory()
     {
         Hyde::setOutputDirectory(Hyde::path('foo'));
         Hyde::setMediaDirectory('bar');
-        $this->assertSame(Hyde::path('foo'.DIRECTORY_SEPARATOR.'bar'), Hyde::siteMediaPath());
+        $this->assertSame(Hyde::path('foo'.Filesystem::DIRECTORY_SEPARATOR.'bar'), Hyde::siteMediaPath());
     }
 
     public function test_media_output_directory_can_be_changed_in_configuration()

--- a/packages/framework/tests/Feature/HydeKernelTest.php
+++ b/packages/framework/tests/Feature/HydeKernelTest.php
@@ -218,13 +218,13 @@ class HydeKernelTest extends TestCase
     public function test_path_returns_qualified_path_for_given_path()
     {
         $this->assertSame(Hyde::getBasePath(), Hyde::path());
-        $this->assertSame(Hyde::getBasePath().Filesystem::DIRECTORY_SEPARATOR.'foo', Hyde::path('foo'));
+        $this->assertSame(Hyde::getBasePath().'/'.'foo', Hyde::path('foo'));
     }
 
     public function test_vendor_path_returns_qualified_path_for_given_path()
     {
-        $this->assertSame(Hyde::getBasePath().Filesystem::DIRECTORY_SEPARATOR.'vendor/hyde/framework', Hyde::vendorPath());
-        $this->assertSame(Hyde::getBasePath().Filesystem::DIRECTORY_SEPARATOR.'vendor/hyde/framework/foo', Hyde::vendorPath('foo'));
+        $this->assertSame(Hyde::getBasePath().'/'.'vendor/hyde/framework', Hyde::vendorPath());
+        $this->assertSame(Hyde::getBasePath().'/'.'vendor/hyde/framework/foo', Hyde::vendorPath('foo'));
     }
 
     public function test_copy_helper_copies_file_from_given_path_to_given_path()
@@ -263,7 +263,7 @@ class HydeKernelTest extends TestCase
         $this->assertSame(Hyde::path('_posts'), Hyde::getMarkdownPostPath());
         $this->assertSame(Hyde::path('_docs'), Hyde::getDocumentationPagePath());
         $this->assertSame(Hyde::path('_site'), Hyde::sitePath());
-        $this->assertSame(Hyde::path('_site'.Filesystem::DIRECTORY_SEPARATOR.'media'), Hyde::siteMediaPath());
+        $this->assertSame(Hyde::path('_site'.'/'.'media'), Hyde::siteMediaPath());
     }
 
     public function test_path_to_relative_helper_returns_relative_path_for_given_path()
@@ -394,20 +394,20 @@ class HydeKernelTest extends TestCase
 
     public function test_can_get_site_media_output_directory()
     {
-        $this->assertSame(Hyde::path('_site'.Filesystem::DIRECTORY_SEPARATOR.'media'), Hyde::siteMediaPath());
+        $this->assertSame(Hyde::path('_site'.'/'.'media'), Hyde::siteMediaPath());
     }
 
     public function test_get_site_media_output_directory_uses_trimmed_version_of_media_source_directory()
     {
         Hyde::setMediaDirectory('_foo');
-        $this->assertSame(Hyde::path('_site'.Filesystem::DIRECTORY_SEPARATOR.'foo'), Hyde::siteMediaPath());
+        $this->assertSame(Hyde::path('_site'.'/'.'foo'), Hyde::siteMediaPath());
     }
 
     public function test_get_site_media_output_directory_uses_configured_site_output_directory()
     {
         Hyde::setOutputDirectory(Hyde::path('foo'));
         Hyde::setMediaDirectory('bar');
-        $this->assertSame(Hyde::path('foo'.Filesystem::DIRECTORY_SEPARATOR.'bar'), Hyde::siteMediaPath());
+        $this->assertSame(Hyde::path('foo'.'/'.'bar'), Hyde::siteMediaPath());
     }
 
     public function test_media_output_directory_can_be_changed_in_configuration()

--- a/packages/framework/tests/Feature/HydeServiceProviderTest.php
+++ b/packages/framework/tests/Feature/HydeServiceProviderTest.php
@@ -184,7 +184,7 @@ class HydeServiceProviderTest extends TestCase
 
         $this->provider->register();
 
-        $this->assertEquals([Hyde::path('_pages')], config('view.paths'));
+        $this->assertEquals([realpath(Hyde::path('_pages'))], config('view.paths'));
     }
 
     public function test_blade_view_locations_are_only_registered_once_per_key()
@@ -195,7 +195,7 @@ class HydeServiceProviderTest extends TestCase
         $this->provider->register();
         $this->provider->register();
 
-        $this->assertEquals([Hyde::path('_pages')], config('view.paths'));
+        $this->assertEquals([realpath(Hyde::path('_pages'))], config('view.paths'));
     }
 
     public function test_provider_registers_console_commands()

--- a/packages/framework/tests/Unit/HydePathHelperTest.php
+++ b/packages/framework/tests/Unit/HydePathHelperTest.php
@@ -28,10 +28,10 @@ class HydePathHelperTest extends TestCase
     public function test_returned_directory_contains_content_expected_to_be_in_the_project_directory()
     {
         $this->assertTrue(
-            file_exists(Hyde::path().'/'.'hyde') &&
-                file_exists(Hyde::path().'/'.'_pages') &&
-                file_exists(Hyde::path().'/'.'_posts') &&
-                file_exists(Hyde::path().'/'.'_site')
+            file_exists(Hyde::path().'/hyde') &&
+                file_exists(Hyde::path().'/_pages') &&
+                file_exists(Hyde::path().'/_posts') &&
+                file_exists(Hyde::path().'/_site')
         );
     }
 }

--- a/packages/framework/tests/Unit/HydePathHelperTest.php
+++ b/packages/framework/tests/Unit/HydePathHelperTest.php
@@ -28,10 +28,10 @@ class HydePathHelperTest extends TestCase
     public function test_returned_directory_contains_content_expected_to_be_in_the_project_directory()
     {
         $this->assertTrue(
-            file_exists(Hyde::path().'/'.'hyde') &&
-                file_exists(Hyde::path().'/'.'_pages') &&
-                file_exists(Hyde::path().'/'.'_posts') &&
-                file_exists(Hyde::path().'/'.'_site')
+            file_exists(Hyde::path().DIRECTORY_SEPARATOR.'hyde') &&
+                file_exists(Hyde::path().DIRECTORY_SEPARATOR.'_pages') &&
+                file_exists(Hyde::path().DIRECTORY_SEPARATOR.'_posts') &&
+                file_exists(Hyde::path().DIRECTORY_SEPARATOR.'_site')
         );
     }
 }

--- a/packages/framework/tests/Unit/HydePathHelperTest.php
+++ b/packages/framework/tests/Unit/HydePathHelperTest.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Hyde\Framework\Testing\Unit;
 
-use Hyde\Foundation\Filesystem;
 use Hyde\Foundation\HydeKernel;
 use Hyde\Hyde;
 use Hyde\Testing\TestCase;
@@ -29,10 +28,10 @@ class HydePathHelperTest extends TestCase
     public function test_returned_directory_contains_content_expected_to_be_in_the_project_directory()
     {
         $this->assertTrue(
-            file_exists(Hyde::path().Filesystem::DIRECTORY_SEPARATOR.'hyde') &&
-                file_exists(Hyde::path().Filesystem::DIRECTORY_SEPARATOR.'_pages') &&
-                file_exists(Hyde::path().Filesystem::DIRECTORY_SEPARATOR.'_posts') &&
-                file_exists(Hyde::path().Filesystem::DIRECTORY_SEPARATOR.'_site')
+            file_exists(Hyde::path().'/'.'hyde') &&
+                file_exists(Hyde::path().'/'.'_pages') &&
+                file_exists(Hyde::path().'/'.'_posts') &&
+                file_exists(Hyde::path().'/'.'_site')
         );
     }
 }

--- a/packages/framework/tests/Unit/HydePathHelperTest.php
+++ b/packages/framework/tests/Unit/HydePathHelperTest.php
@@ -28,10 +28,10 @@ class HydePathHelperTest extends TestCase
     public function test_returned_directory_contains_content_expected_to_be_in_the_project_directory()
     {
         $this->assertTrue(
-            file_exists(Hyde::path().DIRECTORY_SEPARATOR.'hyde') &&
-                file_exists(Hyde::path().DIRECTORY_SEPARATOR.'_pages') &&
-                file_exists(Hyde::path().DIRECTORY_SEPARATOR.'_posts') &&
-                file_exists(Hyde::path().DIRECTORY_SEPARATOR.'_site')
+            file_exists(Hyde::path().'/'.'hyde') &&
+                file_exists(Hyde::path().'/'.'_pages') &&
+                file_exists(Hyde::path().'/'.'_posts') &&
+                file_exists(Hyde::path().'/'.'_site')
         );
     }
 }

--- a/packages/framework/tests/Unit/HydePathHelperTest.php
+++ b/packages/framework/tests/Unit/HydePathHelperTest.php
@@ -28,10 +28,10 @@ class HydePathHelperTest extends TestCase
     public function test_returned_directory_contains_content_expected_to_be_in_the_project_directory()
     {
         $this->assertTrue(
-            file_exists(Hyde::path().'/hyde') &&
-                file_exists(Hyde::path().'/_pages') &&
-                file_exists(Hyde::path().'/_posts') &&
-                file_exists(Hyde::path().'/_site')
+            file_exists(Hyde::path('hyde')) &&
+                file_exists(Hyde::path('_pages')) &&
+                file_exists(Hyde::path('_posts')) &&
+                file_exists(Hyde::path('_site'))
         );
     }
 }

--- a/packages/framework/tests/Unit/HydePathHelperTest.php
+++ b/packages/framework/tests/Unit/HydePathHelperTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Hyde\Framework\Testing\Unit;
 
+use Hyde\Foundation\Filesystem;
 use Hyde\Foundation\HydeKernel;
 use Hyde\Hyde;
 use Hyde\Testing\TestCase;
@@ -28,10 +29,10 @@ class HydePathHelperTest extends TestCase
     public function test_returned_directory_contains_content_expected_to_be_in_the_project_directory()
     {
         $this->assertTrue(
-            file_exists(Hyde::path().DIRECTORY_SEPARATOR.'hyde') &&
-                file_exists(Hyde::path().DIRECTORY_SEPARATOR.'_pages') &&
-                file_exists(Hyde::path().DIRECTORY_SEPARATOR.'_posts') &&
-                file_exists(Hyde::path().DIRECTORY_SEPARATOR.'_site')
+            file_exists(Hyde::path().Filesystem::DIRECTORY_SEPARATOR.'hyde') &&
+                file_exists(Hyde::path().Filesystem::DIRECTORY_SEPARATOR.'_pages') &&
+                file_exists(Hyde::path().Filesystem::DIRECTORY_SEPARATOR.'_posts') &&
+                file_exists(Hyde::path().Filesystem::DIRECTORY_SEPARATOR.'_site')
         );
     }
 }


### PR DESCRIPTION
## About

### Abstract
This will affect virtually all paths generated and assembled by HydePHP to use Unix style directory separators (`/`) instead of using the system-dependent `DIRECTORY_SEPARATOR` constant.

### Why 
Since Windows fully accepts these directory separators, I don't see enough reason to have to bother concatenating in a bulky constant when a simple slash in a scalar value suffices.

You can't honestly tell me that `'foo'.DIRECTORY_SEPARATOR.'bar'` is prettier than `'foo/bar'` can you?