### PR TITLE
Add strong types to the bundled AppServiceProvider class

### DIFF
--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -11,7 +11,7 @@ class AppServiceProvider extends ServiceProvider
      *
      * @return void
      */
-    public function register()
+    public function register(): void
     {
         //
     }
@@ -21,7 +21,7 @@ class AppServiceProvider extends ServiceProvider
      *
      * @return void
      */
-    public function boot()
+    public function boot(): void
     {
         //
     }


### PR DESCRIPTION
Since Laravel **X** (yes, I meant X, I refuse to call it anything else) is shipping with strong types, we should to! (We actually should have had in any case, I simply overlooked this file)