### PR TITLE
Add more publishable options for configs so specific tags can be selected

### DIFF
--- a/packages/framework/src/Foundation/Providers/ConfigurationServiceProvider.php
+++ b/packages/framework/src/Foundation/Providers/ConfigurationServiceProvider.php
@@ -20,5 +20,11 @@ class ConfigurationServiceProvider extends ServiceProvider
         $this->publishes([
             __DIR__.'/../../../config' => config_path(),
         ], 'configs');
+
+        $this->publishes([
+            __DIR__.'/../../../config/hyde.php' => config_path('hyde.php'),
+            __DIR__.'/../../../config/docs.php' => config_path('docs.php'),
+            __DIR__.'/../../../config/markdown.php' => config_path('markdown.php'),
+        ], 'hyde-configs');
     }
 }

--- a/packages/framework/src/Foundation/Providers/ConfigurationServiceProvider.php
+++ b/packages/framework/src/Foundation/Providers/ConfigurationServiceProvider.php
@@ -26,5 +26,12 @@ class ConfigurationServiceProvider extends ServiceProvider
             __DIR__.'/../../../config/docs.php' => config_path('docs.php'),
             __DIR__.'/../../../config/markdown.php' => config_path('markdown.php'),
         ], 'hyde-configs');
+
+        $this->publishes([
+            __DIR__.'/../../../config/view.php' => config_path('view.php'),
+            __DIR__.'/../../../config/cache.php' => config_path('cache.php'),
+            __DIR__.'/../../../config/commands.php' => config_path('commands.php'),
+            __DIR__.'/../../../config/torchlight.php' => config_path('torchlight.php'),
+        ], 'support-configs');
     }
 }


### PR DESCRIPTION
Adds two new publishable groups, one for Hyde configs, and one for support configs.

Fixes the following code review comment:
> Split out publishable key vendor config files? Maybe vendor-configs? It's a bit weird now that when you run the update:config commands new (the removed) files get added. Might be better to have a --no-vendor or --include-vendor option. https://github.com/hydephp/develop/pull/873