### PR TITLE
Update UpdateConfigsCommand to prompt for which tag to publish

### DIFF
--- a/packages/framework/src/Console/Commands/UpdateConfigsCommand.php
+++ b/packages/framework/src/Console/Commands/UpdateConfigsCommand.php
@@ -33,6 +33,12 @@ class UpdateConfigsCommand extends Command
         ];
         $selection = $this->choice('Which configuration files do you want to publish?', $options, 'All configs');
 
+        $tags = [
+            'configs',
+            'hyde-configs',
+            'support-configs',
+        ];
+
         Artisan::call('vendor:publish', [
             '--tag' => $tag,
             '--force' => true,

--- a/packages/framework/src/Console/Commands/UpdateConfigsCommand.php
+++ b/packages/framework/src/Console/Commands/UpdateConfigsCommand.php
@@ -33,13 +33,7 @@ class UpdateConfigsCommand extends Command
         ];
         $selection = $this->choice('Which configuration files do you want to publish?', $options, 'All configs');
 
-        $tags = [
-            'configs',
-            'hyde-configs',
-            'support-configs',
-        ];
-
-        $tag = $tags[array_search($selection, $options)];
+        $tag = $this->parseTagFromSelection($selection, $options);
 
         Artisan::call('vendor:publish', [
             '--tag' => $tag,
@@ -49,5 +43,16 @@ class UpdateConfigsCommand extends Command
         $this->infoComment(sprintf('Published config files to [%s]', Hyde::path('config')));
 
         return Command::SUCCESS;
+    }
+
+    protected function parseTagFromSelection(string $selection, array $options): string
+    {
+        $tags = [
+            'configs',
+            'hyde-configs',
+            'support-configs',
+        ];
+
+        return $tags[array_search($selection, $options)];
     }
 }

--- a/packages/framework/src/Console/Commands/UpdateConfigsCommand.php
+++ b/packages/framework/src/Console/Commands/UpdateConfigsCommand.php
@@ -16,7 +16,7 @@ use Illuminate\Support\Facades\Artisan;
 class UpdateConfigsCommand extends Command
 {
     /** @var string */
-    protected $signature = 'update:configs {tag?}';
+    protected $signature = 'update:configs';
 
     /** @var string */
     protected $description = 'Publish the default configuration files';
@@ -26,7 +26,7 @@ class UpdateConfigsCommand extends Command
 
     public function handle(): int
     {
-        $tag = $this->argument('tag') ?? $this->choice('Which configuration files do you want to publish?', [
+        $tag = $this->choice('Which configuration files do you want to publish?', [
             'configs',
             'hyde-configs',
             'support-configs',

--- a/packages/framework/src/Console/Commands/UpdateConfigsCommand.php
+++ b/packages/framework/src/Console/Commands/UpdateConfigsCommand.php
@@ -16,7 +16,7 @@ use Illuminate\Support\Facades\Artisan;
 class UpdateConfigsCommand extends Command
 {
     /** @var string */
-    protected $signature = 'update:configs';
+    protected $signature = 'update:configs {tag?}';
 
     /** @var string */
     protected $description = 'Publish the default configuration files';
@@ -26,7 +26,7 @@ class UpdateConfigsCommand extends Command
 
     public function handle(): int
     {
-        $tag = $this->choice('Which configuration files do you want to publish?', [
+        $tag = $this->argument('tag') ?? $this->choice('Which configuration files do you want to publish?', [
             'configs',
             'hyde-configs',
             'support-configs',

--- a/packages/framework/src/Console/Commands/UpdateConfigsCommand.php
+++ b/packages/framework/src/Console/Commands/UpdateConfigsCommand.php
@@ -21,9 +21,6 @@ class UpdateConfigsCommand extends Command
     /** @var string */
     protected $description = 'Publish the default configuration files';
 
-    /** @var bool */
-    protected $hidden = true;
-
     public function handle(): int
     {
         $options = [

--- a/packages/framework/src/Console/Commands/UpdateConfigsCommand.php
+++ b/packages/framework/src/Console/Commands/UpdateConfigsCommand.php
@@ -26,11 +26,12 @@ class UpdateConfigsCommand extends Command
 
     public function handle(): int
     {
-        $tag = $this->choice('Which configuration files do you want to publish?', [
+        $options = [
             'All configs',
             '<comment>hyde-configs</comment>: Main configuration files',
             '<comment>support-configs</comment>: Laravel and package configuration files',
-        ], 'All configs');
+        ];
+        $tag = $this->choice('Which configuration files do you want to publish?', $options, 'All configs');
 
         Artisan::call('vendor:publish', [
             '--tag' => $tag,

--- a/packages/framework/src/Console/Commands/UpdateConfigsCommand.php
+++ b/packages/framework/src/Console/Commands/UpdateConfigsCommand.php
@@ -47,11 +47,7 @@ class UpdateConfigsCommand extends Command
 
     protected function parseTagFromSelection(string $selection, array $options): string
     {
-        $tags = [
-            'configs',
-            'hyde-configs',
-            'support-configs',
-        ];
+        $tags = ['configs', 'hyde-configs', 'support-configs'];
 
         return $tags[array_search($selection, $options)];
     }

--- a/packages/framework/src/Console/Commands/UpdateConfigsCommand.php
+++ b/packages/framework/src/Console/Commands/UpdateConfigsCommand.php
@@ -26,8 +26,14 @@ class UpdateConfigsCommand extends Command
 
     public function handle(): int
     {
+        $tag = $this->choice('Which configuration files do you want to publish?', [
+            'configs',
+            'hyde-configs',
+            'support-configs',
+        ], 'configs');
+
         Artisan::call('vendor:publish', [
-            '--tag' => 'configs',
+            '--tag' => $tag,
             '--force' => true,
         ], $this->output);
 

--- a/packages/framework/src/Console/Commands/UpdateConfigsCommand.php
+++ b/packages/framework/src/Console/Commands/UpdateConfigsCommand.php
@@ -31,7 +31,7 @@ class UpdateConfigsCommand extends Command
             '<comment>hyde-configs</comment>: Main configuration files',
             '<comment>support-configs</comment>: Laravel and package configuration files',
         ];
-        $tag = $this->choice('Which configuration files do you want to publish?', $options, 'All configs');
+        $selection = $this->choice('Which configuration files do you want to publish?', $options, 'All configs');
 
         Artisan::call('vendor:publish', [
             '--tag' => $tag,

--- a/packages/framework/src/Console/Commands/UpdateConfigsCommand.php
+++ b/packages/framework/src/Console/Commands/UpdateConfigsCommand.php
@@ -39,6 +39,8 @@ class UpdateConfigsCommand extends Command
             'support-configs',
         ];
 
+        $tag = $tags[array_search($selection, $options)];
+
         Artisan::call('vendor:publish', [
             '--tag' => $tag,
             '--force' => true,

--- a/packages/framework/src/Console/Commands/UpdateConfigsCommand.php
+++ b/packages/framework/src/Console/Commands/UpdateConfigsCommand.php
@@ -27,10 +27,10 @@ class UpdateConfigsCommand extends Command
     public function handle(): int
     {
         $tag = $this->choice('Which configuration files do you want to publish?', [
-            'configs',
-            'hyde-configs',
-            'support-configs',
-        ], 'configs');
+            'All configs',
+            '<comment>hyde-configs</comment>: Main configuration files',
+            '<comment>support-configs</comment>: Laravel and package configuration files',
+        ], 'All configs');
 
         Artisan::call('vendor:publish', [
             '--tag' => $tag,

--- a/packages/framework/tests/Feature/Commands/UpdateConfigsCommandTest.php
+++ b/packages/framework/tests/Feature/Commands/UpdateConfigsCommandTest.php
@@ -33,7 +33,11 @@ class UpdateConfigsCommandTest extends TestCase
     public function test_command_has_expected_output()
     {
         $this->artisan('update:configs')
-            ->expectsChoice('Which configuration files do you want to publish?', 'configs', ['configs', 'hyde-configs', 'support-configs'])
+            ->expectsChoice('Which configuration files do you want to publish?', 'configs', [
+                'All configs',
+                '<comment>hyde-configs</comment>: Main configuration files',
+                '<comment>support-configs</comment>: Laravel and package configuration files',
+            ])
             ->expectsOutput(sprintf('Published config files to [%s]', Hyde::path('config')))
             ->assertExitCode(0);
     }
@@ -43,7 +47,11 @@ class UpdateConfigsCommandTest extends TestCase
         $this->assertDirectoryDoesNotExist(Hyde::path('config'));
 
         $this->artisan('update:configs')
-            ->expectsChoice('Which configuration files do you want to publish?', 'configs', ['configs', 'hyde-configs', 'support-configs'])
+            ->expectsChoice('Which configuration files do you want to publish?', 'configs', [
+                'All configs',
+                '<comment>hyde-configs</comment>: Main configuration files',
+                '<comment>support-configs</comment>: Laravel and package configuration files',
+            ])
             ->assertExitCode(0);
 
         $this->assertFileEquals(Hyde::vendorPath('config/hyde.php'), Hyde::path('config/hyde.php'));
@@ -57,7 +65,11 @@ class UpdateConfigsCommandTest extends TestCase
         File::put(Hyde::path('config/hyde.php'), 'foo');
 
         $this->artisan('update:configs')
-            ->expectsChoice('Which configuration files do you want to publish?', 'configs', ['configs', 'hyde-configs', 'support-configs'])
+            ->expectsChoice('Which configuration files do you want to publish?', 'configs', [
+                'All configs',
+                '<comment>hyde-configs</comment>: Main configuration files',
+                '<comment>support-configs</comment>: Laravel and package configuration files',
+            ])
             ->assertExitCode(0);
 
         $this->assertNotEquals('foo', File::get(Hyde::path('config/hyde.php')));

--- a/packages/framework/tests/Feature/Commands/UpdateConfigsCommandTest.php
+++ b/packages/framework/tests/Feature/Commands/UpdateConfigsCommandTest.php
@@ -33,7 +33,7 @@ class UpdateConfigsCommandTest extends TestCase
     public function test_command_has_expected_output()
     {
         $this->artisan('update:configs')
-            ->expectsChoice('Which configuration files do you want to publish?', 'configs', $this->expectedOptions())
+            ->expectsChoice('Which configuration files do you want to publish?', 'All configs', $this->expectedOptions())
             ->expectsOutput(sprintf('Published config files to [%s]', Hyde::path('config')))
             ->assertExitCode(0);
     }
@@ -43,7 +43,7 @@ class UpdateConfigsCommandTest extends TestCase
         $this->assertDirectoryDoesNotExist(Hyde::path('config'));
 
         $this->artisan('update:configs')
-            ->expectsChoice('Which configuration files do you want to publish?', 'configs', $this->expectedOptions())
+            ->expectsChoice('Which configuration files do you want to publish?', 'All configs', $this->expectedOptions())
             ->assertExitCode(0);
 
         $this->assertFileEquals(Hyde::vendorPath('config/hyde.php'), Hyde::path('config/hyde.php'));
@@ -57,7 +57,7 @@ class UpdateConfigsCommandTest extends TestCase
         File::put(Hyde::path('config/hyde.php'), 'foo');
 
         $this->artisan('update:configs')
-            ->expectsChoice('Which configuration files do you want to publish?', 'configs', $this->expectedOptions())
+            ->expectsChoice('Which configuration files do you want to publish?', 'All configs', $this->expectedOptions())
             ->assertExitCode(0);
 
         $this->assertNotEquals('foo', File::get(Hyde::path('config/hyde.php')));

--- a/packages/framework/tests/Feature/Commands/UpdateConfigsCommandTest.php
+++ b/packages/framework/tests/Feature/Commands/UpdateConfigsCommandTest.php
@@ -33,6 +33,7 @@ class UpdateConfigsCommandTest extends TestCase
     public function test_command_has_expected_output()
     {
         $this->artisan('update:configs')
+            ->expectsChoice('Which configuration files do you want to publish?', 'configs', ['configs', 'hyde-configs', 'support-configs'])
             ->expectsOutput(sprintf('Published config files to [%s]', Hyde::path('config')))
             ->assertExitCode(0);
     }
@@ -41,7 +42,9 @@ class UpdateConfigsCommandTest extends TestCase
     {
         $this->assertDirectoryDoesNotExist(Hyde::path('config'));
 
-        $this->artisan('update:configs')->assertExitCode(0);
+        $this->artisan('update:configs')
+            ->expectsChoice('Which configuration files do you want to publish?', 'configs', ['configs', 'hyde-configs', 'support-configs'])
+            ->assertExitCode(0);
 
         $this->assertFileEquals(Hyde::vendorPath('config/hyde.php'), Hyde::path('config/hyde.php'));
 
@@ -53,7 +56,9 @@ class UpdateConfigsCommandTest extends TestCase
         File::makeDirectory(Hyde::path('config'));
         File::put(Hyde::path('config/hyde.php'), 'foo');
 
-        $this->artisan('update:configs')->assertExitCode(0);
+        $this->artisan('update:configs')
+            ->expectsChoice('Which configuration files do you want to publish?', 'configs', ['configs', 'hyde-configs', 'support-configs'])
+            ->assertExitCode(0);
 
         $this->assertNotEquals('foo', File::get(Hyde::path('config/hyde.php')));
     }

--- a/packages/framework/tests/Feature/Commands/UpdateConfigsCommandTest.php
+++ b/packages/framework/tests/Feature/Commands/UpdateConfigsCommandTest.php
@@ -33,11 +33,7 @@ class UpdateConfigsCommandTest extends TestCase
     public function test_command_has_expected_output()
     {
         $this->artisan('update:configs')
-            ->expectsChoice('Which configuration files do you want to publish?', 'configs', [
-                'All configs',
-                '<comment>hyde-configs</comment>: Main configuration files',
-                '<comment>support-configs</comment>: Laravel and package configuration files',
-            ])
+            ->expectsChoice('Which configuration files do you want to publish?', 'configs', $this->expectedOptions())
             ->expectsOutput(sprintf('Published config files to [%s]', Hyde::path('config')))
             ->assertExitCode(0);
     }
@@ -47,11 +43,7 @@ class UpdateConfigsCommandTest extends TestCase
         $this->assertDirectoryDoesNotExist(Hyde::path('config'));
 
         $this->artisan('update:configs')
-            ->expectsChoice('Which configuration files do you want to publish?', 'configs', [
-                'All configs',
-                '<comment>hyde-configs</comment>: Main configuration files',
-                '<comment>support-configs</comment>: Laravel and package configuration files',
-            ])
+            ->expectsChoice('Which configuration files do you want to publish?', 'configs', $this->expectedOptions())
             ->assertExitCode(0);
 
         $this->assertFileEquals(Hyde::vendorPath('config/hyde.php'), Hyde::path('config/hyde.php'));
@@ -65,13 +57,18 @@ class UpdateConfigsCommandTest extends TestCase
         File::put(Hyde::path('config/hyde.php'), 'foo');
 
         $this->artisan('update:configs')
-            ->expectsChoice('Which configuration files do you want to publish?', 'configs', [
-                'All configs',
-                '<comment>hyde-configs</comment>: Main configuration files',
-                '<comment>support-configs</comment>: Laravel and package configuration files',
-            ])
+            ->expectsChoice('Which configuration files do you want to publish?', 'configs', $this->expectedOptions())
             ->assertExitCode(0);
 
         $this->assertNotEquals('foo', File::get(Hyde::path('config/hyde.php')));
+    }
+
+    protected function expectedOptions(): array
+    {
+        return [
+            'All configs',
+            '<comment>hyde-configs</comment>: Main configuration files',
+            '<comment>support-configs</comment>: Laravel and package configuration files',
+        ];
     }
 }


### PR DESCRIPTION
Takes advantage of the tags introduced in https://github.com/hydephp/develop/pull/983 to allow user to select to only publish Hyde configs, Laravel configs, or both (default).