### PR TITLE
Add internal middlewares to the realtime compiler

### DIFF
--- a/packages/realtime-compiler/src/Http/HttpKernel.php
+++ b/packages/realtime-compiler/src/Http/HttpKernel.php
@@ -14,7 +14,7 @@ use Hyde\RealtimeCompiler\Routing\Router;
  */
 class HttpKernel extends BaseHttpKernel
 {
-    /** @var array<callable(Request): Request> */
+    /** @var class-string[]|array<callable(Request): Request> */
     protected array $middleware = [
         //
     ];
@@ -24,7 +24,9 @@ class HttpKernel extends BaseHttpKernel
         header('X-Server: Hyde/RealtimeCompiler');
 
         foreach ($this->middleware as $middleware) {
-            $request = $middleware($request);
+            $request = is_string($middleware)
+                ? (new $middleware())($request)
+                : $middleware($request);
         }
 
         return (new Router($request))->handle();

--- a/packages/realtime-compiler/src/Http/HttpKernel.php
+++ b/packages/realtime-compiler/src/Http/HttpKernel.php
@@ -14,7 +14,7 @@ use Hyde\RealtimeCompiler\Routing\Router;
  */
 class HttpKernel extends BaseHttpKernel
 {
-    /** @var class-string[]|array<callable(Request): Request> */
+    /** @var class-string<callable>[]|array<callable(Request): Request> */
     protected array $middleware = [
         //
     ];

--- a/packages/realtime-compiler/src/Http/HttpKernel.php
+++ b/packages/realtime-compiler/src/Http/HttpKernel.php
@@ -22,6 +22,10 @@ class HttpKernel extends BaseHttpKernel
     {
         header('X-Server: Hyde/RealtimeCompiler');
 
+        foreach ($this->middleware as $middleware) {
+            $request = $middleware($request);
+        }
+
         return (new Router($request))->handle();
     }
 }

--- a/packages/realtime-compiler/src/Http/HttpKernel.php
+++ b/packages/realtime-compiler/src/Http/HttpKernel.php
@@ -5,6 +5,7 @@ namespace Hyde\RealtimeCompiler\Http;
 use Desilva\Microserve\HttpKernel as BaseHttpKernel;
 use Desilva\Microserve\Request;
 use Desilva\Microserve\Response;
+use Hyde\RealtimeCompiler\Http\Middleware\PathNormalizerMiddleware;
 use Hyde\RealtimeCompiler\Routing\Router;
 
 /**
@@ -16,7 +17,7 @@ class HttpKernel extends BaseHttpKernel
 {
     /** @var array<class-string<callable>>|array<callable(Request): Request> */
     protected array $middleware = [
-        //
+        PathNormalizerMiddleware::class,
     ];
 
     public function handle(Request $request): Response

--- a/packages/realtime-compiler/src/Http/HttpKernel.php
+++ b/packages/realtime-compiler/src/Http/HttpKernel.php
@@ -14,7 +14,7 @@ use Hyde\RealtimeCompiler\Routing\Router;
  */
 class HttpKernel extends BaseHttpKernel
 {
-    /** @var array<callable(Request): Request> $middleware */
+    /** @var array<callable(Request): Request> */
     protected array $middleware = [
         //
     ];

--- a/packages/realtime-compiler/src/Http/HttpKernel.php
+++ b/packages/realtime-compiler/src/Http/HttpKernel.php
@@ -14,6 +14,7 @@ use Hyde\RealtimeCompiler\Routing\Router;
  */
 class HttpKernel extends BaseHttpKernel
 {
+    /** @var array<callable(Request): Request> $middleware */
     protected array $middleware = [
         //
     ];

--- a/packages/realtime-compiler/src/Http/HttpKernel.php
+++ b/packages/realtime-compiler/src/Http/HttpKernel.php
@@ -14,6 +14,10 @@ use Hyde\RealtimeCompiler\Routing\Router;
  */
 class HttpKernel extends BaseHttpKernel
 {
+    protected array $middleware = [
+        //
+    ];
+
     public function handle(Request $request): Response
     {
         header('X-Server: Hyde/RealtimeCompiler');

--- a/packages/realtime-compiler/src/Http/HttpKernel.php
+++ b/packages/realtime-compiler/src/Http/HttpKernel.php
@@ -14,7 +14,7 @@ use Hyde\RealtimeCompiler\Routing\Router;
  */
 class HttpKernel extends BaseHttpKernel
 {
-    /** @var class-string<callable>[]|array<callable(Request): Request> */
+    /** @var array<class-string<callable>>|array<callable(Request): Request> */
     protected array $middleware = [
         //
     ];

--- a/packages/realtime-compiler/src/Http/Middleware/PathNormalizerMiddleware.php
+++ b/packages/realtime-compiler/src/Http/Middleware/PathNormalizerMiddleware.php
@@ -15,11 +15,11 @@ class PathNormalizerMiddleware
 
     public function __invoke(Request $request): Request
     {
+        $request->path = rtrim($request->path, '/');
+
         if (array_key_exists($request->path, $this->pathRewrites)) {
             $request->path = $this->pathRewrites[$request->path];
         }
-
-        $request->path = rtrim($request->path, '/');
 
         return $request;
     }

--- a/packages/realtime-compiler/src/Http/Middleware/PathNormalizerMiddleware.php
+++ b/packages/realtime-compiler/src/Http/Middleware/PathNormalizerMiddleware.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Hyde\RealtimeCompiler\Http\Middleware;
+
+use Desilva\Microserve\Request;
+
+class PathNormalizerMiddleware
+{
+    public function __invoke(Request $request): Request
+    {
+        return $request;
+    }
+}

--- a/packages/realtime-compiler/src/Http/Middleware/PathNormalizerMiddleware.php
+++ b/packages/realtime-compiler/src/Http/Middleware/PathNormalizerMiddleware.php
@@ -8,6 +8,11 @@ use Desilva\Microserve\Request;
 
 class PathNormalizerMiddleware
 {
+    protected array $pathRewrites = [
+        '/docs' => '/docs/index',
+        '/docs/search.html' => '/docs/search',
+    ];
+
     public function __invoke(Request $request): Request
     {
         return $request;

--- a/packages/realtime-compiler/src/Http/Middleware/PathNormalizerMiddleware.php
+++ b/packages/realtime-compiler/src/Http/Middleware/PathNormalizerMiddleware.php
@@ -19,6 +19,8 @@ class PathNormalizerMiddleware
             $request->path = $this->pathRewrites[$request->path];
         }
 
+        $request->path = rtrim($request->path, '/');
+
         return $request;
     }
 }

--- a/packages/realtime-compiler/src/Http/Middleware/PathNormalizerMiddleware.php
+++ b/packages/realtime-compiler/src/Http/Middleware/PathNormalizerMiddleware.php
@@ -15,6 +15,10 @@ class PathNormalizerMiddleware
 
     public function __invoke(Request $request): Request
     {
+        if (array_key_exists($request->path, $this->pathRewrites)) {
+            $request->path = $this->pathRewrites[$request->path];
+        }
+
         return $request;
     }
 }

--- a/packages/realtime-compiler/src/Routing/Router.php
+++ b/packages/realtime-compiler/src/Routing/Router.php
@@ -33,10 +33,6 @@ class Router
             return $this->proxyStatic();
         }
 
-        if (array_key_exists($this->request->path, $this->pathRewrites)) {
-            $this->request->path = $this->pathRewrites[$this->request->path];
-        }
-
         if (in_array($this->request->path, $this->virtualRoutes)) {
             if ($this->request->path === '/docs/search') {
                 return new HtmlResponse(200, 'OK', [

--- a/packages/realtime-compiler/src/Routing/Router.php
+++ b/packages/realtime-compiler/src/Routing/Router.php
@@ -17,11 +17,6 @@ class Router
 
     protected Request $request;
 
-    protected array $pathRewrites = [
-        '/docs' => '/docs/index',
-        '/docs/search.html' => '/docs/search',
-    ];
-
     protected array $virtualRoutes = [
         '/ping',
         '/docs/search',

--- a/packages/realtime-compiler/tests/RealtimeCompilerTest.php
+++ b/packages/realtime-compiler/tests/RealtimeCompilerTest.php
@@ -103,6 +103,24 @@ test('handle sends 404 error response for missing asset', function () {
         ->and($response->statusMessage)->toBe('Not Found');
 });
 
+test('trailing slashes are normalized from route', function () {
+    mockRoute('foo/');
+
+    Filesystem::put('_pages/foo.md', '# Hello World!');
+
+    $kernel = new HttpKernel();
+    $response = $kernel->handle(new Request());
+
+    expect($response)->toBeInstanceOf(Response::class)
+        ->and($response->statusCode)->toBe(200)
+        ->and($response->statusMessage)->toBe('OK');
+
+    expect($response->body)->toContain('<h1>Hello World!</h1>');
+
+    Filesystem::unlink('_pages/foo.md');
+    Filesystem::unlink('_site/foo.html');
+});
+
 test('docs uri path is rerouted to docs/index', function () {
     mockRoute('docs');
 


### PR DESCRIPTION
## Abstract

Adds a simple middleware feature to the realtime compiler `HttpKernel`.


The PR also refactors the path rewriting from https://github.com/hydephp/develop/pull/958 to use a middleware. This separates out the concerns from the router.

There is currently no public API added for this feature. As such, the middleware types are not explicitly enforced.

## Usage

Middlewares are simple. They are callables that accept the incoming `Request` instance, and returns a modified one. Each middleware gets executed in order, and override the request instance, before being passed to the `Router`.

### Closure middleware

```php
$this->middleware[] = function (Request $request): Request {
    // Do something with the request here...

    return $request;
};
```


### Invokable class middleware

```php
class ExampleMiddleware extends BaseHttpKernel
{
    public function __invoke(Request $request): Request
    {
        // Do something with the request here...

        return $request;
    }
}

class HttpKernel
    /** @var array<class-string<callable>>|array<callable(Request): Request> */
    protected array $middleware = [
        PathNormalizerMiddleware::class,
    ];
}
```

### Invokable class middleware (anonymous)

```php
$this->middleware[] = new class {
    public function __invoke(Request $request): Request {
        // Do something with the request here...

        return $request;
    }
};
```
