### PR TITLE
Add feature to use collapsible grouped documentation sidebars

### DIFF
--- a/packages/framework/resources/views/components/docs/grouped-sidebar-navigation.blade.php
+++ b/packages/framework/resources/views/components/docs/grouped-sidebar-navigation.blade.php
@@ -3,7 +3,7 @@
 	@foreach ($sidebar->getGroups() as $group)
 	<li class="sidebar-group mb-4 mt-4 first:mt-0" role="listitem" x-data="{ groupOpen: {{ $page->navigationMenuGroup() === $group ? 'true' : 'false' }} }">
 		<header class="sidebar-group-header flex justify-between items-center mb-2" @click="groupOpen = ! groupOpen">
-            <h4 class="sidebar-group-heading text-base font-semibold -ml-1">{{ Hyde::makeTitle($group) }}</h4>
+            <h4 class="sidebar-group-heading text-base font-semibold -ml-1 cursor-pointer">{{ Hyde::makeTitle($group) }}</h4>
             <button class="sidebar-group-toggle">
                 <svg class="sidebar-group-toggle-icon sidebar-group-toggle-icon-open" x-show="groupOpen" width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
                     <path d="M8 12L12 8L4 8L8 12Z" fill="currentColor" />

--- a/packages/framework/resources/views/components/docs/grouped-sidebar-navigation.blade.php
+++ b/packages/framework/resources/views/components/docs/grouped-sidebar-navigation.blade.php
@@ -4,7 +4,7 @@
 	<li class="sidebar-group mb-4 mt-4 first:mt-0" role="listitem" x-data="{ groupOpen: {{ $page->navigationMenuGroup() === $group ? 'true' : 'false' }} }">
 		<header class="sidebar-group-header flex justify-between items-center group mb-2" @click="groupOpen = ! groupOpen">
             <h4 class="sidebar-group-heading text-base font-semibold -ml-1 cursor-pointer">{{ Hyde::makeTitle($group) }}</h4>
-            <button class="sidebar-group-toggle opacity-75 group-hover:opacity-100">
+            <button class="sidebar-group-toggle opacity-50 group-hover:opacity-100">
                 <svg class="sidebar-group-toggle-icon sidebar-group-toggle-icon-open" x-show="groupOpen" width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
                     <path d="M8 12L12 8L4 8L8 12Z" fill="currentColor" />
                 </svg>

--- a/packages/framework/resources/views/components/docs/grouped-sidebar-navigation.blade.php
+++ b/packages/framework/resources/views/components/docs/grouped-sidebar-navigation.blade.php
@@ -5,8 +5,11 @@
 		<header class="sidebar-group-header flex justify-between items-center mb-2">
             <h4 class="sidebar-group-heading text-base font-semibold -ml-1">{{ Hyde::makeTitle($group) }}</h4>
             <button class="sidebar-group-toggle" @click="groupOpen = ! groupOpen">
-                <svg class="sidebar-group-toggle-icon" width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
+                <svg class="sidebar-group-toggle-icon sidebar-group-toggle-icon-open" x-show="groupOpen" width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
                     <path d="M8 12L12 8L4 8L8 12Z" fill="currentColor" />
+                </svg>
+                <svg class="sidebar-group-toggle-icon sidebar-group-toggle-icon-closed" x-show="! groupOpen" width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
+                    <path d="M12 8L8 12L8 4L12 8Z" fill="currentColor" />
                 </svg>
             </button>
         </header>

--- a/packages/framework/resources/views/components/docs/grouped-sidebar-navigation.blade.php
+++ b/packages/framework/resources/views/components/docs/grouped-sidebar-navigation.blade.php
@@ -2,7 +2,7 @@
 <ul id="sidebar-navigation-items" role="list">
 	@foreach ($sidebar->getGroups() as $group)
 	<li class="sidebar-group mb-4 mt-4 first:mt-0" role="listitem">
-		<header>
+		<header class="sidebar-group-header">
             <h4 class="sidebar-group-heading text-base font-semibold mb-2 -ml-1">{{ Hyde::makeTitle($group) }}</h4>
         </header>
 		<ul class="sidebar-group-list ml-4" role="list">

--- a/packages/framework/resources/views/components/docs/grouped-sidebar-navigation.blade.php
+++ b/packages/framework/resources/views/components/docs/grouped-sidebar-navigation.blade.php
@@ -4,6 +4,7 @@
 	<li class="sidebar-group mb-4 mt-4 first:mt-0" role="listitem">
 		<header class="sidebar-group-header">
             <h4 class="sidebar-group-heading text-base font-semibold mb-2 -ml-1">{{ Hyde::makeTitle($group) }}</h4>
