### PR TITLE
Change input string handler termination sequence to `<<<`

### DIFF
--- a/packages/publications/src/Commands/Helpers/InputStreamHandler.php
+++ b/packages/publications/src/Commands/Helpers/InputStreamHandler.php
@@ -19,7 +19,7 @@ use function trim;
  */
 class InputStreamHandler
 {
-    protected const TERMINATION_SEQUENCE = '';
+    protected const TERMINATION_SEQUENCE = '<<<';
 
     private static ?array $mockedStreamBuffer = null;
 

--- a/packages/publications/src/Commands/Helpers/InputStreamHandler.php
+++ b/packages/publications/src/Commands/Helpers/InputStreamHandler.php
@@ -19,7 +19,7 @@ use function trim;
  */
 class InputStreamHandler
 {
-    protected const TERMINATION_SEQUENCE = '<<<';
+    public const TERMINATION_SEQUENCE = '<<<';
 
     private static ?array $mockedStreamBuffer = null;
 

--- a/packages/publications/src/Commands/Helpers/InputStreamHandler.php
+++ b/packages/publications/src/Commands/Helpers/InputStreamHandler.php
@@ -47,6 +47,11 @@ class InputStreamHandler
         return $lines;
     }
 
+    protected function shouldTerminate(string $line): bool
+    {
+        return $line === self::TERMINATION_SEQUENCE;
+    }
+
     /** @codeCoverageIgnore Allows for mocking of the standard input stream */
     protected function readInputStream(): string
     {
@@ -61,10 +66,5 @@ class InputStreamHandler
     public static function mockInput(string $input): void
     {
         self::$mockedStreamBuffer = explode("\n", $input);
-    }
-
-    protected function shouldTerminate(string $line): bool
-    {
-        return $line === self::TERMINATION_SEQUENCE;
     }
 }

--- a/packages/publications/src/Commands/Helpers/InputStreamHandler.php
+++ b/packages/publications/src/Commands/Helpers/InputStreamHandler.php
@@ -19,6 +19,8 @@ use function trim;
  */
 class InputStreamHandler
 {
+    protected const TERMINATION_SEQUENCE = '';
+
     private static ?array $mockedStreamBuffer = null;
 
     public static function call(): array
@@ -63,6 +65,6 @@ class InputStreamHandler
 
     protected function shouldTerminate(string $line): bool
     {
-        return $line === '';
+        return $line === self::TERMINATION_SEQUENCE;
     }
 }

--- a/packages/publications/src/Commands/Helpers/InputStreamHandler.php
+++ b/packages/publications/src/Commands/Helpers/InputStreamHandler.php
@@ -36,7 +36,7 @@ class InputStreamHandler
         $lines = [];
         do {
             $line = Hyde::stripNewlines($this->readInputStream());
-            if ($line === '') {
+            if ($this->shouldTerminate($line)) {
                 break;
             }
             $lines[] = trim($line);
@@ -59,5 +59,10 @@ class InputStreamHandler
     public static function mockInput(string $input): void
     {
         self::$mockedStreamBuffer = explode("\n", $input);
+    }
+
+    protected function shouldTerminate(string $line): bool
+    {
+        return $line === '';
     }
 }

--- a/packages/publications/src/Commands/MakePublicationCommand.php
+++ b/packages/publications/src/Commands/MakePublicationCommand.php
@@ -128,7 +128,7 @@ class MakePublicationCommand extends ValidatingCommand
 
     protected function captureTextFieldInput(PublicationFieldDefinition $field): PublicationFieldValue
     {
-        $this->infoComment("Enter lines for field [$field->name]");
+        $this->infoComment("Enter lines for field [$field->name] <fg=gray>(terminate with '<<<')</>");
 
         return new PublicationFieldValue(PublicationFieldTypes::Text, implode("\n", InputStreamHandler::call()));
     }

--- a/packages/publications/tests/Feature/InputStreamHandlerTest.php
+++ b/packages/publications/tests/Feature/InputStreamHandlerTest.php
@@ -17,28 +17,42 @@ class InputStreamHandlerTest extends TestCase
 {
     public function testCanCollectInput()
     {
-        InputStreamHandler::mockInput('foo');
+        InputStreamHandler::mockInput("foo\n<<<");
 
         $this->assertSame(0, $this->makeCommand(['foo'])->handle());
     }
 
+    public function testCanTerminateWithHereSequence()
+    {
+        InputStreamHandler::mockInput("foo\nbar\nbaz\n<<<");
+
+        $this->assertSame(0, $this->makeCommand(['foo', 'bar', 'baz'])->handle());
+    }
+
+    public function testCanTerminateWithHereSequenceAfterCarriageReturns()
+    {
+        InputStreamHandler::mockInput("foo\r\nbar\r\nbaz\r\n<<<");
+
+        $this->assertSame(0, $this->makeCommand(['foo', 'bar', 'baz'])->handle());
+    }
+
     public function testCanCollectMultipleInputLines()
     {
-        InputStreamHandler::mockInput("foo\nbar\nbaz\n");
+        InputStreamHandler::mockInput("foo\nbar\nbaz\n<<<");
 
         $this->assertSame(0, $this->makeCommand(['foo', 'bar', 'baz'])->handle());
     }
 
-    public function testCanTerminateWithCarriageReturns()
+    public function testCanEnterMultipleCarriageReturns()
     {
-        InputStreamHandler::mockInput("foo\r\nbar\r\nbaz\r\n");
+        InputStreamHandler::mockInput("foo\r\nbar\r\nbaz\r\n<<<");
 
         $this->assertSame(0, $this->makeCommand(['foo', 'bar', 'baz'])->handle());
     }
 
-    public function testCanTerminateWithUnixEndings()
+    public function testCanEnterMultipleUnixEndings()
     {
-        InputStreamHandler::mockInput("foo\nbar\nbaz\n");
+        InputStreamHandler::mockInput("foo\nbar\nbaz\n<<<");
 
         $this->assertSame(0, $this->makeCommand(['foo', 'bar', 'baz'])->handle());
     }

--- a/packages/publications/tests/Feature/MakePublicationCommandTest.php
+++ b/packages/publications/tests/Feature/MakePublicationCommandTest.php
@@ -217,7 +217,7 @@ class MakePublicationCommandTest extends TestCase
 
     public function test_command_with_text_input()
     {
-        InputStreamHandler::mockInput("Hello\nWorld");
+        InputStreamHandler::mockInput("Hello\nWorld\n<<<");
         $this->makeSchemaFile([
             'canonicalField' => '__createdAt',
             'fields'         =>  [[
@@ -256,7 +256,7 @@ class MakePublicationCommandTest extends TestCase
 
     public function test_command_with_array_input()
     {
-        InputStreamHandler::mockInput("First Tag\nSecond Tag\nThird Tag");
+        InputStreamHandler::mockInput("First Tag\nSecond Tag\nThird Tag\n<<<");
         $this->makeSchemaFile([
             'canonicalField' => '__createdAt',
             'fields'         =>  [[

--- a/packages/publications/tests/Feature/MakePublicationTagCommandTest.php
+++ b/packages/publications/tests/Feature/MakePublicationTagCommandTest.php
@@ -24,7 +24,7 @@ class MakePublicationTagCommandTest extends TestCase
 
     public function testCanCreateNewPublicationTag()
     {
-        InputStreamHandler::mockInput("foo\nbar\nbaz\n");
+        InputStreamHandler::mockInput("foo\nbar\nbaz\n<<<");
 
         $this->artisan('make:publicationTag')
             ->expectsQuestion('Tag name', 'foo')
@@ -49,7 +49,7 @@ class MakePublicationTagCommandTest extends TestCase
 
     public function testCanCreateNewPublicationTagWithTagNameArgument()
     {
-        InputStreamHandler::mockInput("foo\nbar\nbaz\n");
+        InputStreamHandler::mockInput("foo\nbar\nbaz\n<<<");
 
         $this->artisan('make:publicationTag foo')
             ->expectsOutput('Using tag name [foo] from command line argument')
@@ -74,12 +74,12 @@ class MakePublicationTagCommandTest extends TestCase
 
     public function testCommandFailsIfTagNameIsAlreadySet()
     {
-        InputStreamHandler::mockInput("foo\nbar\nbaz\n");
+        InputStreamHandler::mockInput("foo\nbar\nbaz\n<<<");
 
         $this->artisan('make:publicationTag foo')
              ->assertExitCode(0);
 
-        InputStreamHandler::mockInput("foo\nbar\nbaz\n");
+        InputStreamHandler::mockInput("foo\nbar\nbaz\n<<<");
 
         $this->artisan('make:publicationTag foo')
             ->expectsOutput('Error: Tag [foo] already exists')

--- a/packages/publications/tests/Feature/MakePublicationTypeCommandTest.php
+++ b/packages/publications/tests/Feature/MakePublicationTypeCommandTest.php
@@ -260,7 +260,7 @@ class MakePublicationTypeCommandTest extends TestCase
     {
         $this->directory('test-publication');
         $this->cleanUpWhenDone('tags.yml');
-        InputStreamHandler::mockInput("foo\nbar\nbaz\n");
+        InputStreamHandler::mockInput("foo\nbar\nbaz\n<<<");
 
         $this->artisan('make:publicationType "Test Publication"')
             ->expectsQuestion('Enter name for field #1', 'MyTag')


### PR DESCRIPTION
Changes `InputStreamHandler` termination sequence from an empty line (`''`) to `'<<<'`.

While this is slightly more verbose, it prevents confusion and accidental premature termination as input strings might have empty lines. And the use case for entering paragraphs through the command line is (I assume) so slim that the extra characters are acceptable.

Fixes https://github.com/hydephp/publications/issues/2 and resolves code review comment https://github.com/hydephp/develop/pull/685#discussion_r1094682091