### PR TITLE
Allow input stream termination by sending end-of-transmission character

### DIFF
--- a/.github/workflows/smoke-tests.yml
+++ b/.github/workflows/smoke-tests.yml
@@ -35,7 +35,6 @@ jobs:
 
   test-coverage:
     runs-on: ubuntu-latest
-    needs: run-smoke-tests
     steps:
       - uses: shivammathur/setup-php@16011a795d747d5f45038f96371c3b98aec5669d
         with:

--- a/packages/publications/src/Commands/Helpers/InputStreamHandler.php
+++ b/packages/publications/src/Commands/Helpers/InputStreamHandler.php
@@ -72,6 +72,6 @@ class InputStreamHandler
 
     public static function terminationMessage(): string
     {
-        return 'terminate with <comment><<<</comment> or press <comment>Ctrl+D</comment> to finish';
+        return 'Terminate with <comment><<<</comment> or press <comment>Ctrl+D</comment> to finish';
     }
 }

--- a/packages/publications/src/Commands/Helpers/InputStreamHandler.php
+++ b/packages/publications/src/Commands/Helpers/InputStreamHandler.php
@@ -16,7 +16,7 @@ use function trim;
  *
  * @internal
  *
- * @see \Hyde\Framework\Testing\Unit\InputStreamHandlerTest
+ * @see \Hyde\Publications\Testing\Feature\InputStreamHandlerTest
  */
 class InputStreamHandler
 {

--- a/packages/publications/src/Commands/Helpers/InputStreamHandler.php
+++ b/packages/publications/src/Commands/Helpers/InputStreamHandler.php
@@ -72,7 +72,7 @@ class InputStreamHandler
 
     public static function terminationMessage(): string
     {
-        return sprintf("Terminate with <comment>%s</comment> or press %s to finish", self::TERMINATION_SEQUENCE, self::getShortcut());
+        return sprintf('Terminate with <comment>%s</comment> or press %s to finish', self::TERMINATION_SEQUENCE, self::getShortcut());
     }
 
     protected static function getShortcut(): string

--- a/packages/publications/src/Commands/Helpers/InputStreamHandler.php
+++ b/packages/publications/src/Commands/Helpers/InputStreamHandler.php
@@ -61,6 +61,10 @@ class InputStreamHandler
             return array_shift(self::$mockedStreamBuffer) ?? '';
         }
 
+        if (feof(STDIN)) {
+            return self::END_OF_TRANSMISSION;
+        }
+
         return fgets(STDIN);
     }
 

--- a/packages/publications/src/Commands/Helpers/InputStreamHandler.php
+++ b/packages/publications/src/Commands/Helpers/InputStreamHandler.php
@@ -69,4 +69,9 @@ class InputStreamHandler
     {
         self::$mockedStreamBuffer = explode("\n", $input);
     }
+
+    public static function terminationMessage(): string
+    {
+        return 'terminate with <comment><<<</comment> or press <comment>Ctrl+D</comment> to finish';
+    }
 }

--- a/packages/publications/src/Commands/Helpers/InputStreamHandler.php
+++ b/packages/publications/src/Commands/Helpers/InputStreamHandler.php
@@ -72,6 +72,6 @@ class InputStreamHandler
 
     public static function terminationMessage(): string
     {
-        return 'Terminate with <comment><<<</comment> or press <comment>Ctrl+D</comment> to finish';
+        return sprintf("Terminate with <comment>%s</comment> or press <comment>Ctrl+D</comment> to finish", self::TERMINATION_SEQUENCE);
     }
 }

--- a/packages/publications/src/Commands/Helpers/InputStreamHandler.php
+++ b/packages/publications/src/Commands/Helpers/InputStreamHandler.php
@@ -61,11 +61,7 @@ class InputStreamHandler
             return array_shift(self::$mockedStreamBuffer) ?? '';
         }
 
-        if (feof(STDIN)) {
-            return self::END_OF_TRANSMISSION;
-        }
-
-        return fgets(STDIN);
+        return fgets(STDIN) ?: self::END_OF_TRANSMISSION;
     }
 
     /** @internal Allows for mocking of the standard input stream */

