### PR TITLE
Remove config option `docs.output_directory`

### DIFF
--- a/config/docs.php
+++ b/config/docs.php
@@ -25,26 +25,6 @@ return [
 
     /*
     |--------------------------------------------------------------------------
-    | Documentation Site Output Directory
-    |--------------------------------------------------------------------------
-    |
-    | If you want to store the compiled documentation pages in a different
-    | directory than the default 'docs' directory, for example to set the
-    | specified version, you can specify the directory here.
-    |
-    | Note that you need to take care as to not set it to something that
-    | may conflict with other parts, such as media or posts directories.
-    |
-    | The default value is 'docs'. For easy versioning you can do what
-    | HydePHP.com does, setting it to 'docs/master'.
-    |
-    */
-
-    /** @deprecated Use `hyde.output_directories.docs` instead */
-    'output_directory' => 'docs',
-
-    /*
-    |--------------------------------------------------------------------------
     | Collaborative Source Editing Location
     |--------------------------------------------------------------------------
     |

--- a/docs/creating-content/documentation-pages.md
+++ b/docs/creating-content/documentation-pages.md
@@ -190,6 +190,8 @@ for example to specify a version like the Hyde docs does, you can specify the ou
 ]
 ```
 
+Note that you need to take care as to not set it to something that may conflict with other parts, such as media or posts directories.
+
 ### Automatic navigation menu
 
 By default, a link to the documentation page is added to the navigation menu when an index.md file is found in the `_docs` directory. Please see the [the customization page](customization#navigation-menu--sidebar) for more information.

--- a/docs/creating-content/documentation-pages.md
+++ b/docs/creating-content/documentation-pages.md
@@ -183,8 +183,11 @@ If you want to store the compiled documentation pages in a different directory t
 for example to specify a version like the Hyde docs does, you can specify the output directory in the Docs configuration file.
 
 ```php
-'output_directory' => 'docs' // default
-'output_directory' => 'docs/master' // What the Hyde docs use
+// filepath: _config/hyde.php
+'output_directories' => [
+    \Hyde\Pages\DocumentationPage::class => 'docs' // default
+    \Hyde\Pages\DocumentationPage::class => 'docs/master' // What the Hyde docs use
+]
 ```
 
 ### Automatic navigation menu

--- a/docs/creating-content/documentation-pages.md
+++ b/docs/creating-content/documentation-pages.md
@@ -180,7 +180,8 @@ including the documentation pages. Here is a high level overview for quick refer
 ### Output directory
 
 If you want to store the compiled documentation pages in a different directory than the default 'docs' directory,
-for example to specify a version like the Hyde docs does, you can specify the output directory in the Docs configuration file.
+for example to specify a version like the Hyde docs does, you can specify the output directory in the Hyde configuration file.
+The path is relative to the site output, typically `_site`.
 
 ```php
 // filepath: _config/hyde.php

--- a/packages/framework/config/docs.php
+++ b/packages/framework/config/docs.php
@@ -25,26 +25,6 @@ return [
 
     /*
     |--------------------------------------------------------------------------
-    | Documentation Site Output Directory
-    |--------------------------------------------------------------------------
-    |
-    | If you want to store the compiled documentation pages in a different
-    | directory than the default 'docs' directory, for example to set the
-    | specified version, you can specify the directory here.
-    |
-    | Note that you need to take care as to not set it to something that
-    | may conflict with other parts, such as media or posts directories.
-    |
-    | The default value is 'docs'. For easy versioning you can do what
-    | HydePHP.com does, setting it to 'docs/master'.
-    |
-    */
-
-    /** @deprecated Use `hyde.output_directories.docs` instead */
-    'output_directory' => 'docs',
-
-    /*
-    |--------------------------------------------------------------------------
     | Collaborative Source Editing Location
     |--------------------------------------------------------------------------
     |

--- a/packages/framework/src/Framework/HydeServiceProvider.php
+++ b/packages/framework/src/Framework/HydeServiceProvider.php
@@ -44,7 +44,7 @@ class HydeServiceProvider extends ServiceProvider
             BladePage::class => $this->getOutputDirectoryConfiguration(BladePage::class, ''),
             MarkdownPage::class => $this->getOutputDirectoryConfiguration(MarkdownPage::class, ''),
             MarkdownPost::class => $this->getOutputDirectoryConfiguration(MarkdownPost::class, 'posts'),
-            DocumentationPage::class => config('docs.output_directory') ?? $this->getOutputDirectoryConfiguration(DocumentationPage::class, 'docs'),
+            DocumentationPage::class => config('hyde.output_directories.Hyde\Pages\DocumentationPage') ?? $this->getOutputDirectoryConfiguration(DocumentationPage::class, 'docs'),
         ]);
 
         $this->storeCompiledSiteIn(config('hyde.output_directory', '_site'));

--- a/packages/framework/src/Framework/HydeServiceProvider.php
+++ b/packages/framework/src/Framework/HydeServiceProvider.php
@@ -44,7 +44,7 @@ class HydeServiceProvider extends ServiceProvider
             BladePage::class => $this->getOutputDirectoryConfiguration(BladePage::class, ''),
             MarkdownPage::class => $this->getOutputDirectoryConfiguration(MarkdownPage::class, ''),
             MarkdownPost::class => $this->getOutputDirectoryConfiguration(MarkdownPost::class, 'posts'),
-            DocumentationPage::class => config('hyde.output_directories.Hyde\Pages\DocumentationPage') ?? $this->getOutputDirectoryConfiguration(DocumentationPage::class, 'docs'),
+            DocumentationPage::class => $this->getOutputDirectoryConfiguration(DocumentationPage::class, 'docs'),
         ]);
 
         $this->storeCompiledSiteIn(config('hyde.output_directory', '_site'));

--- a/packages/framework/tests/Feature/HydeServiceProviderTest.php
+++ b/packages/framework/tests/Feature/HydeServiceProviderTest.php
@@ -141,7 +141,7 @@ class HydeServiceProviderTest extends TestCase
     {
         $this->assertEquals('docs', DocumentationPage::outputDirectory());
 
-        config(['docs.output_directory' => 'foo']);
+        config(['hyde.output_directories.Hyde\Pages\DocumentationPage' => 'foo']);
 
         $this->provider->register();
 

--- a/packages/framework/tests/Feature/HydeServiceProviderTest.php
+++ b/packages/framework/tests/Feature/HydeServiceProviderTest.php
@@ -136,6 +136,7 @@ class HydeServiceProviderTest extends TestCase
         $this->assertSame('foo', Hyde::getSourceRoot());
     }
 
+    /** @deprecated  */
     public function test_provider_registers_configured_documentation_output_directory()
     {
         $this->assertEquals('docs', DocumentationPage::outputDirectory());

--- a/packages/framework/tests/Feature/HydeServiceProviderTest.php
+++ b/packages/framework/tests/Feature/HydeServiceProviderTest.php
@@ -136,18 +136,6 @@ class HydeServiceProviderTest extends TestCase
         $this->assertSame('foo', Hyde::getSourceRoot());
     }
 
-    /** @deprecated  */
-    public function test_provider_registers_configured_documentation_output_directory()
-    {
-        $this->assertEquals('docs', DocumentationPage::outputDirectory());
-
-        config(['hyde.output_directories.Hyde\Pages\DocumentationPage' => 'foo']);
-
-        $this->provider->register();
-
-        $this->assertEquals('foo', DocumentationPage::outputDirectory());
-    }
-
     public function test_provider_registers_site_output_directory()
     {
         $this->assertEquals('_site', Site::getOutputDirectory());
@@ -293,7 +281,7 @@ class HydeServiceProviderTest extends TestCase
         $this->assertEquals('foo', BladePage::$outputDirectory);
         $this->assertEquals('foo', MarkdownPage::$outputDirectory);
         $this->assertEquals('foo', MarkdownPost::$outputDirectory);
-        // TODO: $this->assertEquals('foo', DocumentationPage::$outputDirectory);
+        $this->assertEquals('foo', DocumentationPage::$outputDirectory);
     }
 
     protected function getDeclaredPages(): array

--- a/packages/framework/tests/Feature/StaticPageBuilderTest.php
+++ b/packages/framework/tests/Feature/StaticPageBuilderTest.php
@@ -132,7 +132,7 @@ class StaticPageBuilderTest extends TestCase
     {
         $page = DocumentationPage::make('foo');
 
-        Config::set('docs.output_directory', 'docs/foo');
+        Config::set('hyde.output_directories.Hyde\Pages\DocumentationPage', 'docs/foo');
         (new HydeServiceProvider($this->app))->register(); // Re-register the service provider to pick up the new config.
 
         new StaticPageBuilder($page, true);

--- a/packages/framework/tests/Unit/DocumentationPageTest.php
+++ b/packages/framework/tests/Unit/DocumentationPageTest.php
@@ -32,7 +32,7 @@ class DocumentationPageTest extends TestCase
         $page = DocumentationPage::make('foo');
         $this->assertEquals('docs/foo', $page->getRouteKey());
 
-        config(['docs.output_directory' => 'documentation/latest/']);
+        config(['hyde.output_directories.Hyde\Pages\DocumentationPage' => 'documentation/latest/']);
         (new HydeServiceProvider($this->app))->register();
         $this->assertEquals('documentation/latest/foo', $page->getRouteKey());
     }
@@ -68,7 +68,7 @@ class DocumentationPageTest extends TestCase
 
     public function test_can_get_documentation_output_path_with_custom_output_directory()
     {
-        config(['docs.output_directory' => 'foo']);
+        config(['hyde.output_directories.Hyde\Pages\DocumentationPage' => 'foo']);
         (new HydeServiceProvider($this->app))->register();
         $this->assertEquals('foo', DocumentationPage::outputDirectory());
     }
@@ -84,7 +84,7 @@ class DocumentationPageTest extends TestCase
         ];
 
         foreach ($tests as $test) {
-            config(['docs.output_directory' => $test]);
+            config(['hyde.output_directories.Hyde\Pages\DocumentationPage' => $test]);
             (new HydeServiceProvider($this->app))->register();
             $this->assertEquals('foo', DocumentationPage::outputDirectory());
         }
