### PR TITLE
Documentation search page class bugfix and cleanup

### DIFF
--- a/packages/framework/src/Framework/Features/Documentation/DocumentationSearchPage.php
+++ b/packages/framework/src/Framework/Features/Documentation/DocumentationSearchPage.php
@@ -21,7 +21,7 @@ class DocumentationSearchPage extends DocumentationPage
 {
     public function __construct()
     {
-        parent::__construct(DocumentationPage::outputDirectory().'/search', [
+        parent::__construct('search', [
             'title' => 'Search',
         ]);
     }

--- a/packages/framework/src/Framework/Features/Documentation/DocumentationSearchPage.php
+++ b/packages/framework/src/Framework/Features/Documentation/DocumentationSearchPage.php
@@ -26,6 +26,11 @@ class DocumentationSearchPage extends DocumentationPage
         ]);
     }
 
+    public function compile(): string
+    {
+        return view('hyde::pages.documentation-search')->render();
+    }
+
     public static function enabled(): bool
     {
         return config('docs.create_search_page', true) && ! Hyde::routes()->has('docs/search');
@@ -34,10 +39,5 @@ class DocumentationSearchPage extends DocumentationPage
     public static function generate(): string
     {
         return (new StaticPageBuilder(new static()))->__invoke();
-    }
-
-    public function compile(): string
-    {
-        return view('hyde::pages.documentation-search')->render();
     }
 }

--- a/packages/framework/src/Framework/Features/Documentation/DocumentationSearchPage.php
+++ b/packages/framework/src/Framework/Features/Documentation/DocumentationSearchPage.php
@@ -43,6 +43,6 @@ class DocumentationSearchPage extends DocumentationPage
 
     public static function routeKey(): string
     {
-        return 'docs/search';
+        return parent::$outputDirectory.'/search';
     }
 }

--- a/packages/framework/src/Framework/Features/Documentation/DocumentationSearchPage.php
+++ b/packages/framework/src/Framework/Features/Documentation/DocumentationSearchPage.php
@@ -33,11 +33,16 @@ class DocumentationSearchPage extends DocumentationPage
 
     public static function enabled(): bool
     {
-        return config('docs.create_search_page', true) && ! Hyde::routes()->has('docs/search');
+        return config('docs.create_search_page', true) && ! Hyde::routes()->has(self::routeKey());
     }
 
     public static function generate(): string
     {
         return (new StaticPageBuilder(new static()))->__invoke();
+    }
+
+    public static function routeKey(): string
+    {
+        return 'docs/search';
     }
 }

--- a/packages/framework/tests/Feature/DocumentationSearchPageTest.php
+++ b/packages/framework/tests/Feature/DocumentationSearchPageTest.php
@@ -59,4 +59,9 @@ class DocumentationSearchPageTest extends TestCase
         Hyde::routes()->put('docs/search', new InMemoryPage('docs/search'));
         $this->assertFalse(DocumentationSearchPage::enabled());
     }
+
+    public function testStaticRouteKeyHelper()
+    {
+        $this->assertSame('docs/search', DocumentationSearchPage::routeKey());
+    }
 }

--- a/packages/framework/tests/Feature/DocumentationSearchPageTest.php
+++ b/packages/framework/tests/Feature/DocumentationSearchPageTest.php
@@ -22,18 +22,18 @@ class DocumentationSearchPageTest extends TestCase
         $this->assertInstanceOf(DocumentationSearchPage::class, new DocumentationSearchPage());
     }
 
-    public function testIdentifierIsSetToDocumentationOutputDirectory()
+    public function testRouteKeyIsSetToDocumentationOutputDirectory()
     {
         $page = new DocumentationSearchPage();
-        $this->assertSame('docs/search', $page->identifier);
+        $this->assertSame('docs/search', $page->routeKey);
     }
 
-    public function testIdentifierIsSetToConfiguredDocumentationOutputDirectory()
+    public function testRouteKeyIsSetToConfiguredDocumentationOutputDirectory()
     {
         DocumentationPage::$outputDirectory = 'foo';
 
         $page = new DocumentationSearchPage();
-        $this->assertSame('foo/search', $page->identifier);
+        $this->assertSame('foo/search', $page->routeKey);
     }
 
     public function testEnabledDefaultsToTrue()

--- a/packages/framework/tests/Feature/DocumentationSearchPageTest.php
+++ b/packages/framework/tests/Feature/DocumentationSearchPageTest.php
@@ -64,4 +64,10 @@ class DocumentationSearchPageTest extends TestCase
     {
         $this->assertSame('docs/search', DocumentationSearchPage::routeKey());
     }
+
+    public function testStaticRouteKeyHelperWithCustomOutputDirectory()
+    {
+        DocumentationPage::$outputDirectory = 'foo';
+        $this->assertSame('foo/search', DocumentationSearchPage::routeKey());
+    }
 }


### PR DESCRIPTION
## Changes

### Remove duplicated route key base from identifier

Forgot to remove this when extending the documentation page class. The directory should not be included in the identifier, as that leads it to being added twice. If this page were file based, it would be in _docs/search.blade.php

### Extract public static helper to get the search page route key

Adds a helper to act as the source of truth for the route key. Makes it easier for things like the realtime compiler to use the same route key value that automatically supports the configured output directory.