+            <button class="sidebar-group-toggle"></button>
         </header>
 		<ul class="sidebar-group-list ml-4" role="list">
 			@foreach ($sidebar->getItemsInGroup($group) as $item)

--- a/packages/framework/resources/views/components/docs/grouped-sidebar-navigation.blade.php
+++ b/packages/framework/resources/views/components/docs/grouped-sidebar-navigation.blade.php
@@ -2,9 +2,9 @@
 <ul id="sidebar-navigation-items" role="list">
 	@foreach ($sidebar->getGroups() as $group)
 	<li class="sidebar-group mb-4 mt-4 first:mt-0" role="listitem" x-data="{ groupOpen: {{ $page->navigationMenuGroup() === $group ? 'true' : 'false' }} }">
-		<header class="sidebar-group-header flex justify-between items-center mb-2" @click="groupOpen = ! groupOpen">
+		<header class="sidebar-group-header flex justify-between items-center group mb-2" @click="groupOpen = ! groupOpen">
             <h4 class="sidebar-group-heading text-base font-semibold -ml-1 cursor-pointer">{{ Hyde::makeTitle($group) }}</h4>
-            <button class="sidebar-group-toggle opacity-75 hover:opacity-100">
+            <button class="sidebar-group-toggle opacity-75 group-hover:opacity-100">
                 <svg class="sidebar-group-toggle-icon sidebar-group-toggle-icon-open" x-show="groupOpen" width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
                     <path d="M8 12L12 8L4 8L8 12Z" fill="currentColor" />
                 </svg>

--- a/packages/framework/resources/views/components/docs/grouped-sidebar-navigation.blade.php
+++ b/packages/framework/resources/views/components/docs/grouped-sidebar-navigation.blade.php
@@ -2,7 +2,9 @@
 <ul id="sidebar-navigation-items" role="list">
 	@foreach ($sidebar->getGroups() as $group)
 	<li class="sidebar-group mb-4 mt-4 first:mt-0" role="listitem">
-		<h4 class="sidebar-group-heading text-base font-semibold mb-2 -ml-1">{{ Hyde::makeTitle($group) }}</h4>
+		<header>
+            <h4 class="sidebar-group-heading text-base font-semibold mb-2 -ml-1">{{ Hyde::makeTitle($group) }}</h4>
+        </header>
 		<ul class="sidebar-group-list ml-4" role="list">
 			@foreach ($sidebar->getItemsInGroup($group) as $item)
 				<x-hyde::docs.grouped-sidebar-item :item="$item" :active="$item->route->getRouteKey() === $currentRoute->getRouteKey()" />

--- a/packages/framework/resources/views/components/docs/grouped-sidebar-navigation.blade.php
+++ b/packages/framework/resources/views/components/docs/grouped-sidebar-navigation.blade.php
@@ -4,7 +4,11 @@
 	<li class="sidebar-group mb-4 mt-4 first:mt-0" role="listitem">
 		<header class="sidebar-group-header">
             <h4 class="sidebar-group-heading text-base font-semibold mb-2 -ml-1">{{ Hyde::makeTitle($group) }}</h4>
-            <button class="sidebar-group-toggle"></button>
+            <button class="sidebar-group-toggle">
+                <svg class="sidebar-group-toggle-icon" width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
+                    <path d="M8 12L12 8L4 8L8 12Z" fill="currentColor" />
+                </svg>
+            </button>
         </header>
 		<ul class="sidebar-group-list ml-4" role="list">
 			@foreach ($sidebar->getItemsInGroup($group) as $item)

--- a/packages/framework/resources/views/components/docs/grouped-sidebar-navigation.blade.php
+++ b/packages/framework/resources/views/components/docs/grouped-sidebar-navigation.blade.php
@@ -1,7 +1,7 @@
 @php /** @var \Hyde\Framework\Features\Navigation\DocumentationSidebar $sidebar */ @endphp
 <ul id="sidebar-navigation-items" role="list">
 	@foreach ($sidebar->getGroups() as $group)
-	<li class="sidebar-group mb-4 mt-4 first:mt-0" role="listitem">
+	<li class="sidebar-group mb-4 mt-4 first:mt-0" role="listitem" x-data="{ groupOpen: false }">
 		<header class="sidebar-group-header flex justify-between items-center mb-2">
             <h4 class="sidebar-group-heading text-base font-semibold -ml-1">{{ Hyde::makeTitle($group) }}</h4>
             <button class="sidebar-group-toggle">

--- a/packages/framework/resources/views/components/docs/grouped-sidebar-navigation.blade.php
+++ b/packages/framework/resources/views/components/docs/grouped-sidebar-navigation.blade.php
@@ -10,7 +10,7 @@
                 </svg>
             </button>
         </header>
