### PR TITLE
Remove deprecated BuildTaskService::findTasksInAppDirectory() method from the public API

### DIFF
--- a/packages/framework/src/Framework/Services/BuildTaskService.php
+++ b/packages/framework/src/Framework/Services/BuildTaskService.php
@@ -55,7 +55,7 @@ class BuildTaskService
     /**
      * @deprecated Public usage of this method is deprecated as the method will be made protected.
      */
-    public static function findTasksInAppDirectory(): array
+    protected static function findTasksInAppDirectory(): array
     {
         $tasks = [];
 

--- a/packages/framework/src/Framework/Services/BuildTaskService.php
+++ b/packages/framework/src/Framework/Services/BuildTaskService.php
@@ -52,9 +52,6 @@ class BuildTaskService
         );
     }
 
-    /**
-     * @deprecated Public usage of this method is deprecated as the method will be made protected.
-     */
     protected static function findTasksInAppDirectory(): array
     {
         $tasks = [];

--- a/packages/framework/tests/Feature/Services/BuildTaskServiceTest.php
+++ b/packages/framework/tests/Feature/Services/BuildTaskServiceTest.php
@@ -186,7 +186,7 @@ class BuildTaskServiceTest extends TestCase
         File::makeDirectory(Hyde::path('app/Actions'));
         Hyde::touch('app/Actions/FooBuildTask.php');
 
-        $this->assertEquals(['App\Actions\FooBuildTask'], BuildTaskService::findTasksInAppDirectory());
+        $this->assertEquals(['App\Actions\FooBuildTask'], (new BuildTaskService())->getPostBuildTasks());
         File::deleteDirectory(Hyde::path('app/Actions'));
     }
 


### PR DESCRIPTION
Fixes https://github.com/hydephp/develop/issues/995