### PR TITLE
Remove `@experimental` annotations for stable code

### DIFF
--- a/packages/framework/src/Console/Concerns/Command.php
+++ b/packages/framework/src/Console/Concerns/Command.php
@@ -92,13 +92,11 @@ abstract class Command extends BaseCommand
         $this->line("<info>$string</info>");
     }
 
-    /** @experimental This method may change (or be removed) before the 1.0.0 release */
     public function gray(string $string): void
     {
         $this->line($this->inlineGray($string));
     }
 
-    /** @experimental This method may change (or be removed) before the 1.0.0 release */
     public function inlineGray(string $string): string
     {
         return "<fg=gray>$string</>";

--- a/packages/framework/src/Framework/Actions/ConvertsMarkdownToPlainText.php
+++ b/packages/framework/src/Framework/Actions/ConvertsMarkdownToPlainText.php
@@ -17,10 +17,6 @@ use function substr;
  * Converts Markdown to plain text.
  *
  * @see \Hyde\Framework\Testing\Feature\Actions\ConvertsMarkdownToPlainTextTest
- *
- * @experimental This class is experimental and does not have a stable API yet.
- *
- * @internal This class is experimental and should not be used outside HydePHP.
  */
 class ConvertsMarkdownToPlainText
 {

--- a/packages/framework/src/Pages/Concerns/UsesFlattenedOutputPaths.php
+++ b/packages/framework/src/Pages/Concerns/UsesFlattenedOutputPaths.php
@@ -8,9 +8,6 @@ use function basename;
 use function unslash;
 
 /**
- * @internal This trait is currently experimental and should not be relied upon outside of Hyde as it may change at any time.
- * @experimental
- *
  * This trait is used to flatten the output path of a page. This is only used for the documentation pages,
  * where all pages are output to the same directory, but where putting the page in a subdirectory will
  * create a nested navigation structure in the sidebar.

--- a/packages/realtime-compiler/src/Http/DashboardController.php
+++ b/packages/realtime-compiler/src/Http/DashboardController.php
@@ -18,10 +18,6 @@ use function sprintf;
 use function str_replace;
 use function str_starts_with;
 
-/**
- * @internal
- * @experimental
- */
 class DashboardController
 {
     public string $title;


### PR DESCRIPTION
The following have had their `@experimental` status removed

1. Command.php (methods `gray` and `inlineGray`))
   - These methods are unlikely to change at this point 
2. ConvertsMarkdownToPlainText.php (class)
   - Class only has one public method (excluding constructor) so API is unlikely to change
3. UsesFlattenedOutputPaths.php (trait)
   - Trait has not been changed in a long time and is unlikely to do so
4. DashboardController.php (RealtimeCompiler class)
   - The Realtime Compiler package has no backwards compatibility guarantees outside of its coupling with standard HydePHP versions, and thus all of its classes can be considered internal

See https://github.com/hydephp/develop/issues/998