### PR TITLE
Deprecate config option `docs.output_directory`

### DIFF
--- a/config/docs.php
+++ b/config/docs.php
@@ -40,7 +40,7 @@ return [
     |
     */
 
-    /** @deprecated Use `hyde.output_directories.docs` instead */
+    /** @deprecated Will be replaced by `hyde.output_directories.docs` */
     'output_directory' => 'docs',
 
     /*

--- a/config/docs.php
+++ b/config/docs.php
@@ -40,6 +40,7 @@ return [
     |
     */
 
+    /** @deprecated Use `hyde.output_directories.docs` instead */
     'output_directory' => 'docs',
 
     /*

--- a/packages/framework/config/docs.php
+++ b/packages/framework/config/docs.php
@@ -40,7 +40,7 @@ return [
     |
     */
 
-    /** @deprecated Use `hyde.output_directories.docs` instead */
+    /** @deprecated Will be replaced by `hyde.output_directories.docs` */
     'output_directory' => 'docs',
 
     /*

--- a/packages/framework/config/docs.php
+++ b/packages/framework/config/docs.php
@@ -40,6 +40,7 @@ return [
     |
     */
 
+    /** @deprecated Use `hyde.output_directories.docs` instead */
     'output_directory' => 'docs',
 
     /*


### PR DESCRIPTION
Deprecates the config option `docs.output_directory` (in docs.php) as it will conflict with https://github.com/hydephp/develop/pull/1014