### PR TITLE
Add RouteCollection::getRoute helper

### DIFF
--- a/packages/framework/src/Foundation/Kernel/RouteCollection.php
+++ b/packages/framework/src/Foundation/Kernel/RouteCollection.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Hyde\Foundation\Kernel;
 
 use Hyde\Foundation\Concerns\BaseFoundationCollection;
+use Hyde\Framework\Exceptions\RouteNotFoundException;
 use Hyde\Pages\Concerns\HydePage;
 use Hyde\Support\Models\Route;
 
@@ -36,6 +37,11 @@ use Hyde\Support\Models\Route;
  */
 final class RouteCollection extends BaseFoundationCollection
 {
+    public function getRoute(string $routeKey): Route
+    {
+        return $this->items[$routeKey] ?? throw new RouteNotFoundException($routeKey.' in route collection');
+    }
+
     public function getRoutes(?string $pageClass = null): self
     {
         return ! $pageClass ? $this : $this->filter(function (Route $route) use ($pageClass): bool {

--- a/packages/framework/tests/Feature/RouteCollectionTest.php
+++ b/packages/framework/tests/Feature/RouteCollectionTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Hyde\Framework\Testing\Feature;
 
 use Hyde\Foundation\Kernel\RouteCollection;
+use Hyde\Framework\Exceptions\RouteNotFoundException;
 use Hyde\Hyde;
 use Hyde\Pages\BladePage;
 use Hyde\Pages\DocumentationPage;
@@ -100,5 +101,16 @@ class RouteCollectionTest extends TestCase
         $collection->addRoute(new Route(new BladePage('new')));
         $this->assertCount(3, $collection);
         $this->assertEquals(new Route(new BladePage('new')), $collection->last());
+    }
+
+    public function test_get_route()
+    {
+        $this->assertEquals(new Route(new BladePage('index')), Hyde::routes()->getRoute('index'));
+    }
+    
+    public function test_get_route_with_non_existing_route()
+    {
+        $this->expectException(RouteNotFoundException::class);
+        Hyde::routes()->getRoute('non-existing');
     }
 }

--- a/packages/framework/tests/Feature/RouteCollectionTest.php
+++ b/packages/framework/tests/Feature/RouteCollectionTest.php
@@ -107,7 +107,7 @@ class RouteCollectionTest extends TestCase
     {
         $this->assertEquals(new Route(new BladePage('index')), Hyde::routes()->getRoute('index'));
     }
-    
+
     public function test_get_route_with_non_existing_route()
     {
         $this->expectException(RouteNotFoundException::class);


### PR DESCRIPTION
We have a PageCollection::getPage helper, so this just makes sense. Simple method to get a route by route key or fail.