### PR TITLE
Add "hidden" configuration option for setting the HydeFront version

### DIFF
--- a/packages/framework/src/Framework/Services/AssetService.php
+++ b/packages/framework/src/Framework/Services/AssetService.php
@@ -24,6 +24,11 @@ class AssetService
      */
     public string $version = 'v2.0';
 
+    public function __construct()
+    {
+        //
+    }
+
     public function version(): string
     {
         return $this->version;

--- a/packages/framework/src/Framework/Services/AssetService.php
+++ b/packages/framework/src/Framework/Services/AssetService.php
@@ -26,7 +26,9 @@ class AssetService
 
     public function __construct()
     {
-        //
+        if (config('hyde.hydefront_version')) {
+            $this->version = config('hyde.hydefront_version');
+        }
     }
 
     public function version(): string

--- a/packages/framework/tests/Feature/AssetServiceTest.php
+++ b/packages/framework/tests/Feature/AssetServiceTest.php
@@ -32,6 +32,13 @@ class AssetServiceTest extends TestCase
         $this->assertEquals($service->version, $service->version());
     }
 
+    public function test_version_can_be_set_in_config()
+    {
+        config(['hyde.hydefront_version' => '1.0.0']);
+        $service = new AssetService();
+        $this->assertEquals('1.0.0', $service->version());
+    }
+
     public function test_cdn_path_constructor_returns_cdn_uri()
     {
         $service = new AssetService();


### PR DESCRIPTION
Updates the AssetService constructor to check config for if a custom HydeFront version is specified. This will then be loaded into the Asset Singleton.

I say it's "hidden" as it's not in the base config file as I think the option is an edge case. I just want it so we can use the master version for the monorepo preview sites, like the upcoming documentation one.