### PR TITLE
Split out internal ManagesHydeKernel trait

### DIFF
--- a/packages/framework/src/Foundation/Concerns/ManagesExtensions.php
+++ b/packages/framework/src/Foundation/Concerns/ManagesExtensions.php
@@ -9,7 +9,7 @@ namespace Hyde\Foundation\Concerns;
  *
  * @see \Hyde\Foundation\HydeKernel
  */
-trait ManagesKernelExtensions
+trait ManagesExtensions
 {
     //
 }

--- a/packages/framework/src/Foundation/Concerns/ManagesExtensions.php
+++ b/packages/framework/src/Foundation/Concerns/ManagesExtensions.php
@@ -19,12 +19,6 @@ use function is_subclass_of;
  */
 trait ManagesExtensions
 {
-    /** @return array<class-string<\Hyde\Pages\Concerns\HydePage>> */
-    public function getRegisteredPageClasses(): array
-    {
-        return array_unique(array_merge(...array_map(fn (string $extension): array => $extension::getPageClasses(), $this->getRegisteredExtensions())));
-    }
-
     /**
      * Register a HydePHP extension within the HydeKernel.
      *
@@ -60,5 +54,11 @@ trait ManagesExtensions
     public function getRegisteredExtensions(): array
     {
         return $this->extensions;
+    }
+
+    /** @return array<class-string<\Hyde\Pages\Concerns\HydePage>> */
+    public function getRegisteredPageClasses(): array
+    {
+        return array_unique(array_merge(...array_map(fn (string $extension): array => $extension::getPageClasses(), $this->getRegisteredExtensions())));
     }
 }

--- a/packages/framework/src/Foundation/Concerns/ManagesExtensions.php
+++ b/packages/framework/src/Foundation/Concerns/ManagesExtensions.php
@@ -4,6 +4,14 @@ declare(strict_types=1);
 
 namespace Hyde\Foundation\Concerns;
 
+use BadMethodCallException;
+use InvalidArgumentException;
+use function array_map;
+use function array_merge;
+use function array_unique;
+use function in_array;
+use function is_subclass_of;
+
 /**
  * @internal Single-use trait for the HydeKernel class.
  *
@@ -11,5 +19,46 @@ namespace Hyde\Foundation\Concerns;
  */
 trait ManagesExtensions
 {
-    //
+    /** @return array<class-string<\Hyde\Pages\Concerns\HydePage>> */
+    public function getRegisteredPageClasses(): array
+    {
+        return array_unique(array_merge(...array_map(fn (string $extension): array => $extension::getPageClasses(), $this->getRegisteredExtensions())));
+    }
+
+    /**
+     * Register a HydePHP extension within the HydeKernel.
+     *
+     * Typically, you would call this method in the register method of a service provider.
+     * If your package uses the standard Laravel (Composer) package discovery feature,
+     * the extension will automatically be enabled when the package is installed.
+     *
+     * @param  class-string<\Hyde\Foundation\Concerns\HydeExtension>  $extension
+     */
+    public function registerExtension(string $extension): void
+    {
+        if ($this->booted) {
+            // We throw an exception here to prevent the developer from registering aa extension after the Kernel has been booted.
+            // The reason we do this is because at this point all the source files have already been discovered and parsed.
+            // If we allowed new classes after this point, we would have to reboot everything which adds complexity.
+
+            throw new BadMethodCallException('Cannot register an extension after the Kernel has been booted.');
+        }
+
+        if (! is_subclass_of($extension, HydeExtension::class)) {
+            // We want to make sure that the extension class extends the HydeExtension class,
+            // so that we won't have to check the methods we need to call exist later on.
+
+            throw new InvalidArgumentException('The specified class must extend the HydeExtension class.');
+        }
+
+        if (! in_array($extension, $this->extensions, true)) {
+            $this->extensions[] = $extension;
+        }
+    }
+
+    /** @return array<class-string<\Hyde\Foundation\Concerns\HydeExtension>> */
+    public function getRegisteredExtensions(): array
+    {
+        return $this->extensions;
+    }
 }

--- a/packages/framework/src/Foundation/Concerns/ManagesHydeKernel.php
+++ b/packages/framework/src/Foundation/Concerns/ManagesHydeKernel.php
@@ -4,14 +4,7 @@ declare(strict_types=1);
 
 namespace Hyde\Foundation\Concerns;
 
-use BadMethodCallException;
 use Hyde\Foundation\HydeKernel;
