### PR TITLE
Add HydeKernel booting callback API

### DIFF
--- a/packages/framework/src/Foundation/Concerns/BootsHydeKernel.php
+++ b/packages/framework/src/Foundation/Concerns/BootsHydeKernel.php
@@ -48,7 +48,6 @@ trait BootsHydeKernel
      * The kernel instance will be passed to your callback.
      *
      * @param  callable(\Hyde\Foundation\HydeKernel): void  $callback
-     * @return void
      */
     public function booting(callable $callback): void
     {
@@ -63,7 +62,6 @@ trait BootsHydeKernel
      * The kernel instance will be passed to your callback.
      *
      * @param  callable(\Hyde\Foundation\HydeKernel): void   $callback
-     * @return void
      */
     public function booted(callable $callback): void
     {

--- a/packages/framework/src/Foundation/Concerns/BootsHydeKernel.php
+++ b/packages/framework/src/Foundation/Concerns/BootsHydeKernel.php
@@ -24,6 +24,9 @@ trait BootsHydeKernel
     /** @var array<callable> */
     protected array $bootedCallbacks = [];
 
+    /**
+     * Boot the Hyde Kernel and run the Auto-Discovery Process.
+     */
     public function boot(): void
     {
         if (! $this->readyToBoot || $this->booting) {

--- a/packages/framework/src/Foundation/Concerns/BootsHydeKernel.php
+++ b/packages/framework/src/Foundation/Concerns/BootsHydeKernel.php
@@ -35,13 +35,13 @@ trait BootsHydeKernel
 
         $this->booting = true;
 
-        foreach ($this->bootingCallbacks as $callback) {
-            $callback($this);
-        }
-
         $this->files = FileCollection::init($this);
         $this->pages = PageCollection::init($this);
         $this->routes = RouteCollection::init($this);
+
+        foreach ($this->bootingCallbacks as $callback) {
+            $callback($this);
+        }
 
         $this->files->boot();
         $this->pages->boot();

--- a/packages/framework/src/Foundation/Concerns/BootsHydeKernel.php
+++ b/packages/framework/src/Foundation/Concerns/BootsHydeKernel.php
@@ -69,7 +69,7 @@ trait BootsHydeKernel
      * You can use this to run any logic after discovery has completed.
      * The kernel instance will be passed to your callback.
      *
-     * @param  callable(\Hyde\Foundation\HydeKernel): void   $callback
+     * @param  callable(\Hyde\Foundation\HydeKernel): void  $callback
      */
     public function booted(callable $callback): void
     {

--- a/packages/framework/src/Foundation/Concerns/BootsHydeKernel.php
+++ b/packages/framework/src/Foundation/Concerns/BootsHydeKernel.php
@@ -49,11 +49,23 @@ trait BootsHydeKernel
         $this->readyToBoot = true;
     }
 
+    /**
+     * Register a new boot listener.
+     *
+     * @param  callable  $callback
+     * @return void
+     */
     public function booting(callable $callback): void
     {
         $this->bootingCallbacks[] = $callback;
     }
 
+    /**
+     * Register a new "booted" listener.
+     *
+     * @param  callable  $callback
+     * @return void
+     */
     public function booted(callable $callback): void
     {
         $this->bootedCallbacks[] = $callback;

--- a/packages/framework/src/Foundation/Concerns/BootsHydeKernel.php
+++ b/packages/framework/src/Foundation/Concerns/BootsHydeKernel.php
@@ -40,15 +40,6 @@ trait BootsHydeKernel
         $this->booted = true;
     }
 
-    /** @internal */
-    public function readyToBoot(): void
-    {
-        // To give package developers ample time to register their services,
-        // don't want to boot the kernel until all providers have been registered.
-
-        $this->readyToBoot = true;
-    }
-
     /**
      * Register a new boot listener.
      *
@@ -69,5 +60,14 @@ trait BootsHydeKernel
     public function booted(callable $callback): void
     {
         $this->bootedCallbacks[] = $callback;
+    }
+
+    /** @internal */
+    public function readyToBoot(): void
+    {
+        // To give package developers ample time to register their services,
+        // don't want to boot the kernel until all providers have been registered.
+
+        $this->readyToBoot = true;
     }
 }

--- a/packages/framework/src/Foundation/Concerns/BootsHydeKernel.php
+++ b/packages/framework/src/Foundation/Concerns/BootsHydeKernel.php
@@ -48,4 +48,14 @@ trait BootsHydeKernel
 
         $this->readyToBoot = true;
     }
+
+    public function booting(callable $callback): void
+    {
+        $this->bootingCallbacks[] = $callback;
+    }
+
+    public function booted(callable $callback): void
+    {
+        $this->bootedCallbacks[] = $callback;
+    }
 }

--- a/packages/framework/src/Foundation/Concerns/BootsHydeKernel.php
+++ b/packages/framework/src/Foundation/Concerns/BootsHydeKernel.php
@@ -47,7 +47,7 @@ trait BootsHydeKernel
      * You can use this to register your own routes, pages, etc.
      * The kernel instance will be passed to your callback.
      *
-     * @param  callable  $callback
+     * @param  callable(\Hyde\Foundation\HydeKernel): void  $callback
      * @return void
      */
     public function booting(callable $callback): void
@@ -62,7 +62,7 @@ trait BootsHydeKernel
      * You can use this to run any logic after discovery has completed.
      * The kernel instance will be passed to your callback.
      *
-     * @param  callable  $callback
+     * @param  callable(\Hyde\Foundation\HydeKernel): void   $callback
      * @return void
      */
     public function booted(callable $callback): void

--- a/packages/framework/src/Foundation/Concerns/BootsHydeKernel.php
+++ b/packages/framework/src/Foundation/Concerns/BootsHydeKernel.php
@@ -18,7 +18,10 @@ trait BootsHydeKernel
     private bool $readyToBoot = false;
     private bool $booting = false;
 
+    /** @var array<callable> */
     protected array $bootingCallbacks = [];
+
+    /** @var array<callable> */
     protected array $bootedCallbacks = [];
 
     public function boot(): void

--- a/packages/framework/src/Foundation/Concerns/BootsHydeKernel.php
+++ b/packages/framework/src/Foundation/Concerns/BootsHydeKernel.php
@@ -32,9 +32,17 @@ trait BootsHydeKernel
 
         $this->booting = true;
 
+        foreach ($this->bootingCallbacks as $callback) {
+            $callback($this);
+        }
+
         $this->files = FileCollection::boot($this);
         $this->pages = PageCollection::boot($this);
         $this->routes = RouteCollection::boot($this);
+
+        foreach ($this->bootedCallbacks as $callback) {
+            $callback($this);
+        }
 
         $this->booting = false;
         $this->booted = true;

--- a/packages/framework/src/Foundation/Concerns/BootsHydeKernel.php
+++ b/packages/framework/src/Foundation/Concerns/BootsHydeKernel.php
@@ -43,6 +43,10 @@ trait BootsHydeKernel
     /**
      * Register a new boot listener.
      *
+     * Your callback will be called before the kernel is booted.
+     * You can use this to register your own routes, pages, etc.
+     * The kernel instance will be passed to your callback.
+     *
      * @param  callable  $callback
      * @return void
      */
@@ -53,6 +57,10 @@ trait BootsHydeKernel
 
     /**
      * Register a new "booted" listener.
+     *
+     * Your callback will be called after the kernel is booted.
+     * You can use this to run any logic after discovery has completed.
+     * The kernel instance will be passed to your callback.
      *
      * @param  callable  $callback
      * @return void

--- a/packages/framework/src/Foundation/Concerns/BootsHydeKernel.php
+++ b/packages/framework/src/Foundation/Concerns/BootsHydeKernel.php
@@ -18,6 +18,9 @@ trait BootsHydeKernel
     private bool $readyToBoot = false;
     private bool $booting = false;
 
+    protected array $bootingCallbacks = [];
+    protected array $bootedCallbacks = [];
+
     public function boot(): void
     {
         if (! $this->readyToBoot || $this->booting) {

--- a/packages/framework/tests/Feature/HydeKernelTest.php
+++ b/packages/framework/tests/Feature/HydeKernelTest.php
@@ -510,7 +510,7 @@ class HydeKernelTest extends TestCase
         $kernel->boot();
 
         $this->assertSame($page, $kernel->pages()->getPage('foo'));
-        $this->assertEquals($page->getRoute(), $kernel->routes()->getRoute('foo'));
+        $this->assertEquals($page->getRoute(), $kernel->routes()->get('foo'));
     }
 }
 

--- a/packages/framework/tests/Feature/HydeKernelTest.php
+++ b/packages/framework/tests/Feature/HydeKernelTest.php
@@ -471,6 +471,30 @@ class HydeKernelTest extends TestCase
         $kernel->readyToBoot();
         $kernel->boot();
     }
+
+    public function test_booting_callback_receives_kernel_instance()
+    {
+        $kernel = new HydeKernel();
+
+        $kernel->booting(function ($_kernel) use ($kernel) {
+            $this->assertSame($kernel, $_kernel);
+        });
+
+        $kernel->readyToBoot();
+        $kernel->boot();
+    }
+
+    public function test_booted_callback_receives_kernel_instance()
+    {
+        $kernel = new HydeKernel();
+
+        $kernel->booted(function ($_kernel) use ($kernel) {
+            $this->assertSame($kernel, $_kernel);
+        });
+
+        $kernel->readyToBoot();
+        $kernel->boot();
+    }
 }
 
 class CallableClass

--- a/packages/framework/tests/Feature/HydeKernelTest.php
+++ b/packages/framework/tests/Feature/HydeKernelTest.php
@@ -440,6 +440,18 @@ class HydeKernelTest extends TestCase
         $kernel->boot();
     }
 
+    public function test_can_register_booted_callback_closure()
+    {
+        $kernel = new HydeKernel();
+
+        $kernel->booted(function () {
+            $this->assertTrue(true);
+        });
+
+        $kernel->readyToBoot();
+        $kernel->boot();
+    }
+
     public function test_can_register_booting_callback_callable()
     {
         $kernel = new HydeKernel();
@@ -456,18 +468,6 @@ class HydeKernelTest extends TestCase
             {
                 $this->test->assertTrue(true);
             }
-        });
-
-        $kernel->readyToBoot();
-        $kernel->boot();
-    }
-
-    public function test_can_register_booted_callback_closure()
-    {
-        $kernel = new HydeKernel();
-
-        $kernel->booted(function () {
-            $this->assertTrue(true);
         });
 
         $kernel->readyToBoot();

--- a/packages/framework/tests/Feature/HydeKernelTest.php
+++ b/packages/framework/tests/Feature/HydeKernelTest.php
@@ -456,7 +456,8 @@ class HydeKernelTest extends TestCase
     {
         $kernel = new HydeKernel();
 
-        $kernel->booting(new class($this) {
+        $kernel->booting(new class($this)
+        {
             private TestCase $test;
 
             public function __construct($test)
@@ -478,7 +479,8 @@ class HydeKernelTest extends TestCase
     {
         $kernel = new HydeKernel();
 
-        $kernel->booted(new class($this) {
+        $kernel->booted(new class($this)
+        {
             private TestCase $test;
 
             public function __construct($test)

--- a/packages/framework/tests/Feature/HydeKernelTest.php
+++ b/packages/framework/tests/Feature/HydeKernelTest.php
@@ -12,6 +12,7 @@ use Hyde\Framework\HydeServiceProvider;
 use Hyde\Hyde;
 use Hyde\Pages\BladePage;
 use Hyde\Pages\DocumentationPage;
+use Hyde\Pages\InMemoryPage;
 use Hyde\Pages\MarkdownPage;
 use Hyde\Pages\MarkdownPost;
 use Hyde\Support\Facades\Render;
@@ -494,6 +495,22 @@ class HydeKernelTest extends TestCase
 
         $kernel->readyToBoot();
         $kernel->boot();
+    }
+
+    public function test_can_use_booting_callbacks_to_inject_custom_pages()
+    {
+        $kernel = new HydeKernel();
+
+        $page = new InMemoryPage('foo');
+        $kernel->booting(function (HydeKernel $kernel) use ($page): void {
+            $kernel->pages()->addPage($page);
+        });
+
+        $kernel->readyToBoot();
+        $kernel->boot();
+
+        $this->assertSame($page, $kernel->pages()->getPage('foo'));
+        $this->assertEquals($page->getRoute(), $kernel->routes()->getRoute('foo'));
     }
 }
 

--- a/packages/framework/tests/Feature/HydeKernelTest.php
+++ b/packages/framework/tests/Feature/HydeKernelTest.php
@@ -427,4 +427,24 @@ class HydeKernelTest extends TestCase
         $this->assertSame(HydeKernel::getInstance(), Hyde::kernel());
         $this->assertSame(HydeKernel::VERSION, Hyde::kernel()->version());
     }
+
+    public function test_can_register_booting_callback_closure()
+    {
+        //
+    }
+
+    public function test_can_register_booting_callback_callable()
+    {
+        //
+    }
+
+    public function test_can_register_booted_callback_closure()
+    {
+        //
+    }
+
+    public function test_can_register_booted_callback_callable()
+    {
+        //
+    }
 }

--- a/packages/framework/tests/Feature/HydeKernelTest.php
+++ b/packages/framework/tests/Feature/HydeKernelTest.php
@@ -510,7 +510,7 @@ class HydeKernelTest extends TestCase
         $kernel->boot();
 
         $this->assertSame($page, $kernel->pages()->getPage('foo'));
-        $this->assertEquals($page->getRoute(), $kernel->routes()->get('foo'));
+        $this->assertEquals($page->getRoute(), $kernel->routes()->getRoute('foo'));
     }
 }
 

--- a/packages/framework/tests/Feature/HydeKernelTest.php
+++ b/packages/framework/tests/Feature/HydeKernelTest.php
@@ -430,21 +430,69 @@ class HydeKernelTest extends TestCase
 
     public function test_can_register_booting_callback_closure()
     {
-        //
+        $kernel = new HydeKernel();
+
+        $kernel->booting(function () {
+            $this->assertTrue(true);
+        });
+
+        $kernel->readyToBoot();
+        $kernel->boot();
     }
 
     public function test_can_register_booting_callback_callable()
     {
-        //
+        $kernel = new HydeKernel();
+
+        $kernel->booting(new class($this) {
+            private TestCase $test;
+
+            public function __construct($test)
+            {
+                $this->test = $test;
+            }
+
+            public function __invoke(): void
+            {
+                $this->test->assertTrue(true);
+            }
+        });
+
+        $kernel->readyToBoot();
+        $kernel->boot();
     }
 
     public function test_can_register_booted_callback_closure()
     {
-        //
+        $kernel = new HydeKernel();
+
+        $kernel->booted(function () {
+            $this->assertTrue(true);
+        });
+
+        $kernel->readyToBoot();
+        $kernel->boot();
     }
 
     public function test_can_register_booted_callback_callable()
     {
-        //
+        $kernel = new HydeKernel();
+
+        $kernel->booted(new class($this) {
+            private TestCase $test;
+
+            public function __construct($test)
+            {
+                $this->test = $test;
+            }
+
+            public function __invoke(): void
+            {
+                $this->test->assertTrue(true);
+            }
+        });
+
+        $kernel->readyToBoot();
+        $kernel->boot();
     }
 }

--- a/packages/framework/tests/Feature/HydeKernelTest.php
+++ b/packages/framework/tests/Feature/HydeKernelTest.php
@@ -456,20 +456,7 @@ class HydeKernelTest extends TestCase
     {
         $kernel = new HydeKernel();
 
-        $kernel->booting(new class($this)
-        {
-            private TestCase $test;
-
-            public function __construct($test)
-            {
-                $this->test = $test;
-            }
-
-            public function __invoke(): void
-            {
-                $this->test->assertTrue(true);
-            }
-        });
+        $kernel->booting(new CallableClass($this));
 
         $kernel->readyToBoot();
         $kernel->boot();
@@ -479,22 +466,24 @@ class HydeKernelTest extends TestCase
     {
         $kernel = new HydeKernel();
 
-        $kernel->booted(new class($this)
-        {
-            private TestCase $test;
-
-            public function __construct($test)
-            {
-                $this->test = $test;
-            }
-
-            public function __invoke(): void
-            {
-                $this->test->assertTrue(true);
-            }
-        });
+        $kernel->booted(new CallableClass($this));
 
         $kernel->readyToBoot();
         $kernel->boot();
+    }
+}
+
+class CallableClass
+{
+    private TestCase $test;
+
+    public function __construct($test)
+    {
+        $this->test = $test;
+    }
+
+    public function __invoke(): void
+    {
+        $this->test->assertTrue(true);
     }
 }


### PR DESCRIPTION
## Abstract

While the Extensions API is very powerful and simple to use, it's often overkill user projects; they're designed for package developers after all.

This PR adds a system of callbacks run before and after the `HydeKernel` boots, just like you might be familiar with from Laravel.

### Example

For example, let's say you want to register an `InMemoryPage` like the `Redirect` page, you can now easily do so, suggestively in the `boot` method of your `AppServiceProvider`:

```php
class AppServiceProvider extends ServiceProvider {
    public function boot(): void {
        Hyde::kernel()->booting(function (HydeKernel $kernel): void {
            $kernel->pages()->addPage(new Redirect('foo', 'bar'));
        });
    }
}
```

#### How it works

Since the initialization and booting of foundation collections were decoupled in https://github.com/hydephp/develop/pull/1038, the `booting` callbacks are run just after the foundation collections are instantiated, and just before they are booted. What this means is that when the `RouteCollection` boots, it will have knowledge of the page added to in the callback.

#### Benefits

The benefit for `Redirects` by using this method of "manual discovery" is that the page is fully integrated into the `HydeKernel`, allowing greater insight into it. It even shows up in the `route:list` command and the new Dashboard. It also is automatically compiled at build time without needing a build task. Even better, the redirect works with the realtime compiler!

As you can see, there are a lot of benefits to this feature, and so far I've only even talked about the Redirect class! Your imagination is the limit.
