### PR TITLE
No longer register the Markdown converter into the service container

### DIFF
--- a/packages/framework/src/Framework/HydeServiceProvider.php
+++ b/packages/framework/src/Framework/HydeServiceProvider.php
@@ -11,7 +11,6 @@ use Hyde\Foundation\Providers\ConfigurationServiceProvider;
 use Hyde\Foundation\Providers\ViewServiceProvider;
 use Hyde\Framework\Concerns\RegistersFileLocations;
 use Hyde\Framework\Services\AssetService;
-use Hyde\Markdown\MarkdownConverter;
 use Hyde\Pages\BladePage;
 use Hyde\Pages\DocumentationPage;
 use Hyde\Pages\HtmlPage;
@@ -38,8 +37,6 @@ class HydeServiceProvider extends ServiceProvider
         $this->kernel = HydeKernel::getInstance();
 
         $this->app->singleton(AssetService::class, AssetService::class);
-
-        $this->app->singleton(MarkdownConverter::class, fn (): MarkdownConverter => new MarkdownConverter());
 
         $this->kernel->setSourceRoot(config('hyde.source_root', ''));
 

--- a/packages/framework/tests/Feature/HydeServiceProviderTest.php
+++ b/packages/framework/tests/Feature/HydeServiceProviderTest.php
@@ -25,7 +25,6 @@ use Hyde\Pages\HtmlPage;
 use Hyde\Pages\MarkdownPage;
 use Hyde\Pages\MarkdownPost;
 use Hyde\Testing\TestCase;
-use Hyde\Markdown\MarkdownConverter;
 use Illuminate\Support\Facades\Artisan;
 use function is_subclass_of;
 use function method_exists;
@@ -75,12 +74,6 @@ class HydeServiceProviderTest extends TestCase
     {
         $this->assertTrue($this->app->bound(AssetService::class));
         $this->assertInstanceOf(AssetService::class, $this->app->make(AssetService::class));
-    }
-
-    public function test_provider_registers_markdown_converter_singleton()
-    {
-        $this->assertTrue($this->app->bound(MarkdownConverter::class));
-        $this->assertInstanceOf(MarkdownConverter::class, $this->app->make(MarkdownConverter::class));
     }
 
     public function test_provider_registers_source_directories()


### PR DESCRIPTION
Assuming the class is loaded, it only takes around `0.040ms/0.020ms` to instantiate a new `MarkdownConverter` instance. Compare that to `0.070ms/0.030ms` for accessing the singleton through the service container.

This tiny difference will never be noticeable in actual use. What's more, since there's nothing special about the singleton it doesn't even need to be registered as one. You can simply call `app(MarkdownConverter::class)` and the service container will resolve a new instance.

Since there's no reason to register this class into the service container I don't think we should. Fixes https://github.com/hydephp/develop/issues/952