-		<ul class="sidebar-group-list ml-4" role="list">
+		<ul class="sidebar-group-list ml-4" role="list" x-show="groupOpen">
 			@foreach ($sidebar->getItemsInGroup($group) as $item)
 				<x-hyde::docs.grouped-sidebar-item :item="$item" :active="$item->route->getRouteKey() === $currentRoute->getRouteKey()" />
 			@endforeach

--- a/packages/framework/resources/views/components/docs/grouped-sidebar-navigation.blade.php
+++ b/packages/framework/resources/views/components/docs/grouped-sidebar-navigation.blade.php
@@ -4,7 +4,7 @@
 	<li class="sidebar-group mb-4 mt-4 first:mt-0" role="listitem">
 		<header class="sidebar-group-header flex justify-between items-center">
             <h4 class="sidebar-group-heading text-base font-semibold mb-2 -ml-1">{{ Hyde::makeTitle($group) }}</h4>
-            <button class="sidebar-group-toggle">
+            <button class="sidebar-group-toggle mb-2">
                 <svg class="sidebar-group-toggle-icon" width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
                     <path d="M8 12L12 8L4 8L8 12Z" fill="currentColor" />
                 </svg>

--- a/packages/framework/resources/views/components/docs/grouped-sidebar-navigation.blade.php
+++ b/packages/framework/resources/views/components/docs/grouped-sidebar-navigation.blade.php
@@ -4,7 +4,7 @@
 	<li class="sidebar-group mb-4 mt-4 first:mt-0" role="listitem" x-data="{ groupOpen: false }">
 		<header class="sidebar-group-header flex justify-between items-center mb-2">
             <h4 class="sidebar-group-heading text-base font-semibold -ml-1">{{ Hyde::makeTitle($group) }}</h4>
-            <button class="sidebar-group-toggle">
+            <button class="sidebar-group-toggle" @click="groupOpen = ! groupOpen">
                 <svg class="sidebar-group-toggle-icon" width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
                     <path d="M8 12L12 8L4 8L8 12Z" fill="currentColor" />
                 </svg>

--- a/packages/framework/resources/views/components/docs/grouped-sidebar-navigation.blade.php
+++ b/packages/framework/resources/views/components/docs/grouped-sidebar-navigation.blade.php
@@ -2,9 +2,9 @@
 <ul id="sidebar-navigation-items" role="list">
 	@foreach ($sidebar->getGroups() as $group)
 	<li class="sidebar-group mb-4 mt-4 first:mt-0" role="listitem" x-data="{ groupOpen: {{ $page->navigationMenuGroup() === $group ? 'true' : 'false' }} }">
-		<header class="sidebar-group-header flex justify-between items-center mb-2">
+		<header class="sidebar-group-header flex justify-between items-center mb-2" @click="groupOpen = ! groupOpen">
             <h4 class="sidebar-group-heading text-base font-semibold -ml-1">{{ Hyde::makeTitle($group) }}</h4>
-            <button class="sidebar-group-toggle" @click="groupOpen = ! groupOpen">
+            <button class="sidebar-group-toggle">
                 <svg class="sidebar-group-toggle-icon sidebar-group-toggle-icon-open" x-show="groupOpen" width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
                     <path d="M8 12L12 8L4 8L8 12Z" fill="currentColor" />
                 </svg>

--- a/packages/framework/resources/views/components/docs/grouped-sidebar-navigation.blade.php
+++ b/packages/framework/resources/views/components/docs/grouped-sidebar-navigation.blade.php
@@ -2,9 +2,9 @@
 <ul id="sidebar-navigation-items" role="list">
 	@foreach ($sidebar->getGroups() as $group)
 	<li class="sidebar-group mb-4 mt-4 first:mt-0" role="listitem">
-		<header class="sidebar-group-header flex justify-between items-center">
-            <h4 class="sidebar-group-heading text-base font-semibold mb-2 -ml-1">{{ Hyde::makeTitle($group) }}</h4>
-            <button class="sidebar-group-toggle mb-2">
+		<header class="sidebar-group-header flex justify-between items-center mb-2">
+            <h4 class="sidebar-group-heading text-base font-semibold -ml-1">{{ Hyde::makeTitle($group) }}</h4>
+            <button class="sidebar-group-toggle">
                 <svg class="sidebar-group-toggle-icon" width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
                     <path d="M8 12L12 8L4 8L8 12Z" fill="currentColor" />
                 </svg>

