### PR TITLE
Remove deprecated BuildTask::getExecutionTime() method

### DIFF
--- a/packages/framework/src/Framework/Features/BuildTasks/BuildTask.php
+++ b/packages/framework/src/Framework/Features/BuildTasks/BuildTask.php
@@ -66,13 +66,6 @@ abstract class BuildTask
         return static::$description;
     }
 
-    /**  @deprecated Will be removed before 1.0.0 - Use $this->getExecutionTimeString() instead */
-    #[Deprecated(reason: 'Use getExecutionTimeString() instead', replacement: '$this->getExecutionTimeString()')]
-    public function getExecutionTime(): string
-    {
-        return $this->getExecutionTimeString();
-    }
-
     public function write(string $message): void
     {
         $this->output?->write($message);

--- a/packages/framework/src/Framework/Features/BuildTasks/BuildTask.php
+++ b/packages/framework/src/Framework/Features/BuildTasks/BuildTask.php
@@ -58,7 +58,7 @@ abstract class BuildTask
 
     public function then(): void
     {
-        $this->writeln('<fg=gray>Done in '.$this->getExecutionTime().'</>');
+        $this->writeln('<fg=gray>Done in '.$this->getExecutionTimeString().'</>');
     }
 
     public function getDescription(): string

--- a/packages/framework/src/Framework/Features/BuildTasks/BuildTask.php
+++ b/packages/framework/src/Framework/Features/BuildTasks/BuildTask.php
@@ -8,7 +8,6 @@ use Hyde\Framework\Concerns\TracksExecutionTime;
 use Hyde\Hyde;
 use Illuminate\Console\Concerns\InteractsWithIO;
 use Illuminate\Console\OutputStyle;
-use JetBrains\PhpStorm\Deprecated;
 use Throwable;
 
 /**


### PR DESCRIPTION
Fixes https://github.com/hydephp/develop/issues/994