### PR TITLE
ProjectFile and inheritors no longer implement Stringable interface

### DIFF
--- a/packages/framework/src/Support/Filesystem/ProjectFile.php
+++ b/packages/framework/src/Support/Filesystem/ProjectFile.php
@@ -10,7 +10,6 @@ use Hyde\Hyde;
 use Hyde\Support\Concerns\Serializable;
 use Hyde\Support\Contracts\SerializableContract;
 use function pathinfo;
-use Stringable;
 
 /**
  * Filesystem abstraction for a file stored in the project.

--- a/packages/framework/src/Support/Filesystem/ProjectFile.php
+++ b/packages/framework/src/Support/Filesystem/ProjectFile.php
@@ -17,7 +17,7 @@ use Stringable;
  *
  * @see \Hyde\Framework\Testing\Feature\Support\ProjectFileTest
  */
-abstract class ProjectFile implements SerializableContract, Stringable
+abstract class ProjectFile implements SerializableContract
 {
     use Serializable;
 
@@ -37,11 +37,6 @@ abstract class ProjectFile implements SerializableContract, Stringable
     public function __construct(string $path)
     {
         $this->path = Hyde::pathToRelative($path);
-    }
-
-    public function __toString(): string
-    {
-        return $this->path;
     }
 
     /**

--- a/packages/framework/tests/Feature/Support/MediaFileTest.php
+++ b/packages/framework/tests/Feature/Support/MediaFileTest.php
@@ -36,11 +36,6 @@ class MediaFileTest extends TestCase
         $this->assertEquals('foo', MediaFile::make(Hyde::path('foo'))->path);
     }
 
-    public function test_to_string_returns_path()
-    {
-        $this->assertSame('foo', (string) MediaFile::make('foo'));
-    }
-
     public function test_get_name_returns_name_of_file()
     {
         $this->assertSame('foo.txt', MediaFile::make('foo.txt')->getName());

--- a/packages/framework/tests/Feature/Support/ProjectFileTest.php
+++ b/packages/framework/tests/Feature/Support/ProjectFileTest.php
@@ -35,11 +35,6 @@ class ProjectFileTest extends TestCase
         $this->assertEquals('foo', ProjectFileTestClass::make(Hyde::path('foo'))->path);
     }
 
-    public function test_to_string_returns_path()
-    {
-        $this->assertSame('foo', (string) ProjectFileTestClass::make('foo'));
-    }
-
     public function test_get_name_returns_name_of_file()
     {
         $this->assertSame('foo.txt', ProjectFileTestClass::make('foo.txt')->getName());

--- a/packages/framework/tests/Feature/Support/SourceFileTest.php
+++ b/packages/framework/tests/Feature/Support/SourceFileTest.php
@@ -54,11 +54,6 @@ class SourceFileTest extends TestCase
         $this->assertEquals('foo', SourceFile::make(Hyde::path('foo'))->path);
     }
 
-    public function test_to_string_returns_path()
-    {
-        $this->assertSame('foo', (string) SourceFile::make('foo'));
-    }
-
     public function test_get_name_returns_name_of_file()
     {
         $this->assertSame('foo.txt', SourceFile::make('foo.txt')->getName());


### PR DESCRIPTION
This method is only used in tests, and I see no real scenario when one would even want to cast something like this to string.