### PR TITLE
Breaking: Make page discovery information properties protected

### DIFF
--- a/docs/advanced-features/page-models.md
+++ b/docs/advanced-features/page-models.md
@@ -33,7 +33,7 @@ Don't worry if you don't understand everything yet, we'll talk more about these 
 ```php
 class MarkdownPost extends BaseMarkdownPage
 {
-    public static string $sourceDirectory = '_posts';
+    protected static string $sourceDirectory = '_posts';
     public static string $outputDirectory = 'posts';
     public static string $fileExtension = '.md';
     public static string $template = 'post';
@@ -60,7 +60,7 @@ Let's again take the simplified `MarkdownPost` class as an example, this time on
 ```php
 class MarkdownPost extends BaseMarkdownPage
 {
-    public static string $sourceDirectory = '_posts';
+    protected static string $sourceDirectory = '_posts';
     public static string $outputDirectory = 'posts';
     public static string $fileExtension = '.md';
     public static string $template = 'post';

--- a/docs/advanced-features/page-models.md
+++ b/docs/advanced-features/page-models.md
@@ -34,7 +34,7 @@ Don't worry if you don't understand everything yet, we'll talk more about these 
 class MarkdownPost extends BaseMarkdownPage
 {
     protected static string $sourceDirectory = '_posts';
-    public static string $outputDirectory = 'posts';
+    protected static string $outputDirectory = 'posts';
     public static string $fileExtension = '.md';
     public static string $template = 'post';
     
@@ -61,7 +61,7 @@ Let's again take the simplified `MarkdownPost` class as an example, this time on
 class MarkdownPost extends BaseMarkdownPage
 {
     protected static string $sourceDirectory = '_posts';
-    public static string $outputDirectory = 'posts';
+    protected static string $outputDirectory = 'posts';
     public static string $fileExtension = '.md';
     public static string $template = 'post';
 }

--- a/docs/advanced-features/page-models.md
+++ b/docs/advanced-features/page-models.md
@@ -35,7 +35,7 @@ class MarkdownPost extends BaseMarkdownPage
 {
     protected static string $sourceDirectory = '_posts';
     protected static string $outputDirectory = 'posts';
-    public static string $fileExtension = '.md';
+    protected static string $fileExtension = '.md';
     public static string $template = 'post';
     
     public string $identifier;
@@ -62,7 +62,7 @@ class MarkdownPost extends BaseMarkdownPage
 {
     protected static string $sourceDirectory = '_posts';
     protected static string $outputDirectory = 'posts';
-    public static string $fileExtension = '.md';
+    protected static string $fileExtension = '.md';
     public static string $template = 'post';
 }
 ```

--- a/packages/framework/src/Console/Commands/ChangeSourceDirectoryCommand.php
+++ b/packages/framework/src/Console/Commands/ChangeSourceDirectoryCommand.php
@@ -64,11 +64,11 @@ class ChangeSourceDirectoryCommand extends Command
     protected function getPageDirectories(): array
     {
         return array_unique([
-            HtmlPage::$sourceDirectory,
-            BladePage::$sourceDirectory,
-            MarkdownPage::$sourceDirectory,
-            MarkdownPost::$sourceDirectory,
-            DocumentationPage::$sourceDirectory,
+            HtmlPage::sourceDirectory(),
+            BladePage::sourceDirectory(),
+            MarkdownPage::sourceDirectory(),
+            MarkdownPost::sourceDirectory(),
+            DocumentationPage::sourceDirectory(),
         ]);
     }
 

--- a/packages/framework/src/Framework/Concerns/RegistersFileLocations.php
+++ b/packages/framework/src/Framework/Concerns/RegistersFileLocations.php
@@ -51,7 +51,7 @@ trait RegistersFileLocations
     {
         foreach ($directoryMapping as $class => $location) {
             /** @var HydePage $class */
-            $class::$outputDirectory = unslash($location);
+            $class::setOutputDirectory(unslash($location));
         }
     }
 

--- a/packages/framework/src/Framework/Concerns/RegistersFileLocations.php
+++ b/packages/framework/src/Framework/Concerns/RegistersFileLocations.php
@@ -33,7 +33,7 @@ trait RegistersFileLocations
     {
         foreach ($directoryMapping as $class => $location) {
             /** @var HydePage $class */
-            $class::$sourceDirectory = unslash(Hyde::getSourceRoot().'/'.unslash($location));
+            $class::setSourceDirectory(unslash(Hyde::getSourceRoot().'/'.unslash($location)));
         }
     }
 

--- a/packages/framework/src/Framework/Features/DataCollections/DataCollection.php
+++ b/packages/framework/src/Framework/Features/DataCollections/DataCollection.php
@@ -18,7 +18,7 @@ class DataCollection extends Collection
 {
     public string $key;
 
-    protected static string $sourceDirectory = 'resources/collections';
+    public static string $sourceDirectory = 'resources/collections';
 
     public function __construct(string $key)
     {
@@ -35,7 +35,7 @@ class DataCollection extends Collection
     public function getMarkdownFiles(): array
     {
         return glob(Hyde::path(
-            static::sourceDirectory().'/'.$this->key.'/*.md'
+            static::$sourceDirectory.'/'.$this->key.'/*.md'
         ));
     }
 

--- a/packages/framework/src/Framework/Features/DataCollections/DataCollection.php
+++ b/packages/framework/src/Framework/Features/DataCollections/DataCollection.php
@@ -18,7 +18,7 @@ class DataCollection extends Collection
 {
     public string $key;
 
-    public static string $sourceDirectory = 'resources/collections';
+    protected static string $sourceDirectory = 'resources/collections';
 
     public function __construct(string $key)
     {

--- a/packages/framework/src/Framework/Features/DataCollections/DataCollection.php
+++ b/packages/framework/src/Framework/Features/DataCollections/DataCollection.php
@@ -35,7 +35,7 @@ class DataCollection extends Collection
     public function getMarkdownFiles(): array
     {
         return glob(Hyde::path(
-            static::$sourceDirectory.'/'.$this->key.'/*.md'
+            static::sourceDirectory().'/'.$this->key.'/*.md'
         ));
     }
 

--- a/packages/framework/src/Framework/Features/Documentation/DocumentationSearchPage.php
+++ b/packages/framework/src/Framework/Features/Documentation/DocumentationSearchPage.php
@@ -43,6 +43,6 @@ class DocumentationSearchPage extends DocumentationPage
 
     public static function routeKey(): string
     {
-        return parent::$outputDirectory.'/search';
+        return parent::outputDirectory().'/search';
     }
 }

--- a/packages/framework/src/Framework/Services/DiscoveryService.php
+++ b/packages/framework/src/Framework/Services/DiscoveryService.php
@@ -102,7 +102,7 @@ class DiscoveryService
     public static function pathToIdentifier(string $model, string $filepath): string
     {
         return unslash(Str::between(Hyde::pathToRelative($filepath),
-            $model::$sourceDirectory.'/',
+            $model::sourceDirectory().'/',
             $model::$fileExtension)
         );
     }

--- a/packages/framework/src/Framework/Services/DiscoveryService.php
+++ b/packages/framework/src/Framework/Services/DiscoveryService.php
@@ -103,7 +103,7 @@ class DiscoveryService
     {
         return unslash(Str::between(Hyde::pathToRelative($filepath),
             $model::sourceDirectory().'/',
-            $model::$fileExtension)
+            $model::fileExtension())
         );
     }
 

--- a/packages/framework/src/Pages/BladePage.php
+++ b/packages/framework/src/Pages/BladePage.php
@@ -21,7 +21,7 @@ class BladePage extends HydePage
 {
     protected static string $sourceDirectory = '_pages';
     protected static string $outputDirectory = '';
-    public static string $fileExtension = '.blade.php';
+    protected static string $fileExtension = '.blade.php';
 
     /**
      * The name of the Blade View to compile. Commonly stored in _pages/{$identifier}.blade.php.

--- a/packages/framework/src/Pages/BladePage.php
+++ b/packages/framework/src/Pages/BladePage.php
@@ -20,7 +20,7 @@ use Illuminate\Support\Facades\View;
 class BladePage extends HydePage
 {
     protected static string $sourceDirectory = '_pages';
-    public static string $outputDirectory = '';
+    protected static string $outputDirectory = '';
     public static string $fileExtension = '.blade.php';
 
     /**

--- a/packages/framework/src/Pages/BladePage.php
+++ b/packages/framework/src/Pages/BladePage.php
@@ -19,7 +19,7 @@ use Illuminate\Support\Facades\View;
  */
 class BladePage extends HydePage
 {
-    public static string $sourceDirectory = '_pages';
+    protected static string $sourceDirectory = '_pages';
     public static string $outputDirectory = '';
     public static string $fileExtension = '.blade.php';
 

--- a/packages/framework/src/Pages/Concerns/BaseMarkdownPage.php
+++ b/packages/framework/src/Pages/Concerns/BaseMarkdownPage.php
@@ -22,7 +22,7 @@ abstract class BaseMarkdownPage extends HydePage implements MarkdownDocumentCont
 {
     public Markdown $markdown;
 
-    public static string $fileExtension = '.md';
+    protected static string $fileExtension = '.md';
 
     public static function make(string $identifier = '', FrontMatter|array $matter = [], Markdown|string $markdown = ''): static
     {

--- a/packages/framework/src/Pages/Concerns/HydePage.php
+++ b/packages/framework/src/Pages/Concerns/HydePage.php
@@ -45,9 +45,7 @@ abstract class HydePage implements PageSchema, DiscoverableContract
     use HasFactory;
 
     protected static string $sourceDirectory;
-
-    /** @internal Will be made protected */
-    public static string $outputDirectory;
+    protected static string $outputDirectory;
 
     /** @internal Will be made protected */
     public static string $fileExtension;

--- a/packages/framework/src/Pages/Concerns/HydePage.php
+++ b/packages/framework/src/Pages/Concerns/HydePage.php
@@ -46,9 +46,7 @@ abstract class HydePage implements PageSchema, DiscoverableContract
 
     protected static string $sourceDirectory;
     protected static string $outputDirectory;
-
-    /** @internal Will be made protected */
-    public static string $fileExtension;
+    protected static string $fileExtension;
 
     public static string $template;
 

--- a/packages/framework/src/Pages/Concerns/HydePage.php
+++ b/packages/framework/src/Pages/Concerns/HydePage.php
@@ -44,8 +44,7 @@ abstract class HydePage implements PageSchema, DiscoverableContract
     use InteractsWithFrontMatter;
     use HasFactory;
 
-    /** @internal Will be made protected */
-    public static string $sourceDirectory;
+    protected static string $sourceDirectory;
 
     /** @internal Will be made protected */
     public static string $outputDirectory;

--- a/packages/framework/src/Pages/DocumentationPage.php
+++ b/packages/framework/src/Pages/DocumentationPage.php
@@ -21,7 +21,7 @@ class DocumentationPage extends BaseMarkdownPage
     use Concerns\UsesFlattenedOutputPaths;
 
     protected static string $sourceDirectory = '_docs';
-    public static string $outputDirectory = 'docs';
+    protected static string $outputDirectory = 'docs';
     public static string $template = 'hyde::layouts/docs';
 
     public static function home(): ?Route

--- a/packages/framework/src/Pages/DocumentationPage.php
+++ b/packages/framework/src/Pages/DocumentationPage.php
@@ -20,7 +20,7 @@ class DocumentationPage extends BaseMarkdownPage
 {
     use Concerns\UsesFlattenedOutputPaths;
 
-    public static string $sourceDirectory = '_docs';
+    protected static string $sourceDirectory = '_docs';
     public static string $outputDirectory = 'docs';
     public static string $template = 'hyde::layouts/docs';
 

--- a/packages/framework/src/Pages/HtmlPage.php
+++ b/packages/framework/src/Pages/HtmlPage.php
@@ -18,7 +18,7 @@ class HtmlPage extends HydePage
 {
     protected static string $sourceDirectory = '_pages';
     protected static string $outputDirectory = '';
-    public static string $fileExtension = '.html';
+    protected static string $fileExtension = '.html';
 
     public function contents(): string
     {

--- a/packages/framework/src/Pages/HtmlPage.php
+++ b/packages/framework/src/Pages/HtmlPage.php
@@ -16,7 +16,7 @@ use Hyde\Pages\Concerns\HydePage;
  */
 class HtmlPage extends HydePage
 {
-    public static string $sourceDirectory = '_pages';
+    protected static string $sourceDirectory = '_pages';
     public static string $outputDirectory = '';
     public static string $fileExtension = '.html';
 

--- a/packages/framework/src/Pages/HtmlPage.php
+++ b/packages/framework/src/Pages/HtmlPage.php
@@ -17,7 +17,7 @@ use Hyde\Pages\Concerns\HydePage;
 class HtmlPage extends HydePage
 {
     protected static string $sourceDirectory = '_pages';
-    public static string $outputDirectory = '';
+    protected static string $outputDirectory = '';
     public static string $fileExtension = '.html';
 
     public function contents(): string

--- a/packages/framework/src/Pages/InMemoryPage.php
+++ b/packages/framework/src/Pages/InMemoryPage.php
@@ -25,7 +25,7 @@ use Illuminate\Support\Facades\View;
  */
 class InMemoryPage extends HydePage
 {
-    public static string $sourceDirectory = '';
+    protected static string $sourceDirectory = '';
     public static string $outputDirectory = '';
     public static string $fileExtension = '';
 

--- a/packages/framework/src/Pages/InMemoryPage.php
+++ b/packages/framework/src/Pages/InMemoryPage.php
@@ -27,7 +27,7 @@ class InMemoryPage extends HydePage
 {
     protected static string $sourceDirectory = '';
     protected static string $outputDirectory = '';
-    public static string $fileExtension = '';
+    protected static string $fileExtension = '';
 
     protected string $contents;
     protected string $view;

--- a/packages/framework/src/Pages/InMemoryPage.php
+++ b/packages/framework/src/Pages/InMemoryPage.php
@@ -26,7 +26,7 @@ use Illuminate\Support\Facades\View;
 class InMemoryPage extends HydePage
 {
     protected static string $sourceDirectory = '';
-    public static string $outputDirectory = '';
+    protected static string $outputDirectory = '';
     public static string $fileExtension = '';
 
     protected string $contents;

--- a/packages/framework/src/Pages/MarkdownPage.php
+++ b/packages/framework/src/Pages/MarkdownPage.php
@@ -17,6 +17,6 @@ use Hyde\Pages\Concerns\BaseMarkdownPage;
 class MarkdownPage extends BaseMarkdownPage
 {
     protected static string $sourceDirectory = '_pages';
-    public static string $outputDirectory = '';
+    protected static string $outputDirectory = '';
     public static string $template = 'hyde::layouts/page';
 }

--- a/packages/framework/src/Pages/MarkdownPage.php
+++ b/packages/framework/src/Pages/MarkdownPage.php
@@ -16,7 +16,7 @@ use Hyde\Pages\Concerns\BaseMarkdownPage;
  */
 class MarkdownPage extends BaseMarkdownPage
 {
-    public static string $sourceDirectory = '_pages';
+    protected static string $sourceDirectory = '_pages';
     public static string $outputDirectory = '';
     public static string $template = 'hyde::layouts/page';
 }

--- a/packages/framework/src/Pages/MarkdownPost.php
+++ b/packages/framework/src/Pages/MarkdownPost.php
@@ -22,7 +22,7 @@ use Hyde\Support\Models\DateString;
 class MarkdownPost extends BaseMarkdownPage implements BlogPostSchema
 {
     protected static string $sourceDirectory = '_posts';
-    public static string $outputDirectory = 'posts';
+    protected static string $outputDirectory = 'posts';
     public static string $template = 'hyde::layouts/post';
 
     public ?string $description;

--- a/packages/framework/src/Pages/MarkdownPost.php
+++ b/packages/framework/src/Pages/MarkdownPost.php
@@ -21,7 +21,7 @@ use Hyde\Support\Models\DateString;
  */
 class MarkdownPost extends BaseMarkdownPage implements BlogPostSchema
 {
-    public static string $sourceDirectory = '_posts';
+    protected static string $sourceDirectory = '_posts';
     public static string $outputDirectory = 'posts';
     public static string $template = 'hyde::layouts/post';
 

--- a/packages/framework/src/Support/Filesystem/SourceFile.php
+++ b/packages/framework/src/Support/Filesystem/SourceFile.php
@@ -44,6 +44,6 @@ class SourceFile extends ProjectFile
     public function withoutDirectoryPrefix(): string
     {
         // Works like basename, but keeps subdirectory names.
-        return Str::after($this->path, $this->model::$sourceDirectory.'/');
+        return Str::after($this->path, $this->model::sourceDirectory().'/');
     }
 }

--- a/packages/framework/tests/Feature/Commands/BuildSearchCommandTest.php
+++ b/packages/framework/tests/Feature/Commands/BuildSearchCommandTest.php
@@ -61,7 +61,7 @@ class BuildSearchCommandTest extends TestCase
 
     public function test_search_files_can_be_generated_for_custom_docs_output_directory()
     {
-        DocumentationPage::$outputDirectory = 'foo';
+        DocumentationPage::setOutputDirectory('foo');
 
         $this->artisan('build:search')->assertExitCode(0);
         $this->assertFileExists(Hyde::path('_site/foo/search.json'));
@@ -84,7 +84,7 @@ class BuildSearchCommandTest extends TestCase
     public function test_search_files_can_be_generated_for_custom_site_and_docs_output_directories()
     {
         Site::setOutputDirectory('foo');
-        DocumentationPage::$outputDirectory = 'bar';
+        DocumentationPage::setOutputDirectory('bar');
 
         $this->artisan('build:search')->assertExitCode(0);
         $this->assertFileExists(Hyde::path('foo/bar/search.json'));
@@ -96,7 +96,7 @@ class BuildSearchCommandTest extends TestCase
     public function test_search_files_can_be_generated_for_custom_site_and_nested_docs_output_directories()
     {
         Site::setOutputDirectory('foo/bar');
-        DocumentationPage::$outputDirectory = 'baz';
+        DocumentationPage::setOutputDirectory('baz');
 
         $this->artisan('build:search')->assertExitCode(0);
         $this->assertFileExists(Hyde::path('foo/bar/baz/search.json'));

--- a/packages/framework/tests/Feature/DataCollectionTest.php
+++ b/packages/framework/tests/Feature/DataCollectionTest.php
@@ -144,12 +144,12 @@ class DataCollectionTest extends TestCase
 
     public function test_class_has_static_source_directory_property()
     {
-        $this->assertEquals('resources/collections', DataCollection::sourceDirectory());
+        $this->assertEquals('resources/collections', DataCollection::$sourceDirectory);
     }
 
     public function test_source_directory_can_be_changed()
     {
-        DataCollection::setSourceDirectory('foo');
+        DataCollection::$sourceDirectory = 'foo';
         mkdir(Hyde::path('foo/bar'), recursive: true);
         Hyde::touch('foo/bar/foo.md');
         $this->assertEquals([

--- a/packages/framework/tests/Feature/DataCollectionTest.php
+++ b/packages/framework/tests/Feature/DataCollectionTest.php
@@ -144,7 +144,7 @@ class DataCollectionTest extends TestCase
 
     public function test_class_has_static_source_directory_property()
     {
-        $this->assertEquals('resources/collections', DataCollection::$sourceDirectory);
+        $this->assertEquals('resources/collections', DataCollection::sourceDirectory());
     }
 
     public function test_source_directory_can_be_changed()

--- a/packages/framework/tests/Feature/DataCollectionTest.php
+++ b/packages/framework/tests/Feature/DataCollectionTest.php
@@ -149,7 +149,7 @@ class DataCollectionTest extends TestCase
 
     public function test_source_directory_can_be_changed()
     {
-        DataCollection::$sourceDirectory = 'foo';
+        DataCollection::setSourceDirectory('foo');
         mkdir(Hyde::path('foo/bar'), recursive: true);
         Hyde::touch('foo/bar/foo.md');
         $this->assertEquals([

--- a/packages/framework/tests/Feature/DiscoveryServiceTest.php
+++ b/packages/framework/tests/Feature/DiscoveryServiceTest.php
@@ -110,11 +110,11 @@ class DiscoveryServiceTest extends TestCase
         foreach ($matrix as $model) {
             // Setup
             @mkdir(Hyde::path('foo'));
-            $sourceDirectoryBackup = $model::$sourceDirectory;
+            $sourceDirectoryBackup = $model::sourceDirectory();
             $fileExtensionBackup = $model::$fileExtension;
 
             // Test baseline
-            $this->unitTestMarkdownBasedPageList($model, $model::$sourceDirectory.'/foo.md');
+            $this->unitTestMarkdownBasedPageList($model, $model::sourceDirectory().'/foo.md');
 
             // Set the source directory to a custom value
             $model::setSourceDirectory('foo');

--- a/packages/framework/tests/Feature/DiscoveryServiceTest.php
+++ b/packages/framework/tests/Feature/DiscoveryServiceTest.php
@@ -123,7 +123,7 @@ class DiscoveryServiceTest extends TestCase
             $this->unitTestMarkdownBasedPageList($model, 'foo/foo.md');
 
             // Set file extension to a custom value
-            $model::$fileExtension = '.foo';
+            $model::setFileExtension('.foo');
 
             // Test customized file extension
             $this->unitTestMarkdownBasedPageList($model, 'foo/foo.foo', 'foo');
@@ -131,7 +131,7 @@ class DiscoveryServiceTest extends TestCase
             // Cleanup
             File::deleteDirectory(Hyde::path('foo'));
             $model::setSourceDirectory($sourceDirectoryBackup);
-            $model::$fileExtension = $fileExtensionBackup;
+            $model::setFileExtension($fileExtensionBackup);
         }
     }
 

--- a/packages/framework/tests/Feature/DiscoveryServiceTest.php
+++ b/packages/framework/tests/Feature/DiscoveryServiceTest.php
@@ -111,7 +111,7 @@ class DiscoveryServiceTest extends TestCase
             // Setup
             @mkdir(Hyde::path('foo'));
             $sourceDirectoryBackup = $model::sourceDirectory();
-            $fileExtensionBackup = $model::$fileExtension;
+            $fileExtensionBackup = $model::fileExtension();
 
             // Test baseline
             $this->unitTestMarkdownBasedPageList($model, $model::sourceDirectory().'/foo.md');

--- a/packages/framework/tests/Feature/DiscoveryServiceTest.php
+++ b/packages/framework/tests/Feature/DiscoveryServiceTest.php
@@ -117,7 +117,7 @@ class DiscoveryServiceTest extends TestCase
             $this->unitTestMarkdownBasedPageList($model, $model::$sourceDirectory.'/foo.md');
 
             // Set the source directory to a custom value
-            $model::$sourceDirectory = 'foo';
+            $model::setSourceDirectory('foo');
 
             // Test customized source directory
             $this->unitTestMarkdownBasedPageList($model, 'foo/foo.md');
@@ -130,7 +130,7 @@ class DiscoveryServiceTest extends TestCase
 
             // Cleanup
             File::deleteDirectory(Hyde::path('foo'));
-            $model::$sourceDirectory = $sourceDirectoryBackup;
+            $model::setSourceDirectory($sourceDirectoryBackup);
             $model::$fileExtension = $fileExtensionBackup;
         }
     }

--- a/packages/framework/tests/Feature/DocumentationSearchPageTest.php
+++ b/packages/framework/tests/Feature/DocumentationSearchPageTest.php
@@ -30,7 +30,7 @@ class DocumentationSearchPageTest extends TestCase
 
     public function testRouteKeyIsSetToConfiguredDocumentationOutputDirectory()
     {
-        DocumentationPage::$outputDirectory = 'foo';
+        DocumentationPage::setOutputDirectory('foo');
 
         $page = new DocumentationSearchPage();
         $this->assertSame('foo/search', $page->routeKey);
@@ -67,7 +67,7 @@ class DocumentationSearchPageTest extends TestCase
 
     public function testStaticRouteKeyHelperWithCustomOutputDirectory()
     {
-        DocumentationPage::$outputDirectory = 'foo';
+        DocumentationPage::setOutputDirectory('foo');
         $this->assertSame('foo/search', DocumentationSearchPage::routeKey());
     }
 }

--- a/packages/framework/tests/Feature/HydeExtensionFeatureTest.php
+++ b/packages/framework/tests/Feature/HydeExtensionFeatureTest.php
@@ -268,7 +268,7 @@ class InspectableTestExtension extends HydeExtension
 
 class HydeExtensionTestPage extends HydePage
 {
-    public static string $sourceDirectory = 'foo';
+    protected static string $sourceDirectory = 'foo';
     public static string $outputDirectory = 'foo';
     public static string $fileExtension = '.txt';
 
@@ -280,7 +280,7 @@ class HydeExtensionTestPage extends HydePage
 
 class TestPageClass extends HydePage
 {
-    public static string $sourceDirectory = 'foo';
+    protected static string $sourceDirectory = 'foo';
     public static string $outputDirectory = 'foo';
     public static string $fileExtension = '.txt';
 

--- a/packages/framework/tests/Feature/HydeExtensionFeatureTest.php
+++ b/packages/framework/tests/Feature/HydeExtensionFeatureTest.php
@@ -270,7 +270,7 @@ class HydeExtensionTestPage extends HydePage
 {
     protected static string $sourceDirectory = 'foo';
     protected static string $outputDirectory = 'foo';
-    public static string $fileExtension = '.txt';
+    protected static string $fileExtension = '.txt';
 
     public function compile(): string
     {
@@ -282,7 +282,7 @@ class TestPageClass extends HydePage
 {
     protected static string $sourceDirectory = 'foo';
     protected static string $outputDirectory = 'foo';
-    public static string $fileExtension = '.txt';
+    protected static string $fileExtension = '.txt';
 
     public function compile(): string
     {

--- a/packages/framework/tests/Feature/HydeExtensionFeatureTest.php
+++ b/packages/framework/tests/Feature/HydeExtensionFeatureTest.php
@@ -269,7 +269,7 @@ class InspectableTestExtension extends HydeExtension
 class HydeExtensionTestPage extends HydePage
 {
     protected static string $sourceDirectory = 'foo';
-    public static string $outputDirectory = 'foo';
+    protected static string $outputDirectory = 'foo';
     public static string $fileExtension = '.txt';
 
     public function compile(): string
@@ -281,7 +281,7 @@ class HydeExtensionTestPage extends HydePage
 class TestPageClass extends HydePage
 {
     protected static string $sourceDirectory = 'foo';
-    public static string $outputDirectory = 'foo';
+    protected static string $outputDirectory = 'foo';
     public static string $fileExtension = '.txt';
 
     public function compile(): string

--- a/packages/framework/tests/Feature/HydePageTest.php
+++ b/packages/framework/tests/Feature/HydePageTest.php
@@ -421,7 +421,7 @@ class HydePageTest extends TestCase
         ];
 
         foreach ($pages as $page => $expected) {
-            $this->assertEquals($expected, $page::$sourceDirectory);
+            $this->assertEquals($expected, $page::sourceDirectory());
         }
     }
 

--- a/packages/framework/tests/Feature/HydePageTest.php
+++ b/packages/framework/tests/Feature/HydePageTest.php
@@ -435,7 +435,7 @@ class HydePageTest extends TestCase
         ];
 
         foreach ($pages as $page => $expected) {
-            $this->assertEquals($expected, $page::$outputDirectory);
+            $this->assertEquals($expected, $page::outputDirectory());
         }
     }
 

--- a/packages/framework/tests/Feature/HydePageTest.php
+++ b/packages/framework/tests/Feature/HydePageTest.php
@@ -449,7 +449,7 @@ class HydePageTest extends TestCase
         ];
 
         foreach ($pages as $page => $expected) {
-            $this->assertEquals($expected, $page::$fileExtension);
+            $this->assertEquals($expected, $page::fileExtension());
         }
     }
 
@@ -475,7 +475,7 @@ class HydePageTest extends TestCase
 
     public function test_abstract_markdown_page_file_extension_property_is_set_to_md()
     {
-        $this->assertEquals('.md', BaseMarkdownPage::$fileExtension);
+        $this->assertEquals('.md', BaseMarkdownPage::fileExtension());
     }
 
     public function test_abstract_markdown_page_constructor_arguments_are_optional()

--- a/packages/framework/tests/Feature/HydePageTest.php
+++ b/packages/framework/tests/Feature/HydePageTest.php
@@ -1134,7 +1134,7 @@ class DiscoverablePage extends HydePage
 {
     protected static string $sourceDirectory = 'foo';
     protected static string $outputDirectory = '';
-    public static string $fileExtension = '';
+    protected static string $fileExtension = '';
 
     public function compile(): string
     {
@@ -1147,7 +1147,7 @@ class NonDiscoverablePage extends HydePage
 {
     protected static string $sourceDirectory ;
     protected static string $outputDirectory;
-    public static string $fileExtension;
+    protected static string $fileExtension;
 
     public function compile(): string
     {
@@ -1160,7 +1160,7 @@ class PartiallyDiscoverablePage extends HydePage
 {
     protected static string $sourceDirectory = 'foo';
     protected static string $outputDirectory;
-    public static string $fileExtension;
+    protected static string $fileExtension;
 
     public function compile(): string
     {
@@ -1173,7 +1173,7 @@ class DiscoverablePageWithInvalidSourceDirectory extends HydePage
 {
     protected static string $sourceDirectory = '';
     protected static string $outputDirectory = '';
-    public static string $fileExtension = '';
+    protected static string $fileExtension = '';
 
     public function compile(): string
     {

--- a/packages/framework/tests/Feature/HydePageTest.php
+++ b/packages/framework/tests/Feature/HydePageTest.php
@@ -1105,9 +1105,9 @@ class HydePageTest extends TestCase
 
 class TestPage extends HydePage
 {
-    public static string $sourceDirectory = 'source';
-    public static string $outputDirectory = 'output';
-    public static string $fileExtension = '.md';
+    protected static string $sourceDirectory = 'source';
+    protected static string $outputDirectory = 'output';
+    protected static string $fileExtension = '.md';
     public static string $template = 'template';
 
     public function compile(): string
@@ -1118,9 +1118,9 @@ class TestPage extends HydePage
 
 class ConfigurableSourcesTestPage extends HydePage
 {
-    public static string $sourceDirectory;
-    public static string $outputDirectory;
-    public static string $fileExtension;
+    protected static string $sourceDirectory;
+    protected static string $outputDirectory;
+    protected static string $fileExtension;
     public static string $template;
 
     public function compile(): string

--- a/packages/framework/tests/Feature/HydePageTest.php
+++ b/packages/framework/tests/Feature/HydePageTest.php
@@ -205,21 +205,21 @@ class HydePageTest extends TestCase
 
     public function test_get_file_extension_returns_static_property()
     {
-        MarkdownPage::$fileExtension = '.foo';
+        MarkdownPage::setFileExtension('.foo');
         $this->assertEquals('.foo', MarkdownPage::fileExtension());
         $this->resetDirectoryConfiguration();
     }
 
     public function test_get_file_extension_forces_leading_period()
     {
-        MarkdownPage::$fileExtension = 'foo';
+        MarkdownPage::setFileExtension('foo');
         $this->assertEquals('.foo', MarkdownPage::fileExtension());
         $this->resetDirectoryConfiguration();
     }
 
     public function test_get_file_extension_removes_trailing_period()
     {
-        MarkdownPage::$fileExtension = 'foo.';
+        MarkdownPage::setFileExtension('foo.');
         $this->assertEquals('.foo', MarkdownPage::fileExtension());
         $this->resetDirectoryConfiguration();
     }
@@ -305,7 +305,7 @@ class HydePageTest extends TestCase
     public function test_qualify_basename_uses_the_static_properties()
     {
         MarkdownPage::setSourceDirectory('foo');
-        MarkdownPage::$fileExtension = 'txt';
+        MarkdownPage::setFileExtension('txt');
         $this->assertEquals('foo/bar.txt', MarkdownPage::sourcePath('bar'));
         $this->resetDirectoryConfiguration();
     }
@@ -1099,7 +1099,7 @@ class HydePageTest extends TestCase
         MarkdownPage::setSourceDirectory('_pages');
         MarkdownPost::setSourceDirectory('_posts');
         DocumentationPage::setSourceDirectory('_docs');
-        MarkdownPage::$fileExtension = '.md';
+        MarkdownPage::setFileExtension('.md');
     }
 }
 

--- a/packages/framework/tests/Feature/HydePageTest.php
+++ b/packages/framework/tests/Feature/HydePageTest.php
@@ -1133,7 +1133,7 @@ class ConfigurableSourcesTestPage extends HydePage
 class DiscoverablePage extends HydePage
 {
     protected static string $sourceDirectory = 'foo';
-    public static string $outputDirectory = '';
+    protected static string $outputDirectory = '';
     public static string $fileExtension = '';
 
     public function compile(): string
@@ -1146,7 +1146,7 @@ class DiscoverablePage extends HydePage
 class NonDiscoverablePage extends HydePage
 {
     protected static string $sourceDirectory ;
-    public static string $outputDirectory;
+    protected static string $outputDirectory;
     public static string $fileExtension;
 
     public function compile(): string
@@ -1159,7 +1159,7 @@ class NonDiscoverablePage extends HydePage
 class PartiallyDiscoverablePage extends HydePage
 {
     protected static string $sourceDirectory = 'foo';
-    public static string $outputDirectory;
+    protected static string $outputDirectory;
     public static string $fileExtension;
 
     public function compile(): string
@@ -1172,7 +1172,7 @@ class PartiallyDiscoverablePage extends HydePage
 class DiscoverablePageWithInvalidSourceDirectory extends HydePage
 {
     protected static string $sourceDirectory = '';
-    public static string $outputDirectory = '';
+    protected static string $outputDirectory = '';
     public static string $fileExtension = '';
 
     public function compile(): string

--- a/packages/framework/tests/Feature/HydePageTest.php
+++ b/packages/framework/tests/Feature/HydePageTest.php
@@ -177,14 +177,14 @@ class HydePageTest extends TestCase
 
     public function test_get_source_directory_returns_static_property()
     {
-        MarkdownPage::$sourceDirectory = 'foo';
+        MarkdownPage::setSourceDirectory('foo');
         $this->assertEquals('foo', MarkdownPage::sourceDirectory());
         $this->resetDirectoryConfiguration();
     }
 
     public function test_get_source_directory_trims_trailing_slashes()
     {
-        MarkdownPage::$sourceDirectory = '/foo/\\';
+        MarkdownPage::setSourceDirectory('/foo/\\');
         $this->assertEquals('foo', MarkdownPage::sourceDirectory());
         $this->resetDirectoryConfiguration();
     }
@@ -304,7 +304,7 @@ class HydePageTest extends TestCase
 
     public function test_qualify_basename_uses_the_static_properties()
     {
-        MarkdownPage::$sourceDirectory = 'foo';
+        MarkdownPage::setSourceDirectory('foo');
         MarkdownPage::$fileExtension = 'txt';
         $this->assertEquals('foo/bar.txt', MarkdownPage::sourcePath('bar'));
         $this->resetDirectoryConfiguration();
@@ -1095,10 +1095,10 @@ class HydePageTest extends TestCase
 
     protected function resetDirectoryConfiguration(): void
     {
-        BladePage::$sourceDirectory = '_pages';
-        MarkdownPage::$sourceDirectory = '_pages';
-        MarkdownPost::$sourceDirectory = '_posts';
-        DocumentationPage::$sourceDirectory = '_docs';
+        BladePage::setSourceDirectory('_pages');
+        MarkdownPage::setSourceDirectory('_pages');
+        MarkdownPost::setSourceDirectory('_posts');
+        DocumentationPage::setSourceDirectory('_docs');
         MarkdownPage::$fileExtension = '.md';
     }
 }

--- a/packages/framework/tests/Feature/HydePageTest.php
+++ b/packages/framework/tests/Feature/HydePageTest.php
@@ -1132,7 +1132,7 @@ class ConfigurableSourcesTestPage extends HydePage
 /** @deprecated */
 class DiscoverablePage extends HydePage
 {
-    public static string $sourceDirectory = 'foo';
+    protected static string $sourceDirectory = 'foo';
     public static string $outputDirectory = '';
     public static string $fileExtension = '';
 
@@ -1145,7 +1145,7 @@ class DiscoverablePage extends HydePage
 /** @deprecated */
 class NonDiscoverablePage extends HydePage
 {
-    public static string $sourceDirectory;
+    protected static string $sourceDirectory ;
     public static string $outputDirectory;
     public static string $fileExtension;
 
@@ -1158,7 +1158,7 @@ class NonDiscoverablePage extends HydePage
 /** @deprecated */
 class PartiallyDiscoverablePage extends HydePage
 {
-    public static string $sourceDirectory = 'foo';
+    protected static string $sourceDirectory = 'foo';
     public static string $outputDirectory;
     public static string $fileExtension;
 
@@ -1171,7 +1171,7 @@ class PartiallyDiscoverablePage extends HydePage
 /** @deprecated */
 class DiscoverablePageWithInvalidSourceDirectory extends HydePage
 {
-    public static string $sourceDirectory = '';
+    protected static string $sourceDirectory = '';
     public static string $outputDirectory = '';
     public static string $fileExtension = '';
 

--- a/packages/framework/tests/Feature/HydePageTest.php
+++ b/packages/framework/tests/Feature/HydePageTest.php
@@ -1145,7 +1145,7 @@ class DiscoverablePage extends HydePage
 /** @deprecated */
 class NonDiscoverablePage extends HydePage
 {
-    protected static string $sourceDirectory ;
+    protected static string $sourceDirectory;
     protected static string $outputDirectory;
     protected static string $fileExtension;
 

--- a/packages/framework/tests/Feature/HydePageTest.php
+++ b/packages/framework/tests/Feature/HydePageTest.php
@@ -191,14 +191,14 @@ class HydePageTest extends TestCase
 
     public function test_get_output_directory_returns_static_property()
     {
-        MarkdownPage::$outputDirectory = 'foo';
+        MarkdownPage::setOutputDirectory('foo');
         $this->assertEquals('foo', MarkdownPage::outputDirectory());
         $this->resetDirectoryConfiguration();
     }
 
     public function test_get_output_directory_trims_trailing_slashes()
     {
-        MarkdownPage::$outputDirectory = '/foo/\\';
+        MarkdownPage::setOutputDirectory('/foo/\\');
         $this->assertEquals('foo', MarkdownPage::outputDirectory());
         $this->resetDirectoryConfiguration();
     }
@@ -338,14 +338,14 @@ class HydePageTest extends TestCase
 
     public function test_get_output_location_returns_the_configured_location()
     {
-        MarkdownPage::$outputDirectory = 'foo';
+        MarkdownPage::setOutputDirectory('foo');
         $this->assertEquals('foo/bar.html', MarkdownPage::outputPath('bar'));
         $this->resetDirectoryConfiguration();
     }
 
     public function test_get_output_location_trims_trailing_slashes_from_directory_setting()
     {
-        MarkdownPage::$outputDirectory = '/foo/\\';
+        MarkdownPage::setOutputDirectory('/foo/\\');
         $this->assertEquals('foo/bar.html', MarkdownPage::outputPath('bar'));
         $this->resetDirectoryConfiguration();
     }
@@ -363,7 +363,7 @@ class HydePageTest extends TestCase
 
     public function test_get_current_page_path_returns_output_directory_and_basename_for_configured_directory()
     {
-        MarkdownPage::$outputDirectory = 'foo';
+        MarkdownPage::setOutputDirectory('foo');
         $page = new MarkdownPage('bar');
         $this->assertEquals('foo/bar', $page->getRouteKey());
         $this->resetDirectoryConfiguration();
@@ -371,7 +371,7 @@ class HydePageTest extends TestCase
 
     public function test_get_current_page_path_trims_trailing_slashes_from_directory_setting()
     {
-        MarkdownPage::$outputDirectory = '/foo/\\';
+        MarkdownPage::setOutputDirectory('/foo/\\');
         $page = new MarkdownPage('bar');
         $this->assertEquals('foo/bar', $page->getRouteKey());
         $this->resetDirectoryConfiguration();

--- a/packages/framework/tests/Feature/HydeServiceProviderTest.php
+++ b/packages/framework/tests/Feature/HydeServiceProviderTest.php
@@ -85,10 +85,10 @@ class HydeServiceProviderTest extends TestCase
 
     public function test_provider_registers_output_directories()
     {
-        BladePage::$outputDirectory = 'foo';
-        MarkdownPage::$outputDirectory = 'foo';
-        MarkdownPost::$outputDirectory = 'foo';
-        DocumentationPage::$outputDirectory = 'foo';
+        BladePage::setOutputDirectory('foo');
+        MarkdownPage::setOutputDirectory('foo');
+        MarkdownPost::setOutputDirectory('foo');
+        DocumentationPage::setOutputDirectory('foo');
 
         $this->assertEquals('foo', BladePage::outputDirectory());
         $this->assertEquals('foo', MarkdownPage::outputDirectory());
@@ -231,7 +231,7 @@ class HydeServiceProviderTest extends TestCase
 
         /** @var \Hyde\Pages\Concerns\HydePage|string $page */
         foreach ($pages as $page) {
-            $page::$outputDirectory = 'foo';
+            $page::setOutputDirectory('foo');
         }
 
         $this->provider->register();

--- a/packages/framework/tests/Feature/HydeServiceProviderTest.php
+++ b/packages/framework/tests/Feature/HydeServiceProviderTest.php
@@ -221,7 +221,7 @@ class HydeServiceProviderTest extends TestCase
         $this->provider->register();
 
         foreach ($pages as $page) {
-            $this->assertNotEquals('foo', $page::$sourceDirectory, "Source directory for $page was not set");
+            $this->assertNotEquals('foo', $page::sourceDirectory(), "Source directory for $page was not set");
         }
     }
 
@@ -253,11 +253,11 @@ class HydeServiceProviderTest extends TestCase
 
         $this->provider->register();
 
-        $this->assertEquals('foo', HtmlPage::$sourceDirectory);
-        $this->assertEquals('foo', BladePage::$sourceDirectory);
-        $this->assertEquals('foo', MarkdownPage::$sourceDirectory);
-        $this->assertEquals('foo', MarkdownPost::$sourceDirectory);
-        $this->assertEquals('foo', DocumentationPage::$sourceDirectory);
+        $this->assertEquals('foo', HtmlPage::sourceDirectory());
+        $this->assertEquals('foo', BladePage::sourceDirectory());
+        $this->assertEquals('foo', MarkdownPage::sourceDirectory());
+        $this->assertEquals('foo', MarkdownPost::sourceDirectory());
+        $this->assertEquals('foo', DocumentationPage::sourceDirectory());
     }
 
     public function test_source_directories_can_be_set_using_kebab_case_class_names()
@@ -272,11 +272,11 @@ class HydeServiceProviderTest extends TestCase
 
         $this->provider->register();
 
-        $this->assertEquals('foo', HtmlPage::$sourceDirectory);
-        $this->assertEquals('foo', BladePage::$sourceDirectory);
-        $this->assertEquals('foo', MarkdownPage::$sourceDirectory);
-        $this->assertEquals('foo', MarkdownPost::$sourceDirectory);
-        $this->assertEquals('foo', DocumentationPage::$sourceDirectory);
+        $this->assertEquals('foo', HtmlPage::sourceDirectory());
+        $this->assertEquals('foo', BladePage::sourceDirectory());
+        $this->assertEquals('foo', MarkdownPage::sourceDirectory());
+        $this->assertEquals('foo', MarkdownPost::sourceDirectory());
+        $this->assertEquals('foo', DocumentationPage::sourceDirectory());
     }
 
     public function test_provider_registers_output_directories_using_options_in_configuration()

--- a/packages/framework/tests/Feature/HydeServiceProviderTest.php
+++ b/packages/framework/tests/Feature/HydeServiceProviderTest.php
@@ -237,7 +237,7 @@ class HydeServiceProviderTest extends TestCase
         $this->provider->register();
 
         foreach ($pages as $page) {
-            $this->assertNotEquals('foo', $page::$outputDirectory, "Output directory for $page was not set");
+            $this->assertNotEquals('foo', $page::outputDirectory(), "Output directory for $page was not set");
         }
     }
 
@@ -291,11 +291,11 @@ class HydeServiceProviderTest extends TestCase
 
         $this->provider->register();
 
-        $this->assertEquals('foo', HtmlPage::$outputDirectory);
-        $this->assertEquals('foo', BladePage::$outputDirectory);
-        $this->assertEquals('foo', MarkdownPage::$outputDirectory);
-        $this->assertEquals('foo', MarkdownPost::$outputDirectory);
-        $this->assertEquals('foo', DocumentationPage::$outputDirectory);
+        $this->assertEquals('foo', HtmlPage::outputDirectory());
+        $this->assertEquals('foo', BladePage::outputDirectory());
+        $this->assertEquals('foo', MarkdownPage::outputDirectory());
+        $this->assertEquals('foo', MarkdownPost::outputDirectory());
+        $this->assertEquals('foo', DocumentationPage::outputDirectory());
     }
 
     public function test_output_directories_can_be_set_using_kebab_case_class_names()
@@ -310,10 +310,10 @@ class HydeServiceProviderTest extends TestCase
 
         $this->provider->register();
 
-        $this->assertEquals('foo', HtmlPage::$outputDirectory);
-        $this->assertEquals('foo', BladePage::$outputDirectory);
-        $this->assertEquals('foo', MarkdownPage::$outputDirectory);
-        $this->assertEquals('foo', MarkdownPost::$outputDirectory);
-        $this->assertEquals('foo', DocumentationPage::$outputDirectory);
+        $this->assertEquals('foo', HtmlPage::outputDirectory());
+        $this->assertEquals('foo', BladePage::outputDirectory());
+        $this->assertEquals('foo', MarkdownPage::outputDirectory());
+        $this->assertEquals('foo', MarkdownPost::outputDirectory());
+        $this->assertEquals('foo', DocumentationPage::outputDirectory());
     }
 }

--- a/packages/framework/tests/Feature/HydeServiceProviderTest.php
+++ b/packages/framework/tests/Feature/HydeServiceProviderTest.php
@@ -65,10 +65,10 @@ class HydeServiceProviderTest extends TestCase
 
     public function test_provider_registers_source_directories()
     {
-        BladePage::$sourceDirectory = '';
-        MarkdownPage::$sourceDirectory = '';
-        MarkdownPost::$sourceDirectory = '';
-        DocumentationPage::$sourceDirectory = '';
+        BladePage::setSourceDirectory('');
+        MarkdownPage::setSourceDirectory('');
+        MarkdownPost::setSourceDirectory('');
+        DocumentationPage::setSourceDirectory('');
 
         $this->assertEquals('', BladePage::sourceDirectory());
         $this->assertEquals('', MarkdownPage::sourceDirectory());

--- a/packages/framework/tests/Feature/HydeServiceProviderTest.php
+++ b/packages/framework/tests/Feature/HydeServiceProviderTest.php
@@ -215,7 +215,7 @@ class HydeServiceProviderTest extends TestCase
 
         /** @var \Hyde\Pages\Concerns\HydePage|string $page */
         foreach ($pages as $page) {
-            $page::$sourceDirectory = 'foo';
+            $page::setSourceDirectory('foo');
         }
 
         $this->provider->register();

--- a/packages/framework/tests/Feature/PageCollectionTest.php
+++ b/packages/framework/tests/Feature/PageCollectionTest.php
@@ -155,10 +155,10 @@ class PageCollectionTest extends TestCase
 
     public function test_pages_with_custom_source_directories_are_discovered_properly()
     {
-        BladePage::$sourceDirectory = '.source/pages';
-        MarkdownPage::$sourceDirectory = '.source/pages';
-        MarkdownPost::$sourceDirectory = '.source/posts';
-        DocumentationPage::$sourceDirectory = '.source/docs';
+        BladePage::setSourceDirectory('.source/pages');
+        MarkdownPage::setSourceDirectory('.source/pages');
+        MarkdownPost::setSourceDirectory('.source/posts');
+        DocumentationPage::setSourceDirectory('.source/docs');
 
         mkdir(Hyde::path('.source'));
         mkdir(Hyde::path('.source/pages'));

--- a/packages/framework/tests/Feature/SourceDirectoriesCanBeChangedTest.php
+++ b/packages/framework/tests/Feature/SourceDirectoriesCanBeChangedTest.php
@@ -29,11 +29,11 @@ class SourceDirectoriesCanBeChangedTest extends TestCase
 
     public function test_source_directories_can_be_changed_programmatically()
     {
-        HtmlPage::$sourceDirectory = '.source/pages';
-        BladePage::$sourceDirectory = '.source/pages';
-        MarkdownPage::$sourceDirectory = '.source/pages';
-        MarkdownPost::$sourceDirectory = '.source/posts';
-        DocumentationPage::$sourceDirectory = '.source/docs';
+        HtmlPage::setSourceDirectory('.source/pages');
+        BladePage::setSourceDirectory('.source/pages');
+        MarkdownPage::setSourceDirectory('.source/pages');
+        MarkdownPost::setSourceDirectory('.source/posts');
+        DocumentationPage::setSourceDirectory('.source/docs');
 
         $this->assertEquals('.source/pages', HtmlPage::$sourceDirectory);
         $this->assertEquals('.source/pages', BladePage::$sourceDirectory);
@@ -63,7 +63,7 @@ class SourceDirectoriesCanBeChangedTest extends TestCase
 
     public function test_build_service_recognizes_changed_directory()
     {
-        MarkdownPost::$sourceDirectory = '_source/posts';
+        MarkdownPost::setSourceDirectory('_source/posts');
 
         $this->assertEquals(
             '_source/posts',
@@ -76,7 +76,7 @@ class SourceDirectoriesCanBeChangedTest extends TestCase
         $this->directory('_source');
         $this->file('_source/test.md');
 
-        MarkdownPost::$sourceDirectory = '_source';
+        MarkdownPost::setSourceDirectory('_source');
 
         $this->assertEquals(
             ['test'],
@@ -89,7 +89,7 @@ class SourceDirectoriesCanBeChangedTest extends TestCase
         $this->directory('_source/posts');
         $this->file('_source/posts/test.md');
 
-        MarkdownPost::$sourceDirectory = '_source/posts';
+        MarkdownPost::setSourceDirectory('_source/posts');
 
         $this->assertEquals(
             ['test'],

--- a/packages/framework/tests/Feature/SourceDirectoriesCanBeChangedTest.php
+++ b/packages/framework/tests/Feature/SourceDirectoriesCanBeChangedTest.php
@@ -20,11 +20,11 @@ class SourceDirectoriesCanBeChangedTest extends TestCase
 {
     public function test_baselines()
     {
-        $this->assertEquals('_pages', HtmlPage::$sourceDirectory);
-        $this->assertEquals('_pages', BladePage::$sourceDirectory);
-        $this->assertEquals('_pages', MarkdownPage::$sourceDirectory);
-        $this->assertEquals('_posts', MarkdownPost::$sourceDirectory);
-        $this->assertEquals('_docs', DocumentationPage::$sourceDirectory);
+        $this->assertEquals('_pages', HtmlPage::sourceDirectory());
+        $this->assertEquals('_pages', BladePage::sourceDirectory());
+        $this->assertEquals('_pages', MarkdownPage::sourceDirectory());
+        $this->assertEquals('_posts', MarkdownPost::sourceDirectory());
+        $this->assertEquals('_docs', DocumentationPage::sourceDirectory());
     }
 
     public function test_source_directories_can_be_changed_programmatically()
@@ -35,11 +35,11 @@ class SourceDirectoriesCanBeChangedTest extends TestCase
         MarkdownPost::setSourceDirectory('.source/posts');
         DocumentationPage::setSourceDirectory('.source/docs');
 
-        $this->assertEquals('.source/pages', HtmlPage::$sourceDirectory);
-        $this->assertEquals('.source/pages', BladePage::$sourceDirectory);
-        $this->assertEquals('.source/pages', MarkdownPage::$sourceDirectory);
-        $this->assertEquals('.source/posts', MarkdownPost::$sourceDirectory);
-        $this->assertEquals('.source/docs', DocumentationPage::$sourceDirectory);
+        $this->assertEquals('.source/pages', HtmlPage::sourceDirectory());
+        $this->assertEquals('.source/pages', BladePage::sourceDirectory());
+        $this->assertEquals('.source/pages', MarkdownPage::sourceDirectory());
+        $this->assertEquals('.source/posts', MarkdownPost::sourceDirectory());
+        $this->assertEquals('.source/docs', DocumentationPage::sourceDirectory());
     }
 
     public function test_source_directories_can_be_changed_in_config()
@@ -54,11 +54,11 @@ class SourceDirectoriesCanBeChangedTest extends TestCase
 
         (new HydeServiceProvider($this->app))->register();
 
-        $this->assertEquals('.source/pages', HtmlPage::$sourceDirectory);
-        $this->assertEquals('.source/pages', BladePage::$sourceDirectory);
-        $this->assertEquals('.source/pages', MarkdownPage::$sourceDirectory);
-        $this->assertEquals('.source/posts', MarkdownPost::$sourceDirectory);
-        $this->assertEquals('.source/docs', DocumentationPage::$sourceDirectory);
+        $this->assertEquals('.source/pages', HtmlPage::sourceDirectory());
+        $this->assertEquals('.source/pages', BladePage::sourceDirectory());
+        $this->assertEquals('.source/pages', MarkdownPage::sourceDirectory());
+        $this->assertEquals('.source/posts', MarkdownPost::sourceDirectory());
+        $this->assertEquals('.source/docs', DocumentationPage::sourceDirectory());
     }
 
     public function test_build_service_recognizes_changed_directory()

--- a/packages/framework/tests/Feature/StaticPageBuilderTest.php
+++ b/packages/framework/tests/Feature/StaticPageBuilderTest.php
@@ -53,7 +53,7 @@ class StaticPageBuilderTest extends TestCase
 
     public function test_can_build_blade_page()
     {
-        file_put_contents(BladePage::$sourceDirectory.'/foo.blade.php', 'bar');
+        file_put_contents(BladePage::sourceDirectory().'/foo.blade.php', 'bar');
 
         $page = new BladePage('foo');
 
@@ -62,7 +62,7 @@ class StaticPageBuilderTest extends TestCase
         $this->assertFileExists(Hyde::path('_site/foo.html'));
         $this->assertStringEqualsFile(Hyde::path('_site/foo.html'), 'bar');
 
-        unlink(BladePage::$sourceDirectory.'/foo.blade.php');
+        unlink(BladePage::sourceDirectory().'/foo.blade.php');
         Hyde::unlink('_site/foo.html');
     }
 

--- a/packages/framework/tests/Unit/ConfigFileTest.php
+++ b/packages/framework/tests/Unit/ConfigFileTest.php
@@ -50,7 +50,7 @@ class ConfigFileTest extends TestCase
     public function test_default_source_directories_values_cover_all_core_extension_classes()
     {
         expect($this->getConfig('source_directories'))->toBe(collect(HydeCoreExtension::getPageClasses())
-            ->mapWithKeys(fn ($pageClass) => [$pageClass => $pageClass::$sourceDirectory])
+            ->mapWithKeys(fn ($pageClass) => [$pageClass => $pageClass::sourceDirectory()])
             ->toArray()
         );
     }

--- a/packages/framework/tests/Unit/ConfigFileTest.php
+++ b/packages/framework/tests/Unit/ConfigFileTest.php
@@ -69,7 +69,7 @@ class ConfigFileTest extends TestCase
     public function test_default_output_directories_values_cover_all_core_extension_classes()
     {
         expect($this->getConfig('output_directories'))->toBe(collect(HydeCoreExtension::getPageClasses())
-            ->mapWithKeys(fn ($pageClass) => [$pageClass => $pageClass::$outputDirectory])
+            ->mapWithKeys(fn ($pageClass) => [$pageClass => $pageClass::outputDirectory()])
             ->toArray()
         );
     }

--- a/packages/framework/tests/Unit/SourceFilesInCustomDirectoriesCanBeCompiledTest.php
+++ b/packages/framework/tests/Unit/SourceFilesInCustomDirectoriesCanBeCompiledTest.php
@@ -38,7 +38,7 @@ class SourceFilesInCustomDirectoriesCanBeCompiledTest extends TestCase
         mkdir(Hyde::path('testSourceDir/blog'));
         Hyde::touch('testSourceDir/blog/test.md');
 
-        MarkdownPost::$sourceDirectory = 'testSourceDir/blog';
+        MarkdownPost::setSourceDirectory('testSourceDir/blog');
 
         new StaticPageBuilder(
             MarkdownPost::parse('test'),
@@ -54,7 +54,7 @@ class SourceFilesInCustomDirectoriesCanBeCompiledTest extends TestCase
         mkdir(Hyde::path('testSourceDir/pages'));
         Hyde::touch('testSourceDir/pages/test.md');
 
-        MarkdownPage::$sourceDirectory = 'testSourceDir/pages';
+        MarkdownPage::setSourceDirectory('testSourceDir/pages');
 
         new StaticPageBuilder(
             MarkdownPage::parse('test'),
@@ -70,7 +70,7 @@ class SourceFilesInCustomDirectoriesCanBeCompiledTest extends TestCase
         mkdir(Hyde::path('testSourceDir/documentation'));
         Hyde::touch('testSourceDir/documentation/test.md');
 
-        DocumentationPage::$sourceDirectory = 'testSourceDir/documentation';
+        DocumentationPage::setSourceDirectory('testSourceDir/documentation');
 
         new StaticPageBuilder(
             DocumentationPage::parse('test'),
@@ -86,7 +86,7 @@ class SourceFilesInCustomDirectoriesCanBeCompiledTest extends TestCase
         mkdir(Hyde::path('testSourceDir/blade'));
         Hyde::touch('testSourceDir/blade/test.blade.php');
 
-        BladePage::$sourceDirectory = 'testSourceDir/blade';
+        BladePage::setSourceDirectory('testSourceDir/blade');
         Config::set('view.paths', ['testSourceDir/blade']);
 
         new StaticPageBuilder(


### PR DESCRIPTION
### Abstract

To scope down the public API, the discovery information properties will be made protected, which is breaking, but will fix https://github.com/hydephp/develop/issues/1010. They may also be moved down to the classes that are discoverable, possibly via a trait or (unlikely a new base class)

### API Change

```php
// Before
HydePage::$sourceDirectory;
HydePage::$sourceDirectory = 'foo';

// After
HydePage::sourceDirectory();
HydePage::setSourceDirectory('foo');
```

### Benefits:

- Only one canonical place to get the source information (just getter, not getter or property)
- Can normalize and validate input using setter

### Drawbacks:
- Needs setter which adds extra methods
- No PhpStorm default value hint when using accessor<br>
  &nbsp; &nbsp; ![image](https://user-images.githubusercontent.com/95144705/218426657-dd6ad51a-5d6f-4d2e-9944-71f62c231e38.png)
  &nbsp; &nbsp; _We would lose this, but maybe there's an annotation we can use instead?_

### Upgrade path:
Note that HydePage is a base class, so replacements must be made on its inheritors as well. (Searching for `::$sourceDirectory`, etc, across files makes this a breeze)

- Replace `HydePage::$sourceDirectory = $var` usages with `HydePage::setSourceDirectory($var)`
- Replace `HydePage::$outputDirectory = $var` usages with `HydePage::setOutputDirectory($var)`
- Replace `HydePage::$fileExtension = $var` usages with `HydePage::setFileExtension($var)`
- Replace `HydePage::$sourceDirectory` usages with `HydePage::sourceDirectory()`
- Replace `HydePage::$outputDirectory` usages with `HydePage::outputDirectory()`
- Replace `HydePage::$fileExtension` usages with `HydePage::fileExtension()`

You can also use this regex created by ChatGPT to make the replacements automatically, (tested in PhpStorm search+replace across files), just substitute the variable names for each replacement.

```
Search: (\b\w+::)\$sourceDirectory\s*=\s*(.+?);
Replace: $1setSourceDirectory($2);
```
