### PR TITLE
Typed config facade now only uses strict mode

### DIFF
--- a/packages/framework/src/Facades/Config.php
+++ b/packages/framework/src/Facades/Config.php
@@ -27,32 +27,32 @@ class Config extends \Illuminate\Support\Facades\Config
 
     public static function getArray(string $key, array $default = null, #[Deprecated] bool $strict = self::STRICT_DEFAULT): array
     {
-        return (array) self::validated(static::get($key, $default), 'array', $key, $strict);
+        return (array) self::validated(static::get($key, $default), 'array', $key, true);
     }
 
     public static function getString(string $key, string $default = null, #[Deprecated] bool $strict = self::STRICT_DEFAULT): string
     {
-        return (string) self::validated(static::get($key, $default), 'string', $key, $strict);
+        return (string) self::validated(static::get($key, $default), 'string', $key, true);
     }
 
     public static function getInt(string $key, int $default = null, #[Deprecated] bool $strict = self::STRICT_DEFAULT): int
     {
-        return (int) self::validated(static::get($key, $default), 'int', $key, $strict);
+        return (int) self::validated(static::get($key, $default), 'int', $key, true);
     }
 
     public static function getBool(string $key, bool $default = null, #[Deprecated] bool $strict = self::STRICT_DEFAULT): bool
     {
-        return (bool) self::validated(static::get($key, $default), 'bool', $key, $strict);
+        return (bool) self::validated(static::get($key, $default), 'bool', $key, true);
     }
 
     public static function getFloat(string $key, float $default = null, #[Deprecated] bool $strict = self::STRICT_DEFAULT): float
     {
-        return (float) self::validated(static::get($key, $default), 'float', $key, $strict);
+        return (float) self::validated(static::get($key, $default), 'float', $key, true);
     }
 
     protected static function validated(mixed $value, string $type, string $key, #[Deprecated] bool $strict): mixed
     {
-        if ($strict && ! ("is_$type")($value)) {
+        if (true && ! ("is_$type")($value)) {
             throw new TypeError(sprintf('%s(): Config value %s must be of type %s, %s given', __METHOD__, $key, $type, gettype($value)));
         }
 

--- a/packages/framework/src/Facades/Config.php
+++ b/packages/framework/src/Facades/Config.php
@@ -10,9 +10,6 @@ use TypeError;
  * An extension of the Laravel Config facade with extra
  * accessors that ensure the types of the returned values.
  *
- * @internal This facade is not (yet) meant to be used by the end user.
- * @experimental This facade is experimental and may change in the future.
- *
  * @todo If class is kept internal, the facade alias should be removed from config.
  *
  * @see \Illuminate\Config\Repository

--- a/packages/framework/src/Facades/Config.php
+++ b/packages/framework/src/Facades/Config.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Hyde\Facades;
 
+use JetBrains\PhpStorm\Deprecated;
 use TypeError;
 
 /**
@@ -24,32 +25,32 @@ class Config extends \Illuminate\Support\Facades\Config
     /** @var true */
     protected const STRICT_DEFAULT = true;
 
-    public static function getArray(string $key, array $default = null, bool $strict = self::STRICT_DEFAULT): array
+    public static function getArray(string $key, array $default = null, #[Deprecated] bool $strict = self::STRICT_DEFAULT): array
     {
         return (array) self::validated(static::get($key, $default), 'array', $key, $strict);
     }
 
-    public static function getString(string $key, string $default = null, bool $strict = self::STRICT_DEFAULT): string
+    public static function getString(string $key, string $default = null, #[Deprecated] bool $strict = self::STRICT_DEFAULT): string
     {
         return (string) self::validated(static::get($key, $default), 'string', $key, $strict);
     }
 
-    public static function getInt(string $key, int $default = null, bool $strict = self::STRICT_DEFAULT): int
+    public static function getInt(string $key, int $default = null, #[Deprecated] bool $strict = self::STRICT_DEFAULT): int
     {
         return (int) self::validated(static::get($key, $default), 'int', $key, $strict);
     }
 
-    public static function getBool(string $key, bool $default = null, bool $strict = self::STRICT_DEFAULT): bool
+    public static function getBool(string $key, bool $default = null, #[Deprecated] bool $strict = self::STRICT_DEFAULT): bool
     {
         return (bool) self::validated(static::get($key, $default), 'bool', $key, $strict);
     }
 
-    public static function getFloat(string $key, float $default = null, bool $strict = self::STRICT_DEFAULT): float
+    public static function getFloat(string $key, float $default = null, #[Deprecated] bool $strict = self::STRICT_DEFAULT): float
     {
         return (float) self::validated(static::get($key, $default), 'float', $key, $strict);
     }
 
-    protected static function validated(mixed $value, string $type, string $key, bool $strict): mixed
+    protected static function validated(mixed $value, string $type, string $key, #[Deprecated] bool $strict): mixed
     {
         if ($strict && ! ("is_$type")($value)) {
             throw new TypeError(sprintf('%s(): Config value %s must be of type %s, %s given', __METHOD__, $key, $type, gettype($value)));

--- a/packages/framework/src/Facades/Config.php
+++ b/packages/framework/src/Facades/Config.php
@@ -10,8 +10,6 @@ use TypeError;
  * An extension of the Laravel Config facade with extra
  * accessors that ensure the types of the returned values.
  *
- * @todo If class is kept internal, the facade alias should be removed from config.
- *
  * @see \Illuminate\Config\Repository
  * @see \Illuminate\Support\Facades\Config
  * @see \Hyde\Framework\Testing\Feature\TypedConfigFacadeTest

--- a/packages/framework/src/Facades/Config.php
+++ b/packages/framework/src/Facades/Config.php
@@ -52,7 +52,7 @@ class Config extends \Illuminate\Support\Facades\Config
 
     protected static function validated(mixed $value, string $type, string $key, #[Deprecated] bool $strict): mixed
     {
-        if (true && ! ("is_$type")($value)) {
+        if (! ("is_$type")($value)) {
             throw new TypeError(sprintf('%s(): Config value %s must be of type %s, %s given', __METHOD__, $key, $type, gettype($value)));
         }
 

--- a/packages/framework/src/Facades/Config.php
+++ b/packages/framework/src/Facades/Config.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Hyde\Facades;
 
-use JetBrains\PhpStorm\Deprecated;
 use TypeError;
 
 /**
@@ -25,32 +24,32 @@ class Config extends \Illuminate\Support\Facades\Config
     /** @var true */
     protected const STRICT_DEFAULT = true;
 
-    public static function getArray(string $key, array $default = null, #[Deprecated] bool $strict = self::STRICT_DEFAULT): array
+    public static function getArray(string $key, array $default = null): array
     {
-        return (array) self::validated(static::get($key, $default), 'array', $key, true);
+        return (array) self::validated(static::get($key, $default), 'array', $key);
     }
 
-    public static function getString(string $key, string $default = null, #[Deprecated] bool $strict = self::STRICT_DEFAULT): string
+    public static function getString(string $key, string $default = null): string
     {
-        return (string) self::validated(static::get($key, $default), 'string', $key, true);
+        return (string) self::validated(static::get($key, $default), 'string', $key);
     }
 
-    public static function getInt(string $key, int $default = null, #[Deprecated] bool $strict = self::STRICT_DEFAULT): int
+    public static function getInt(string $key, int $default = null): int
     {
-        return (int) self::validated(static::get($key, $default), 'int', $key, true);
+        return (int) self::validated(static::get($key, $default), 'int', $key);
     }
 
-    public static function getBool(string $key, bool $default = null, #[Deprecated] bool $strict = self::STRICT_DEFAULT): bool
+    public static function getBool(string $key, bool $default = null): bool
     {
-        return (bool) self::validated(static::get($key, $default), 'bool', $key, true);
+        return (bool) self::validated(static::get($key, $default), 'bool', $key);
     }
 
-    public static function getFloat(string $key, float $default = null, #[Deprecated] bool $strict = self::STRICT_DEFAULT): float
+    public static function getFloat(string $key, float $default = null): float
     {
-        return (float) self::validated(static::get($key, $default), 'float', $key, true);
+        return (float) self::validated(static::get($key, $default), 'float', $key);
     }
 
-    protected static function validated(mixed $value, string $type, string $key, #[Deprecated] bool $strict): mixed
+    protected static function validated(mixed $value, string $type, string $key): mixed
     {
         if (! ("is_$type")($value)) {
             throw new TypeError(sprintf('%s(): Config value %s must be of type %s, %s given', __METHOD__, $key, $type, gettype($value)));

--- a/packages/framework/src/Facades/Config.php
+++ b/packages/framework/src/Facades/Config.php
@@ -21,9 +21,6 @@ use TypeError;
  */
 class Config extends \Illuminate\Support\Facades\Config
 {
-    /** @var true */
-    protected const STRICT_DEFAULT = true;
-
     public static function getArray(string $key, array $default = null): array
     {
         return (array) self::validated(static::get($key, $default), 'array', $key);

--- a/packages/framework/src/Facades/Config.php
+++ b/packages/framework/src/Facades/Config.php
@@ -21,8 +21,8 @@ use TypeError;
  */
 class Config extends \Illuminate\Support\Facades\Config
 {
-    /** @var false {@todo Consider setting to true} */
-    protected const STRICT_DEFAULT = false;
+    /** @var true */
+    protected const STRICT_DEFAULT = true;
 
     public static function getArray(string $key, array $default = null, bool $strict = self::STRICT_DEFAULT): array
     {

--- a/packages/framework/tests/Feature/TypedConfigFacadeTest.php
+++ b/packages/framework/tests/Feature/TypedConfigFacadeTest.php
@@ -17,26 +17,31 @@ class TypedConfigFacadeTest extends TestCase
 {
     public function testGetArray()
     {
+        config(['foo' => ['bar']]);
         $this->assertIsArray(Config::getArray('foo'));
     }
 
     public function testGetString()
     {
+        config(['foo' => 'bar']);
         $this->assertIsString(Config::getString('foo'));
     }
 
     public function testGetBool()
     {
+        config(['foo' => true]);
         $this->assertIsBool(Config::getBool('foo'));
     }
 
     public function testGetInt()
     {
+        config(['foo' => 10]);
         $this->assertIsInt(Config::getInt('foo'));
     }
 
     public function testGetFloat()
     {
+        config(['foo' => 10.0]);
         $this->assertIsFloat(Config::getFloat('foo'));
     }
 
@@ -125,75 +130,9 @@ class TypedConfigFacadeTest extends TestCase
         $this->runUnitTest(['bar' => 'baz'], ['bar' => 'baz'], Config::getArray(...));
     }
 
-    public function testGetArrayWithNull()
-    {
-        $this->runUnitTest(null, [], Config::getArray(...));
-    }
-
-    public function testGetArrayWithString()
-    {
-        $this->runUnitTest('bar', ['bar'], Config::getArray(...));
-    }
-
-    public function testGetArrayWithBool()
-    {
-        $this->runUnitTest(true, [true], Config::getArray(...));
-    }
-
-    public function testGetArrayWithInt()
-    {
-        $this->runUnitTest(1, [1], Config::getArray(...));
-    }
-
-    public function testGetArrayWithFloat()
-    {
-        $this->runUnitTest(1.1, [1.1], Config::getArray(...));
-    }
-
-    public function testGetStringWithArray()
-    {
-        $this->expectException(ErrorException::class);
-        $this->runUnitTest(['bar' => 'baz'], 'Array', Config::getString(...));
-    }
-
-    public function testGetStringWithNull()
-    {
-        $this->runUnitTest(null, '', Config::getString(...));
-    }
-
     public function testGetStringWithString()
     {
         $this->runUnitTest('bar', 'bar', Config::getString(...));
-    }
-
-    public function testGetStringWithBool()
-    {
-        $this->runUnitTest(true, '1', Config::getString(...));
-    }
-
-    public function testGetStringWithInt()
-    {
-        $this->runUnitTest(1, '1', Config::getString(...));
-    }
-
-    public function testGetStringWithFloat()
-    {
-        $this->runUnitTest(1.1, '1.1', Config::getString(...));
-    }
-
-    public function testGetBoolWithArray()
-    {
-        $this->runUnitTest(['bar' => 'baz'], true, Config::getBool(...));
-    }
-
-    public function testGetBoolWithNull()
-    {
-        $this->runUnitTest(null, false, Config::getBool(...));
-    }
-
-    public function testGetBoolWithString()
-    {
-        $this->runUnitTest('bar', true, Config::getBool(...));
     }
 
     public function testGetBoolWithBool()
@@ -201,69 +140,9 @@ class TypedConfigFacadeTest extends TestCase
         $this->runUnitTest(true, true, Config::getBool(...));
     }
 
-    public function testGetBoolWithInt()
-    {
-        $this->runUnitTest(1, true, Config::getBool(...));
-    }
-
-    public function testGetBoolWithFloat()
-    {
-        $this->runUnitTest(1.1, true, Config::getBool(...));
-    }
-
-    public function testGetIntWithArray()
-    {
-        $this->runUnitTest(0, 0, Config::getInt(...));
-    }
-
-    public function testGetIntWithNull()
-    {
-        $this->runUnitTest(null, 0, Config::getInt(...));
-    }
-
-    public function testGetIntWithString()
-    {
-        $this->runUnitTest('bar', 0, Config::getInt(...));
-    }
-
-    public function testGetIntWithBool()
-    {
-        $this->runUnitTest(true, 1, Config::getInt(...));
-    }
-
     public function testGetIntWithInt()
     {
         $this->runUnitTest(1, 1, Config::getInt(...));
-    }
-
-    public function testGetIntWithFloat()
-    {
-        $this->runUnitTest(1.1, 1, Config::getInt(...));
-    }
-
-    public function testGetFloatWithArray()
-    {
-        $this->runUnitTest(['bar' => 'baz'], 1.0, Config::getFloat(...));
-    }
-
-    public function testGetFloatWithNull()
-    {
-        $this->runUnitTest(null, 0.0, Config::getFloat(...));
-    }
-
-    public function testGetFloatWithString()
-    {
-        $this->runUnitTest('bar', 0.0, Config::getFloat(...));
-    }
-
-    public function testGetFloatWithBool()
-    {
-        $this->runUnitTest(true, 1.0, Config::getFloat(...));
-    }
-
-    public function testGetFloatWithInt()
-    {
-        $this->runUnitTest(1, 1.0, Config::getFloat(...));
     }
 
     public function testGetFloatWithFloat()

--- a/packages/framework/tests/Feature/TypedConfigFacadeTest.php
+++ b/packages/framework/tests/Feature/TypedConfigFacadeTest.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Hyde\Framework\Testing\Feature;
 
-use ErrorException;
 use Hyde\Facades\Config;
 use Hyde\Testing\TestCase;
 use TypeError;

--- a/packages/framework/tests/Feature/TypedConfigFacadeTest.php
+++ b/packages/framework/tests/Feature/TypedConfigFacadeTest.php
@@ -158,6 +158,6 @@ class TypedConfigFacadeTest extends TestCase
     protected function runUnitTestStrict($actual, $expected, $method): void
     {
         config(['foo' => $actual]);
-        $this->assertSame($expected, $method('foo', strict: true));
+        $this->assertSame($expected, $method('foo'));
     }
 }

--- a/packages/framework/tests/Feature/TypedConfigFacadeTest.php
+++ b/packages/framework/tests/Feature/TypedConfigFacadeTest.php
@@ -71,57 +71,57 @@ class TypedConfigFacadeTest extends TestCase
 
     public function testGetArrayWithStrictMode()
     {
-        $this->runUnitTestStrict(['bar'], ['bar'], Config::getArray(...));
+        $this->runUnitTest(['bar'], ['bar'], Config::getArray(...));
     }
 
     public function testGetStringWithStrictMode()
     {
-        $this->runUnitTestStrict('bar', 'bar', Config::getString(...));
+        $this->runUnitTest('bar', 'bar', Config::getString(...));
     }
 
     public function testGetBoolWithStrictMode()
     {
-        $this->runUnitTestStrict(true, true, Config::getBool(...));
+        $this->runUnitTest(true, true, Config::getBool(...));
     }
 
     public function testGetIntWithStrictMode()
     {
-        $this->runUnitTestStrict(10, 10, Config::getInt(...));
+        $this->runUnitTest(10, 10, Config::getInt(...));
     }
 
     public function testGetFloatWithStrictMode()
     {
-        $this->runUnitTestStrict(10.0, 10.0, Config::getFloat(...));
+        $this->runUnitTest(10.0, 10.0, Config::getFloat(...));
     }
 
     public function testGetArrayWithFailingStrictMode()
     {
         $this->expectException(TypeError::class);
-        $this->runUnitTestStrict(null, null, Config::getArray(...));
+        $this->runUnitTest(null, null, Config::getArray(...));
     }
 
     public function testGetStringWithFailingStrictMode()
     {
         $this->expectException(TypeError::class);
-        $this->runUnitTestStrict(null, null, Config::getString(...));
+        $this->runUnitTest(null, null, Config::getString(...));
     }
 
     public function testGetBoolWithFailingStrictMode()
     {
         $this->expectException(TypeError::class);
-        $this->runUnitTestStrict(null, null, Config::getBool(...));
+        $this->runUnitTest(null, null, Config::getBool(...));
     }
 
     public function testGetIntWithFailingStrictMode()
     {
         $this->expectException(TypeError::class);
-        $this->runUnitTestStrict(null, null, Config::getInt(...));
+        $this->runUnitTest(null, null, Config::getInt(...));
     }
 
     public function testGetFloatWithFailingStrictMode()
     {
         $this->expectException(TypeError::class);
-        $this->runUnitTestStrict(null, null, Config::getFloat(...));
+        $this->runUnitTest(null, null, Config::getFloat(...));
     }
 
     public function testGetArrayWithArray()
@@ -150,12 +150,6 @@ class TypedConfigFacadeTest extends TestCase
     }
 
     protected function runUnitTest($actual, $expected, $method): void
-    {
-        config(['foo' => $actual]);
-        $this->assertSame($expected, $method('foo'));
-    }
-
-    protected function runUnitTestStrict($actual, $expected, $method): void
     {
         config(['foo' => $actual]);
         $this->assertSame($expected, $method('foo'));


### PR DESCRIPTION
This removes a lot of complexity, and if you are using a typed config facade it's probably because you want to be sure of the type. Implicit type casting may cause unintended results when a failing state is desired for invalid/missing data.