### PR TITLE
Restructure service providers

### DIFF
--- a/config/app.php
+++ b/config/app.php
@@ -79,6 +79,7 @@ return [
     'providers' => [
         App\Providers\AppServiceProvider::class,
         Hyde\Framework\HydeServiceProvider::class,
+        Hyde\Foundation\Providers\ConfigurationServiceProvider::class,
     ],
 
     /*

--- a/config/app.php
+++ b/config/app.php
@@ -81,7 +81,7 @@ return [
         Hyde\Framework\HydeServiceProvider::class,
         Hyde\Foundation\Providers\ViewServiceProvider::class,
         Hyde\Foundation\Providers\ConfigurationServiceProvider::class,
-        Hyde\Console\HydeConsoleServiceProvider::class,
+        Hyde\Console\ConsoleServiceProvider::class,
     ],
 
     /*

--- a/config/app.php
+++ b/config/app.php
@@ -79,6 +79,7 @@ return [
     'providers' => [
         App\Providers\AppServiceProvider::class,
         Hyde\Framework\HydeServiceProvider::class,
+        Hyde\Foundation\Providers\ViewServiceProvider::class,
         Hyde\Foundation\Providers\ConfigurationServiceProvider::class,
         Hyde\Console\HydeConsoleServiceProvider::class,
     ],

--- a/config/app.php
+++ b/config/app.php
@@ -80,6 +80,7 @@ return [
         App\Providers\AppServiceProvider::class,
         Hyde\Framework\HydeServiceProvider::class,
         Hyde\Foundation\Providers\ConfigurationServiceProvider::class,
+        Hyde\Console\HydeConsoleServiceProvider::class,
     ],
 
     /*

--- a/packages/framework/src/Console/ConsoleServiceProvider.php
+++ b/packages/framework/src/Console/ConsoleServiceProvider.php
@@ -11,9 +11,6 @@ use Illuminate\Support\ServiceProvider;
  */
 class ConsoleServiceProvider extends ServiceProvider
 {
-    /**
-     * Register any console services.
-     */
     public function register(): void
     {
         $this->commands([
@@ -39,5 +36,10 @@ class ConsoleServiceProvider extends ServiceProvider
 
             Commands\ChangeSourceDirectoryCommand::class,
         ]);
+    }
+
+    public function boot(): void
+    {
+        //
     }
 }

--- a/packages/framework/src/Console/ConsoleServiceProvider.php
+++ b/packages/framework/src/Console/ConsoleServiceProvider.php
@@ -9,7 +9,7 @@ use Illuminate\Support\ServiceProvider;
 /**
  * Register the HydeCLI console commands.
  */
-class HydeConsoleServiceProvider extends ServiceProvider
+class ConsoleServiceProvider extends ServiceProvider
 {
     /**
      * Register any console services.

--- a/packages/framework/src/Foundation/Providers/ViewServiceProvider.php
+++ b/packages/framework/src/Foundation/Providers/ViewServiceProvider.php
@@ -9,6 +9,9 @@ use Hyde\Hyde;
 use Illuminate\Support\Facades\Blade;
 use Illuminate\Support\ServiceProvider;
 
+/**
+ * Register the Hyde view components.
+ */
 class ViewServiceProvider extends ServiceProvider
 {
     public function register(): void

--- a/packages/framework/src/Framework/HydeServiceProvider.php
+++ b/packages/framework/src/Framework/HydeServiceProvider.php
@@ -16,7 +16,7 @@ use Hyde\Pages\MarkdownPost;
 use Illuminate\Support\ServiceProvider;
 
 /**
- * Register and bootstrap Hyde application services.
+ * Register and bootstrap core Hyde application services.
  */
 class HydeServiceProvider extends ServiceProvider
 {
@@ -24,9 +24,6 @@ class HydeServiceProvider extends ServiceProvider
 
     protected HydeKernel $kernel;
 
-    /**
-     * Register any application services.
-     */
     public function register(): void
     {
         $this->kernel = HydeKernel::getInstance();
@@ -60,17 +57,11 @@ class HydeServiceProvider extends ServiceProvider
         $this->discoverBladeViewsIn(BladePage::sourceDirectory());
     }
 
-    /**
-     * Bootstrap any application services.
-     */
     public function boot(): void
     {
         $this->kernel->readyToBoot();
     }
 
-    /**
-     * Register the page model classes that Hyde should use.
-     */
     protected function registerPageModels(): void
     {
         if (Features::hasHtmlPages()) {

--- a/packages/framework/src/Framework/HydeServiceProvider.php
+++ b/packages/framework/src/Framework/HydeServiceProvider.php
@@ -58,8 +58,6 @@ class HydeServiceProvider extends ServiceProvider
         $this->useMediaDirectory(config('site.media_directory', '_media'));
 
         $this->discoverBladeViewsIn(BladePage::sourceDirectory());
-
-        $this->registerModuleServiceProviders();
     }
 
     /**
@@ -94,13 +92,5 @@ class HydeServiceProvider extends ServiceProvider
         if (Features::hasDocumentationPages()) {
             $this->kernel->registerPageClass(DocumentationPage::class);
         }
-    }
-
-    /**
-     * Register module service providers.
-     */
-    protected function registerModuleServiceProviders(): void
-    {
-        //
     }
 }

--- a/packages/framework/src/Framework/HydeServiceProvider.php
+++ b/packages/framework/src/Framework/HydeServiceProvider.php
@@ -7,7 +7,6 @@ namespace Hyde\Framework;
 use Hyde\Console\HydeConsoleServiceProvider;
 use Hyde\Facades\Features;
 use Hyde\Foundation\HydeKernel;
-use Hyde\Foundation\Providers\ConfigurationServiceProvider;
 use Hyde\Foundation\Providers\ViewServiceProvider;
 use Hyde\Framework\Concerns\RegistersFileLocations;
 use Hyde\Framework\Services\AssetService;
@@ -32,8 +31,6 @@ class HydeServiceProvider extends ServiceProvider
      */
     public function register(): void
     {
-        $this->initializeConfiguration();
-
         $this->kernel = HydeKernel::getInstance();
 
         $this->app->singleton(AssetService::class, AssetService::class);
@@ -73,12 +70,6 @@ class HydeServiceProvider extends ServiceProvider
     public function boot(): void
     {
         $this->kernel->readyToBoot();
-    }
-
-    /** @deprecated Todo: Move this to app.php */
-    protected function initializeConfiguration(): void
-    {
-        $this->app->register(ConfigurationServiceProvider::class);
     }
 
     /**

--- a/packages/framework/src/Framework/HydeServiceProvider.php
+++ b/packages/framework/src/Framework/HydeServiceProvider.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Hyde\Framework;
 
-use Hyde\Console\HydeConsoleServiceProvider;
 use Hyde\Facades\Features;
 use Hyde\Foundation\HydeKernel;
 use Hyde\Foundation\Providers\ViewServiceProvider;
@@ -103,7 +102,6 @@ class HydeServiceProvider extends ServiceProvider
      */
     protected function registerModuleServiceProviders(): void
     {
-        $this->app->register(HydeConsoleServiceProvider::class);
         $this->app->register(ViewServiceProvider::class);
     }
 }

--- a/packages/framework/src/Framework/HydeServiceProvider.php
+++ b/packages/framework/src/Framework/HydeServiceProvider.php
@@ -6,7 +6,6 @@ namespace Hyde\Framework;
 
 use Hyde\Facades\Features;
 use Hyde\Foundation\HydeKernel;
-use Hyde\Foundation\Providers\ViewServiceProvider;
 use Hyde\Framework\Concerns\RegistersFileLocations;
 use Hyde\Framework\Services\AssetService;
 use Hyde\Pages\BladePage;
@@ -102,6 +101,6 @@ class HydeServiceProvider extends ServiceProvider
      */
     protected function registerModuleServiceProviders(): void
     {
-        $this->app->register(ViewServiceProvider::class);
+        //
     }
 }

--- a/packages/framework/tests/Feature/HydeServiceProviderTest.php
+++ b/packages/framework/tests/Feature/HydeServiceProviderTest.php
@@ -13,7 +13,7 @@ use function config;
 use function get_class;
 use function get_declared_classes;
 use function glob;
-use Hyde\Console\HydeConsoleServiceProvider;
+use Hyde\Console\ConsoleServiceProvider;
 use Hyde\Facades\Site;
 use Hyde\Framework\HydeServiceProvider;
 use Hyde\Framework\Services\AssetService;
@@ -212,7 +212,7 @@ class HydeServiceProviderTest extends TestCase
     {
         $this->provider->register();
 
-        $this->assertArrayHasKey(HydeConsoleServiceProvider::class, $this->app->getLoadedProviders());
+        $this->assertArrayHasKey(ConsoleServiceProvider::class, $this->app->getLoadedProviders());
     }
 
     public function test_provider_registers_all_page_model_source_paths()


### PR DESCRIPTION
### Abstract
Further restructures the Hyde service providers so each one has their own scoped function. See https://github.com/hydephp/develop/issues/939

### Main changes

1. Register providers in the `app.php` config instead of through the `HydeServiceProvider`
\- This allows them to be swapped out by advanced end users
2. Renames `HydeConsoleServiceProvider` to `ConsoleServiceProvider`
\- This is because no other providers have such a prefix, nor is it warranted
3. Normalize service provider code style and presentation
\- This is purely cosmetic