### PR TITLE
Breaking: Decouple discovery booting from foundation collection instantiation

### DIFF
--- a/packages/framework/src/Foundation/Concerns/BaseFoundationCollection.php
+++ b/packages/framework/src/Foundation/Concerns/BaseFoundationCollection.php
@@ -26,12 +26,12 @@ abstract class BaseFoundationCollection extends Collection
 
     public static function init(HydeKernel $kernel): static
     {
-        return (new static())->setKernel($kernel)->runDiscovery();
+        return (new static())->setKernel($kernel);
     }
 
     public function boot(): static
     {
-        //
+        return $this->runDiscovery();
     }
 
     protected function __construct(array|Arrayable|null $items = [])

--- a/packages/framework/src/Foundation/Concerns/BaseFoundationCollection.php
+++ b/packages/framework/src/Foundation/Concerns/BaseFoundationCollection.php
@@ -29,6 +29,11 @@ abstract class BaseFoundationCollection extends Collection
         return (new static())->setKernel($kernel)->runDiscovery();
     }
 
+    public function boot(): static
+    {
+        //
+    }
+
     protected function __construct(array|Arrayable|null $items = [])
     {
         parent::__construct($items);

--- a/packages/framework/src/Foundation/Concerns/BaseFoundationCollection.php
+++ b/packages/framework/src/Foundation/Concerns/BaseFoundationCollection.php
@@ -24,7 +24,7 @@ abstract class BaseFoundationCollection extends Collection
 
     abstract protected function runExtensionCallbacks(): self;
 
-    public static function boot(HydeKernel $kernel): static
+    public static function init(HydeKernel $kernel): static
     {
         return (new static())->setKernel($kernel)->runDiscovery();
     }

--- a/packages/framework/src/Foundation/Concerns/BootsHydeKernel.php
+++ b/packages/framework/src/Foundation/Concerns/BootsHydeKernel.php
@@ -26,9 +26,13 @@ trait BootsHydeKernel
 
         $this->booting = true;
 
-        $this->files = FileCollection::boot($this);
-        $this->pages = PageCollection::boot($this);
-        $this->routes = RouteCollection::boot($this);
+        $this->files = FileCollection::init($this);
+        $this->pages = PageCollection::init($this);
+        $this->routes = RouteCollection::init($this);
+
+        $this->files->boot();
+        $this->pages->boot();
+        $this->routes->boot();
 
         $this->booting = false;
         $this->booted = true;

--- a/packages/framework/tests/Feature/FileCollectionTest.php
+++ b/packages/framework/tests/Feature/FileCollectionTest.php
@@ -23,7 +23,7 @@ class FileCollectionTest extends TestCase
 {
     public function test_boot_method_creates_new_page_collection_and_discovers_pages_automatically()
     {
-        $collection = FileCollection::boot(Hyde::getInstance());
+        $collection = FileCollection::init(Hyde::getInstance())->boot();
         $this->assertInstanceOf(FileCollection::class, $collection);
         $this->assertInstanceOf(Collection::class, $collection);
 
@@ -36,7 +36,7 @@ class FileCollectionTest extends TestCase
 
     public function test_get_source_files_returns_all_discovered_source_files_when_no_parameter_is_supplied()
     {
-        $collection = FileCollection::boot(Hyde::getInstance());
+        $collection = FileCollection::init(Hyde::getInstance())->boot();
 
         $this->assertEquals([
             '_pages/404.blade.php' => new SourceFile('_pages/404.blade.php', BladePage::class),
@@ -49,7 +49,7 @@ class FileCollectionTest extends TestCase
         $this->withoutDefaultPages();
         $this->file('_pages/foo.txt');
 
-        $collection = FileCollection::boot(Hyde::getInstance());
+        $collection = FileCollection::init(Hyde::getInstance())->boot();
         $this->assertEquals([], $collection->getSourceFiles()->all());
 
         $this->restoreDefaultPages();
@@ -57,7 +57,7 @@ class FileCollectionTest extends TestCase
 
     public function test_get_media_files_returns_all_discovered_media_files()
     {
-        $collection = FileCollection::boot(Hyde::getInstance());
+        $collection = FileCollection::init(Hyde::getInstance())->boot();
         $this->assertEquals([
             '_media/app.css' => new MediaFile('_media/app.css'),
         ], $collection->getMediaFiles()->all());
@@ -66,7 +66,7 @@ class FileCollectionTest extends TestCase
     public function test_get_media_files_does_not_include_non_media_files()
     {
         $this->file('_media/foo.blade.php');
-        $collection = FileCollection::boot(Hyde::getInstance());
+        $collection = FileCollection::init(Hyde::getInstance())->boot();
         $this->assertEquals([
             '_media/app.css' => new MediaFile('_media/app.css'),
         ], $collection->getMediaFiles()->all());
@@ -75,7 +75,7 @@ class FileCollectionTest extends TestCase
     public function test_blade_pages_are_discovered()
     {
         $this->file('_pages/foo.blade.php');
-        $collection = FileCollection::boot(Hyde::getInstance());
+        $collection = FileCollection::init(Hyde::getInstance())->boot();
 
         $this->assertArrayHasKey('_pages/foo.blade.php', $collection->toArray());
         $this->assertEquals(new SourceFile('_pages/foo.blade.php', BladePage::class), $collection->get('_pages/foo.blade.php'));
@@ -84,7 +84,7 @@ class FileCollectionTest extends TestCase
     public function test_markdown_pages_are_discovered()
     {
         $this->file('_pages/foo.md');
-        $collection = FileCollection::boot(Hyde::getInstance());
+        $collection = FileCollection::init(Hyde::getInstance())->boot();
 
         $this->assertArrayHasKey('_pages/foo.md', $collection->toArray());
         $this->assertEquals(new SourceFile('_pages/foo.md', MarkdownPage::class), $collection->get('_pages/foo.md'));
@@ -93,7 +93,7 @@ class FileCollectionTest extends TestCase
     public function test_markdown_posts_are_discovered()
     {
         $this->file('_posts/foo.md');
-        $collection = FileCollection::boot(Hyde::getInstance());
+        $collection = FileCollection::init(Hyde::getInstance())->boot();
 
         $this->assertArrayHasKey('_posts/foo.md', $collection->toArray());
         $this->assertEquals(new SourceFile('_posts/foo.md', MarkdownPost::class), $collection->get('_posts/foo.md'));
@@ -102,7 +102,7 @@ class FileCollectionTest extends TestCase
     public function test_documentation_pages_are_discovered()
     {
         $this->file('_docs/foo.md');
-        $collection = FileCollection::boot(Hyde::getInstance());
+        $collection = FileCollection::init(Hyde::getInstance())->boot();
         $this->assertArrayHasKey('_docs/foo.md', $collection->toArray());
         $this->assertEquals(new SourceFile('_docs/foo.md', DocumentationPage::class), $collection->get('_docs/foo.md'));
     }

--- a/packages/framework/tests/Feature/HydeExtensionFeatureTest.php
+++ b/packages/framework/tests/Feature/HydeExtensionFeatureTest.php
@@ -174,7 +174,7 @@ class HydeExtensionFeatureTest extends TestCase
     public function test_custom_registered_pages_are_discovered_by_the_file_collection_class()
     {
         app(HydeKernel::class)->registerExtension(TestPageExtension::class);
-        FileCollection::boot(app(HydeKernel::class));
+        FileCollection::init(app(HydeKernel::class))->boot();
 
         $this->directory('foo');
         $this->file('foo/bar.txt');
@@ -189,7 +189,7 @@ class HydeExtensionFeatureTest extends TestCase
         $this->file('foo/bar.txt');
 
         app(HydeKernel::class)->registerExtension(TestPageExtension::class);
-        PageCollection::boot(app(HydeKernel::class));
+        PageCollection::init(app(HydeKernel::class))->boot();
 
         $this->assertArrayHasKey('foo/bar.txt', Pages::all());
         $this->assertEquals(new TestPageClass('bar'), Pages::get('foo/bar.txt'));
@@ -201,7 +201,7 @@ class HydeExtensionFeatureTest extends TestCase
         $this->file('foo/bar.txt');
 
         app(HydeKernel::class)->registerExtension(TestPageExtension::class);
-        RouteCollection::boot(app(HydeKernel::class));
+        RouteCollection::init(app(HydeKernel::class))->boot();
 
         $this->assertArrayHasKey('foo/bar', Routes::all());
         $this->assertEquals(new Route(new TestPageClass('bar')), Routes::get('foo/bar'));

--- a/packages/framework/tests/Feature/PageCollectionTest.php
+++ b/packages/framework/tests/Feature/PageCollectionTest.php
@@ -24,7 +24,7 @@ class PageCollectionTest extends TestCase
 {
     public function test_boot_method_creates_new_page_collection_and_discovers_pages_automatically()
     {
-        $collection = PageCollection::boot(Hyde::getInstance());
+        $collection = PageCollection::init(Hyde::getInstance())->boot();
         $this->assertInstanceOf(PageCollection::class, $collection);
         $this->assertInstanceOf(Collection::class, $collection);
 
@@ -37,7 +37,7 @@ class PageCollectionTest extends TestCase
     public function test_blade_pages_are_discovered()
     {
         $this->file('_pages/foo.blade.php');
-        $collection = PageCollection::boot(Hyde::getInstance());
+        $collection = PageCollection::init(Hyde::getInstance())->boot();
 
         $this->assertArrayHasKey('_pages/foo.blade.php', $collection->toArray());
         $this->assertEquals(new BladePage('foo'), $collection->get('_pages/foo.blade.php'));
@@ -46,7 +46,7 @@ class PageCollectionTest extends TestCase
     public function test_markdown_pages_are_discovered()
     {
         $this->file('_pages/foo.md');
-        $collection = PageCollection::boot(Hyde::getInstance());
+        $collection = PageCollection::init(Hyde::getInstance())->boot();
 
         $this->assertArrayHasKey('_pages/foo.md', $collection->toArray());
         $this->assertEquals(new MarkdownPage('foo'), $collection->get('_pages/foo.md'));
@@ -55,7 +55,7 @@ class PageCollectionTest extends TestCase
     public function test_markdown_posts_are_discovered()
     {
         $this->file('_posts/foo.md');
-        $collection = PageCollection::boot(Hyde::getInstance());
+        $collection = PageCollection::init(Hyde::getInstance())->boot();
 
         $this->assertArrayHasKey('_posts/foo.md', $collection->toArray());
         $this->assertEquals(new MarkdownPost('foo'), $collection->get('_posts/foo.md'));
@@ -64,7 +64,7 @@ class PageCollectionTest extends TestCase
     public function test_documentation_pages_are_discovered()
     {
         $this->file('_docs/foo.md');
-        $collection = PageCollection::boot(Hyde::getInstance());
+        $collection = PageCollection::init(Hyde::getInstance())->boot();
         $this->assertArrayHasKey('_docs/foo.md', $collection->toArray());
         $this->assertEquals(new DocumentationPage('foo'), $collection->get('_docs/foo.md'));
     }
@@ -72,7 +72,7 @@ class PageCollectionTest extends TestCase
     public function test_get_page_returns_parsed_page_object_for_given_source_path()
     {
         $this->file('_pages/foo.blade.php');
-        $collection = PageCollection::boot(Hyde::getInstance());
+        $collection = PageCollection::init(Hyde::getInstance())->boot();
         $this->assertEquals(new BladePage('foo'), $collection->getPage('_pages/foo.blade.php'));
     }
 
@@ -86,7 +86,7 @@ class PageCollectionTest extends TestCase
         $this->file('_docs/foo.md');
         $this->file('_pages/foo.html');
 
-        $collection = PageCollection::boot(Hyde::getInstance());
+        $collection = PageCollection::init(Hyde::getInstance())->boot();
         $this->assertCount(5, $collection);
 
         $this->assertContainsOnlyInstancesOf(BladePage::class, $collection->getPages(BladePage::class));
@@ -114,7 +114,7 @@ class PageCollectionTest extends TestCase
         $this->file('_docs/foo.md');
         $this->file('_pages/foo.html');
 
-        $collection = PageCollection::boot(Hyde::getInstance())->getPages();
+        $collection = PageCollection::init(Hyde::getInstance())->boot()->getPages();
         $this->assertCount(5, $collection);
 
         $this->assertEquals(new BladePage('foo'), $collection->get('_pages/foo.blade.php'));
@@ -129,7 +129,7 @@ class PageCollectionTest extends TestCase
     public function test_get_pages_returns_empty_collection_when_no_pages_are_discovered()
     {
         $this->withoutDefaultPages();
-        $collection = PageCollection::boot(Hyde::getInstance());
+        $collection = PageCollection::init(Hyde::getInstance())->boot();
         $this->assertEmpty($collection->getPages());
         $this->restoreDefaultPages();
     }
@@ -145,7 +145,7 @@ class PageCollectionTest extends TestCase
         touch('_posts/post.md');
         touch('_docs/doc.md');
 
-        $this->assertEmpty(PageCollection::boot(Hyde::getInstance()));
+        $this->assertEmpty(PageCollection::init(Hyde::getInstance())->boot());
 
         unlink('_pages/blade.blade.php');
         unlink('_pages/markdown.md');
@@ -170,7 +170,7 @@ class PageCollectionTest extends TestCase
         touch(Hyde::path('.source/posts/foo.md'));
         touch(Hyde::path('.source/docs/foo.md'));
 
-        $collection = PageCollection::boot(Hyde::getInstance())->getPages();
+        $collection = PageCollection::init(Hyde::getInstance())->boot()->getPages();
         $this->assertCount(4, $collection);
 
         $this->assertEquals(new BladePage('foo'), $collection->get('.source/pages/foo.blade.php'));

--- a/packages/framework/tests/Feature/RouteCollectionTest.php
+++ b/packages/framework/tests/Feature/RouteCollectionTest.php
@@ -23,7 +23,7 @@ class RouteCollectionTest extends TestCase
 {
     public function test_boot_method_discovers_all_pages()
     {
-        $collection = RouteCollection::boot(Hyde::getInstance());
+        $collection = RouteCollection::init(Hyde::getInstance())->boot();
 
         $this->assertInstanceOf(RouteCollection::class, $collection);
         $this->assertInstanceOf(Collection::class, $collection);

--- a/packages/framework/tests/Unit/BaseFoundationCollectionTest.php
+++ b/packages/framework/tests/Unit/BaseFoundationCollectionTest.php
@@ -13,9 +13,9 @@ use Hyde\Testing\TestCase;
  */
 class BaseFoundationCollectionTest extends TestCase
 {
-    public function test_boot()
+    public function test_init()
     {
-        $booted = BaseFoundationCollectionTestClass::boot(HydeKernel::getInstance());
+        $booted = BaseFoundationCollectionTestClass::init(HydeKernel::getInstance())->boot();
 
         $this->assertInstanceOf(BaseFoundationCollection::class, $booted);
         $this->assertInstanceOf(BaseFoundationCollectionTestClass::class, $booted);
@@ -26,7 +26,7 @@ class BaseFoundationCollectionTest extends TestCase
 
     public function test_get_instance()
     {
-        $booted = BaseFoundationCollectionTestClass::boot(HydeKernel::getInstance());
+        $booted = BaseFoundationCollectionTestClass::init(HydeKernel::getInstance())->boot();
 
         $this->assertSame($booted, $booted->getInstance());
     }


### PR DESCRIPTION
## Abstract

This breaking (though I doubt anyone is using these methods yet) PR splits the `BaseFoundationCollection::boot()` method into two: `BaseFoundationCollection::init()` and `$foundationCollectionInstance->boot()`. This allows us to execute code between the object construction and the booting process, for example to run a booting callback like is being added in https://github.com/hydephp/develop/pull/1037.

### API change
Previous behaviour can easily be attained by chaining the boot method to the init call. See 1280c262d3bb24615fb2571524e98f385c1f69be
```php
- BaseFoundationCollection::boot(HydeKernel::getInstance())
+ BaseFoundationCollection::init(HydeKernel::getInstance())->boot()
```