### PR TITLE
Update Realtime Compiler readme

### DIFF
--- a/packages/realtime-compiler/README.md
+++ b/packages/realtime-compiler/README.md
@@ -20,4 +20,4 @@ See the [Security Policy](https://github.com/hydephp/realtime-compiler/security/
 | 1.x     | :shield:           | (LTS*)   |
 | < 1.0   | :x:                | Alpha    |
 
-*1.x LTS receives security fixes only
+*1.x LTS receives security fixes only (End of Life: 2023-03-01)

--- a/packages/realtime-compiler/README.md
+++ b/packages/realtime-compiler/README.md
@@ -13,10 +13,11 @@ Any third-party integrations will need to be handled manually. v1.0x will receiv
 See the [Security Policy](https://github.com/hydephp/realtime-compiler/security/policy).
 
 
-| Version | Supported          | Notes  |
-|---------|--------------------|--------|
-| 2.x     | :white_check_mark: | Latest |
-| 1.x     | :shield:           | (LTS*) |
-| < 1.0   | :x:                | Alpha  |
+| Version | Supported          | Notes    |
+|---------|--------------------|----------|
+| 3.x     | :test_tube:        | Upcoming |
+| 2.x     | :white_check_mark: | Latest   |
+| 1.x     | :shield:           | (LTS*)   |
+| < 1.0   | :x:                | Alpha    |
 
 *1.x LTS receives security fixes only

--- a/packages/realtime-compiler/SECURITY.md
+++ b/packages/realtime-compiler/SECURITY.md
@@ -7,12 +7,14 @@ The 2.0 release brings a total rewrite and may be unstable up until the first fe
 The upgrade will be handled within Hyde/Framework and standard usage will not be affected.
 Any third-party integrations will need to be handled manually. v1.0x will receive security fixes for the time being. 
 
+| Version | Supported          | Notes    |
+|---------|--------------------|----------|
+| 3.x     | :test_tube:        | Upcoming |
+| 2.x     | :white_check_mark: | Latest   |
+| 1.x     | :shield:           | (LTS*)   |
+| < 1.0   | :x:                | Alpha    |
 
-| Version | Supported                     | Notes  |
-|---------|-------------------------------|--------|
-| 2.0.x   | :white_check_mark::test_tube: | Latest |
-| 1.0.x   | :white_check_mark:            | (LTS)  |
-| < 1.0   | :x:                           | Alpha  |
+*1.x LTS receives security fixes only (End of Life: 2023-03-01)
 
 ## Reporting a Vulnerability
 


### PR DESCRIPTION
- Adds the upcoming version to realtime compiler readme
- Realtime Compiler LTS version 1.0 reaches End of Life: 2023-03-01
