### PR TITLE
Update coloured blockquotes to support inner Markdown

### DIFF
--- a/packages/framework/src/Markdown/Processing/ColoredBlockquotes.php
+++ b/packages/framework/src/Markdown/Processing/ColoredBlockquotes.php
@@ -27,10 +27,14 @@ abstract class ColoredBlockquotes implements MarkdownShortcodeContract
 
     protected static function expand(string $input): string
     {
+        $template = '<blockquote class="%s">%s</blockquote>';
+        $signature = static::getClassNameFromSignature(static::signature());
+        $value = trim(substr($input, strlen(static::signature())), ' ');
+
         return sprintf(
-            '<blockquote class="%s">%s</blockquote>',
-            static::getClassNameFromSignature(static::signature()),
-            trim(substr($input, strlen(static::signature())), ' ')
+            $template,
+            $signature,
+            $value
         );
     }
 

--- a/packages/framework/src/Markdown/Processing/ColoredBlockquotes.php
+++ b/packages/framework/src/Markdown/Processing/ColoredBlockquotes.php
@@ -32,7 +32,7 @@ abstract class ColoredBlockquotes implements MarkdownShortcodeContract
         $signature = static::getClassNameFromSignature(static::signature());
         $value = trim(substr($input, strlen(static::signature())), ' ');
 
-        $value = Markdown::render($value);
+        $value = trim(Markdown::render($value));
 
         return sprintf(
             $template,

--- a/packages/framework/src/Markdown/Processing/ColoredBlockquotes.php
+++ b/packages/framework/src/Markdown/Processing/ColoredBlockquotes.php
@@ -30,9 +30,7 @@ abstract class ColoredBlockquotes implements MarkdownShortcodeContract
     {
         $template = '<blockquote class="%s">%s</blockquote>';
         $signature = static::getClassNameFromSignature(static::signature());
-        $value = trim(substr($input, strlen(static::signature())), ' ');
-
-        $value = trim(Markdown::render($value));
+        $value = trim(Markdown::render(trim(substr($input, strlen(static::signature())), ' ')));
 
         return sprintf(
             $template,

--- a/packages/framework/src/Markdown/Processing/ColoredBlockquotes.php
+++ b/packages/framework/src/Markdown/Processing/ColoredBlockquotes.php
@@ -28,14 +28,10 @@ abstract class ColoredBlockquotes implements MarkdownShortcodeContract
 
     protected static function expand(string $input): string
     {
-        $template = '<blockquote class="%s">%s</blockquote>';
-        $signature = static::getClassNameFromSignature(static::signature());
-        $value = trim(Markdown::render(trim(substr($input, strlen(static::signature())), ' ')));
-
         return sprintf(
-            $template,
-            $signature,
-            $value
+            '<blockquote class="%s">%s</blockquote>',
+            static::getClassNameFromSignature(static::signature()),
+            trim(Markdown::render(trim(substr($input, strlen(static::signature())), ' ')))
         );
     }
 

--- a/packages/framework/src/Markdown/Processing/ColoredBlockquotes.php
+++ b/packages/framework/src/Markdown/Processing/ColoredBlockquotes.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Hyde\Markdown\Processing;
 
 use Hyde\Markdown\Contracts\MarkdownShortcodeContract;
+use Hyde\Markdown\Models\Markdown;
 
 /**
  * @see \Hyde\Framework\Testing\Feature\ColoredBlockquoteShortcodesTest
@@ -30,6 +31,8 @@ abstract class ColoredBlockquotes implements MarkdownShortcodeContract
         $template = '<blockquote class="%s">%s</blockquote>';
         $signature = static::getClassNameFromSignature(static::signature());
         $value = trim(substr($input, strlen(static::signature())), ' ');
+
+        $value = Markdown::render($value);
 
         return sprintf(
             $template,

--- a/packages/framework/tests/Feature/ColoredBlockquoteShortcodesTest.php
+++ b/packages/framework/tests/Feature/ColoredBlockquoteShortcodesTest.php
@@ -26,4 +26,11 @@ class ColoredBlockquoteShortcodesTest extends TestCase
         $this->assertContainsOnlyInstancesOf(ColoredBlockquotes::class,
             ColoredBlockquotes::get());
     }
+
+    public function test_can_use_markdown_within_blockquote()
+    {
+        $this->assertEquals('<blockquote class="color"><p>foo <strong>bar</strong></p></blockquote>',
+            ColoredBlockquotes::resolve('>color foo **bar**')
+        );
+    }
 }

--- a/packages/framework/tests/Feature/ColoredBlockquoteShortcodesTest.php
+++ b/packages/framework/tests/Feature/ColoredBlockquoteShortcodesTest.php
@@ -16,7 +16,7 @@ class ColoredBlockquoteShortcodesTest extends TestCase
 {
     public function test_resolve_method()
     {
-        $this->assertEquals('<blockquote class="color">foo</blockquote>',
+        $this->assertEquals('<blockquote class="color"><p>foo</p></blockquote>',
             ColoredBlockquotes::resolve('>color foo'));
     }
 

--- a/packages/framework/tests/Feature/Services/Markdown/ShortcodeProcessorTest.php
+++ b/packages/framework/tests/Feature/Services/Markdown/ShortcodeProcessorTest.php
@@ -25,7 +25,7 @@ class ShortcodeProcessorTest extends TestCase
     {
         $processor = new ShortcodeProcessor('>info foo');
 
-        $this->assertEquals('<blockquote class="info">foo</blockquote>',
+        $this->assertEquals('<blockquote class="info"><p>foo</p></blockquote>',
             $processor->run());
     }
 
@@ -38,7 +38,7 @@ class ShortcodeProcessorTest extends TestCase
 
     public function test_process_static_shorthand()
     {
-        $this->assertEquals('<blockquote class="info">foo</blockquote>',
+        $this->assertEquals('<blockquote class="info"><p>foo</p></blockquote>',
             ShortcodeProcessor::preprocess('>info foo'));
     }
 


### PR DESCRIPTION
## Update coloured blockquotes to support inner Markdown

Since the shortcode resolves to an already compiled `<blockquote>` element, the Markdown processor treats its contents as literal strings. This PR fixes https://github.com/hydephp/develop/issues/971 and renders the Markdown value within to HTML.

In other words, `>info foo **bar**` now becomes 'foo **bar**' instead of just 'foo \*\*bar**'

### Increased padding

As a side effect, this means that the content is also wrapped in a `<p>` element, but since that I think is more semantically correct I'm okay with that. 

Note that it does mean that the rendered result has some increased padding which I think is good because it makes them blend in better with the normal blockquotes.

| Before                                                                                                          | After                                                                                                           |
|-----------------------------------------------------------------------------------------------------------------|-----------------------------------------------------------------------------------------------------------------|
| ![image](https://user-images.githubusercontent.com/95144705/218311685-ac44b62d-e456-4fd4-b601-58617d638a8b.png) | ![image](https://user-images.githubusercontent.com/95144705/218311692-43abab2f-dd14-482a-8f5a-ece2f8911b37.png) |
