### PR TITLE
Revert breaking output directory changes

### DIFF
--- a/docs/advanced-features/page-models.md
+++ b/docs/advanced-features/page-models.md
@@ -34,7 +34,7 @@ Don't worry if you don't understand everything yet, we'll talk more about these 
 class MarkdownPost extends BaseMarkdownPage
 {
     protected static string $sourceDirectory = '_posts';
-    protected static string $outputDirectory = 'posts';
+    public static string $outputDirectory = 'posts';
     protected static string $fileExtension = '.md';
     public static string $template = 'post';
     
@@ -61,7 +61,7 @@ Let's again take the simplified `MarkdownPost` class as an example, this time on
 class MarkdownPost extends BaseMarkdownPage
 {
     protected static string $sourceDirectory = '_posts';
-    protected static string $outputDirectory = 'posts';
+    public static string $outputDirectory = 'posts';
     protected static string $fileExtension = '.md';
     public static string $template = 'post';
 }

--- a/packages/framework/src/Pages/BladePage.php
+++ b/packages/framework/src/Pages/BladePage.php
@@ -20,7 +20,7 @@ use Illuminate\Support\Facades\View;
 class BladePage extends DiscoverablePage
 {
     protected static string $sourceDirectory = '_pages';
-    protected static string $outputDirectory = '';
+    public static string $outputDirectory = '';
     protected static string $fileExtension = '.blade.php';
 
     /**

--- a/packages/framework/src/Pages/Concerns/DiscoverablePage.php
+++ b/packages/framework/src/Pages/Concerns/DiscoverablePage.php
@@ -18,11 +18,6 @@ abstract class DiscoverablePage extends HydePage implements DiscoverableContract
     protected static string $sourceDirectory;
 
     /**
-     * @var string The output subdirectory to store compiled page HTML. Relative to the _site directory.
-     */
-    public static string $outputDirectory;
-
-    /**
      * @var string The file extension of the source files. Normalized to include a leading dot.
      */
     protected static string $fileExtension;
@@ -35,14 +30,6 @@ abstract class DiscoverablePage extends HydePage implements DiscoverableContract
     public static function sourceDirectory(): string
     {
         return static::$sourceDirectory;
-    }
-
-    /**
-     * Get the output subdirectory to store compiled HTML.
-     */
-    public static function outputDirectory(): string
-    {
-        return static::$outputDirectory;
     }
 
     /**
@@ -61,14 +48,6 @@ abstract class DiscoverablePage extends HydePage implements DiscoverableContract
     public static function setSourceDirectory(string $sourceDirectory): void
     {
         static::$sourceDirectory = unslash($sourceDirectory);
-    }
-
-    /**
-     * Set the source directory for the HydePage class.
-     */
-    public static function setOutputDirectory(string $outputDirectory): void
-    {
-        static::$outputDirectory = unslash($outputDirectory);
     }
 
     /**

--- a/packages/framework/src/Pages/Concerns/DiscoverablePage.php
+++ b/packages/framework/src/Pages/Concerns/DiscoverablePage.php
@@ -20,7 +20,7 @@ abstract class DiscoverablePage extends HydePage implements DiscoverableContract
     /**
      * @var string The output subdirectory to store compiled page HTML. Relative to the _site directory.
      */
-    protected static string $outputDirectory;
+    public static string $outputDirectory;
 
     /**
      * @var string The file extension of the source files. Normalized to include a leading dot.

--- a/packages/framework/src/Pages/Concerns/HydePage.php
+++ b/packages/framework/src/Pages/Concerns/HydePage.php
@@ -44,6 +44,7 @@ abstract class HydePage implements PageSchema
     use InteractsWithFrontMatter;
     use HasFactory;
 
+    public static string $outputDirectory;
     public static string $template;
 
     public string $identifier;
@@ -127,6 +128,22 @@ abstract class HydePage implements PageSchema
     }
 
     // Section: Filesystem
+
+    /**
+     * Get the output subdirectory to store compiled HTML.
+     */
+    public static function outputDirectory(): string
+    {
+        return static::$outputDirectory;
+    }
+
+    /**
+     * Set the source directory for the HydePage class.
+     */
+    public static function setOutputDirectory(string $outputDirectory): void
+    {
+        static::$outputDirectory = unslash($outputDirectory);
+    }
 
     /**
      * Qualify a page identifier into a local file path for the page source file relative to the project root.

--- a/packages/framework/src/Pages/Concerns/HydePage.php
+++ b/packages/framework/src/Pages/Concerns/HydePage.php
@@ -15,6 +15,7 @@ use Hyde\Framework\Services\DiscoveryService;
 use Hyde\Hyde;
 use Hyde\Markdown\Contracts\FrontMatter\PageSchema;
 use Hyde\Markdown\Models\FrontMatter;
+use Hyde\Support\Contracts\DiscoverableContract;
 use Hyde\Support\Models\Route;
 use Hyde\Support\Models\RouteKey;
 use function unslash;

--- a/packages/framework/src/Pages/DocumentationPage.php
+++ b/packages/framework/src/Pages/DocumentationPage.php
@@ -21,7 +21,7 @@ class DocumentationPage extends BaseMarkdownPage
     use Concerns\UsesFlattenedOutputPaths;
 
     protected static string $sourceDirectory = '_docs';
-    protected static string $outputDirectory = 'docs';
+    public static string $outputDirectory = 'docs';
     public static string $template = 'hyde::layouts/docs';
 
     public static function home(): ?Route

--- a/packages/framework/src/Pages/HtmlPage.php
+++ b/packages/framework/src/Pages/HtmlPage.php
@@ -17,7 +17,7 @@ use Hyde\Pages\Concerns\DiscoverablePage;
 class HtmlPage extends DiscoverablePage
 {
     protected static string $sourceDirectory = '_pages';
-    protected static string $outputDirectory = '';
+    public static string $outputDirectory = '';
     protected static string $fileExtension = '.html';
 
     public function contents(): string

--- a/packages/framework/src/Pages/InMemoryPage.php
+++ b/packages/framework/src/Pages/InMemoryPage.php
@@ -26,7 +26,7 @@ use Illuminate\Support\Facades\View;
 class InMemoryPage extends HydePage
 {
     protected static string $sourceDirectory = '';
-    protected static string $outputDirectory = '';
+    public static string $outputDirectory = '';
     protected static string $fileExtension = '';
 
     protected string $contents;

--- a/packages/framework/src/Pages/MarkdownPage.php
+++ b/packages/framework/src/Pages/MarkdownPage.php
@@ -17,6 +17,6 @@ use Hyde\Pages\Concerns\BaseMarkdownPage;
 class MarkdownPage extends BaseMarkdownPage
 {
     protected static string $sourceDirectory = '_pages';
-    protected static string $outputDirectory = '';
+    public static string $outputDirectory = '';
     public static string $template = 'hyde::layouts/page';
 }

--- a/packages/framework/src/Pages/MarkdownPost.php
+++ b/packages/framework/src/Pages/MarkdownPost.php
@@ -22,7 +22,7 @@ use Hyde\Support\Models\DateString;
 class MarkdownPost extends BaseMarkdownPage implements BlogPostSchema
 {
     protected static string $sourceDirectory = '_posts';
-    protected static string $outputDirectory = 'posts';
+    public static string $outputDirectory = 'posts';
     public static string $template = 'hyde::layouts/post';
 
     public ?string $description;

--- a/packages/framework/tests/Feature/HydeExtensionFeatureTest.php
+++ b/packages/framework/tests/Feature/HydeExtensionFeatureTest.php
@@ -269,7 +269,7 @@ class InspectableTestExtension extends HydeExtension
 class HydeExtensionTestPage extends HydePage
 {
     protected static string $sourceDirectory = 'foo';
-    protected static string $outputDirectory = 'foo';
+    public static string $outputDirectory = 'foo';
     protected static string $fileExtension = '.txt';
 
     public function compile(): string
@@ -281,7 +281,7 @@ class HydeExtensionTestPage extends HydePage
 class TestPageClass extends HydePage
 {
     protected static string $sourceDirectory = 'foo';
-    protected static string $outputDirectory = 'foo';
+    public static string $outputDirectory = 'foo';
     protected static string $fileExtension = '.txt';
 
     public function compile(): string

--- a/packages/framework/tests/Feature/HydePageTest.php
+++ b/packages/framework/tests/Feature/HydePageTest.php
@@ -1097,7 +1097,7 @@ class HydePageTest extends TestCase
 class TestPage extends \Hyde\Pages\Concerns\DiscoverablePage
 {
     protected static string $sourceDirectory = 'source';
-    protected static string $outputDirectory = 'output';
+    public static string $outputDirectory = 'output';
     protected static string $fileExtension = '.md';
     public static string $template = 'template';
 
@@ -1110,7 +1110,7 @@ class TestPage extends \Hyde\Pages\Concerns\DiscoverablePage
 class ConfigurableSourcesTestPage extends \Hyde\Pages\Concerns\DiscoverablePage
 {
     protected static string $sourceDirectory;
-    protected static string $outputDirectory;
+    public static string $outputDirectory;
     protected static string $fileExtension;
     public static string $template;
 
@@ -1124,7 +1124,7 @@ class ConfigurableSourcesTestPage extends \Hyde\Pages\Concerns\DiscoverablePage
 class DiscoverablePage extends HydePage
 {
     protected static string $sourceDirectory = 'foo';
-    protected static string $outputDirectory = '';
+    public static string $outputDirectory = '';
     protected static string $fileExtension = '';
 
     public function compile(): string

--- a/packages/framework/tests/Feature/HydePageTest.php
+++ b/packages/framework/tests/Feature/HydePageTest.php
@@ -10,6 +10,7 @@ use Hyde\Hyde;
 use Hyde\Markdown\Models\Markdown;
 use Hyde\Pages\BladePage;
 use Hyde\Pages\Concerns\BaseMarkdownPage;
+use Hyde\Pages\Concerns\DiscoverablePage;
 use Hyde\Pages\Concerns\HydePage;
 use Hyde\Pages\DocumentationPage;
 use Hyde\Pages\HtmlPage;
@@ -1064,8 +1065,7 @@ class HydePageTest extends TestCase
 
     public function test_is_discoverable_method_returns_false_for_non_discoverable_pages()
     {
-        $this->markTestSkipped('Condition is always true at the moment.');
-        $this->assertFalse(NonDiscoverablePage::isDiscoverable());
+        $this->assertFalse(NonDiscoverableTestPage::isDiscoverable());
     }
 
     public function test_all_core_extension_pages_are_discoverable()
@@ -1094,7 +1094,7 @@ class HydePageTest extends TestCase
     }
 }
 
-class TestPage extends \Hyde\Pages\Concerns\DiscoverablePage
+class TestPage extends DiscoverablePage
 {
     protected static string $sourceDirectory = 'source';
     public static string $outputDirectory = 'output';
@@ -1107,7 +1107,7 @@ class TestPage extends \Hyde\Pages\Concerns\DiscoverablePage
     }
 }
 
-class ConfigurableSourcesTestPage extends \Hyde\Pages\Concerns\DiscoverablePage
+class ConfigurableSourcesTestPage extends DiscoverablePage
 {
     protected static string $sourceDirectory;
     public static string $outputDirectory;
@@ -1120,8 +1120,7 @@ class ConfigurableSourcesTestPage extends \Hyde\Pages\Concerns\DiscoverablePage
     }
 }
 
-/** @deprecated */
-class DiscoverablePage extends HydePage
+class NonDiscoverableTestPage extends HydePage
 {
     protected static string $sourceDirectory = 'foo';
     public static string $outputDirectory = '';


### PR DESCRIPTION
This reverts some mistakes I made when thinking in the following PRs, none of which has yet been merged into master. The problem was including the outputDirectory setting when refactoring properties relating to discovery. 

This reverts some of the changes in the following PRs:
- https://github.com/hydephp/develop/pull/1061
- https://github.com/hydephp/develop/pull/1062
- https://github.com/hydephp/develop/pull/1066
- https://github.com/hydephp/develop/pull/1067
- https://github.com/hydephp/develop/pull/1068

I'm keeping commits like e4522ca53e9e90f7994ff8e868cd8e7f838e08fc and f24bfb4068e9207fc119ea658bcc9e33236d199b as they still are valid, though they are broken out of the contract and put back into the base class.

After this simplification, I will also have to reconsider which of these changes if any are overall worth it.