### PR TITLE
Determine discoverable state depending on interface implementation

### DIFF
--- a/packages/framework/src/Pages/Concerns/HydePage.php
+++ b/packages/framework/src/Pages/Concerns/HydePage.php
@@ -79,9 +79,7 @@ abstract class HydePage implements PageSchema, DiscoverableContract
 
     public static function isDiscoverable(): bool
     {
-        // TODO: Check if static implements DiscoverableContract
-
-        return isset(static::$sourceDirectory, static::$outputDirectory, static::$fileExtension) && filled(static::$sourceDirectory);
+        return in_array(DiscoverableContract::class, class_implements(static::class));
     }
 
     // Section: Query

--- a/packages/framework/tests/Feature/HydePageTest.php
+++ b/packages/framework/tests/Feature/HydePageTest.php
@@ -1063,18 +1063,8 @@ class HydePageTest extends TestCase
 
     public function test_is_discoverable_method_returns_false_for_non_discoverable_pages()
     {
+        $this->markTestSkipped('Condition is always true at the moment.');
         $this->assertFalse(NonDiscoverablePage::isDiscoverable());
-    }
-
-    public function test_is_discoverable_method_requires_all_required_data_to_be_present()
-    {
-        $this->assertFalse(PartiallyDiscoverablePage::isDiscoverable());
-    }
-
-    /** @deprecated */
-    public function test_is_discoverable_method_requires_source_directory_to_be_filled()
-    {
-        $this->assertFalse(DiscoverablePageWithInvalidSourceDirectory::isDiscoverable());
     }
 
     public function test_all_core_extension_pages_are_discoverable()
@@ -1133,45 +1123,6 @@ class ConfigurableSourcesTestPage extends HydePage
 class DiscoverablePage extends HydePage
 {
     protected static string $sourceDirectory = 'foo';
-    protected static string $outputDirectory = '';
-    protected static string $fileExtension = '';
-
-    public function compile(): string
-    {
-        return '';
-    }
-}
-
-/** @deprecated */
-class NonDiscoverablePage extends HydePage
-{
-    protected static string $sourceDirectory;
-    protected static string $outputDirectory;
-    protected static string $fileExtension;
-
-    public function compile(): string
-    {
-        return '';
-    }
-}
-
-/** @deprecated */
-class PartiallyDiscoverablePage extends HydePage
-{
-    protected static string $sourceDirectory = 'foo';
-    protected static string $outputDirectory;
-    protected static string $fileExtension;
-
-    public function compile(): string
-    {
-        return '';
-    }
-}
-
-/** @deprecated */
-class DiscoverablePageWithInvalidSourceDirectory extends HydePage
-{
-    protected static string $sourceDirectory = '';
     protected static string $outputDirectory = '';
     protected static string $fileExtension = '';
 


### PR DESCRIPTION
This implicit dynamic state became obsolete by https://github.com/hydephp/develop/pull/1061 as state now does not need to be calculated as contracted implementations are forced to implement discovery data.

This partially reverts PR https://github.com/hydephp/develop/pull/1019.