### PR TITLE
Extract trait for Discoverable HydePages

### DIFF
--- a/packages/framework/src/Pages/Concerns/Discoverable.php
+++ b/packages/framework/src/Pages/Concerns/Discoverable.php
@@ -4,6 +4,10 @@ declare(strict_types=1);
 
 namespace Hyde\Pages\Concerns;
 
+/**
+ * This trait implements the DiscoverableContract interface,
+ * and is used by auto-discoverable HydePage classes.
+ */
 trait Discoverable
 {
     //

--- a/packages/framework/src/Pages/Concerns/Discoverable.php
+++ b/packages/framework/src/Pages/Concerns/Discoverable.php
@@ -10,5 +10,7 @@ namespace Hyde\Pages\Concerns;
  */
 trait Discoverable
 {
-    //
+    protected static string $sourceDirectory;
+    protected static string $outputDirectory;
+    protected static string $fileExtension;
 }

--- a/packages/framework/src/Pages/Concerns/Discoverable.php
+++ b/packages/framework/src/Pages/Concerns/Discoverable.php
@@ -13,4 +13,52 @@ trait Discoverable
     protected static string $sourceDirectory;
     protected static string $outputDirectory;
     protected static string $fileExtension;
+
+    /**
+     * Get the directory in where source files are stored.
+     */
+    public static function sourceDirectory(): string
+    {
+        return static::$sourceDirectory;
+    }
+
+    /**
+     * Get the output subdirectory to store compiled HTML.
+     */
+    public static function outputDirectory(): string
+    {
+        return static::$outputDirectory;
+    }
+
+    /**
+     * Get the file extension of the source files.
+     */
+    public static function fileExtension(): string
+    {
+        return static::$fileExtension;
+    }
+
+    /**
+     * Set the output directory for the HydePage class.
+     */
+    public static function setSourceDirectory(string $sourceDirectory): void
+    {
+        static::$sourceDirectory = unslash($sourceDirectory);
+    }
+
+    /**
+     * Set the source directory for the HydePage class.
+     */
+    public static function setOutputDirectory(string $outputDirectory): void
+    {
+        static::$outputDirectory = unslash($outputDirectory);
+    }
+
+    /**
+     * Set the file extension for the HydePage class.
+     */
+    public static function setFileExtension(string $fileExtension): void
+    {
+        static::$fileExtension = rtrim('.'.ltrim($fileExtension, '.'), '.');
+    }
 }

--- a/packages/framework/src/Pages/Concerns/Discoverable.php
+++ b/packages/framework/src/Pages/Concerns/Discoverable.php
@@ -27,6 +27,8 @@ trait Discoverable
 
     /**
      * Get the directory in where source files are stored.
+     *
+     * @return non-empty-string
      */
     public static function sourceDirectory(): string
     {
@@ -51,6 +53,8 @@ trait Discoverable
 
     /**
      * Set the output directory for the HydePage class.
+     *
+     * @param  non-empty-string  $sourceDirectory
      */
     public static function setSourceDirectory(string $sourceDirectory): void
     {

--- a/packages/framework/src/Pages/Concerns/Discoverable.php
+++ b/packages/framework/src/Pages/Concerns/Discoverable.php
@@ -10,8 +10,19 @@ namespace Hyde\Pages\Concerns;
  */
 trait Discoverable
 {
+    /**
+     * @var non-empty-string The directory in where source files are stored. Relative to the Hyde root directory.
+     */
     protected static string $sourceDirectory;
+
+    /**
+     * @var string The output subdirectory to store compiled page HTML. Relative to the _site directory.
+     */
     protected static string $outputDirectory;
+
+    /**
+     * @var string The file extension of the source files. Normalized to include a leading dot.
+     */
     protected static string $fileExtension;
 
     /**

--- a/packages/framework/src/Pages/Concerns/Discoverable.php
+++ b/packages/framework/src/Pages/Concerns/Discoverable.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Hyde\Pages\Concerns;
+
+trait Discoverable
+{
+    //
+}

--- a/packages/framework/src/Pages/Concerns/HydePage.php
+++ b/packages/framework/src/Pages/Concerns/HydePage.php
@@ -43,6 +43,7 @@ abstract class HydePage implements PageSchema, DiscoverableContract
 {
     use InteractsWithFrontMatter;
     use HasFactory;
+    use Discoverable;
 
     protected static string $sourceDirectory;
     protected static string $outputDirectory;

--- a/packages/framework/src/Pages/Concerns/HydePage.php
+++ b/packages/framework/src/Pages/Concerns/HydePage.php
@@ -132,54 +132,6 @@ abstract class HydePage implements PageSchema, DiscoverableContract
     // Section: Filesystem
 
     /**
-     * Get the directory in where source files are stored.
-     */
-    public static function sourceDirectory(): string
-    {
-        return static::$sourceDirectory;
-    }
-
-    /**
-     * Get the output subdirectory to store compiled HTML.
-     */
-    public static function outputDirectory(): string
-    {
-        return static::$outputDirectory;
-    }
-
-    /**
-     * Get the file extension of the source files.
-     */
-    public static function fileExtension(): string
-    {
-        return static::$fileExtension;
-    }
-
-    /**
-     * Set the output directory for the HydePage class.
-     */
-    public static function setSourceDirectory(string $sourceDirectory): void
-    {
-        static::$sourceDirectory = unslash($sourceDirectory);
-    }
-
-    /**
-     * Set the source directory for the HydePage class.
-     */
-    public static function setOutputDirectory(string $outputDirectory): void
-    {
-        static::$outputDirectory = unslash($outputDirectory);
-    }
-
-    /**
-     * Set the file extension for the HydePage class.
-     */
-    public static function setFileExtension(string $fileExtension): void
-    {
-        static::$fileExtension = rtrim('.'.ltrim($fileExtension, '.'), '.');
-    }
-
-    /**
      * Qualify a page identifier into a local file path for the page source file relative to the project root.
      */
     public static function sourcePath(string $identifier): string

--- a/packages/framework/src/Pages/Concerns/HydePage.php
+++ b/packages/framework/src/Pages/Concerns/HydePage.php
@@ -45,10 +45,6 @@ abstract class HydePage implements PageSchema, DiscoverableContract
     use HasFactory;
     use Discoverable;
 
-    protected static string $sourceDirectory;
-    protected static string $outputDirectory;
-    protected static string $fileExtension;
-
     public static string $template;
 
     public string $identifier;

--- a/packages/framework/tests/Feature/HydePageTest.php
+++ b/packages/framework/tests/Feature/HydePageTest.php
@@ -26,6 +26,7 @@ use Hyde\Testing\TestCase;
  * since it's the simplest implementation.
  *
  * @covers \Hyde\Pages\Concerns\HydePage
+ * @covers \Hyde\Pages\Concerns\Discoverable
  * @covers \Hyde\Pages\Concerns\BaseMarkdownPage
  * @covers \Hyde\Framework\Factories\Concerns\HasFactory
  * @covers \Hyde\Framework\Factories\NavigationDataFactory


### PR DESCRIPTION
To scope down the public API, the discovery information properties were made protected in https://github.com/hydephp/develop/pull/1062. This PR extracts the contracted methods for classes that are discoverable, into a Discoverable trait that can be shared among HydePage child classes.