### PR TITLE
Rename foundation collection facades

### DIFF
--- a/packages/framework/src/Console/Commands/RebuildStaticPageCommand.php
+++ b/packages/framework/src/Console/Commands/RebuildStaticPageCommand.php
@@ -6,7 +6,7 @@ namespace Hyde\Console\Commands;
 
 use Exception;
 use Hyde\Console\Concerns\Command;
-use Hyde\Foundation\Facades\PageCollection;
+use Hyde\Foundation\Facades\Pages;
 use Hyde\Framework\Features\BuildTasks\BuildTask;
 use Hyde\Framework\Services\BuildService;
 use Hyde\Framework\Services\RebuildService;
@@ -73,7 +73,7 @@ class RebuildStaticPageCommand extends Command
             public function then(): void
             {
                 $this->createdSiteFile(Command::createClickableFilepath(
-                    PageCollection::getPage($this->path)->getOutputPath()
+                    Pages::getPage($this->path)->getOutputPath()
                 ))->withExecutionTime();
             }
 

--- a/packages/framework/src/Foundation/Facades/Files.php
+++ b/packages/framework/src/Foundation/Facades/Files.php
@@ -10,7 +10,7 @@ use Illuminate\Support\Facades\Facade;
 /**
  * @mixin \Hyde\Foundation\Kernel\FileCollection
  */