--- a/packages/publications/src/Commands/Helpers/InputStreamHandler.php
+++ b/packages/publications/src/Commands/Helpers/InputStreamHandler.php
@@ -72,6 +72,11 @@ class InputStreamHandler
 
     public static function terminationMessage(): string
     {
-        return sprintf("Terminate with <comment>%s</comment> or press <comment>Ctrl+D</comment> to finish", self::TERMINATION_SEQUENCE);
+        return sprintf("Terminate with <comment>%s</comment> or press %s to finish", self::TERMINATION_SEQUENCE, self::getShortcut());
+    }
+
+    protected static function getShortcut(): string
+    {
+        return '<comment>Ctrl+D</comment>';
     }
 }

--- a/packages/publications/src/Commands/Helpers/InputStreamHandler.php
+++ b/packages/publications/src/Commands/Helpers/InputStreamHandler.php
@@ -8,6 +8,7 @@ use function array_shift;
 use function explode;
 use function fgets;
 use Hyde\Hyde;
+use function str_contains;
 use function trim;
 
 /**
@@ -50,7 +51,7 @@ class InputStreamHandler
 
     protected function shouldTerminate(string $line): bool
     {
-        return $line === self::TERMINATION_SEQUENCE;
+        return $line === self::TERMINATION_SEQUENCE || str_contains($line, self::END_OF_TRANSMISSION);
     }
 
     /** @codeCoverageIgnore Allows for mocking of the standard input stream */

--- a/packages/publications/src/Commands/Helpers/InputStreamHandler.php
+++ b/packages/publications/src/Commands/Helpers/InputStreamHandler.php
@@ -77,6 +77,6 @@ class InputStreamHandler
 
     protected static function getShortcut(): string
     {
-        return '<comment>Ctrl+D</comment>' . (PHP_OS_FAMILY === 'Windows' ? ' then <comment>Enter</comment>' : '');
+        return '<comment>Ctrl+D</comment>'.(PHP_OS_FAMILY === 'Windows' ? ' then <comment>Enter</comment>' : '');
     }
 }

--- a/packages/publications/src/Commands/Helpers/InputStreamHandler.php
+++ b/packages/publications/src/Commands/Helpers/InputStreamHandler.php
@@ -77,6 +77,6 @@ class InputStreamHandler
 
     protected static function getShortcut(): string
     {
-        return '<comment>Ctrl+D</comment>';
+        return '<comment>Ctrl+D</comment>' . (PHP_OS_FAMILY === 'Windows' ? ' then <comment>Enter</comment>' : '');
     }
 }

