### PR TITLE
Create helper to get the documentation page home route name

### DIFF
--- a/packages/framework/src/Framework/Factories/NavigationDataFactory.php
+++ b/packages/framework/src/Framework/Factories/NavigationDataFactory.php
@@ -131,7 +131,7 @@ class NavigationDataFactory extends Concerns\PageDataFactory implements Navigati
     {
         return Arr::get(config('hyde.navigation.labels', [
             'index' => 'Home',
-            'docs/index' => 'Docs',
+            DocumentationPage::baseRouteKey().'/index' => 'Docs',
         ]), $this->routeKey);
     }
 

--- a/packages/framework/src/Framework/Factories/NavigationDataFactory.php
+++ b/packages/framework/src/Framework/Factories/NavigationDataFactory.php
@@ -131,7 +131,7 @@ class NavigationDataFactory extends Concerns\PageDataFactory implements Navigati
     {
         return Arr::get(config('hyde.navigation.labels', [
             'index' => 'Home',
-            DocumentationPage::baseRouteKey().'/index' => 'Docs',
+            DocumentationPage::homeRouteName() => 'Docs',
         ]), $this->routeKey);
     }
 

--- a/packages/framework/src/Framework/Features/Navigation/DocumentationSidebar.php
+++ b/packages/framework/src/Framework/Features/Navigation/DocumentationSidebar.php
@@ -46,6 +46,6 @@ class DocumentationSidebar extends BaseNavigationMenu
 
     protected static function shouldItemBeHidden(NavItem $item): bool
     {
-        return parent::shouldItemBeHidden($item) || $item->getRoute()?->is('docs/index');
+        return parent::shouldItemBeHidden($item) || $item->getRoute()?->is(DocumentationPage::homeRouteName());
     }
 }

--- a/packages/framework/src/Framework/Features/Navigation/NavigationMenu.php
+++ b/packages/framework/src/Framework/Features/Navigation/NavigationMenu.php
@@ -81,6 +81,6 @@ class NavigationMenu extends BaseNavigationMenu
     protected static function shouldItemBeHidden(NavItem $item): bool
     {
         return parent::shouldItemBeHidden($item) ||
-            $item->getRoute()?->getPage() instanceof DocumentationPage && ! $item->getRoute()->is('docs/index');
+            $item->getRoute()?->getPage() instanceof DocumentationPage && ! $item->getRoute()->is(DocumentationPage::homeRouteName());
     }
 }

--- a/packages/framework/src/Pages/DocumentationPage.php
+++ b/packages/framework/src/Pages/DocumentationPage.php
@@ -31,7 +31,7 @@ class DocumentationPage extends BaseMarkdownPage
 
     public static function homeRouteName(): string
     {
-        return static::$outputDirectory.'/index';
+        return static::baseRouteKey().'/index';
     }
 
     /** @see https://hydephp.com/docs/master/documentation-pages#automatic-edit-page-button */

--- a/packages/framework/src/Pages/DocumentationPage.php
+++ b/packages/framework/src/Pages/DocumentationPage.php
@@ -26,7 +26,12 @@ class DocumentationPage extends BaseMarkdownPage
 
     public static function home(): ?Route
     {
-        return Route::get(static::$outputDirectory.'/index');
+        return Route::get(static::homeRouteName());
+    }
+
+    public static function homeRouteName(): string
+    {
+        return static::$outputDirectory.'/index';
     }
 
     /** @see https://hydephp.com/docs/master/documentation-pages#automatic-edit-page-button */

--- a/packages/framework/tests/Unit/DocumentationPageTest.php
+++ b/packages/framework/tests/Unit/DocumentationPageTest.php
@@ -144,6 +144,19 @@ class DocumentationPageTest extends TestCase
         File::deleteDirectory(Hyde::path('foo'));
     }
 
+    public function test_home_route_name_method_returns_output_directory_slash_index()
+    {
+        $this->assertSame('docs/index', DocumentationPage::homeRouteName());
+    }
+
+    public function test_home_route_name_method_returns_customized_output_directory_slash_index()
+    {
+        config(['docs.output_directory' => 'foo/bar']);
+        (new HydeServiceProvider($this->app))->register();
+
+        $this->assertSame('foo/bar/index', DocumentationPage::homeRouteName());
+    }
+
     public function test_has_table_of_contents()
     {
         $this->assertIsBool(DocumentationPage::hasTableOfContents());


### PR DESCRIPTION
Allows us to use `DocumentationPage::homeRouteName()` instead of `DocumentationPage::$outputDirectory.'/index'`, or worse yet, hardcoding `'docs/index'` which breaks if the user changes the output directory.

Fixes https://github.com/hydephp/develop/issues/972