### PR TITLE
Add static `HydePage::baseRouteKey()` helper method

### DIFF
--- a/packages/framework/src/Framework/Services/YamlConfigurationService.php
+++ b/packages/framework/src/Framework/Services/YamlConfigurationService.php
@@ -10,6 +10,8 @@ use Symfony\Component\Yaml\Yaml;
 
 /**
  * @see \Hyde\Framework\Testing\Feature\YamlConfigurationServiceTest
+ *
+ * @internal
  */
 class YamlConfigurationService
 {

--- a/packages/framework/src/Pages/Concerns/HydePage.php
+++ b/packages/framework/src/Pages/Concerns/HydePage.php
@@ -172,6 +172,14 @@ abstract class HydePage implements PageSchema
     }
 
     /**
+     * Get the route key base for the page model.
+     */
+    public static function baseRouteKey(): string
+    {
+        return static::outputDirectory();
+    }
+
+    /**
      * Compile the page into static HTML.
      *
      * @return string The compiled HTML for the page.

--- a/packages/framework/src/Support/Models/RouteKey.php
+++ b/packages/framework/src/Support/Models/RouteKey.php
@@ -42,6 +42,6 @@ final class RouteKey implements Stringable
     public static function fromPage(string $pageClass, string $identifier): self
     {
         /** @var \Hyde\Pages\Concerns\HydePage $pageClass */
-        return new self(unslash($pageClass::outputDirectory().'/'.$identifier));
+        return new self(unslash($pageClass::baseRouteKey().'/'.$identifier));
     }
 }

--- a/packages/framework/tests/Feature/HydePageTest.php
+++ b/packages/framework/tests/Feature/HydePageTest.php
@@ -85,6 +85,14 @@ class HydePageTest extends TestCase
         );
     }
 
+    public function testBaseRouteKey()
+    {
+        $this->assertSame(
+            TestPage::outputDirectory(),
+            TestPage::baseRouteKey()
+        );
+    }
+
     public function testGetSourcePath()
     {
         $this->assertSame(

--- a/packages/framework/tests/Unit/Pages/BaseHydePageUnitTest.php
+++ b/packages/framework/tests/Unit/Pages/BaseHydePageUnitTest.php
@@ -26,6 +26,8 @@ abstract class BaseHydePageUnitTest extends TestCase
 
     abstract public function testPath();
 
+    abstract public function testBaseRouteKey();
+
     abstract public function testGetBladeView();
 
     abstract public function testSourcePath();

--- a/packages/framework/tests/Unit/Pages/BladePageUnitTest.php
+++ b/packages/framework/tests/Unit/Pages/BladePageUnitTest.php
@@ -29,6 +29,11 @@ class BladePageUnitTest extends BaseHydePageUnitTest
         $this->assertSame('', BladePage::outputDirectory());
     }
 
+    public function testBaseRouteKey()
+    {
+        $this->assertSame('', BladePage::baseRouteKey());
+    }
+
     public function testFileExtension()
     {
         $this->assertSame('.blade.php', BladePage::fileExtension());

--- a/packages/framework/tests/Unit/Pages/DocumentationPageUnitTest.php
+++ b/packages/framework/tests/Unit/Pages/DocumentationPageUnitTest.php
@@ -30,6 +30,11 @@ class DocumentationPageUnitTest extends BaseMarkdownPageUnitTest
         $this->assertSame('docs', DocumentationPage::outputDirectory());
     }
 
+    public function testBaseRouteKey()
+    {
+        $this->assertSame('docs', DocumentationPage::baseRouteKey());
+    }
+
     public function testFileExtension()
     {
         $this->assertSame('.md', DocumentationPage::fileExtension());

--- a/packages/framework/tests/Unit/Pages/HtmlPageUnitTest.php
+++ b/packages/framework/tests/Unit/Pages/HtmlPageUnitTest.php
@@ -35,6 +35,14 @@ class HtmlPageUnitTest extends BaseHydePageUnitTest
         );
     }
 
+    public function testBaseRouteKey()
+    {
+        $this->assertSame(
+            '',
+            HtmlPage::baseRouteKey()
+        );
+    }
+
     public function testFileExtension()
     {
         $this->assertSame(

--- a/packages/framework/tests/Unit/Pages/InMemoryPageUnitTest.php
+++ b/packages/framework/tests/Unit/Pages/InMemoryPageUnitTest.php
@@ -38,6 +38,14 @@ class InMemoryPageUnitTest extends BaseHydePageUnitTest
         );
     }
 
+    public function testBaseRouteKey()
+    {
+        $this->assertSame(
+            '',
+            InMemoryPage::baseRouteKey()
+        );
+    }
+
     public function testFileExtension()
     {
         $this->assertSame(

--- a/packages/framework/tests/Unit/Pages/MarkdownPageUnitTest.php
+++ b/packages/framework/tests/Unit/Pages/MarkdownPageUnitTest.php
@@ -36,6 +36,14 @@ class MarkdownPageUnitTest extends BaseMarkdownPageUnitTest
         );
     }
 
+    public function testBaseRouteKey()
+    {
+        $this->assertSame(
+            '',
+            MarkdownPage::baseRouteKey()
+        );
+    }
+
     public function testFileExtension()
     {
         $this->assertSame(

--- a/packages/framework/tests/Unit/Pages/MarkdownPostUnitTest.php
+++ b/packages/framework/tests/Unit/Pages/MarkdownPostUnitTest.php
@@ -36,6 +36,14 @@ class MarkdownPostUnitTest extends BaseMarkdownPageUnitTest
         );
     }
 
+    public function testBaseRouteKey()
+    {
+        $this->assertSame(
+            'posts',
+            MarkdownPost::baseRouteKey()
+        );
+    }
+
     public function testFileExtension()
     {
         $this->assertSame(


### PR DESCRIPTION
Adds a static helper accessor method to get the output directory, as it makes the tight relationship between routes and output directories clearer in my opinion.