### PR TITLE
Removes deprecated MarkdownCollection class

### DIFF
--- a/app/config.php
+++ b/app/config.php
@@ -101,7 +101,6 @@ return [
         'MarkdownPost' => \Hyde\Pages\MarkdownPost::class,
         'DocumentationPage' => \Hyde\Pages\DocumentationPage::class,
         'Filesystem' => \Hyde\Facades\Filesystem::class,
-        'MarkdownCollection' => \Hyde\Framework\Features\DataCollections\Facades\MarkdownCollection::class,
     ],
 
 ];

--- a/packages/framework/src/Framework/Features/DataCollections/Facades/MarkdownCollection.php
+++ b/packages/framework/src/Framework/Features/DataCollections/Facades/MarkdownCollection.php
@@ -5,15 +5,3 @@ declare(strict_types=1);
 namespace Hyde\Framework\Features\DataCollections\Facades;
 
 use Hyde\Framework\Features\DataCollections\DataCollection;
-
-/**
- * @see \Hyde\Framework\Testing\Feature\DataCollectionTest
- * @deprecated Since this class is so simple, it could easily be inlined.
- */
-class MarkdownCollection
-{
-    public static function get(string $collectionKey): DataCollection
-    {
-        return DataCollection::markdown($collectionKey);
-    }
-}

--- a/packages/framework/src/Framework/Features/DataCollections/Facades/MarkdownCollection.php
+++ b/packages/framework/src/Framework/Features/DataCollections/Facades/MarkdownCollection.php
@@ -1,7 +1,0 @@
-<?php
-
-declare(strict_types=1);
-
-namespace Hyde\Framework\Features\DataCollections\Facades;
-
-use Hyde\Framework\Features\DataCollections\DataCollection;

--- a/packages/framework/tests/Feature/DataCollectionTest.php
+++ b/packages/framework/tests/Feature/DataCollectionTest.php
@@ -144,21 +144,6 @@ class DataCollectionTest extends TestCase
         File::deleteDirectory(Hyde::path('resources/collections/foo'));
     }
 
-    public function test_markdown_facade_returns_same_result_as_static_markdown_helper()
-    {
-        $expected = DataCollection::markdown('foo');
-        $actual = MarkdownCollection::get('foo');
-        unset($expected->parseTimeInMs);
-        unset($actual->parseTimeInMs);
-        $this->assertEquals($expected, $actual);
-    }
-
-    public function test_data_collection_service_provider_registers_the_facade_as_an_alias()
-    {
-        $this->assertArrayHasKey('MarkdownCollection', AliasLoader::getInstance()->getAliases());
-        $this->assertContains(MarkdownCollection::class, AliasLoader::getInstance()->getAliases());
-    }
-
     public function test_class_has_static_source_directory_property()
     {
         $this->assertEquals('resources/collections', DataCollection::$sourceDirectory);

--- a/packages/framework/tests/Feature/DataCollectionTest.php
+++ b/packages/framework/tests/Feature/DataCollectionTest.php
@@ -6,11 +6,9 @@ namespace Hyde\Framework\Testing\Feature;
 
 use ArgumentCountError;
 use Hyde\Framework\Features\DataCollections\DataCollection;
-use Hyde\Framework\Features\DataCollections\Facades\MarkdownCollection;
 use Hyde\Hyde;
 use Hyde\Markdown\Models\MarkdownDocument;
 use Hyde\Testing\TestCase;
-use Illuminate\Foundation\AliasLoader;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\File;
 

--- a/packages/framework/tests/Feature/DataCollectionTest.php
+++ b/packages/framework/tests/Feature/DataCollectionTest.php
@@ -16,7 +16,6 @@ use Illuminate\Support\Facades\File;
 
 /**
  * @covers \Hyde\Framework\Features\DataCollections\DataCollection
- * @covers \Hyde\Framework\Features\DataCollections\Facades\MarkdownCollection
  */
 class DataCollectionTest extends TestCase
 {


### PR DESCRIPTION
This class is so incredibly simple it offers very little value.

To upgrade, simply replace the following:

```diff
- MarkdownCollection::get($collectionKey);
+ DataCollection::markdown($collectionKey);
```

Yeah, that's all the class does. It's just an alias for this single method. No need to have an entire file for it.

Fixes https://github.com/hydephp/develop/issues/997