### PR TITLE
Revert overengineered PR changes

### DIFF
--- a/docs/advanced-features/page-models.md
+++ b/docs/advanced-features/page-models.md
@@ -33,7 +33,7 @@ Don't worry if you don't understand everything yet, we'll talk more about these 
 ```php
 class MarkdownPost extends BaseMarkdownPage
 {
-    protected static string $sourceDirectory = '_posts';
+    public static string $sourceDirectory = '_posts';
     public static string $outputDirectory = 'posts';
     protected static string $fileExtension = '.md';
     public static string $template = 'post';
@@ -60,7 +60,7 @@ Let's again take the simplified `MarkdownPost` class as an example, this time on
 ```php
 class MarkdownPost extends BaseMarkdownPage
 {
-    protected static string $sourceDirectory = '_posts';
+    public static string $sourceDirectory = '_posts';
     public static string $outputDirectory = 'posts';
     protected static string $fileExtension = '.md';
     public static string $template = 'post';

--- a/docs/advanced-features/page-models.md
+++ b/docs/advanced-features/page-models.md
@@ -35,7 +35,7 @@ class MarkdownPost extends BaseMarkdownPage
 {
     public static string $sourceDirectory = '_posts';
     public static string $outputDirectory = 'posts';
-    protected static string $fileExtension = '.md';
+    public static string $fileExtension = '.md';
     public static string $template = 'post';
     
     public string $identifier;
@@ -62,7 +62,7 @@ class MarkdownPost extends BaseMarkdownPage
 {
     public static string $sourceDirectory = '_posts';
     public static string $outputDirectory = 'posts';
-    protected static string $fileExtension = '.md';
+    public static string $fileExtension = '.md';
     public static string $template = 'post';
 }
 ```

--- a/packages/framework/src/Pages/BladePage.php
+++ b/packages/framework/src/Pages/BladePage.php
@@ -21,7 +21,7 @@ class BladePage extends HydePage
 {
     public static string $sourceDirectory = '_pages';
     public static string $outputDirectory = '';
-    protected static string $fileExtension = '.blade.php';
+    public static string $fileExtension = '.blade.php';
 
     /**
      * The name of the Blade View to compile. Commonly stored in _pages/{$identifier}.blade.php.

--- a/packages/framework/src/Pages/BladePage.php
+++ b/packages/framework/src/Pages/BladePage.php
@@ -19,7 +19,7 @@ use Illuminate\Support\Facades\View;
  */
 class BladePage extends HydePage
 {
-    protected static string $sourceDirectory = '_pages';
+    public static string $sourceDirectory = '_pages';
     public static string $outputDirectory = '';
     protected static string $fileExtension = '.blade.php';
 

--- a/packages/framework/src/Pages/Concerns/BaseMarkdownPage.php
+++ b/packages/framework/src/Pages/Concerns/BaseMarkdownPage.php
@@ -22,7 +22,7 @@ abstract class BaseMarkdownPage extends HydePage implements MarkdownDocumentCont
 {
     public Markdown $markdown;
 
-    protected static string $fileExtension = '.md';
+    public static string $fileExtension = '.md';
 
     public static function make(string $identifier = '', FrontMatter|array $matter = [], Markdown|string $markdown = ''): static
     {

--- a/packages/framework/src/Pages/Concerns/HydePage.php
+++ b/packages/framework/src/Pages/Concerns/HydePage.php
@@ -44,7 +44,7 @@ abstract class HydePage implements PageSchema
     use HasFactory;
 
     public static string $sourceDirectory;
-    protected static string $fileExtension;
+    public static string $fileExtension;
     public static string $outputDirectory;
     public static string $template;
 

--- a/packages/framework/src/Pages/Concerns/HydePage.php
+++ b/packages/framework/src/Pages/Concerns/HydePage.php
@@ -43,7 +43,7 @@ abstract class HydePage implements PageSchema
     use InteractsWithFrontMatter;
     use HasFactory;
 
-    protected static string $sourceDirectory;
+    public static string $sourceDirectory;
     protected static string $fileExtension;
     public static string $outputDirectory;
     public static string $template;

--- a/packages/framework/src/Pages/DocumentationPage.php
+++ b/packages/framework/src/Pages/DocumentationPage.php
@@ -20,7 +20,7 @@ class DocumentationPage extends BaseMarkdownPage
 {
     use Concerns\UsesFlattenedOutputPaths;
 
-    protected static string $sourceDirectory = '_docs';
+    public static string $sourceDirectory = '_docs';
     public static string $outputDirectory = 'docs';
     public static string $template = 'hyde::layouts/docs';
 

--- a/packages/framework/src/Pages/HtmlPage.php
+++ b/packages/framework/src/Pages/HtmlPage.php
@@ -18,7 +18,7 @@ class HtmlPage extends HydePage
 {
     public static string $sourceDirectory = '_pages';
     public static string $outputDirectory = '';
-    protected static string $fileExtension = '.html';
+    public static string $fileExtension = '.html';
 
     public function contents(): string
     {

--- a/packages/framework/src/Pages/HtmlPage.php
+++ b/packages/framework/src/Pages/HtmlPage.php
@@ -16,7 +16,7 @@ use Hyde\Pages\Concerns\HydePage;
  */
 class HtmlPage extends HydePage
 {
-    protected static string $sourceDirectory = '_pages';
+    public static string $sourceDirectory = '_pages';
     public static string $outputDirectory = '';
     protected static string $fileExtension = '.html';
 

--- a/packages/framework/src/Pages/InMemoryPage.php
+++ b/packages/framework/src/Pages/InMemoryPage.php
@@ -25,7 +25,7 @@ use Illuminate\Support\Facades\View;
  */
 class InMemoryPage extends HydePage
 {
-    protected static string $sourceDirectory = '';
+    public static string $sourceDirectory = '';
     public static string $outputDirectory = '';
     protected static string $fileExtension = '';
 

--- a/packages/framework/src/Pages/InMemoryPage.php
+++ b/packages/framework/src/Pages/InMemoryPage.php
@@ -27,7 +27,7 @@ class InMemoryPage extends HydePage
 {
     public static string $sourceDirectory = '';
     public static string $outputDirectory = '';
-    protected static string $fileExtension = '';
+    public static string $fileExtension = '';
 
     protected string $contents;
     protected string $view;

--- a/packages/framework/src/Pages/MarkdownPage.php
+++ b/packages/framework/src/Pages/MarkdownPage.php
@@ -16,7 +16,7 @@ use Hyde\Pages\Concerns\BaseMarkdownPage;
  */
 class MarkdownPage extends BaseMarkdownPage
 {
-    protected static string $sourceDirectory = '_pages';
+    public static string $sourceDirectory = '_pages';
     public static string $outputDirectory = '';
     public static string $template = 'hyde::layouts/page';
 }

--- a/packages/framework/src/Pages/MarkdownPost.php
+++ b/packages/framework/src/Pages/MarkdownPost.php
@@ -21,7 +21,7 @@ use Hyde\Support\Models\DateString;
  */
 class MarkdownPost extends BaseMarkdownPage implements BlogPostSchema
 {
-    protected static string $sourceDirectory = '_posts';
+    public static string $sourceDirectory = '_posts';
     public static string $outputDirectory = 'posts';
     public static string $template = 'hyde::layouts/post';
 

--- a/packages/framework/tests/Feature/HydeExtensionFeatureTest.php
+++ b/packages/framework/tests/Feature/HydeExtensionFeatureTest.php
@@ -270,7 +270,7 @@ class HydeExtensionTestPage extends HydePage
 {
     public static string $sourceDirectory = 'foo';
     public static string $outputDirectory = 'foo';
-    protected static string $fileExtension = '.txt';
+    public static string $fileExtension = '.txt';
 
     public function compile(): string
     {
@@ -282,7 +282,7 @@ class TestPageClass extends HydePage
 {
     public static string $sourceDirectory = 'foo';
     public static string $outputDirectory = 'foo';
-    protected static string $fileExtension = '.txt';
+    public static string $fileExtension = '.txt';
 
     public function compile(): string
     {

--- a/packages/framework/tests/Feature/HydeExtensionFeatureTest.php
+++ b/packages/framework/tests/Feature/HydeExtensionFeatureTest.php
@@ -268,7 +268,7 @@ class InspectableTestExtension extends HydeExtension
 
 class HydeExtensionTestPage extends HydePage
 {
-    protected static string $sourceDirectory = 'foo';
+    public static string $sourceDirectory = 'foo';
     public static string $outputDirectory = 'foo';
     protected static string $fileExtension = '.txt';
 
@@ -280,7 +280,7 @@ class HydeExtensionTestPage extends HydePage
 
 class TestPageClass extends HydePage
 {
-    protected static string $sourceDirectory = 'foo';
+    public static string $sourceDirectory = 'foo';
     public static string $outputDirectory = 'foo';
     protected static string $fileExtension = '.txt';
 

--- a/packages/framework/tests/Feature/HydePageTest.php
+++ b/packages/framework/tests/Feature/HydePageTest.php
@@ -1105,7 +1105,7 @@ class HydePageTest extends TestCase
 
 class TestPage extends HydePage
 {
-    protected static string $sourceDirectory = 'source';
+    public static string $sourceDirectory = 'source';
     public static string $outputDirectory = 'output';
     protected static string $fileExtension = '.md';
     public static string $template = 'template';
@@ -1118,7 +1118,7 @@ class TestPage extends HydePage
 
 class ConfigurableSourcesTestPage extends HydePage
 {
-    protected static string $sourceDirectory;
+    public static string $sourceDirectory;
     public static string $outputDirectory;
     protected static string $fileExtension;
     public static string $template;
@@ -1131,7 +1131,7 @@ class ConfigurableSourcesTestPage extends HydePage
 
 class DiscoverableTestPage extends HydePage
 {
-    protected static string $sourceDirectory = 'foo';
+    public static string $sourceDirectory = 'foo';
     public static string $outputDirectory = 'bar';
     protected static string $fileExtension = 'baz';
     public static string $template;
@@ -1144,7 +1144,7 @@ class DiscoverableTestPage extends HydePage
 
 class NonDiscoverableTestPage extends HydePage
 {
-    protected static string $sourceDirectory;
+    public static string $sourceDirectory;
     public static string $outputDirectory;
     protected static string $fileExtension;
 
@@ -1156,7 +1156,7 @@ class NonDiscoverableTestPage extends HydePage
 
 class PartiallyDiscoverablePage extends HydePage
 {
-    protected static string $sourceDirectory = 'foo';
+    public static string $sourceDirectory = 'foo';
     public static string $outputDirectory;
     protected static string $fileExtension;
 
@@ -1168,7 +1168,7 @@ class PartiallyDiscoverablePage extends HydePage
 
 class DiscoverablePageWithInvalidSourceDirectory extends HydePage
 {
-    protected static string $sourceDirectory = '';
+    public static string $sourceDirectory = '';
     public static string $outputDirectory = '';
     protected static string $fileExtension = '';
 

--- a/packages/framework/tests/Feature/HydePageTest.php
+++ b/packages/framework/tests/Feature/HydePageTest.php
@@ -1107,7 +1107,7 @@ class TestPage extends HydePage
 {
     public static string $sourceDirectory = 'source';
     public static string $outputDirectory = 'output';
-    protected static string $fileExtension = '.md';
+    public static string $fileExtension = '.md';
     public static string $template = 'template';
 
     public function compile(): string
@@ -1120,7 +1120,7 @@ class ConfigurableSourcesTestPage extends HydePage
 {
     public static string $sourceDirectory;
     public static string $outputDirectory;
-    protected static string $fileExtension;
+    public static string $fileExtension;
     public static string $template;
 
     public function compile(): string
@@ -1133,7 +1133,7 @@ class DiscoverableTestPage extends HydePage
 {
     public static string $sourceDirectory = 'foo';
     public static string $outputDirectory = 'bar';
-    protected static string $fileExtension = 'baz';
+    public static string $fileExtension = 'baz';
     public static string $template;
 
     public function compile(): string
@@ -1146,7 +1146,7 @@ class NonDiscoverableTestPage extends HydePage
 {
     public static string $sourceDirectory;
     public static string $outputDirectory;
-    protected static string $fileExtension;
+    public static string $fileExtension;
 
     public function compile(): string
     {
@@ -1158,7 +1158,7 @@ class PartiallyDiscoverablePage extends HydePage
 {
     public static string $sourceDirectory = 'foo';
     public static string $outputDirectory;
-    protected static string $fileExtension;
+    public static string $fileExtension;
 
     public function compile(): string
     {
@@ -1170,7 +1170,7 @@ class DiscoverablePageWithInvalidSourceDirectory extends HydePage
 {
     public static string $sourceDirectory = '';
     public static string $outputDirectory = '';
-    protected static string $fileExtension = '';
+    public static string $fileExtension = '';
 
     public function compile(): string
     {


### PR DESCRIPTION
Partially reverts PR https://github.com/hydephp/develop/pull/1062 (not yet merged into master)

- Reverts the making of public properties protected (mainly because all other properties are protected in the class, and that's not a huge problem IMO)
- It does keep the added setters as an alternative syntax (and it's still recommended* to use these as they normalize the input)

*It's actually best to use the configuration options, but if you have to modify the static properties, do it via the setters.