### PR TITLE
Add feature to allow custom HydeFront CDN link to be set in config

### DIFF
--- a/packages/framework/src/Framework/Services/AssetService.php
+++ b/packages/framework/src/Framework/Services/AssetService.php
@@ -24,10 +24,16 @@ class AssetService
      */
     public string $version = 'v2.0';
 
+    protected ?string $hydefrontUrl = null;
+
     public function __construct()
     {
         if (config('hyde.hydefront_version')) {
             $this->version = config('hyde.hydefront_version');
+        }
+
+        if (config('hyde.hydefront_url')) {
+            $this->hydefrontUrl = config('hyde.hydefront_url');
         }
     }
 
@@ -38,7 +44,7 @@ class AssetService
 
     public function constructCdnPath(string $file): string
     {
-        return 'https://cdn.jsdelivr.net/npm/hydefront@'.$this->version().'/dist/'.$file;
+        return $this->hydefrontUrl ?? 'https://cdn.jsdelivr.net/npm/hydefront@'.$this->version().'/dist/'.$file;
     }
 
     /**

--- a/packages/framework/tests/Feature/AssetServiceTest.php
+++ b/packages/framework/tests/Feature/AssetServiceTest.php
@@ -46,6 +46,14 @@ class AssetServiceTest extends TestCase
         $this->assertStringContainsString('styles.css', $path);
     }
 
+    public function test_can_set_custom_cdn_uri_in_config()
+    {
+        config(['hyde.hydefront_url' => 'https://example.com']);
+        $service = new AssetService();
+        $this->assertSame('https://example.com', $service->constructCdnPath('styles.css'));
+        $this->assertSame('https://example.com', $service->cdnLink('styles.css'));
+    }
+
     public function test_media_link_returns_media_path_with_cache_key()
     {
         $service = new AssetService();


### PR DESCRIPTION
Adds another "hidden" config option, here letting users specify a custom CDN URI to load. For example, if you want to use something other than jsDelivr. This is of course not compatible with the custom versioning or dynamic paths supported by the defaults, but the option is there for power users who want customization without having to publish the view component which may get outdated.