@@ -121,7 +121,7 @@ class DocumentationPageTest extends TestCase
 
     public function test_home_method_finds_docs_index_for_custom_output_directory()
     {
-        config(['docs.output_directory' => 'foo']);
+        config(['hyde.output_directories.Hyde\Pages\DocumentationPage' => 'foo']);
         (new HydeServiceProvider($this->app))->register();
         mkdir(Hyde::path('foo'));
         Hyde::touch('_docs/index.md');
@@ -133,7 +133,7 @@ class DocumentationPageTest extends TestCase
 
     public function test_home_method_finds_docs_index_for_custom_nested_output_directory()
     {
-        config(['docs.output_directory' => 'foo/bar']);
+        config(['hyde.output_directories.Hyde\Pages\DocumentationPage' => 'foo/bar']);
         (new HydeServiceProvider($this->app))->register();
         mkdir(Hyde::path('foo'));
         mkdir(Hyde::path('foo/bar'));
@@ -151,7 +151,7 @@ class DocumentationPageTest extends TestCase
 
     public function test_home_route_name_method_returns_customized_output_directory_slash_index()
     {
-        config(['docs.output_directory' => 'foo/bar']);
+        config(['hyde.output_directories.Hyde\Pages\DocumentationPage' => 'foo/bar']);
         (new HydeServiceProvider($this->app))->register();
 
         $this->assertSame('foo/bar/index', DocumentationPage::homeRouteName());


### PR DESCRIPTION
This is being replaced by `hyde.source_directories.Hyde\Pages\DocumentationPage` in https://github.com/hydephp/develop/pull/1014

So, instead of the following in `config/docs.php`
```php
'output_directory' => 'foo',
```

You would use the following in `config/hyde.php`
```php
'output_directories' => [
    // [...]

    \Hyde\Pages\DocumentationPage::class => 'foo',
],
```
