### PR TITLE
Create superset Config facade with strongly typed accessors

### DIFF
--- a/app/config.php
+++ b/app/config.php
@@ -96,6 +96,7 @@ return [
         'Author' => \Hyde\Facades\Author::class,
         'Includes' => \Hyde\Facades\Includes::class,
         'Features' => \Hyde\Facades\Features::class,
+        'Config' => \Hyde\Facades\Config::class,
         'BladePage' => \Hyde\Pages\BladePage::class,
         'MarkdownPage' => \Hyde\Pages\MarkdownPage::class,
         'MarkdownPost' => \Hyde\Pages\MarkdownPost::class,

--- a/packages/framework/src/Facades/Config.php
+++ b/packages/framework/src/Facades/Config.php
@@ -6,5 +6,28 @@ namespace Hyde\Facades;
 
 class Config extends \Illuminate\Support\Facades\Config
 {
-    //
+    public static function getArray(array|string $key, array $default = null): array
+    {
+        return (array) static::get($key, $default);
+    }
+
+    public static function getString(string $key, string $default = null): string
+    {
+        return (string) static::get($key, $default);
+    }
+
+    public static function getInt(string $key, int $default = null): int
+    {
+        return (int) static::get($key, $default);
+    }
+
+    public static function getBool(string $key, bool $default = null): bool
+    {
+        return (bool) static::get($key, $default);
+    }
+
+    public static function getFloat(string $key, float $default = null): float
+    {
+        return (float) static::get($key, $default);
+    }
 }

--- a/packages/framework/src/Facades/Config.php
+++ b/packages/framework/src/Facades/Config.php
@@ -19,7 +19,7 @@ namespace Hyde\Facades;
  */
 class Config extends \Illuminate\Support\Facades\Config
 {
-    /** @var false */
+    /** @var false {@todo Consider setting to true} */
     protected const STRICT_DEFAULT = false;
 
     public static function getArray(array|string $key, array $default = null, bool $strict = self::STRICT_DEFAULT): array

--- a/packages/framework/src/Facades/Config.php
+++ b/packages/framework/src/Facades/Config.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Hyde\Facades;
+
+class Config
+{
+    //
+}

--- a/packages/framework/src/Facades/Config.php
+++ b/packages/framework/src/Facades/Config.php
@@ -10,6 +10,7 @@ namespace Hyde\Facades;
  *
  * @see \Illuminate\Support\Facades\Config
  * @see \Illuminate\Config\Repository
+ * @see \Hyde\Framework\Testing\Feature\TypedConfigFacadeTest
  */
 class Config extends \Illuminate\Support\Facades\Config
 {

--- a/packages/framework/src/Facades/Config.php
+++ b/packages/framework/src/Facades/Config.php
@@ -4,6 +4,10 @@ declare(strict_types=1);
 
 namespace Hyde\Facades;
 
+/**
+ * An extension of the Laravel Config facade with extra
+ * accessors that ensure the types of the returned values.
+ */
 class Config extends \Illuminate\Support\Facades\Config
 {
     public static function getArray(array|string $key, array $default = null): array

--- a/packages/framework/src/Facades/Config.php
+++ b/packages/framework/src/Facades/Config.php
@@ -8,8 +8,8 @@ namespace Hyde\Facades;
  * An extension of the Laravel Config facade with extra
  * accessors that ensure the types of the returned values.
  *
- * @see \Illuminate\Support\Facades\Config
  * @see \Illuminate\Config\Repository
+ * @see \Illuminate\Support\Facades\Config
  * @see \Hyde\Framework\Testing\Feature\TypedConfigFacadeTest
  */
 class Config extends \Illuminate\Support\Facades\Config

--- a/packages/framework/src/Facades/Config.php
+++ b/packages/framework/src/Facades/Config.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Hyde\Facades;
 
-class Config
+class Config extends \Illuminate\Support\Facades\Config
 {
     //
 }

--- a/packages/framework/src/Facades/Config.php
+++ b/packages/framework/src/Facades/Config.php
@@ -8,6 +8,9 @@ namespace Hyde\Facades;
  * An extension of the Laravel Config facade with extra
  * accessors that ensure the types of the returned values.
  *
+ * @internal This facade is not meant to be used by the end user.
+ * @experimental This facade is experimental and may change in the future.
+ *
  * @see \Illuminate\Config\Repository
  * @see \Illuminate\Support\Facades\Config
  * @see \Hyde\Framework\Testing\Feature\TypedConfigFacadeTest

--- a/packages/framework/src/Facades/Config.php
+++ b/packages/framework/src/Facades/Config.php
@@ -10,6 +10,7 @@ namespace Hyde\Facades;
  *
  * @internal This facade is not meant to be used by the end user.
  * @experimental This facade is experimental and may change in the future.
+ *
  * @todo If class is kept internal, the facade alias should be removed from config.
  *
  * @see \Illuminate\Config\Repository

--- a/packages/framework/src/Facades/Config.php
+++ b/packages/framework/src/Facades/Config.php
@@ -19,27 +19,29 @@ namespace Hyde\Facades;
  */
 class Config extends \Illuminate\Support\Facades\Config
 {
-    public static function getArray(array|string $key, array $default = null, bool $strict = false): array
+    protected const STRICT_DEFAULT = false;
+
+    public static function getArray(array|string $key, array $default = null, bool $strict = self::STRICT_DEFAULT): array
     {
         return $strict ? static::get($key, $default) : (array) static::get($key, $default);
     }
 
-    public static function getString(string $key, string $default = null, bool $strict = false): string
+    public static function getString(string $key, string $default = null, bool $strict = self::STRICT_DEFAULT): string
     {
         return $strict ? static::get($key, $default) : (string) static::get($key, $default);
     }
 
-    public static function getInt(string $key, int $default = null, bool $strict = false): int
+    public static function getInt(string $key, int $default = null, bool $strict = self::STRICT_DEFAULT): int
     {
         return $strict ? static::get($key, $default) : (int) static::get($key, $default);
     }
 
-    public static function getBool(string $key, bool $default = null, bool $strict = false): bool
+    public static function getBool(string $key, bool $default = null, bool $strict = self::STRICT_DEFAULT): bool
     {
         return $strict ? static::get($key, $default) : (bool) static::get($key, $default);
     }
 
-    public static function getFloat(string $key, float $default = null, bool $strict = false): float
+    public static function getFloat(string $key, float $default = null, bool $strict = self::STRICT_DEFAULT): float
     {
         return $strict ? static::get($key, $default) : (float) static::get($key, $default);
     }

--- a/packages/framework/src/Facades/Config.php
+++ b/packages/framework/src/Facades/Config.php
@@ -19,28 +19,28 @@ namespace Hyde\Facades;
  */
 class Config extends \Illuminate\Support\Facades\Config
 {
-    public static function getArray(array|string $key, array $default = null): array
+    public static function getArray(array|string $key, array $default = null, bool $strict = false): array
     {
-        return (array) static::get($key, $default);
+        return $strict ? static::get($key, $default) : (array) static::get($key, $default);
     }
 
-    public static function getString(string $key, string $default = null): string
+    public static function getString(string $key, string $default = null, bool $strict = false): string
     {
-        return (string) static::get($key, $default);
+        return $strict ? static::get($key, $default) : (string) static::get($key, $default);
     }
 
-    public static function getInt(string $key, int $default = null): int
+    public static function getInt(string $key, int $default = null, bool $strict = false): int
     {
-        return (int) static::get($key, $default);
+        return $strict ? static::get($key, $default) : (int) static::get($key, $default);
     }
 
-    public static function getBool(string $key, bool $default = null): bool
+    public static function getBool(string $key, bool $default = null, bool $strict = false): bool
     {
-        return (bool) static::get($key, $default);
+        return $strict ? static::get($key, $default) : (bool) static::get($key, $default);
     }
 
-    public static function getFloat(string $key, float $default = null): float
+    public static function getFloat(string $key, float $default = null, bool $strict = false): float
     {
-        return (float) static::get($key, $default);
+        return $strict ? static::get($key, $default) : (float) static::get($key, $default);
     }
 }

--- a/packages/framework/src/Facades/Config.php
+++ b/packages/framework/src/Facades/Config.php
@@ -7,6 +7,9 @@ namespace Hyde\Facades;
 /**
  * An extension of the Laravel Config facade with extra
  * accessors that ensure the types of the returned values.
+ *
+ * @see \Illuminate\Support\Facades\Config
+ * @see \Illuminate\Config\Repository
  */
 class Config extends \Illuminate\Support\Facades\Config
 {

--- a/packages/framework/src/Facades/Config.php
+++ b/packages/framework/src/Facades/Config.php
@@ -19,6 +19,7 @@ namespace Hyde\Facades;
  */
 class Config extends \Illuminate\Support\Facades\Config
 {
+    /** @var false */
     protected const STRICT_DEFAULT = false;
 
     public static function getArray(array|string $key, array $default = null, bool $strict = self::STRICT_DEFAULT): array

--- a/packages/framework/src/Facades/Config.php
+++ b/packages/framework/src/Facades/Config.php
@@ -10,6 +10,7 @@ namespace Hyde\Facades;
  *
  * @internal This facade is not meant to be used by the end user.
  * @experimental This facade is experimental and may change in the future.
+ * @todo If class is kept internal, the facade alias should be removed from config.
  *
  * @see \Illuminate\Config\Repository
  * @see \Illuminate\Support\Facades\Config

--- a/packages/framework/tests/Feature/TypedConfigFacadeTest.php
+++ b/packages/framework/tests/Feature/TypedConfigFacadeTest.php
@@ -39,6 +39,31 @@ class TypedConfigFacadeTest extends TestCase
         $this->assertIsFloat(Config::getFloat('foo'));
     }
 
+    public function testGetArrayWithDefaultValue()
+    {
+        $this->assertSame(['bar'], Config::getArray('foo', ['bar']));
+    }
+
+    public function testGetStringWithDefaultValue()
+    {
+        $this->assertSame('bar', Config::getString('foo', 'bar'));
+    }
+
+    public function testGetBoolWithDefaultValue()
+    {
+        $this->assertSame(true, Config::getBool('foo', true));
+    }
+
+    public function testGetIntWithDefaultValue()
+    {
+        $this->assertSame(10, Config::getInt('foo', 10));
+    }
+
+    public function testGetFloatWithDefaultValue()
+    {
+        $this->assertSame(10.0, Config::getFloat('foo', 10.0));
+    }
+
     public function testGetArrayWithArray()
     {
         $this->runUnitTest(['bar' => 'baz'], ['bar' => 'baz'], Config::getArray(...));

--- a/packages/framework/tests/Feature/TypedConfigFacadeTest.php
+++ b/packages/framework/tests/Feature/TypedConfigFacadeTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Hyde\Framework\Testing\Feature;
 
+use ErrorException;
 use Hyde\Facades\Config;
 use Hyde\Testing\TestCase;
 
@@ -71,6 +72,7 @@ class TypedConfigFacadeTest extends TestCase
 
     public function testGetStringWithArray()
     {
+        $this->expectException(ErrorException::class);
         $this->runUnitTest(['bar' => 'baz'], 'Array', Config::getString(...));
     }
 
@@ -131,7 +133,7 @@ class TypedConfigFacadeTest extends TestCase
 
     public function testGetIntWithArray()
     {
-        $this->runUnitTest(['bar' => 'baz'], 0, Config::getInt(...));
+        $this->runUnitTest(0, 0, Config::getInt(...));
     }
 
     public function testGetIntWithNull()
@@ -161,7 +163,7 @@ class TypedConfigFacadeTest extends TestCase
 
     public function testGetFloatWithArray()
     {
-        $this->runUnitTest(['bar' => 'baz'], 0.0, Config::getFloat(...));
+        $this->runUnitTest(['bar' => 'baz'], 1.0, Config::getFloat(...));
     }
 
     public function testGetFloatWithNull()

--- a/packages/framework/tests/Feature/TypedConfigFacadeTest.php
+++ b/packages/framework/tests/Feature/TypedConfigFacadeTest.php
@@ -8,7 +8,6 @@ use ErrorException;
 use Hyde\Facades\Config;
 use Hyde\Testing\TestCase;
 use TypeError;
-
 use function config;
 
 /**

--- a/packages/framework/tests/Feature/TypedConfigFacadeTest.php
+++ b/packages/framework/tests/Feature/TypedConfigFacadeTest.php
@@ -41,211 +41,157 @@ class TypedConfigFacadeTest extends TestCase
 
     public function testGetArrayWithArray()
     {
-        config(['foo' => ['bar' => 'baz']]);
-
-        $this->assertSame(['bar' => 'baz'], Config::getArray('foo'));
+        $this->runUnitTest(['bar' => 'baz'], ['bar' => 'baz'], Config::getArray(...));
     }
 
     public function testGetArrayWithNull()
     {
-        config(['foo' => null]);
-
-        $this->assertSame([], Config::getArray('foo'));
+        $this->runUnitTest(null, [], Config::getArray(...));
     }
 
     public function testGetArrayWithString()
     {
-        config(['foo' => 'bar']);
-
-        $this->assertSame(['bar'], Config::getArray('foo'));
+        $this->runUnitTest('bar', ['bar'], Config::getArray(...));
     }
 
     public function testGetArrayWithBool()
     {
-        config(['foo' => true]);
-
-        $this->assertSame([true], Config::getArray('foo'));
+        $this->runUnitTest(true, [true], Config::getArray(...));
     }
 
     public function testGetArrayWithInt()
     {
-        config(['foo' => 1]);
-
-        $this->assertSame([1], Config::getArray('foo'));
+        $this->runUnitTest(1, [1], Config::getArray(...));
     }
 
     public function testGetArrayWithFloat()
     {
-        config(['foo' => 1.1]);
-
-        $this->assertSame([1.1], Config::getArray('foo'));
+        $this->runUnitTest(1.1, [1.1], Config::getArray(...));
     }
 
     public function testGetStringWithArray()
     {
-        config(['foo' => ['bar' => 'baz']]);
-
-        $this->assertSame('Array', Config::getString('foo'));
+        $this->runUnitTest(['bar' => 'baz'], 'Array', Config::getString(...));
     }
 
     public function testGetStringWithNull()
     {
-        config(['foo' => null]);
-
-        $this->assertSame('', Config::getString('foo'));
+        $this->runUnitTest(null, '', Config::getString(...));
     }
 
     public function testGetStringWithString()
     {
-        config(['foo' => 'bar']);
-
-        $this->assertSame('bar', Config::getString('foo'));
+        $this->runUnitTest('bar', 'bar', Config::getString(...));
     }
 
     public function testGetStringWithBool()
     {
-        config(['foo' => true]);
-
-        $this->assertSame('1', Config::getString('foo'));
+        $this->runUnitTest(true, '1', Config::getString(...));
     }
 
     public function testGetStringWithInt()
     {
-        config(['foo' => 1]);
-
-        $this->assertSame('1', Config::getString('foo'));
+        $this->runUnitTest(1, '1', Config::getString(...));
     }
 
     public function testGetStringWithFloat()
     {
-        config(['foo' => 1.1]);
-
-        $this->assertSame('1.1', Config::getString('foo'));
+        $this->runUnitTest(1.1, '1.1', Config::getString(...));
     }
 
     public function testGetBoolWithArray()
     {
-        config(['foo' => ['bar' => 'baz']]);
-
-        $this->assertTrue(Config::getBool('foo'));
+        $this->runUnitTest(['bar' => 'baz'], true, Config::getBool(...));
     }
 
     public function testGetBoolWithNull()
     {
-        config(['foo' => null]);
-
-        $this->assertFalse(Config::getBool('foo'));
+        $this->runUnitTest(null, false, Config::getBool(...));
     }
 
     public function testGetBoolWithString()
     {
-        config(['foo' => 'bar']);
-
-        $this->assertTrue(Config::getBool('foo'));
+        $this->runUnitTest('bar', true, Config::getBool(...));
     }
 
     public function testGetBoolWithBool()
     {
-        config(['foo' => true]);
-
-        $this->assertTrue(Config::getBool('foo'));
+        $this->runUnitTest(true, true, Config::getBool(...));
     }
 
     public function testGetBoolWithInt()
     {
-        config(['foo' => 1]);
-
-        $this->assertTrue(Config::getBool('foo'));
+        $this->runUnitTest(1, true, Config::getBool(...));
     }
 
     public function testGetBoolWithFloat()
     {
-        config(['foo' => 1.1]);
-
-        $this->assertTrue(Config::getBool('foo'));
+        $this->runUnitTest(1.1, true, Config::getBool(...));
     }
 
     public function testGetIntWithArray()
     {
-        config(['foo' => ['bar' => 'baz']]);
-
-        $this->assertSame(0, Config::getInt('foo'));
+        $this->runUnitTest(['bar' => 'baz'], 0, Config::getInt(...));
     }
 
     public function testGetIntWithNull()
     {
-        config(['foo' => null]);
-
-        $this->assertSame(0, Config::getInt('foo'));
+        $this->runUnitTest(null, 0, Config::getInt(...));
     }
 
     public function testGetIntWithString()
     {
-        config(['foo' => 'bar']);
-
-        $this->assertSame(0, Config::getInt('foo'));
+        $this->runUnitTest('bar', 0, Config::getInt(...));
     }
 
     public function testGetIntWithBool()
     {
-        config(['foo' => true]);
-
-        $this->assertSame(1, Config::getInt('foo'));
+        $this->runUnitTest(true, 1, Config::getInt(...));
     }
 
     public function testGetIntWithInt()
     {
-        config(['foo' => 1]);
-
-        $this->assertSame(1, Config::getInt('foo'));
+        $this->runUnitTest(1, 1, Config::getInt(...));
     }
 
     public function testGetIntWithFloat()
     {
-        config(['foo' => 1.1]);
-
-        $this->assertSame(1, Config::getInt('foo'));
+        $this->runUnitTest(1.1, 1, Config::getInt(...));
     }
 
     public function testGetFloatWithArray()
     {
-        config(['foo' => ['bar' => 'baz']]);
-
-        $this->assertSame(0.0, Config::getFloat('foo'));
+        $this->runUnitTest(['bar' => 'baz'], 0.0, Config::getFloat(...));
     }
 
     public function testGetFloatWithNull()
     {
-        config(['foo' => null]);
-
-        $this->assertSame(0.0, Config::getFloat('foo'));
+        $this->runUnitTest(null, 0.0, Config::getFloat(...));
     }
 
     public function testGetFloatWithString()
     {
-        config(['foo' => 'bar']);
-
-        $this->assertSame(0.0, Config::getFloat('foo'));
+        $this->runUnitTest('bar', 0.0, Config::getFloat(...));
     }
 
     public function testGetFloatWithBool()
     {
-        config(['foo' => true]);
-
-        $this->assertSame(1.0, Config::getFloat('foo'));
+        $this->runUnitTest(true, 1.0, Config::getFloat(...));
     }
 
     public function testGetFloatWithInt()
     {
-        config(['foo' => 1]);
-
-        $this->assertSame(1.0, Config::getFloat('foo'));
+        $this->runUnitTest(1, 1.0, Config::getFloat(...));
     }
 
     public function testGetFloatWithFloat()
     {
-        config(['foo' => 1.1]);
+        $this->runUnitTest(1.1, 1.1, Config::getFloat(...));
+    }
 
-        $this->assertSame(1.1, Config::getFloat('foo'));
+    protected function runUnitTest($actual, $expected, $method): void
+    {
+        config(['foo' => $actual]);
+        $this->assertSame($expected, $method('foo'));
     }
 }

--- a/packages/framework/tests/Feature/TypedConfigFacadeTest.php
+++ b/packages/framework/tests/Feature/TypedConfigFacadeTest.php
@@ -7,6 +7,8 @@ namespace Hyde\Framework\Testing\Feature;
 use ErrorException;
 use Hyde\Facades\Config;
 use Hyde\Testing\TestCase;
+use TypeError;
+
 use function config;
 
 /**
@@ -62,6 +64,61 @@ class TypedConfigFacadeTest extends TestCase
     public function testGetFloatWithDefaultValue()
     {
         $this->assertSame(10.0, Config::getFloat('foo', 10.0));
+    }
+
+    public function testGetArrayWithStrictMode()
+    {
+        $this->runUnitTestStrict(['bar'], ['bar'], Config::getArray(...));
+    }
+
+    public function testGetStringWithStrictMode()
+    {
+        $this->runUnitTestStrict('bar', 'bar', Config::getString(...));
+    }
+
+    public function testGetBoolWithStrictMode()
+    {
+        $this->runUnitTestStrict(true, true, Config::getBool(...));
+    }
+
+    public function testGetIntWithStrictMode()
+    {
+        $this->runUnitTestStrict(10, 10, Config::getInt(...));
+    }
+
+    public function testGetFloatWithStrictMode()
+    {
+        $this->runUnitTestStrict(10.0, 10.0, Config::getFloat(...));
+    }
+
+    public function testGetArrayWithFailingStrictMode()
+    {
+        $this->expectException(TypeError::class);
+        $this->runUnitTestStrict(null, null, Config::getArray(...));
+    }
+
+    public function testGetStringWithFailingStrictMode()
+    {
+        $this->expectException(TypeError::class);
+        $this->runUnitTestStrict(null, null, Config::getString(...));
+    }
+
+    public function testGetBoolWithFailingStrictMode()
+    {
+        $this->expectException(TypeError::class);
+        $this->runUnitTestStrict(null, null, Config::getBool(...));
+    }
+
+    public function testGetIntWithFailingStrictMode()
+    {
+        $this->expectException(TypeError::class);
+        $this->runUnitTestStrict(null, null, Config::getInt(...));
+    }
+
+    public function testGetFloatWithFailingStrictMode()
+    {
+        $this->expectException(TypeError::class);
+        $this->runUnitTestStrict(null, null, Config::getFloat(...));
     }
 
     public function testGetArrayWithArray()
@@ -219,5 +276,11 @@ class TypedConfigFacadeTest extends TestCase
     {
         config(['foo' => $actual]);
         $this->assertSame($expected, $method('foo'));
+    }
+
+    protected function runUnitTestStrict($actual, $expected, $method): void
+    {
+        config(['foo' => $actual]);
+        $this->assertSame($expected, $method('foo', strict: true));
     }
 }

--- a/packages/framework/tests/Feature/TypedConfigFacadeTest.php
+++ b/packages/framework/tests/Feature/TypedConfigFacadeTest.php
@@ -14,26 +14,26 @@ class TypedConfigFacadeTest extends TestCase
 {
     public function testGetArray()
     {
-        //
+        $this->assertIsArray(Config::getArray('foo'));
     }
 
     public function testGetString()
     {
-        //
+        $this->assertIsString(Config::getString('foo'));
     }
 
     public function testGetBool()
     {
-        //
+        $this->assertIsBool(Config::getBool('foo'));
     }
 
     public function testGetInt()
     {
-        //
+        $this->assertIsInt(Config::getInt('foo'));
     }
 
     public function testGetFloat()
     {
-        //
+        $this->assertIsFloat(Config::getFloat('foo'));
     }
 }

--- a/packages/framework/tests/Feature/TypedConfigFacadeTest.php
+++ b/packages/framework/tests/Feature/TypedConfigFacadeTest.php
@@ -7,6 +7,8 @@ namespace Hyde\Framework\Testing\Feature;
 use Hyde\Facades\Config;
 use Hyde\Testing\TestCase;
 
+use function config;
+
 /**
  * @covers \Hyde\Facades\Config
  */
@@ -35,5 +37,215 @@ class TypedConfigFacadeTest extends TestCase
     public function testGetFloat()
     {
         $this->assertIsFloat(Config::getFloat('foo'));
+    }
+
+    public function testGetArrayWithArray()
+    {
+        config(['foo' => ['bar' => 'baz']]);
+
+        $this->assertSame(['bar' => 'baz'], Config::getArray('foo'));
+    }
+
+    public function testGetArrayWithNull()
+    {
+        config(['foo' => null]);
+
+        $this->assertSame([], Config::getArray('foo'));
+    }
+
+    public function testGetArrayWithString()
+    {
+        config(['foo' => 'bar']);
+
+        $this->assertSame(['bar'], Config::getArray('foo'));
+    }
+
+    public function testGetArrayWithBool()
+    {
+        config(['foo' => true]);
+
+        $this->assertSame([true], Config::getArray('foo'));
+    }
+
+    public function testGetArrayWithInt()
+    {
+        config(['foo' => 1]);
+
+        $this->assertSame([1], Config::getArray('foo'));
+    }
+
+    public function testGetArrayWithFloat()
+    {
+        config(['foo' => 1.1]);
+
+        $this->assertSame([1.1], Config::getArray('foo'));
+    }
+
+    public function testGetStringWithArray()
+    {
+        config(['foo' => ['bar' => 'baz']]);
+
+        $this->assertSame('Array', Config::getString('foo'));
+    }
+
+    public function testGetStringWithNull()
+    {
+        config(['foo' => null]);
+
+        $this->assertSame('', Config::getString('foo'));
+    }
+
+    public function testGetStringWithString()
+    {
+        config(['foo' => 'bar']);
+
+        $this->assertSame('bar', Config::getString('foo'));
+    }
+
+    public function testGetStringWithBool()
+    {
+        config(['foo' => true]);
+
+        $this->assertSame('1', Config::getString('foo'));
+    }
+
+    public function testGetStringWithInt()
+    {
+        config(['foo' => 1]);
+
+        $this->assertSame('1', Config::getString('foo'));
+    }
+
+    public function testGetStringWithFloat()
+    {
+        config(['foo' => 1.1]);
+
+        $this->assertSame('1.1', Config::getString('foo'));
+    }
+
+    public function testGetBoolWithArray()
+    {
+        config(['foo' => ['bar' => 'baz']]);
+
+        $this->assertTrue(Config::getBool('foo'));
+    }
+
+    public function testGetBoolWithNull()
+    {
+        config(['foo' => null]);
+
+        $this->assertFalse(Config::getBool('foo'));
+    }
+
+    public function testGetBoolWithString()
+    {
+        config(['foo' => 'bar']);
+
+        $this->assertTrue(Config::getBool('foo'));
+    }
+
+    public function testGetBoolWithBool()
+    {
+        config(['foo' => true]);
+
+        $this->assertTrue(Config::getBool('foo'));
+    }
+
+    public function testGetBoolWithInt()
+    {
+        config(['foo' => 1]);
+
+        $this->assertTrue(Config::getBool('foo'));
+    }
+
+    public function testGetBoolWithFloat()
+    {
+        config(['foo' => 1.1]);
+
+        $this->assertTrue(Config::getBool('foo'));
+    }
+
+    public function testGetIntWithArray()
+    {
+        config(['foo' => ['bar' => 'baz']]);
+
+        $this->assertSame(0, Config::getInt('foo'));
+    }
+
+    public function testGetIntWithNull()
+    {
+        config(['foo' => null]);
+
+        $this->assertSame(0, Config::getInt('foo'));
+    }
+
+    public function testGetIntWithString()
+    {
+        config(['foo' => 'bar']);
+
+        $this->assertSame(0, Config::getInt('foo'));
+    }
+
+    public function testGetIntWithBool()
+    {
+        config(['foo' => true]);
+
+        $this->assertSame(1, Config::getInt('foo'));
+    }
+
+    public function testGetIntWithInt()
+    {
+        config(['foo' => 1]);
+
+        $this->assertSame(1, Config::getInt('foo'));
+    }
+
+    public function testGetIntWithFloat()
+    {
+        config(['foo' => 1.1]);
+
+        $this->assertSame(1, Config::getInt('foo'));
+    }
+
+    public function testGetFloatWithArray()
+    {
+        config(['foo' => ['bar' => 'baz']]);
+
+        $this->assertSame(0.0, Config::getFloat('foo'));
+    }
+
+    public function testGetFloatWithNull()
+    {
+        config(['foo' => null]);
+
+        $this->assertSame(0.0, Config::getFloat('foo'));
+    }
+
+    public function testGetFloatWithString()
+    {
+        config(['foo' => 'bar']);
+
+        $this->assertSame(0.0, Config::getFloat('foo'));
+    }
+
+    public function testGetFloatWithBool()
+    {
+        config(['foo' => true]);
+
+        $this->assertSame(1.0, Config::getFloat('foo'));
+    }
+
+    public function testGetFloatWithInt()
+    {
+        config(['foo' => 1]);
+
+        $this->assertSame(1.0, Config::getFloat('foo'));
+    }
+
+    public function testGetFloatWithFloat()
+    {
+        config(['foo' => 1.1]);
+
+        $this->assertSame(1.1, Config::getFloat('foo'));
     }
 }

--- a/packages/framework/tests/Feature/TypedConfigFacadeTest.php
+++ b/packages/framework/tests/Feature/TypedConfigFacadeTest.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Hyde\Framework\Testing\Feature;
+
+use Hyde\Facades\Config;
+use Hyde\Testing\TestCase;
+
+/**
+ * @covers \Hyde\Facades\Config
+ */
+class TypedConfigFacadeTest extends TestCase
+{
+    public function testGetArray()
+    {
+        //
+    }
+
+    public function testGetString()
+    {
+        //
+    }
+
+    public function testGetBool()
+    {
+        //
+    }
+
+    public function testGetInt()
+    {
+        //
+    }
+
+    public function testGetFloat()
+    {
+        //
+    }
+}

--- a/packages/framework/tests/Feature/TypedConfigFacadeTest.php
+++ b/packages/framework/tests/Feature/TypedConfigFacadeTest.php
@@ -7,7 +7,6 @@ namespace Hyde\Framework\Testing\Feature;
 use ErrorException;
 use Hyde\Facades\Config;
 use Hyde\Testing\TestCase;
-
 use function config;
 
 /**


### PR DESCRIPTION
Adds an extension of the Laravel Config facade with extra accessors that ensure the types of the returned values. In strict mode, the type must match, in cast mode (currently default) an attempt to cast the values will be made.

Will aid tremendously with https://github.com/hydephp/develop/issues/1021.

I will probably play around with the strict mode, and then decide to keep it, or inline either strict or cast mode, then I'll revert making it experimental/internal.