-use InvalidArgumentException;
-use function array_map;
-use function array_merge;
-use function array_unique;
-use function in_array;
-use function is_subclass_of;
 use function ltrim;
 use function rtrim;
 
@@ -75,49 +68,6 @@ trait ManagesHydeKernel
     public function getMediaOutputDirectory(): string
     {
         return ltrim($this->getMediaDirectory(), '_');
-    }
-
-    /** @return array<class-string<\Hyde\Pages\Concerns\HydePage>> */
-    public function getRegisteredPageClasses(): array
-    {
-        return array_unique(array_merge(...array_map(fn (string $extension): array => $extension::getPageClasses(), $this->getRegisteredExtensions())));
-    }
-
-    /**
-     * Register a HydePHP extension within the HydeKernel.
-     *
-     * Typically, you would call this method in the register method of a service provider.
-     * If your package uses the standard Laravel (Composer) package discovery feature,
-     * the extension will automatically be enabled when the package is installed.
-     *
-     * @param  class-string<\Hyde\Foundation\Concerns\HydeExtension>  $extension
-     */
-    public function registerExtension(string $extension): void
-    {
-        if ($this->booted) {
-            // We throw an exception here to prevent the developer from registering aa extension after the Kernel has been booted.
-            // The reason we do this is because at this point all the source files have already been discovered and parsed.
-            // If we allowed new classes after this point, we would have to reboot everything which adds complexity.
-
-            throw new BadMethodCallException('Cannot register an extension after the Kernel has been booted.');
-        }
-
-        if (! is_subclass_of($extension, HydeExtension::class)) {
-            // We want to make sure that the extension class extends the HydeExtension class,
-            // so that we won't have to check the methods we need to call exist later on.
-
-            throw new InvalidArgumentException('The specified class must extend the HydeExtension class.');
-        }
-
-        if (! in_array($extension, $this->extensions, true)) {
-            $this->extensions[] = $extension;
-        }
-    }
-
-    /** @return array<class-string<\Hyde\Foundation\Concerns\HydeExtension>> */
-    public function getRegisteredExtensions(): array
-    {
-        return $this->extensions;
     }
 
     protected function normalizeSourcePath(string $outputDirectory): string

--- a/packages/framework/src/Foundation/Concerns/ManagesKernelExtensions.php
+++ b/packages/framework/src/Foundation/Concerns/ManagesKernelExtensions.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Hyde\Foundation\Concerns;
+
+/**
+ * @internal Single-use trait for the HydeKernel class.
+ *
+ * @see \Hyde\Foundation\HydeKernel
+ */
+trait ManagesKernelExtensions
+{
+    //
+}

--- a/packages/framework/src/Foundation/HydeKernel.php
+++ b/packages/framework/src/Foundation/HydeKernel.php
@@ -42,7 +42,7 @@ class HydeKernel implements SerializableContract
     use Concerns\ForwardsHyperlinks;
     use Concerns\ForwardsFilesystem;
     use Concerns\ManagesHydeKernel;
-    use Concerns\ManagesKernelExtensions;
+    use Concerns\ManagesExtensions;
     use Concerns\ManagesViewData;
     use Concerns\BootsHydeKernel;
 

--- a/packages/framework/src/Foundation/HydeKernel.php
+++ b/packages/framework/src/Foundation/HydeKernel.php
@@ -42,6 +42,7 @@ class HydeKernel implements SerializableContract
     use Concerns\ForwardsHyperlinks;
     use Concerns\ForwardsFilesystem;
     use Concerns\ManagesHydeKernel;
+    use Concerns\ManagesKernelExtensions;
     use Concerns\ManagesViewData;
     use Concerns\BootsHydeKernel;
 

--- a/packages/framework/tests/Feature/HydeExtensionFeatureTest.php
+++ b/packages/framework/tests/Feature/HydeExtensionFeatureTest.php
@@ -31,7 +31,7 @@ use function func_get_args;
 
 /**
  * @covers \Hyde\Foundation\Concerns\HydeExtension
- * @covers \Hyde\Foundation\Concerns\ManagesHydeKernel
+ * @covers \Hyde\Foundation\Concerns\ManagesExtensions
  * @covers \Hyde\Foundation\HydeKernel
  * @covers \Hyde\Foundation\Kernel\FileCollection
  * @covers \Hyde\Foundation\Kernel\PageCollection


### PR DESCRIPTION
Splits out internal ManagesHydeKernel trait to move the helpers related to extensions into a new internal ManagesExtensions trait.