### PR TITLE
Display different message for dynamic pages in route list command

### DIFF
--- a/packages/framework/src/Console/Commands/RouteListCommand.php
+++ b/packages/framework/src/Console/Commands/RouteListCommand.php
@@ -6,6 +6,7 @@ namespace Hyde\Console\Commands;
 
 use Hyde\Console\Concerns\Command;
 use Hyde\Hyde;
+use Hyde\Pages\Contracts\DynamicPage;
 
 /**
  * Hyde command to display the list of site routes.
@@ -39,7 +40,7 @@ class RouteListCommand extends Command
         foreach (Hyde::routes() as $route) {
             $routes[] = [
                 $this->formatPageType($route->getPageClass()),
-                $this->formatSourcePath($route->getSourcePath()),
+                $this->formatSourcePath($route->getSourcePath(), $route->getPageClass()),
                 $this->formatOutputPath($route->getOutputPath()),
                 $route->getRouteKey(),
             ];
@@ -53,8 +54,12 @@ class RouteListCommand extends Command
         return str_starts_with($class, 'Hyde') ? class_basename($class) : $class;
     }
 
-    protected function formatSourcePath(string $path): string
+    protected function formatSourcePath(string $path, string $class): string
     {
+        if (is_a($class, DynamicPage::class, true)) {
+            return '<fg=yellow>dynamic</>';
+        }
+
         return $this->clickablePathLink(static::createClickableFilepath(Hyde::path($path)), $path);
     }
 

--- a/packages/framework/src/Foundation/Concerns/HydeExtension.php
+++ b/packages/framework/src/Foundation/Concerns/HydeExtension.php
@@ -32,7 +32,7 @@ use Hyde\Foundation\RouteCollection;
 abstract class HydeExtension
 {
     /**
-     * If your extension adds new page classes, you should register them here.
+     * If your extension adds new discoverable page classes, you should register them here.
      *
      * Hyde will then automatically discover source files for the new page class,
      * generate routes, and compile the pages during the build process.

--- a/packages/framework/tests/Feature/Commands/RouteListCommandTest.php
+++ b/packages/framework/tests/Feature/Commands/RouteListCommandTest.php
@@ -4,6 +4,9 @@ declare(strict_types=1);
 
 namespace Hyde\Framework\Testing\Feature\Commands;
 
+use Hyde\Hyde;
+use Hyde\Pages\VirtualPage;
+use Hyde\Support\Models\Route;
 use Hyde\Testing\TestCase;
 
 /**
@@ -35,5 +38,32 @@ class RouteListCommandTest extends TestCase
         $this->file('_site/index.html');
         $this->artisan('route:list')
             ->assertExitCode(0);
+    }
+
+    public function testWithDynamicPages()
+    {
+        Hyde::routes()->put('foo', new Route(new VirtualPage('foo')));
+
+        $this->artisan('route:list')
+            ->expectsTable(['Page Type', 'Source File', 'Output File', 'Route Key'], [
+                [
+                    'BladePage',
+                    '_pages/404.blade.php',
+                    '_site/404.html',
+                    '404',
+                ],
+                [
+                    'BladePage',
+                    '_pages/index.blade.php',
+                    '_site/index.html',
+                    'index',
+                ],
+                [
+                    'VirtualPage',
+                    '<fg=yellow>dynamic</>',
+                    '_site/foo.html',
+                    'foo',
+                ],
+            ])->assertExitCode(0);
     }
 }


### PR DESCRIPTION
Since these pages don't have source files it makes little sense to attempt to show one.

We could also in the future add a dynamic annotation briefly explaining what this means, and have a link to the docs/blog post.