### PR TITLE
Move config publisher to configuration service provider

### DIFF
--- a/packages/framework/src/Foundation/Providers/ConfigurationServiceProvider.php
+++ b/packages/framework/src/Foundation/Providers/ConfigurationServiceProvider.php
@@ -26,6 +26,8 @@ class ConfigurationServiceProvider extends ServiceProvider
 
     public function boot(): void
     {
-        //
+        $this->publishes([
+            __DIR__.'/../../../config' => config_path(),
+        ], 'configs');
     }
 }

--- a/packages/framework/src/Framework/HydeServiceProvider.php
+++ b/packages/framework/src/Framework/HydeServiceProvider.php
@@ -74,10 +74,6 @@ class HydeServiceProvider extends ServiceProvider
      */
     public function boot(): void
     {
-        $this->publishes([
-            __DIR__.'/../../config' => config_path(),
-        ], 'configs');
-
         HydeKernel::getInstance()->readyToBoot();
     }
 


### PR DESCRIPTION
Moves the `$this->publishes('configs')` call to the new `ConfigurationServiceProvider`