### PR TITLE
Register inlined configuration files in bootstrapper class

### DIFF
--- a/app/config.php
+++ b/app/config.php
@@ -70,9 +70,9 @@ return [
 
     'providers' => [
         App\Providers\AppServiceProvider::class,
-        Hyde\Foundation\Providers\ConfigurationServiceProvider::class,
         Hyde\Framework\HydeServiceProvider::class,
         Hyde\Foundation\Providers\ViewServiceProvider::class,
+        Hyde\Foundation\Providers\ConfigurationServiceProvider::class,
         Hyde\Console\ConsoleServiceProvider::class,
     ],
 

--- a/app/config.php
+++ b/app/config.php
@@ -70,9 +70,9 @@ return [
 
     'providers' => [
         App\Providers\AppServiceProvider::class,
+        Hyde\Foundation\Providers\ConfigurationServiceProvider::class,
         Hyde\Framework\HydeServiceProvider::class,
         Hyde\Foundation\Providers\ViewServiceProvider::class,
-        Hyde\Foundation\Providers\ConfigurationServiceProvider::class,
         Hyde\Console\ConsoleServiceProvider::class,
     ],
 

--- a/packages/framework/src/Foundation/Internal/LoadConfiguration.php
+++ b/packages/framework/src/Foundation/Internal/LoadConfiguration.php
@@ -25,6 +25,6 @@ class LoadConfiguration extends BaseLoadConfiguration
     {
         parent::loadConfigurationFiles($app, $repository);
 
-        //
+        $repository->set('view', require __DIR__.'/../../../config/view.php');
     }
 }

--- a/packages/framework/src/Foundation/Internal/LoadConfiguration.php
+++ b/packages/framework/src/Foundation/Internal/LoadConfiguration.php
@@ -25,7 +25,7 @@ class LoadConfiguration extends BaseLoadConfiguration
     {
         parent::loadConfigurationFiles($app, $repository);
 
-        $this->mergeConfigurationFiles($repository, ['view']);
+        $this->mergeConfigurationFiles($repository, ['view', 'cache', 'commands', 'torchlight']);
     }
 
     protected function mergeConfigurationFiles(RepositoryContract $repository, array $keys): void

--- a/packages/framework/src/Foundation/Internal/LoadConfiguration.php
+++ b/packages/framework/src/Foundation/Internal/LoadConfiguration.php
@@ -25,7 +25,14 @@ class LoadConfiguration extends BaseLoadConfiguration
     {
         parent::loadConfigurationFiles($app, $repository);
 
-        $this->mergeConfigurationFile($repository, 'view');
+        $this->mergeConfigurationFiles($repository, ['view']);
+    }
+
+    protected function mergeConfigurationFiles(RepositoryContract $repository, array $keys): void
+    {
+        foreach ($keys as $key) {
+            $this->mergeConfigurationFile($repository, $key);
+        }
     }
 
     protected function mergeConfigurationFile(RepositoryContract $repository, string $key): void

--- a/packages/framework/src/Foundation/Internal/LoadConfiguration.php
+++ b/packages/framework/src/Foundation/Internal/LoadConfiguration.php
@@ -25,6 +25,9 @@ class LoadConfiguration extends BaseLoadConfiguration
     {
         parent::loadConfigurationFiles($app, $repository);
 
-        $repository->set('view', require __DIR__.'/../../../config/view.php');
+        $repository->set('view', array_merge(
+            require __DIR__.'/../../../config/view.php',
+            $repository->get('view', [])
+        ));
     }
 }

