### PR TITLE
Update Hyde::vendorPath() helper to allow a Hyde package to be specified

### DIFF
--- a/packages/framework/src/Foundation/Concerns/ForwardsFilesystem.php
+++ b/packages/framework/src/Foundation/Concerns/ForwardsFilesystem.php
@@ -23,9 +23,9 @@ trait ForwardsFilesystem
         return $this->filesystem->path($path);
     }
 
-    public function vendorPath(string $path = ''): string
+    public function vendorPath(string $path = '', string $package = 'framework'): string
     {
-        return $this->filesystem->vendorPath($path);
+        return $this->filesystem->vendorPath($path, $package);
     }
 
     public function copy(string $from, string $to): bool

--- a/packages/framework/src/Foundation/Filesystem.php
+++ b/packages/framework/src/Foundation/Filesystem.php
@@ -134,9 +134,9 @@ class Filesystem
     /**
      * Works similarly to the path() function, but returns a file in the Framework package.
      */
-    public function vendorPath(string $path = ''): string
+    public function vendorPath(string $path = '', string $package = 'framework'): string
     {
-        return $this->path('vendor/hyde/framework/'.unslash($path));
+        return $this->path("vendor/hyde/$package/".unslash($path));
     }
 
     /**

--- a/packages/framework/src/Hyde.php
+++ b/packages/framework/src/Hyde.php
@@ -25,7 +25,7 @@ use Illuminate\Support\HtmlString;
  * @license MIT License
  *
  * @method static string path(string $path = '') $basePath
- * @method static string vendorPath(string $path = '')
+ * @method static string vendorPath(string $path = '', string $package = 'framework')
  * @method static string pathToAbsolute(string $path)
  * @method static string pathToRelative(string $path)
  * @method static string getModelSourcePath(string $model, string $path = '')

--- a/packages/framework/tests/Feature/Foundation/FilesystemTest.php
+++ b/packages/framework/tests/Feature/Foundation/FilesystemTest.php
@@ -111,6 +111,12 @@ class FilesystemTest extends TestCase
         $this->assertEquals('/foo/vendor/hyde/framework/file.php', $this->filesystem->vendorPath('\\//file.php/'));
     }
 
+    public function test_vendor_path_can_specify_which_hyde_package_to_use()
+    {
+        $this->assertDirectoryExists(Hyde::vendorPath(package: 'realtime-compiler'));
+        $this->assertFileExists(Hyde::vendorPath('composer.json', 'realtime-compiler'));
+    }
+
     public function test_copy_method()
     {
         touch(Hyde::path('foo'));

--- a/packages/framework/tests/Unit/HydeVendorPathHelperTest.php
+++ b/packages/framework/tests/Unit/HydeVendorPathHelperTest.php
@@ -31,4 +31,11 @@ class HydeVendorPathHelperTest extends TestCase
         $this->assertFileExists(Hyde::vendorPath().'/composer.json');
         $this->assertStringContainsString('"name": "hyde/framework",', file_get_contents(Hyde::vendorPath().'/composer.json'));
     }
+
+    public function test_can_specify_which_hyde_package_to_use()
+    {
+        $this->assertDirectoryExists(Hyde::vendorPath(package: 'realtime-compiler'));
+        $this->assertFileExists(Hyde::vendorPath('composer.json', 'realtime-compiler'));
+        $this->assertStringContainsString('"name": "hyde/realtime-compiler",', file_get_contents(Hyde::vendorPath('composer.json', 'realtime-compiler')));
+    }
 }


### PR DESCRIPTION
This allows the helper to access vendor files from our other packages. The added argument is optional and provides a default value matching existing behaviour, so this change is not breaking.