--- a/packages/publications/src/Commands/Helpers/InputStreamHandler.php
+++ b/packages/publications/src/Commands/Helpers/InputStreamHandler.php
@@ -20,6 +20,7 @@ use function trim;
 class InputStreamHandler
 {
     public const TERMINATION_SEQUENCE = '<<<';
+    public const END_OF_TRANSMISSION = "\x04";
 
     private static ?array $mockedStreamBuffer = null;
 

--- a/packages/publications/src/Commands/MakePublicationCommand.php
+++ b/packages/publications/src/Commands/MakePublicationCommand.php
@@ -128,7 +128,7 @@ class MakePublicationCommand extends ValidatingCommand
 
     protected function captureTextFieldInput(PublicationFieldDefinition $field): PublicationFieldValue
     {
-        $this->infoComment("Enter lines for field [$field->name] (".InputStreamHandler::terminationMessage().")");
+        $this->infoComment(sprintf("Enter lines for field [$field->name] (%s)", InputStreamHandler::terminationMessage()));
 
         return new PublicationFieldValue(PublicationFieldTypes::Text, implode("\n", InputStreamHandler::call()));
     }

--- a/packages/publications/src/Commands/MakePublicationCommand.php
+++ b/packages/publications/src/Commands/MakePublicationCommand.php
@@ -135,7 +135,7 @@ class MakePublicationCommand extends ValidatingCommand
 
     protected function captureArrayFieldInput(PublicationFieldDefinition $field): PublicationFieldValue
     {
-        $this->infoComment("Enter values for field [$field->name]");
+        $this->infoComment(sprintf("Enter values for field [$field->name] (%s)", InputStreamHandler::terminationMessage()));
 
         return new PublicationFieldValue(PublicationFieldTypes::Array, InputStreamHandler::call());
     }

--- a/packages/publications/src/Commands/MakePublicationCommand.php
+++ b/packages/publications/src/Commands/MakePublicationCommand.php
@@ -128,7 +128,7 @@ class MakePublicationCommand extends ValidatingCommand
 
     protected function captureTextFieldInput(PublicationFieldDefinition $field): PublicationFieldValue
     {
-        $this->infoComment("Enter lines for field [$field->name] (terminate with <comment><<<</comment> or press <comment>Ctrl+D</comment> to finish)");
+        $this->infoComment("Enter lines for field [$field->name] (".InputStreamHandler::terminationMessage().")");
 
         return new PublicationFieldValue(PublicationFieldTypes::Text, implode("\n", InputStreamHandler::call()));
     }

--- a/packages/publications/src/Commands/MakePublicationCommand.php
+++ b/packages/publications/src/Commands/MakePublicationCommand.php
@@ -128,7 +128,7 @@ class MakePublicationCommand extends ValidatingCommand
 
     protected function captureTextFieldInput(PublicationFieldDefinition $field): PublicationFieldValue
     {
-        $this->infoComment("Enter lines for field [$field->name] <fg=gray>(terminate with '<<<')</>");
+        $this->infoComment("Enter lines for field [$field->name] (press <comment>Ctrl+D</comment> or enter <comment><<<</comment> to finish)");
 
         return new PublicationFieldValue(PublicationFieldTypes::Text, implode("\n", InputStreamHandler::call()));
     }

--- a/packages/publications/src/Commands/MakePublicationCommand.php
+++ b/packages/publications/src/Commands/MakePublicationCommand.php
@@ -128,7 +128,7 @@ class MakePublicationCommand extends ValidatingCommand
 
     protected function captureTextFieldInput(PublicationFieldDefinition $field): PublicationFieldValue
     {
-        $this->infoComment("Enter lines for field [$field->name] (press <comment>Ctrl+D</comment> or enter <comment><<<</comment> to finish)");
+        $this->infoComment("Enter lines for field [$field->name] (terminate with <comment><<<</comment> or press <comment>Ctrl+D</comment> to finish)");
 
         return new PublicationFieldValue(PublicationFieldTypes::Text, implode("\n", InputStreamHandler::call()));
     }

--- a/packages/publications/src/Commands/MakePublicationTagCommand.php
+++ b/packages/publications/src/Commands/MakePublicationTagCommand.php
@@ -72,7 +72,7 @@ class MakePublicationTagCommand extends ValidatingCommand
 
     protected function collectTags(): void
     {
-        $this->info('Enter the tag values: ('.InputStreamHandler::terminationMessage().')');
+        $this->info(sprintf('Enter the tag values: (%s)', InputStreamHandler::terminationMessage()));
         $this->tags = [$this->tagName => InputStreamHandler::call()];
     }
 

--- a/packages/publications/src/Commands/MakePublicationTagCommand.php
+++ b/packages/publications/src/Commands/MakePublicationTagCommand.php
@@ -72,7 +72,7 @@ class MakePublicationTagCommand extends ValidatingCommand
 
     protected function collectTags(): void
     {
-        $this->info('Enter the tag values: (end with an empty line)');
+        $this->info('Enter the tag values: ('.InputStreamHandler::terminationMessage().')');
         $this->tags = [$this->tagName => InputStreamHandler::call()];
     }
 

--- a/packages/publications/tests/Feature/InputStreamHandlerTest.php
+++ b/packages/publications/tests/Feature/InputStreamHandlerTest.php
@@ -64,6 +64,17 @@ class InputStreamHandlerTest extends TestCase
         $this->assertSame(0, $this->makeCommand(['foo', 'bar', 'baz'])->handle());
     }
 
