### PR TITLE
Breaking: Break out discoverable properties from HydePage base class

### DIFF
--- a/packages/framework/src/Pages/BladePage.php
+++ b/packages/framework/src/Pages/BladePage.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Hyde\Pages;
 
 use Hyde\Markdown\Models\FrontMatter;
+use Hyde\Pages\Concerns\Discoverable;
 use Hyde\Pages\Concerns\HydePage;
 use Hyde\Support\Contracts\DiscoverableContract;
 use Illuminate\Support\Facades\View;
@@ -20,6 +21,8 @@ use Illuminate\Support\Facades\View;
  */
 class BladePage extends HydePage implements DiscoverableContract
 {
+    use Discoverable;
+
     protected static string $sourceDirectory = '_pages';
     protected static string $outputDirectory = '';
     protected static string $fileExtension = '.blade.php';

--- a/packages/framework/src/Pages/BladePage.php
+++ b/packages/framework/src/Pages/BladePage.php
@@ -6,6 +6,7 @@ namespace Hyde\Pages;
 
 use Hyde\Markdown\Models\FrontMatter;
 use Hyde\Pages\Concerns\HydePage;
+use Hyde\Support\Contracts\DiscoverableContract;
 use Illuminate\Support\Facades\View;
 
 /**
@@ -17,7 +18,7 @@ use Illuminate\Support\Facades\View;
  * @see https://hydephp.com/docs/master/static-pages#creating-blade-pages
  * @see https://laravel.com/docs/master/blade
  */
-class BladePage extends HydePage
+class BladePage extends HydePage implements DiscoverableContract
 {
     protected static string $sourceDirectory = '_pages';
     protected static string $outputDirectory = '';

--- a/packages/framework/src/Pages/Concerns/BaseMarkdownPage.php
+++ b/packages/framework/src/Pages/Concerns/BaseMarkdownPage.php
@@ -8,6 +8,7 @@ use Hyde\Hyde;
 use Hyde\Markdown\Contracts\MarkdownDocumentContract;
 use Hyde\Markdown\Models\FrontMatter;
 use Hyde\Markdown\Models\Markdown;
+use Hyde\Support\Contracts\DiscoverableContract;
 
 /**
  * The base class for all Markdown-based page models.
@@ -18,7 +19,7 @@ use Hyde\Markdown\Models\Markdown;
  * @see \Hyde\Pages\Concerns\HydePage
  * @see \Hyde\Framework\Testing\Feature\HydePageTest
  */
-abstract class BaseMarkdownPage extends HydePage implements MarkdownDocumentContract
+abstract class BaseMarkdownPage extends HydePage implements MarkdownDocumentContract, DiscoverableContract
 {
     public Markdown $markdown;
 

--- a/packages/framework/src/Pages/Concerns/BaseMarkdownPage.php
+++ b/packages/framework/src/Pages/Concerns/BaseMarkdownPage.php
@@ -21,6 +21,8 @@ use Hyde\Support\Contracts\DiscoverableContract;
  */
 abstract class BaseMarkdownPage extends HydePage implements MarkdownDocumentContract, DiscoverableContract
 {
+    use Discoverable;
+
     public Markdown $markdown;
 
     protected static string $fileExtension = '.md';

--- a/packages/framework/src/Pages/Concerns/Discoverable.php
+++ b/packages/framework/src/Pages/Concerns/Discoverable.php
@@ -4,6 +4,10 @@ declare(strict_types=1);
 
 namespace Hyde\Pages\Concerns;
 
+/**
+ * This trait implements the DiscoverableContract interface,
+ * and is used by auto-discoverable HydePage classes.
+ */
 trait Discoverable
 {
     //

--- a/packages/framework/src/Pages/Concerns/Discoverable.php
+++ b/packages/framework/src/Pages/Concerns/Discoverable.php
@@ -10,5 +10,7 @@ namespace Hyde\Pages\Concerns;
  */
 trait Discoverable
 {
-    //
+    protected static string $sourceDirectory;
+    protected static string $outputDirectory;
+    protected static string $fileExtension;
 }

--- a/packages/framework/src/Pages/Concerns/Discoverable.php
+++ b/packages/framework/src/Pages/Concerns/Discoverable.php
@@ -13,4 +13,52 @@ trait Discoverable
     protected static string $sourceDirectory;
     protected static string $outputDirectory;
     protected static string $fileExtension;
+
+    /**
+     * Get the directory in where source files are stored.
+     */
+    public static function sourceDirectory(): string
+    {
+        return static::$sourceDirectory;
+    }
+
+    /**
+     * Get the output subdirectory to store compiled HTML.
+     */
+    public static function outputDirectory(): string
+    {
+        return static::$outputDirectory;
+    }
+
+    /**
+     * Get the file extension of the source files.
+     */
+    public static function fileExtension(): string
+    {
+        return static::$fileExtension;
+    }
+
+    /**
+     * Set the output directory for the HydePage class.
+     */
+    public static function setSourceDirectory(string $sourceDirectory): void
+    {
+        static::$sourceDirectory = unslash($sourceDirectory);
+    }
+
+    /**
+     * Set the source directory for the HydePage class.
+     */
+    public static function setOutputDirectory(string $outputDirectory): void
+    {
+        static::$outputDirectory = unslash($outputDirectory);
+    }
+
+    /**
+     * Set the file extension for the HydePage class.
+     */
+    public static function setFileExtension(string $fileExtension): void
+    {
+        static::$fileExtension = rtrim('.'.ltrim($fileExtension, '.'), '.');
+    }
 }

--- a/packages/framework/src/Pages/Concerns/Discoverable.php
+++ b/packages/framework/src/Pages/Concerns/Discoverable.php
@@ -27,6 +27,8 @@ trait Discoverable
 
     /**
      * Get the directory in where source files are stored.
+     *
+     * @return non-empty-string
      */
     public static function sourceDirectory(): string
     {
@@ -51,6 +53,8 @@ trait Discoverable
 
     /**
      * Set the output directory for the HydePage class.
+     *
+     * @param  non-empty-string  $sourceDirectory
      */
     public static function setSourceDirectory(string $sourceDirectory): void
     {

--- a/packages/framework/src/Pages/Concerns/Discoverable.php
+++ b/packages/framework/src/Pages/Concerns/Discoverable.php
@@ -10,8 +10,19 @@ namespace Hyde\Pages\Concerns;
  */
 trait Discoverable
 {
+    /**
+     * @var non-empty-string The directory in where source files are stored. Relative to the Hyde root directory.
+     */
     protected static string $sourceDirectory;
+
+    /**
+     * @var string The output subdirectory to store compiled page HTML. Relative to the _site directory.
+     */
     protected static string $outputDirectory;
+
+    /**
+     * @var string The file extension of the source files. Normalized to include a leading dot.
+     */
     protected static string $fileExtension;
 
     /**

--- a/packages/framework/src/Pages/Concerns/Discoverable.php
+++ b/packages/framework/src/Pages/Concerns/Discoverable.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Hyde\Pages\Concerns;
+
+trait Discoverable
+{
+    //
+}

--- a/packages/framework/src/Pages/Concerns/HydePage.php
+++ b/packages/framework/src/Pages/Concerns/HydePage.php
@@ -43,6 +43,7 @@ abstract class HydePage implements PageSchema, DiscoverableContract
 {
     use InteractsWithFrontMatter;
     use HasFactory;
+    use Discoverable;
 
     protected static string $sourceDirectory;
     protected static string $outputDirectory;

--- a/packages/framework/src/Pages/Concerns/HydePage.php
+++ b/packages/framework/src/Pages/Concerns/HydePage.php
@@ -144,6 +144,8 @@ abstract class HydePage implements PageSchema, DiscoverableContract
      */
     public static function sourceDirectory(): string
     {
+        // Todo: This will no longer be normalized here
+
         return unslash(static::$sourceDirectory);
     }
 
@@ -152,6 +154,8 @@ abstract class HydePage implements PageSchema, DiscoverableContract
      */
     public static function outputDirectory(): string
     {
+        // Todo: This will no longer be normalized here
+
         return unslash(static::$outputDirectory);
     }
 
@@ -160,6 +164,8 @@ abstract class HydePage implements PageSchema, DiscoverableContract
      */
     public static function fileExtension(): string
     {
+        // Todo: This will no longer be normalized here
+
         return rtrim('.'.ltrim(static::$fileExtension, '.'), '.');
     }
 

--- a/packages/framework/src/Pages/Concerns/HydePage.php
+++ b/packages/framework/src/Pages/Concerns/HydePage.php
@@ -132,54 +132,6 @@ abstract class HydePage implements PageSchema, DiscoverableContract
     // Section: Filesystem
 
     /**
-     * Get the directory in where source files are stored.
-     */
-    public static function sourceDirectory(): string
-    {
-        return static::$sourceDirectory;
-    }
-
-    /**
-     * Get the output subdirectory to store compiled HTML.
-     */
-    public static function outputDirectory(): string
-    {
-        return static::$outputDirectory;
-    }
-
-    /**
-     * Get the file extension of the source files.
-     */
-    public static function fileExtension(): string
-    {
-        return static::$fileExtension;
-    }
-
-    /**
-     * Set the output directory for the HydePage class.
-     */
-    public static function setSourceDirectory(string $sourceDirectory): void
-    {
-        static::$sourceDirectory = unslash($sourceDirectory);
-    }
-
-    /**
-     * Set the source directory for the HydePage class.
-     */
-    public static function setOutputDirectory(string $outputDirectory): void
-    {
-        static::$outputDirectory = unslash($outputDirectory);
-    }
-
-    /**
-     * Set the file extension for the HydePage class.
-     */
-    public static function setFileExtension(string $fileExtension): void
-    {
-        static::$fileExtension = rtrim('.'.ltrim($fileExtension, '.'), '.');
-    }
-
-    /**
      * Qualify a page identifier into a local file path for the page source file relative to the project root.
      */
     public static function sourcePath(string $identifier): string

--- a/packages/framework/src/Pages/Concerns/HydePage.php
+++ b/packages/framework/src/Pages/Concerns/HydePage.php
@@ -42,7 +42,6 @@ abstract class HydePage implements PageSchema
 {
     use InteractsWithFrontMatter;
     use HasFactory;
-    use Discoverable;
 
     public static string $template;
 

--- a/packages/framework/src/Pages/Concerns/HydePage.php
+++ b/packages/framework/src/Pages/Concerns/HydePage.php
@@ -45,10 +45,6 @@ abstract class HydePage implements PageSchema, DiscoverableContract
     use HasFactory;
     use Discoverable;
 
-    protected static string $sourceDirectory;
-    protected static string $outputDirectory;
-    protected static string $fileExtension;
-
     public static string $template;
 
     public string $identifier;

--- a/packages/framework/src/Pages/Concerns/HydePage.php
+++ b/packages/framework/src/Pages/Concerns/HydePage.php
@@ -139,9 +139,7 @@ abstract class HydePage implements PageSchema, DiscoverableContract
      */
     public static function sourceDirectory(): string
     {
-        // Todo: This will no longer be normalized here
-
-        return unslash(static::$sourceDirectory);
+        return static::$sourceDirectory;
     }
 
     /**
@@ -149,9 +147,7 @@ abstract class HydePage implements PageSchema, DiscoverableContract
      */
     public static function outputDirectory(): string
     {
-        // Todo: This will no longer be normalized here
-
-        return unslash(static::$outputDirectory);
+        return static::$outputDirectory;
     }
 
     /**
@@ -159,9 +155,7 @@ abstract class HydePage implements PageSchema, DiscoverableContract
      */
     public static function fileExtension(): string
     {
-        // Todo: This will no longer be normalized here
-
-        return rtrim('.'.ltrim(static::$fileExtension, '.'), '.');
+        return static::$fileExtension;
     }
 
     /**

--- a/packages/framework/src/Pages/Concerns/HydePage.php
+++ b/packages/framework/src/Pages/Concerns/HydePage.php
@@ -164,7 +164,7 @@ abstract class HydePage implements PageSchema, DiscoverableContract
     }
 
     /**
-     * Get the output directory for the HydePage class.
+     * Set the output directory for the HydePage class.
      */
     public static function setSourceDirectory(string $sourceDirectory): void
     {

--- a/packages/framework/src/Pages/Concerns/HydePage.php
+++ b/packages/framework/src/Pages/Concerns/HydePage.php
@@ -15,7 +15,6 @@ use Hyde\Framework\Services\DiscoveryService;
 use Hyde\Hyde;
 use Hyde\Markdown\Contracts\FrontMatter\PageSchema;
 use Hyde\Markdown\Models\FrontMatter;
-use Hyde\Support\Contracts\DiscoverableContract;
 use Hyde\Support\Models\Route;
 use Hyde\Support\Models\RouteKey;
 use function unslash;
@@ -39,7 +38,7 @@ use function unslash;
  * @see \Hyde\Pages\Concerns\BaseMarkdownPage
  * @see \Hyde\Framework\Testing\Feature\HydePageTest
  */
-abstract class HydePage implements PageSchema, DiscoverableContract
+abstract class HydePage implements PageSchema
 {
     use InteractsWithFrontMatter;
     use HasFactory;

--- a/packages/framework/src/Pages/Concerns/HydePage.php
+++ b/packages/framework/src/Pages/Concerns/HydePage.php
@@ -168,7 +168,7 @@ abstract class HydePage implements PageSchema, DiscoverableContract
      */
     public static function setSourceDirectory(string $sourceDirectory): void
     {
-        static::$sourceDirectory = $sourceDirectory;
+        static::$sourceDirectory = unslash($sourceDirectory);
     }
 
     /**
@@ -176,7 +176,7 @@ abstract class HydePage implements PageSchema, DiscoverableContract
      */
     public static function setOutputDirectory(string $outputDirectory): void
     {
-        static::$outputDirectory = $outputDirectory;
+        static::$outputDirectory = unslash($outputDirectory);
     }
 
     /**
@@ -184,7 +184,7 @@ abstract class HydePage implements PageSchema, DiscoverableContract
      */
     public static function setFileExtension(string $fileExtension): void
     {
-        static::$fileExtension = $fileExtension;
+        static::$fileExtension = rtrim('.'.ltrim($fileExtension, '.'), '.');
     }
 
     /**

--- a/packages/framework/src/Pages/HtmlPage.php
+++ b/packages/framework/src/Pages/HtmlPage.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Hyde\Pages;
 
 use Hyde\Pages\Concerns\HydePage;
+use Hyde\Support\Contracts\DiscoverableContract;
 
 /**
  * Page class for HTML pages.
@@ -14,7 +15,7 @@ use Hyde\Pages\Concerns\HydePage;
  *
  * @see https://hydephp.com/docs/master/static-pages#bonus-creating-html-pages
  */
-class HtmlPage extends HydePage
+class HtmlPage extends HydePage implements DiscoverableContract
 {
     protected static string $sourceDirectory = '_pages';
     protected static string $outputDirectory = '';

--- a/packages/framework/src/Pages/HtmlPage.php
+++ b/packages/framework/src/Pages/HtmlPage.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Hyde\Pages;
 
+use Hyde\Pages\Concerns\Discoverable;
 use Hyde\Pages\Concerns\HydePage;
 use Hyde\Support\Contracts\DiscoverableContract;
 
@@ -17,6 +18,8 @@ use Hyde\Support\Contracts\DiscoverableContract;
  */
 class HtmlPage extends HydePage implements DiscoverableContract
 {
+    use Discoverable;
+
     protected static string $sourceDirectory = '_pages';
     protected static string $outputDirectory = '';
     protected static string $fileExtension = '.html';

--- a/packages/framework/tests/Feature/HydePageTest.php
+++ b/packages/framework/tests/Feature/HydePageTest.php
@@ -1098,6 +1098,19 @@ class TestPage extends HydePage
     }
 }
 
+class ConfigurableSourcesTestPage extends HydePage
+{
+    public static string $sourceDirectory;
+    public static string $outputDirectory;
+    public static string $fileExtension;
+    public static string $template;
+
+    public function compile(): string
+    {
+        return '';
+    }
+}
+
 /** @deprecated */
 class DiscoverablePage extends HydePage
 {

--- a/packages/framework/tests/Feature/HydePageTest.php
+++ b/packages/framework/tests/Feature/HydePageTest.php
@@ -26,6 +26,7 @@ use Hyde\Testing\TestCase;
  * since it's the simplest implementation.
  *
  * @covers \Hyde\Pages\Concerns\HydePage
+ * @covers \Hyde\Pages\Concerns\Discoverable
  * @covers \Hyde\Pages\Concerns\BaseMarkdownPage
  * @covers \Hyde\Framework\Factories\Concerns\HasFactory
  * @covers \Hyde\Framework\Factories\NavigationDataFactory

--- a/packages/framework/tests/Feature/HydePageTest.php
+++ b/packages/framework/tests/Feature/HydePageTest.php
@@ -230,17 +230,20 @@ class HydePageTest extends TestCase
         $this->assertEquals('foo', $page->getIdentifier());
     }
 
-    public function test_set_source_directory() {
+    public function test_set_source_directory()
+    {
         ConfigurableSourcesTestPage::setSourceDirectory('foo');
         $this->assertEquals('foo', ConfigurableSourcesTestPage::sourceDirectory());
     }
 
-    public function test_set_output_directory() {
+    public function test_set_output_directory()
+    {
         ConfigurableSourcesTestPage::setOutputDirectory('foo');
         $this->assertEquals('foo', ConfigurableSourcesTestPage::outputDirectory());
     }
 
-    public function test_set_file_extension() {
+    public function test_set_file_extension()
+    {
         ConfigurableSourcesTestPage::setFileExtension('.foo');
         $this->assertEquals('.foo', ConfigurableSourcesTestPage::fileExtension());
     }

--- a/packages/framework/tests/Feature/HydePageTest.php
+++ b/packages/framework/tests/Feature/HydePageTest.php
@@ -230,6 +230,21 @@ class HydePageTest extends TestCase
         $this->assertEquals('foo', $page->getIdentifier());
     }
 
+    public function test_set_source_directory() {
+        ConfigurableSourcesTestPage::setSourceDirectory('foo');
+        $this->assertEquals('foo', ConfigurableSourcesTestPage::sourceDirectory());
+    }
+
+    public function test_set_output_directory() {
+        ConfigurableSourcesTestPage::setOutputDirectory('foo');
+        $this->assertEquals('foo', ConfigurableSourcesTestPage::outputDirectory());
+    }
+
+    public function test_set_file_extension() {
+        ConfigurableSourcesTestPage::setFileExtension('.foo');
+        $this->assertEquals('.foo', ConfigurableSourcesTestPage::fileExtension());
+    }
+
     public function test_static_get_method_returns_discovered_page()
     {
         $this->assertEquals(BladePage::parse('index'), BladePage::get('index'));

--- a/packages/framework/tests/Feature/HydePageTest.php
+++ b/packages/framework/tests/Feature/HydePageTest.php
@@ -182,7 +182,7 @@ class HydePageTest extends TestCase
         $this->resetDirectoryConfiguration();
     }
 
-    public function test_get_source_directory_trims_trailing_slashes()
+    public function test_set_source_directory_trims_trailing_slashes()
     {
         MarkdownPage::setSourceDirectory('/foo/\\');
         $this->assertEquals('foo', MarkdownPage::sourceDirectory());
@@ -196,7 +196,7 @@ class HydePageTest extends TestCase
         $this->resetDirectoryConfiguration();
     }
 
-    public function test_get_output_directory_trims_trailing_slashes()
+    public function test_set_output_directory_trims_trailing_slashes()
     {
         MarkdownPage::setOutputDirectory('/foo/\\');
         $this->assertEquals('foo', MarkdownPage::outputDirectory());
@@ -210,14 +210,14 @@ class HydePageTest extends TestCase
         $this->resetDirectoryConfiguration();
     }
 
-    public function test_get_file_extension_forces_leading_period()
+    public function test_set_file_extension_forces_leading_period()
     {
         MarkdownPage::setFileExtension('foo');
         $this->assertEquals('.foo', MarkdownPage::fileExtension());
         $this->resetDirectoryConfiguration();
     }
 
-    public function test_get_file_extension_removes_trailing_period()
+    public function test_set_file_extension_removes_trailing_period()
     {
         MarkdownPage::setFileExtension('foo.');
         $this->assertEquals('.foo', MarkdownPage::fileExtension());


### PR DESCRIPTION
Changes the HydePage classes to use the Discoverable trait added in https://github.com/hydephp/develop/pull/1066 so that only discoverable pages use the trait, not the base HydePage class.