--- a/packages/framework/src/Foundation/Internal/LoadConfiguration.php
+++ b/packages/framework/src/Foundation/Internal/LoadConfiguration.php
@@ -25,9 +25,14 @@ class LoadConfiguration extends BaseLoadConfiguration
     {
         parent::loadConfigurationFiles($app, $repository);
 
-        $repository->set('view', array_merge(
-            require __DIR__.'/../../../config/view.php',
-            $repository->get('view', [])
+        $this->mergeConfigurationFile($repository, 'view');
+    }
+
+    protected function mergeConfigurationFile(RepositoryContract $repository, string $key): void
+    {
+        $repository->set($key, array_merge(
+            require __DIR__."/../../../config/$key.php",
+            $repository->get($key, [])
         ));
     }
 }

--- a/packages/framework/src/Foundation/Internal/LoadConfiguration.php
+++ b/packages/framework/src/Foundation/Internal/LoadConfiguration.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Hyde\Foundation\Internal;
 
+use Illuminate\Contracts\Config\Repository as RepositoryContract;
 use Illuminate\Contracts\Foundation\Application;
 use Illuminate\Foundation\Bootstrap\LoadConfiguration as BaseLoadConfiguration;
 
@@ -17,5 +18,13 @@ class LoadConfiguration extends BaseLoadConfiguration
             // Inject our custom config file which is stored in `app/config.php`.
             $files['app'] = $app->basePath().DIRECTORY_SEPARATOR.'app'.DIRECTORY_SEPARATOR.'config.php';
         });
+    }
+
+    /** Load the configuration items from all the files. */
+    protected function loadConfigurationFiles(Application $app, RepositoryContract $repository): void
+    {
+        parent::loadConfigurationFiles($app, $repository);
+
+        //
     }
 }

--- a/packages/framework/src/Foundation/Internal/LoadConfiguration.php
+++ b/packages/framework/src/Foundation/Internal/LoadConfiguration.php
@@ -28,6 +28,7 @@ class LoadConfiguration extends BaseLoadConfiguration
         $this->mergeConfigurationFiles($repository, ['view', 'cache', 'commands', 'torchlight']);
     }
 
+    /** These files do commonly not need to be customized by the user, so to get them out of the way, we don't include them in the default project install. */
     protected function mergeConfigurationFiles(RepositoryContract $repository, array $keys): void
     {
         foreach ($keys as $key) {
@@ -35,6 +36,7 @@ class LoadConfiguration extends BaseLoadConfiguration
         }
     }
 
+    /** We of course want the user to be able to customize the config files, if they're present, so we'll merge their changes here. */
     protected function mergeConfigurationFile(RepositoryContract $repository, string $key): void
     {
         $repository->set($key, array_merge(

--- a/packages/framework/src/Foundation/Providers/ConfigurationServiceProvider.php
+++ b/packages/framework/src/Foundation/Providers/ConfigurationServiceProvider.php
@@ -14,12 +14,6 @@ class ConfigurationServiceProvider extends ServiceProvider
         $this->mergeConfigFrom(__DIR__.'/../../../config/hyde.php', 'hyde');
         $this->mergeConfigFrom(__DIR__.'/../../../config/docs.php', 'docs');
         $this->mergeConfigFrom(__DIR__.'/../../../config/markdown.php', 'markdown');
-
-        // Illuminate/Vendor Configuration Files
-        $this->mergeConfigFrom(__DIR__.'/../../../config/view.php', 'view');
-        $this->mergeConfigFrom(__DIR__.'/../../../config/cache.php', 'cache');
-        $this->mergeConfigFrom(__DIR__.'/../../../config/commands.php', 'commands');
-        $this->mergeConfigFrom(__DIR__.'/../../../config/torchlight.php', 'torchlight');
     }
 
     public function boot(): void

--- a/packages/framework/src/Foundation/Providers/ConfigurationServiceProvider.php
+++ b/packages/framework/src/Foundation/Providers/ConfigurationServiceProvider.php
@@ -6,6 +6,9 @@ namespace Hyde\Foundation\Providers;
 
 use Illuminate\Support\ServiceProvider;
 
+/**
+ * @deprecated Simplified class can now be inlined in the HydeServiceProvider.
+ */
 class ConfigurationServiceProvider extends ServiceProvider
 {
     public function register(): void


### PR DESCRIPTION
Since the removed config files like view and cache were moved to the vendor directory in https://github.com/hydephp/develop/pull/873, they then became dependent on a service provider registration. Since their registration order is not guaranteed, this PR refactors to merge those configuration files in the configuration loading bootstrapper.

See https://github.com/hydephp/develop/pull/873#discussion_r1103767486

The PR also deprecates `ConfigurationServiceProvider.php` as it's so simplified that it can be merged into the HydeServiceProvider.