-class FileCollection extends Facade
+class Files extends Facade
 {
     public static function getFacadeRoot(): \Hyde\Foundation\Kernel\FileCollection
     {

--- a/packages/framework/src/Foundation/Facades/Files.php
+++ b/packages/framework/src/Foundation/Facades/Files.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Hyde\Foundation\Facades;
 
 use Hyde\Foundation\HydeKernel;
+use Hyde\Foundation\Kernel\FileCollection;
 use Illuminate\Support\Facades\Facade;
 
 /**
@@ -12,7 +13,7 @@ use Illuminate\Support\Facades\Facade;
  */
 class Files extends Facade
 {
-    public static function getFacadeRoot(): \Hyde\Foundation\Kernel\FileCollection
+    public static function getFacadeRoot(): FileCollection
     {
         return HydeKernel::getInstance()->files();
     }

--- a/packages/framework/src/Foundation/Facades/Pages.php
+++ b/packages/framework/src/Foundation/Facades/Pages.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Hyde\Foundation\Facades;
 
 use Hyde\Foundation\HydeKernel;
+use Hyde\Foundation\Kernel\PageCollection;
 use Illuminate\Support\Facades\Facade;
 
 /**
@@ -12,7 +13,7 @@ use Illuminate\Support\Facades\Facade;
  */
 class Pages extends Facade
 {
-    public static function getFacadeRoot(): \Hyde\Foundation\Kernel\PageCollection
+    public static function getFacadeRoot(): PageCollection
     {
         return HydeKernel::getInstance()->pages();
     }

--- a/packages/framework/src/Foundation/Facades/Pages.php
+++ b/packages/framework/src/Foundation/Facades/Pages.php
@@ -10,7 +10,7 @@ use Illuminate\Support\Facades\Facade;
 /**
  * @mixin \Hyde\Foundation\Kernel\PageCollection
  */
-class PageCollection extends Facade
+class Pages extends Facade
 {
     public static function getFacadeRoot(): \Hyde\Foundation\Kernel\PageCollection
     {

--- a/packages/framework/src/Foundation/Facades/Routes.php
+++ b/packages/framework/src/Foundation/Facades/Routes.php
@@ -11,7 +11,7 @@ use Illuminate\Support\Facades\Facade;
 /**
  * @mixin \Hyde\Foundation\Kernel\RouteCollection
  */
-class Router extends Facade
+class Routes extends Facade
 {
     public static function getFacadeRoot(): RouteCollection
     {

--- a/packages/framework/src/Foundation/Kernel/FileCollection.php
+++ b/packages/framework/src/Foundation/Kernel/FileCollection.php
@@ -18,7 +18,7 @@ use Hyde\Support\Filesystem\SourceFile;
  * This class is stored as a singleton in the HydeKernel.
  * You would commonly access it via one of the facades:
  *
- * @see \Hyde\Foundation\Facades\FileCollection
+ * @see \Hyde\Foundation\Facades\Files
  * @see \Hyde\Hyde::files()
  */
 final class FileCollection extends BaseFoundationCollection

--- a/packages/framework/src/Framework/Features/Navigation/BaseNavigationMenu.php
+++ b/packages/framework/src/Framework/Features/Navigation/BaseNavigationMenu.php
@@ -6,7 +6,7 @@ namespace Hyde\Framework\Features\Navigation;
 
 use function collect;
 use function config;
-use Hyde\Foundation\Facades\Router;
+use Hyde\Foundation\Facades\Routes;
 use Hyde\Support\Models\Route;
 use Illuminate\Support\Collection;
 
@@ -30,7 +30,7 @@ abstract class BaseNavigationMenu
     /** @return $this */
     public function generate(): static
     {
-        Router::each(function (Route $route): void {
+        Routes::each(function (Route $route): void {
             $this->items->put($route->getRouteKey(), NavItem::fromRoute($route));
         });
 

--- a/packages/framework/src/Framework/Features/Navigation/DocumentationSidebar.php
+++ b/packages/framework/src/Framework/Features/Navigation/DocumentationSidebar.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Hyde\Framework\Features\Navigation;
 
-use Hyde\Foundation\Facades\Router;
+use Hyde\Foundation\Facades\Routes;
 use Hyde\Pages\DocumentationPage;
 use Hyde\Support\Models\Route;
 use Illuminate\Support\Collection;
@@ -18,7 +18,7 @@ class DocumentationSidebar extends BaseNavigationMenu
     /** @return $this */
     public function generate(): static
     {
-        Router::getRoutes(DocumentationPage::class)->each(function (Route $route): void {
+        Routes::getRoutes(DocumentationPage::class)->each(function (Route $route): void {
             $this->items->put($route->getRouteKey(), NavItem::fromRoute($route));
         });
 

--- a/packages/framework/src/Framework/Services/DiscoveryService.php
+++ b/packages/framework/src/Framework/Services/DiscoveryService.php
@@ -7,7 +7,7 @@ namespace Hyde\Framework\Services;
 use function class_exists;
 use function config;
 use function glob;
-use Hyde\Foundation\Facades\FileCollection;
+use Hyde\Foundation\Facades\Files;
 use Hyde\Framework\Exceptions\UnsupportedPageTypeException;
 use Hyde\Hyde;
 use Hyde\Pages\BladePage;
@@ -74,7 +74,7 @@ class DiscoveryService
             throw new UnsupportedPageTypeException($model);
         }
 
-        return FileCollection::getSourceFiles($model)->flatten()->map(function (SourceFile $file) use ($model): string {
+        return Files::getSourceFiles($model)->flatten()->map(function (SourceFile $file) use ($model): string {
             return static::pathToIdentifier($model, $file->withoutDirectoryPrefix());
         })->toArray();
     }

--- a/packages/framework/src/Framework/Services/RebuildService.php
+++ b/packages/framework/src/Framework/Services/RebuildService.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Hyde\Framework\Services;
 
-use Hyde\Foundation\Facades\PageCollection;
+use Hyde\Foundation\Facades\Pages;
 use Hyde\Framework\Actions\StaticPageBuilder;
 
 /**
@@ -42,7 +42,7 @@ class RebuildService
     public function execute(): StaticPageBuilder
     {
         return $this->builder = (new StaticPageBuilder(
-            PageCollection::getPage($this->filepath),
+            Pages::getPage($this->filepath),
             true
         ));
     }

--- a/packages/framework/src/Pages/Concerns/HydePage.php
+++ b/packages/framework/src/Pages/Concerns/HydePage.php
@@ -118,7 +118,7 @@ abstract class HydePage implements PageSchema
      */
     public static function all(): PageCollection
     {
-        return Facades\PageCollection::getPages(static::class);
+        return Facades\Pages::getPages(static::class);
     }
 
     // Section: Filesystem

--- a/packages/framework/src/Support/Models/Route.php
+++ b/packages/framework/src/Support/Models/Route.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Hyde\Support\Models;
 
-use Hyde\Foundation\Facades\Router;
+use Hyde\Foundation\Facades\Routes;
 use Hyde\Foundation\Kernel\RouteCollection;
 use Hyde\Framework\Exceptions\RouteNotFoundException;
 use Hyde\Hyde;
@@ -112,7 +112,7 @@ class Route implements Stringable, SerializableContract
 
     public static function get(string $routeKey): ?Route
     {
-        return Router::get(str_replace('.', '/', $routeKey));
+        return Routes::get(str_replace('.', '/', $routeKey));
     }
 
     public static function getOrFail(string $routeKey): Route
@@ -132,6 +132,6 @@ class Route implements Stringable, SerializableContract
 
     public static function exists(string $routeKey): bool
     {
-        return Router::has($routeKey);
+        return Routes::has($routeKey);
     }
 }

--- a/packages/framework/tests/Feature/HydeKernelDynamicPageClassesTest.php
+++ b/packages/framework/tests/Feature/HydeKernelDynamicPageClassesTest.php
@@ -98,8 +98,8 @@ class HydeKernelDynamicPageClassesTest extends TestCase
         $this->file('foo/bar.txt');
         app(HydeKernel::class)->registerPageClass(TestPageClassWithSourceInformation::class);
 
-        $this->assertArrayHasKey('foo/bar.txt', Facades\FileCollection::all());
-        $this->assertEquals(new SourceFile('foo/bar.txt', TestPageClassWithSourceInformation::class), Facades\FileCollection::get('foo/bar.txt'));
+        $this->assertArrayHasKey('foo/bar.txt', Facades\Files::all());
+        $this->assertEquals(new SourceFile('foo/bar.txt', TestPageClassWithSourceInformation::class), Facades\Files::get('foo/bar.txt'));
     }
 
     public function test_custom_registered_pages_are_discovered_by_the_page_collection_class()

--- a/packages/framework/tests/Feature/HydeKernelDynamicPageClassesTest.php
+++ b/packages/framework/tests/Feature/HydeKernelDynamicPageClassesTest.php
@@ -107,8 +107,8 @@ class HydeKernelDynamicPageClassesTest extends TestCase
         $this->directory('foo');
         $this->file('foo/bar.txt');
         app(HydeKernel::class)->registerPageClass(TestPageClassWithSourceInformation::class);
-        $this->assertArrayHasKey('foo/bar.txt', Facades\PageCollection::all());
-        $this->assertEquals(new TestPageClassWithSourceInformation('bar'), Facades\PageCollection::get('foo/bar.txt'));
+        $this->assertArrayHasKey('foo/bar.txt', Facades\Pages::all());
+        $this->assertEquals(new TestPageClassWithSourceInformation('bar'), Facades\Pages::get('foo/bar.txt'));
     }
 
     public function test_custom_registered_pages_are_discovered_by_the_route_collection_class()

--- a/packages/framework/tests/Feature/HydeKernelDynamicPageClassesTest.php
+++ b/packages/framework/tests/Feature/HydeKernelDynamicPageClassesTest.php
@@ -116,8 +116,8 @@ class HydeKernelDynamicPageClassesTest extends TestCase
         $this->directory('foo');
         $this->file('foo/bar.txt');
         app(HydeKernel::class)->registerPageClass(TestPageClassWithSourceInformation::class);
-        $this->assertArrayHasKey('foo/bar', Facades\Router::all());
-        $this->assertEquals(new Route(new TestPageClassWithSourceInformation('bar')), Facades\Router::get('foo/bar'));
+        $this->assertArrayHasKey('foo/bar', Facades\Routes::all());
+        $this->assertEquals(new Route(new TestPageClassWithSourceInformation('bar')), Facades\Routes::get('foo/bar'));
     }
 }
 

--- a/packages/framework/tests/Feature/NavigationMenuTest.php
+++ b/packages/framework/tests/Feature/NavigationMenuTest.php
@@ -7,7 +7,7 @@ namespace Hyde\Framework\Testing\Feature;
 use BadMethodCallException;
 use function collect;
 use function config;
-use Hyde\Foundation\Facades\Router;
+use Hyde\Foundation\Facades\Routes;
 use Hyde\Framework\Features\Navigation\DropdownNavItem;
 use Hyde\Framework\Features\Navigation\NavigationMenu;
 use Hyde\Framework\Features\Navigation\NavItem;
@@ -393,8 +393,8 @@ class NavigationMenuTest extends TestCase
     {
         config(['hyde.navigation.subdirectories' => 'dropdown']);
 
-        Router::push((new MarkdownPage('foo'))->getRoute());
-        Router::push((new MarkdownPage('bar/baz'))->getRoute());
+        Routes::push((new MarkdownPage('foo'))->getRoute());
+        Routes::push((new MarkdownPage('bar/baz'))->getRoute());
         $menu = NavigationMenu::create();
 
         $this->assertCount(3, $menu->items);

--- a/packages/framework/tests/Unit/FoundationFacadesTest.php
+++ b/packages/framework/tests/Unit/FoundationFacadesTest.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Hyde\Framework\Testing\Unit;
 
-use Hyde\Foundation\Facades\FileCollection;
+use Hyde\Foundation\Facades\Files;
 use Hyde\Foundation\Facades\PageCollection;
 use Hyde\Foundation\Facades\Router;
 use Hyde\Foundation\HydeKernel;
@@ -12,7 +12,7 @@ use Hyde\Hyde;
 use Hyde\Testing\TestCase;
 
 /**
- * @covers \Hyde\Foundation\Facades\FileCollection
+ * @covers \Hyde\Foundation\Facades\Files
  */
 class FoundationFacadesTest extends TestCase
 {
@@ -20,12 +20,12 @@ class FoundationFacadesTest extends TestCase
     {
         $this->assertSame(
             HydeKernel::getInstance()->files(),
-            FileCollection::getInstance()
+            Files::getInstance()
         );
 
         $this->assertEquals(
             Hyde::files()->getSourceFiles(),
-            FileCollection::getSourceFiles()
+            Files::getSourceFiles()
         );
     }
 
@@ -57,7 +57,7 @@ class FoundationFacadesTest extends TestCase
 
     public function test_facade_roots()
     {
-        $this->assertSame(FileCollection::getInstance(), FileCollection::getFacadeRoot());
+        $this->assertSame(Files::getInstance(), Files::getFacadeRoot());
         $this->assertSame(PageCollection::getInstance(), PageCollection::getFacadeRoot());
         $this->assertSame(Router::getInstance(), Router::getFacadeRoot());
     }

--- a/packages/framework/tests/Unit/FoundationFacadesTest.php
+++ b/packages/framework/tests/Unit/FoundationFacadesTest.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace Hyde\Framework\Testing\Unit;
 
 use Hyde\Foundation\Facades\Files;
-use Hyde\Foundation\Facades\PageCollection;
+use Hyde\Foundation\Facades\Pages;
 use Hyde\Foundation\Facades\Router;
 use Hyde\Foundation\HydeKernel;
 use Hyde\Hyde;
@@ -33,12 +33,12 @@ class FoundationFacadesTest extends TestCase
     {
         $this->assertSame(
             HydeKernel::getInstance()->pages(),
-            PageCollection::getInstance()
+            Pages::getInstance()
         );
 
         $this->assertEquals(
             Hyde::pages()->getPages(),
-            PageCollection::getPages()
+            Pages::getPages()
         );
     }
 
@@ -58,7 +58,7 @@ class FoundationFacadesTest extends TestCase
     public function test_facade_roots()
     {
         $this->assertSame(Files::getInstance(), Files::getFacadeRoot());
-        $this->assertSame(PageCollection::getInstance(), PageCollection::getFacadeRoot());
+        $this->assertSame(Pages::getInstance(), Pages::getFacadeRoot());
         $this->assertSame(Router::getInstance(), Router::getFacadeRoot());
     }
 }

--- a/packages/framework/tests/Unit/FoundationFacadesTest.php
+++ b/packages/framework/tests/Unit/FoundationFacadesTest.php
@@ -13,6 +13,8 @@ use Hyde\Testing\TestCase;
 
 /**
  * @covers \Hyde\Foundation\Facades\Files
+ * @covers \Hyde\Foundation\Facades\Pages
+ * @covers \Hyde\Foundation\Facades\Routes
  */
 class FoundationFacadesTest extends TestCase
 {

--- a/packages/framework/tests/Unit/FoundationFacadesTest.php
+++ b/packages/framework/tests/Unit/FoundationFacadesTest.php
@@ -6,7 +6,7 @@ namespace Hyde\Framework\Testing\Unit;
 
 use Hyde\Foundation\Facades\Files;
 use Hyde\Foundation\Facades\Pages;
-use Hyde\Foundation\Facades\Router;
+use Hyde\Foundation\Facades\Routes;
 use Hyde\Foundation\HydeKernel;
 use Hyde\Hyde;
 use Hyde\Testing\TestCase;
@@ -46,12 +46,12 @@ class FoundationFacadesTest extends TestCase
     {
         $this->assertSame(
             HydeKernel::getInstance()->routes(),
-            Router::getInstance()
+            Routes::getInstance()
         );
 
         $this->assertEquals(
             Hyde::routes()->getRoutes(),
-            Router::getRoutes()
+            Routes::getRoutes()
         );
     }
 
@@ -59,6 +59,6 @@ class FoundationFacadesTest extends TestCase
     {
         $this->assertSame(Files::getInstance(), Files::getFacadeRoot());
         $this->assertSame(Pages::getInstance(), Pages::getFacadeRoot());
-        $this->assertSame(Router::getInstance(), Router::getFacadeRoot());
+        $this->assertSame(Routes::getInstance(), Routes::getFacadeRoot());
     }
 }


### PR DESCRIPTION
### Rename foundation collection facades

| Old                                      | New                              |
|------------------------------------------|----------------------------------|
| `Hyde\Foundation\Facades\FileCollection` | `Hyde\Foundation\Facades\Files`  |
| `Hyde\Foundation\Facades\PageCollection` | `Hyde\Foundation\Facades\Pages`  |
| `Hyde\Foundation\Facades\Router`         | `Hyde\Foundation\Facades\Router` |

This provides two benefits:

1. First, better IDE autocompletion as the facades will not conflict with the underlying classes.
2. And second, they would match the syntax of `Hyde::files()`, `Hyde::pages()`, and `Hyde::routes()`.


Fixes https://github.com/hydephp/develop/issues/980