### PR TITLE
Add configuration option to disable the sidebar footer

### DIFF
--- a/config/docs.php
+++ b/config/docs.php
@@ -25,6 +25,18 @@ return [
 
     /*
     |--------------------------------------------------------------------------
+    | Sidebar Footer
+    |--------------------------------------------------------------------------
+    |
+    | By default, there is a small footer in the sidebar that links to your home page.
+    | If this is not your cup of tea, you can disable it by setting the option below to false.
+    |
+    */
+
+    'sidebar_footer' => true,
+
+    /*
+    |--------------------------------------------------------------------------
     | Collaborative Source Editing Location
     |--------------------------------------------------------------------------
     |

--- a/packages/framework/config/docs.php
+++ b/packages/framework/config/docs.php
@@ -25,6 +25,18 @@ return [
 
     /*
     |--------------------------------------------------------------------------
+    | Sidebar Footer
+    |--------------------------------------------------------------------------
+    |
+    | By default, there is a small footer in the sidebar that links to your home page.
+    | If this is not your cup of tea, you can disable it by setting the option below to false.
+    |
+    */
+
+    'sidebar_footer' => true,
+
+    /*
+    |--------------------------------------------------------------------------
     | Collaborative Source Editing Location
     |--------------------------------------------------------------------------
     |

--- a/packages/framework/resources/views/components/docs/sidebar.blade.php
+++ b/packages/framework/resources/views/components/docs/sidebar.blade.php
@@ -15,7 +15,9 @@
             @include('hyde::components.docs.sidebar-navigation')
         @endif
     </nav>
-    <footer id="sidebar-footer" class="h-16 absolute p-4 w-full bottom-0 left-0 text-center leading-8">
-        @include('hyde::components.docs.sidebar-footer')
-    </footer>
+    @if(config('docs.sidebar_footer', true))
+        <footer id="sidebar-footer" class="h-16 absolute p-4 w-full bottom-0 left-0 text-center leading-8">
+            @include('hyde::components.docs.sidebar-footer')
+        </footer>
+    @endif
 </aside>

--- a/packages/framework/resources/views/components/docs/sidebar.blade.php
+++ b/packages/framework/resources/views/components/docs/sidebar.blade.php
@@ -4,7 +4,7 @@
         @include('hyde::components.docs.sidebar-brand')
     </header>
     <nav id="sidebar-navigation"
-        @class(['p-4 overflow-y-auto border-y border-gray-300 dark:border-[#1b2533] h-[calc(100vh_-_8rem)]'])>
+        @class(['p-4 overflow-y-auto border-y border-gray-300 dark:border-[#1b2533]', config('docs.sidebar_footer', true) ? 'h-[calc(100vh_-_8rem)]': 'h-[calc(100vh_-_4rem)]'])>
         @php
             $sidebar = \Hyde\Framework\Features\Navigation\DocumentationSidebar::create();
         @endphp

--- a/packages/framework/resources/views/components/docs/sidebar.blade.php
+++ b/packages/framework/resources/views/components/docs/sidebar.blade.php
@@ -4,7 +4,7 @@
         @include('hyde::components.docs.sidebar-brand')
     </header>
     <nav id="sidebar-navigation"
-         class="p-4 overflow-y-auto border-y border-gray-300 dark:border-[#1b2533] h-[calc(100vh_-_8rem)]">
+        @class(['p-4 overflow-y-auto border-y border-gray-300 dark:border-[#1b2533] h-[calc(100vh_-_8rem)]'])>
         @php
             $sidebar = \Hyde\Framework\Features\Navigation\DocumentationSidebar::create();
         @endphp


### PR DESCRIPTION
## Abstract

Makes the documentation sidebar footer configurable

| With footer (default)                                                                                                                                     | Without footer                                                                                                                                        |
|-----------------------------------------------------------------------------------------------------------------------------------------------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------|
| ![localhost_8080_docs_index html(Macbook Pro) (1)](https://user-images.githubusercontent.com/95144705/219017752-2fa2370f-17b1-4f80-8131-2aa8ee09c2cc.png) | ![localhost_8080_docs_index html(Macbook Pro)](https://user-images.githubusercontent.com/95144705/219018051-848986a5-afb6-45ff-b9e2-f84f43d307a4.png) |


### Bug encountered

Some trouble here, the sidebar has a fixed height, so this change requires a ternary class, and a HydeFront update. But making this change now, and then I'll refactor the height to be dynamic in an other PR.

#### Workaround
- [Convert class attribute to dynamic blade class directive](https://github.com/hydephp/develop/commit/d999dff44da1be7ec21e38886b1507331312276b)
- [Dynamically set height depending on config setting](https://github.com/hydephp/develop/commit/1c491e4ad94f2f9201068e64b1bf8571304d976a)
