### PR TITLE
Rename conflicting sidebar HTML ID

### DIFF
--- a/packages/framework/resources/views/components/docs/grouped-sidebar-navigation.blade.php
+++ b/packages/framework/resources/views/components/docs/grouped-sidebar-navigation.blade.php
@@ -1,5 +1,5 @@
 @php /** @var \Hyde\Framework\Features\Navigation\DocumentationSidebar $sidebar */ @endphp
-<ul id="sidebar-navigation" role="list">
+<ul id="sidebar-navigation-items" role="list">
 	@foreach ($sidebar->getGroups() as $group)
 	<li class="sidebar-group mb-4 mt-4 first:mt-0" role="listitem">
 		<h4 class="sidebar-group-heading text-base font-semibold mb-2 -ml-1">{{ Hyde::makeTitle($group) }}</h4>

--- a/tests/Browser/HighLevelViewTest.php
+++ b/tests/Browser/HighLevelViewTest.php
@@ -178,10 +178,10 @@ date: 2022-01-01 12:00
                 ->assertSee('Page1')
                 ->assertSee('Page2')
                 ->assertSee('Page3')
-                ->assertAttributeContains('#sidebar-navigation-inner > li', 'class', 'sidebar-group')
-                ->assertSeeIn('#sidebar-navigation-inner > li:nth-child(1) > h4.sidebar-group-heading', 'Group 1')
-                ->assertAriaAttribute('#sidebar-navigation-inner > li:nth-child(1) > ul > li.sidebar-navigation-item.active > a', 'current', 'true')
-                ->assertSeeIn('#sidebar-navigation-inner > li:nth-child(2) > h4.sidebar-group-heading', 'Other')
+                ->assertAttributeContains('#sidebar-navigation-items > li', 'class', 'sidebar-group')
+                ->assertSeeIn('#sidebar-navigation-items > li:nth-child(1) > h4.sidebar-group-heading', 'Group 1')
+                ->assertAriaAttribute('#sidebar-navigation-items > li:nth-child(1) > ul > li.sidebar-navigation-item.active > a', 'current', 'true')
+                ->assertSeeIn('#sidebar-navigation-items > li:nth-child(2) > h4.sidebar-group-heading', 'Other')
                 ->screenshot('docs/with_grouped_sidebar_pages')
                 ->storeSourceAsHtml('docs/with_grouped_sidebar_pages');
         });

--- a/tests/Browser/HighLevelViewTest.php
+++ b/tests/Browser/HighLevelViewTest.php
@@ -178,10 +178,10 @@ date: 2022-01-01 12:00
                 ->assertSee('Page1')
                 ->assertSee('Page2')
                 ->assertSee('Page3')
-                ->assertAttributeContains('#sidebar-navigation > li', 'class', 'sidebar-group')
-                ->assertSeeIn('#sidebar-navigation > li:nth-child(1) > h4.sidebar-group-heading', 'Group 1')
-                ->assertAriaAttribute('#sidebar-navigation > li:nth-child(1) > ul > li.sidebar-navigation-item.active > a', 'current', 'true')
-                ->assertSeeIn('#sidebar-navigation > li:nth-child(2) > h4.sidebar-group-heading', 'Other')
+                ->assertAttributeContains('#sidebar-navigation-inner > li', 'class', 'sidebar-group')
+                ->assertSeeIn('#sidebar-navigation-inner > li:nth-child(1) > h4.sidebar-group-heading', 'Group 1')
+                ->assertAriaAttribute('#sidebar-navigation-inner > li:nth-child(1) > ul > li.sidebar-navigation-item.active > a', 'current', 'true')
+                ->assertSeeIn('#sidebar-navigation-inner > li:nth-child(2) > h4.sidebar-group-heading', 'Other')
                 ->screenshot('docs/with_grouped_sidebar_pages')
                 ->storeSourceAsHtml('docs/with_grouped_sidebar_pages');
         });


### PR DESCRIPTION
Fixes https://github.com/hydephp/develop/issues/1028

Changes the inner conflicting element. As far as I can tell, this the only internal use we have is for Dusk identifiers but custom sites may of course rely on this, but that's a BC risk I'm willing to take as this is a bug and the framework is still in beta and has no BC promise yet.

**Before:** `#sidebar-navigation > #sidebar-navigation`
![image](https://user-images.githubusercontent.com/95144705/219030105-f721ed39-7aca-4544-9974-69e79e110ebe.png)

**After:**  `#sidebar-navigation > #sidebar-navigation-items`
![image](https://user-images.githubusercontent.com/95144705/219030029-5aa1fc1f-381a-45d0-a7de-7889e07aef6f.png)