+    public function testTerminationMessage()
+    {
+        $base = 'Terminate with <comment><<<</comment> or press <comment>Ctrl+D</comment>';
+        if (PHP_OS_FAMILY === 'Windows') {
+            $base .= ' then <comment>Enter</comment>';
+        }
+        $expected = $base . ' to finish';
+
+        $this->assertSame($expected, InputStreamHandler::terminationMessage());
+    }
+
     protected function makeCommand(array $expected): TestCommand
     {
         $command = new TestCommand;

--- a/packages/publications/tests/Feature/InputStreamHandlerTest.php
+++ b/packages/publications/tests/Feature/InputStreamHandlerTest.php
@@ -70,7 +70,7 @@ class InputStreamHandlerTest extends TestCase
         if (PHP_OS_FAMILY === 'Windows') {
             $base .= ' then <comment>Enter</comment>';
         }
-        $expected = $base . ' to finish';
+        $expected = "$base to finish";
 
         $this->assertSame($expected, InputStreamHandler::terminationMessage());
     }

--- a/packages/publications/tests/Feature/InputStreamHandlerTest.php
+++ b/packages/publications/tests/Feature/InputStreamHandlerTest.php
@@ -36,6 +36,13 @@ class InputStreamHandlerTest extends TestCase
         $this->assertSame(0, $this->makeCommand(['foo', 'bar', 'baz'])->handle());
     }
 
+    public function testCanTerminateWithEndOfTransmissionSequence()
+    {
+        InputStreamHandler::mockInput("foo\nbar\nbaz\n\x04");
+
+        $this->assertSame(0, $this->makeCommand(['foo', 'bar', 'baz'])->handle());
+    }
+
     public function testCanCollectMultipleInputLines()
     {
         InputStreamHandler::mockInput("foo\nbar\nbaz\n<<<");

--- a/packages/publications/tests/Feature/InputStreamHandlerTest.php
+++ b/packages/publications/tests/Feature/InputStreamHandlerTest.php
@@ -66,11 +66,11 @@ class InputStreamHandlerTest extends TestCase
 
     public function testTerminationMessage()
     {
-        $base = 'Terminate with <comment><<<</comment> or press <comment>Ctrl+D</comment>';
+        $message = 'Terminate with <comment><<<</comment> or press <comment>Ctrl+D</comment>';
         if (PHP_OS_FAMILY === 'Windows') {
-            $base .= ' then <comment>Enter</comment>';
+            $message .= ' then <comment>Enter</comment>';
         }
-        $expected = "$base to finish";
+        $expected = "$message to finish";
 
         $this->assertSame($expected, InputStreamHandler::terminationMessage());
     }

--- a/packages/publications/tests/Feature/InputStreamHandlerTest.php
+++ b/packages/publications/tests/Feature/InputStreamHandlerTest.php
@@ -75,6 +75,16 @@ class InputStreamHandlerTest extends TestCase
         $this->assertSame($expected, InputStreamHandler::terminationMessage());
     }
 