--- a/packages/framework/resources/views/components/docs/grouped-sidebar-navigation.blade.php
+++ b/packages/framework/resources/views/components/docs/grouped-sidebar-navigation.blade.php
@@ -3,7 +3,7 @@
 	@foreach ($sidebar->getGroups() as $group)
 	<li class="sidebar-group mb-4 mt-4 first:mt-0" role="listitem" x-data="{ groupOpen: {{ $page->navigationMenuGroup() === $group ? 'true' : 'false' }} }">
 		<header class="sidebar-group-header flex justify-between items-center group mb-2" @click="groupOpen = ! groupOpen">
-            <h4 class="sidebar-group-heading text-base font-semibold -ml-1 cursor-pointer">{{ Hyde::makeTitle($group) }}</h4>
+            <h4 class="sidebar-group-heading text-base font-semibold -ml-1 cursor-pointer dark:group-hover:text-white">{{ Hyde::makeTitle($group) }}</h4>
             <button class="sidebar-group-toggle opacity-50 group-hover:opacity-100">
                 <svg class="sidebar-group-toggle-icon sidebar-group-toggle-icon-open" x-show="groupOpen" width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
                     <path d="M8 12L12 8L4 8L8 12Z" fill="currentColor" />

--- a/packages/framework/resources/views/components/docs/grouped-sidebar-navigation.blade.php
+++ b/packages/framework/resources/views/components/docs/grouped-sidebar-navigation.blade.php
@@ -2,7 +2,7 @@
 <ul id="sidebar-navigation-items" role="list">
 	@foreach ($sidebar->getGroups() as $group)
 	<li class="sidebar-group mb-4 mt-4 first:mt-0" role="listitem">
-		<header class="sidebar-group-header">
+		<header class="sidebar-group-header flex justify-between items-center">
             <h4 class="sidebar-group-heading text-base font-semibold mb-2 -ml-1">{{ Hyde::makeTitle($group) }}</h4>
             <button class="sidebar-group-toggle">
                 <svg class="sidebar-group-toggle-icon" width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">

--- a/packages/framework/resources/views/components/docs/grouped-sidebar-navigation.blade.php
+++ b/packages/framework/resources/views/components/docs/grouped-sidebar-navigation.blade.php
@@ -4,7 +4,7 @@
 	<li class="sidebar-group mb-4 mt-4 first:mt-0" role="listitem" x-data="{ groupOpen: {{ $page->navigationMenuGroup() === $group ? 'true' : 'false' }} }">
 		<header class="sidebar-group-header flex justify-between items-center mb-2" @click="groupOpen = ! groupOpen">
             <h4 class="sidebar-group-heading text-base font-semibold -ml-1 cursor-pointer">{{ Hyde::makeTitle($group) }}</h4>
-            <button class="sidebar-group-toggle">
+            <button class="sidebar-group-toggle opacity-75 hover:opacity-100">
                 <svg class="sidebar-group-toggle-icon sidebar-group-toggle-icon-open" x-show="groupOpen" width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
                     <path d="M8 12L12 8L4 8L8 12Z" fill="currentColor" />
                 </svg>

--- a/packages/framework/resources/views/components/docs/grouped-sidebar-navigation.blade.php
+++ b/packages/framework/resources/views/components/docs/grouped-sidebar-navigation.blade.php
@@ -1,7 +1,7 @@
 @php /** @var \Hyde\Framework\Features\Navigation\DocumentationSidebar $sidebar */ @endphp
 <ul id="sidebar-navigation-items" role="list">
 	@foreach ($sidebar->getGroups() as $group)
-	<li class="sidebar-group mb-4 mt-4 first:mt-0" role="listitem" x-data="{ groupOpen: false }">
+	<li class="sidebar-group mb-4 mt-4 first:mt-0" role="listitem" x-data="{ groupOpen: {{ $page->navigationMenuGroup() === $group ? 'true' : 'false' }} }">
 		<header class="sidebar-group-header flex justify-between items-center mb-2">
             <h4 class="sidebar-group-heading text-base font-semibold -ml-1">{{ Hyde::makeTitle($group) }}</h4>
             <button class="sidebar-group-toggle" @click="groupOpen = ! groupOpen">


### PR DESCRIPTION
> If possible to create without complexity and bloat, it'd be nice if the grouped sidebar had an option to be collapsible. Preferably, the active sidebar group would automatically be open. And others would be togglable with a chevron justified to the right of the group heading.
> 
> To further signify the interactivity the heading row should darken when hovered upon, similar to the actual navigation items.
> 
> Bonus if the transition is animated.

Todos

- [ ] Make it configurable
- [ ] Write better PR description
- [ ] Extract components as needed
- [x] Darken chevron when not active/hovered
- [ ] Darken background for hovered header state (rows need individual padding first)
- [x] Click entire header to toggle state
- [ ] Increased vertical spacing?
- [ ] Dusk interaction test
- [ ] Animations! 