### PR TITLE
Update internal page class name resolver for config helper method to support kebab-case class names

### DIFF
--- a/packages/framework/src/Framework/Concerns/RegistersFileLocations.php
+++ b/packages/framework/src/Framework/Concerns/RegistersFileLocations.php
@@ -87,6 +87,10 @@ trait RegistersFileLocations
 
     protected function getSourceDirectoryConfiguration(string $class, string $default): string
     {
-        return config("hyde.source_directories.$class") ?? $default;
+        if (config("hyde.source_directories.$class")) {
+            return config("hyde.source_directories.$class");
+        } else {
+            return $default;
+        }
     }
 }

--- a/packages/framework/src/Framework/Concerns/RegistersFileLocations.php
+++ b/packages/framework/src/Framework/Concerns/RegistersFileLocations.php
@@ -92,8 +92,8 @@ trait RegistersFileLocations
             return config("hyde.source_directories.$class");
         } else {
             $kebab = Str::kebab(class_basename($class));
-            if (config("hyde.source_directories.$kebab")) {
-                return config("hyde.source_directories.$kebab");
+            if (config('hyde.source_directories.'.$kebab)) {
+                return config('hyde.source_directories.'.$kebab);
             }
 
             return $default;

--- a/packages/framework/src/Framework/Concerns/RegistersFileLocations.php
+++ b/packages/framework/src/Framework/Concerns/RegistersFileLocations.php
@@ -88,14 +88,8 @@ trait RegistersFileLocations
 
     protected function getSourceDirectoryConfiguration(string $class, string $default): string
     {
-        if (config("hyde.source_directories.$class")) {
-            return config("hyde.source_directories.$class");
-        } else {
-            if (config('hyde.source_directories.'.Str::kebab(class_basename($class)))) {
-                return config('hyde.source_directories.'.Str::kebab(class_basename($class)));
-            }
-
-            return $default;
-        }
+        return config("hyde.source_directories.$class")
+            ?? config('hyde.source_directories.'.Str::kebab(class_basename($class)))
+            ?? $default;
     }
 }

--- a/packages/framework/src/Framework/Concerns/RegistersFileLocations.php
+++ b/packages/framework/src/Framework/Concerns/RegistersFileLocations.php
@@ -87,6 +87,6 @@ trait RegistersFileLocations
 
     protected function getSourceDirectoryConfiguration(string $class, string $default): string
     {
-        return config("hyde.source_directories.$class", $default);
+        return config("hyde.source_directories.$class") ?? $default;
     }
 }

--- a/packages/framework/src/Framework/Concerns/RegistersFileLocations.php
+++ b/packages/framework/src/Framework/Concerns/RegistersFileLocations.php
@@ -91,9 +91,8 @@ trait RegistersFileLocations
         if (config("hyde.source_directories.$class")) {
             return config("hyde.source_directories.$class");
         } else {
-            $kebab = Str::kebab(class_basename($class));
-            if (config('hyde.source_directories.'.$kebab)) {
-                return config('hyde.source_directories.'.$kebab);
+            if (config('hyde.source_directories.'.Str::kebab(class_basename($class)))) {
+                return config('hyde.source_directories.'.Str::kebab(class_basename($class)));
             }
 
             return $default;

--- a/packages/framework/src/Framework/Concerns/RegistersFileLocations.php
+++ b/packages/framework/src/Framework/Concerns/RegistersFileLocations.php
@@ -7,6 +7,7 @@ namespace Hyde\Framework\Concerns;
 use Hyde\Facades\Site;
 use Hyde\Hyde;
 use Hyde\Pages\Concerns\HydePage;
+use Illuminate\Support\Str;
 
 /**
  * This trait registers the file paths for important Hyde locations.
@@ -90,6 +91,11 @@ trait RegistersFileLocations
         if (config("hyde.source_directories.$class")) {
             return config("hyde.source_directories.$class");
         } else {
+            $kebab = Str::kebab(class_basename($class));
+            if (config("hyde.source_directories.$kebab")) {
+                return config("hyde.source_directories.$kebab");
+            }
+
             return $default;
         }
     }

--- a/packages/framework/tests/Feature/HydeServiceProviderTest.php
+++ b/packages/framework/tests/Feature/HydeServiceProviderTest.php
@@ -294,7 +294,7 @@ class HydeServiceProviderTest extends TestCase
         $this->assertEquals('foo', MarkdownPost::$sourceDirectory);
         $this->assertEquals('foo', DocumentationPage::$sourceDirectory);
     }
-    
+
     protected function getDeclaredPages(): array
     {
         return array_values(array_filter(get_declared_classes(), function ($class) {

--- a/packages/framework/tests/Feature/HydeServiceProviderTest.php
+++ b/packages/framework/tests/Feature/HydeServiceProviderTest.php
@@ -276,6 +276,25 @@ class HydeServiceProviderTest extends TestCase
         $this->assertEquals('foo', DocumentationPage::$sourceDirectory);
     }
 
+    public function test_source_directories_can_be_set_using_kebab_case_class_names()
+    {
+        config(['hyde.source_directories' => [
+            'html-page' => 'foo',
+            'blade-page' => 'foo',
+            'markdown-page' => 'foo',
+            'markdown-post' => 'foo',
+            'documentation-page' => 'foo',
+        ]]);
+
+        $this->provider->register();
+
+        $this->assertEquals('foo', HtmlPage::$sourceDirectory);
+        $this->assertEquals('foo', BladePage::$sourceDirectory);
+        $this->assertEquals('foo', MarkdownPage::$sourceDirectory);
+        $this->assertEquals('foo', MarkdownPost::$sourceDirectory);
+        $this->assertEquals('foo', DocumentationPage::$sourceDirectory);
+    }
+    
     protected function getDeclaredPages(): array
     {
         return array_values(array_filter(get_declared_classes(), function ($class) {


### PR DESCRIPTION
Resolves semantics in https://github.com/hydephp/develop/issues/1009

Could be improved by checking if class exists in our namespace, but don't think the complexity is worth it at this point.

