### PR TITLE
Reference environment variable instead of configuration option in docs.php config file

### DIFF
--- a/config/docs.php
+++ b/config/docs.php
@@ -21,7 +21,7 @@ return [
     |
     */
 
-    'header_title' => config('site.name', 'HydePHP').' Docs',
+    'header_title' => env('SITE_NAME', 'HydePHP').' Docs',
 
     /*
     |--------------------------------------------------------------------------

--- a/packages/framework/config/docs.php
+++ b/packages/framework/config/docs.php
@@ -21,7 +21,7 @@ return [
     |
     */
 
-    'header_title' => config('site.name', 'HydePHP').' Docs',
+    'header_title' => env('SITE_NAME', 'HydePHP').' Docs',
 
     /*
     |--------------------------------------------------------------------------


### PR DESCRIPTION
Reference environment variable instead of configuration option in config/docs.php as the loading order of configuration files is not guaranteed.

Fixes https://github.com/hydephp/develop/issues/967