+    public function testTerminationSequenceConstant()
+    {
+        $this->assertSame('<<<', InputStreamHandler::TERMINATION_SEQUENCE);
+    }
+
+    public function testEndOfTransmissionConstant()
+    {
+        $this->assertSame("\x04", InputStreamHandler::END_OF_TRANSMISSION);
+    }
+
     protected function makeCommand(array $expected): TestCommand
     {
         $command = new TestCommand;

--- a/packages/publications/tests/Feature/MakePublicationTagCommandTest.php
+++ b/packages/publications/tests/Feature/MakePublicationTagCommandTest.php
@@ -28,7 +28,7 @@ class MakePublicationTagCommandTest extends TestCase
 
         $this->artisan('make:publicationTag')
             ->expectsQuestion('Tag name', 'foo')
-            ->expectsOutput('Enter the tag values: (end with an empty line)')
+            ->expectsOutputToContain('Enter the tag values:')
             ->expectsOutput('Adding the following tags:')
             ->expectsOutput('  foo: foo, bar, baz')
             ->expectsOutput('Saving tag data to [file://'.str_replace('\\', '/', Hyde::path('tags.yml')).']')

--- a/packages/publications/tests/Feature/MakePublicationTagCommandTest.php
+++ b/packages/publications/tests/Feature/MakePublicationTagCommandTest.php
@@ -53,7 +53,7 @@ class MakePublicationTagCommandTest extends TestCase
 
         $this->artisan('make:publicationTag foo')
             ->expectsOutput('Using tag name [foo] from command line argument')
-            ->expectsOutput('Enter the tag values: (end with an empty line)')
+            ->expectsOutputToContain('Enter the tag values:')
             ->expectsOutput('Adding the following tags:')
             ->expectsOutput('  foo: foo, bar, baz')
             ->expectsOutput('Saving tag data to [file://'.str_replace('\\', '/', Hyde::path('tags.yml')).']')

--- a/packages/publications/tests/Feature/MakePublicationTagCommandTest.php
+++ b/packages/publications/tests/Feature/MakePublicationTagCommandTest.php
@@ -53,7 +53,7 @@ class MakePublicationTagCommandTest extends TestCase
 
         $this->artisan('make:publicationTag foo')
             ->expectsOutput('Using tag name [foo] from command line argument')
-            ->expectsOutput(sprintf("Enter the tag values: (%s)", InputStreamHandler::terminationMessage()))
+            ->expectsOutput('Enter the tag values: (end with an empty line)')
             ->expectsOutput('Adding the following tags:')
             ->expectsOutput('  foo: foo, bar, baz')
             ->expectsOutput('Saving tag data to [file://'.str_replace('\\', '/', Hyde::path('tags.yml')).']')

--- a/packages/publications/tests/Feature/MakePublicationTagCommandTest.php
+++ b/packages/publications/tests/Feature/MakePublicationTagCommandTest.php
@@ -53,7 +53,7 @@ class MakePublicationTagCommandTest extends TestCase
 
         $this->artisan('make:publicationTag foo')
             ->expectsOutput('Using tag name [foo] from command line argument')
-            ->expectsOutput('Enter the tag values: (end with an empty line)')
+            ->expectsOutput(sprintf("Enter the tag values: (%s)", InputStreamHandler::terminationMessage()))
             ->expectsOutput('Adding the following tags:')
             ->expectsOutput('  foo: foo, bar, baz')
             ->expectsOutput('Saving tag data to [file://'.str_replace('\\', '/', Hyde::path('tags.yml')).']')


### PR DESCRIPTION
In addition to the added `'<<<'` sequence added in https://github.com/hydephp/develop/pull/936, this PR allows for an alternate method to terminate an input stream: by sending an [End-of-Transmission character](https://en.wikipedia.org/wiki/End-of-Transmission_character), usually via `CTRL+D`

<s>You still need to finish with hitting enter as I have not yet figured out a way to read live input instead of a line-to-line basis.</s>

Edit: It seems like `CTRL+D` on Windows sends an EOT Ascii character, `but CTRL+Z+Enter` on Windows seems to provide the same result as `CTRL+D` on Unix. This actually seems to return false from the standard input stream in PHP, so I think we should use that. It's also what [Symfony uses](https://github.com/symfony/console/blob/4c631f95ca95bfa4ed9869c7b74e12a29e28d832/Helper/SymfonyQuestionHelper.php)

Okay: ways to terminate:

- `'<<<'` on single line (Windows+Unix*)
- `CTRL+D` (Unix*)
- `CTRL+D` then `enter` (Windows)
- `CTRL+Z` then `enter` (Windows)


*Tested only in WSL2 but should work on actual Linux and macOS systems.

This IMO is nicer than the Symfony implementation, as it allows for cross platform `CTRL+D` support (in theory).

**The PR also updates output messages for this and the previous change, hence why the PR is so comparatively big.**