### PR TITLE
Rename HydePage::htmlTitle method to HydePage::title

### DIFF
--- a/packages/framework/resources/views/layouts/head.blade.php
+++ b/packages/framework/resources/views/layouts/head.blade.php
@@ -1,6 +1,6 @@
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
-<title>{{ $page->pageTitle() }}</title>
+<title>{{ $page->title() }}</title>
 
 @if (file_exists(Hyde::mediaPath('favicon.ico'))) 
 <link rel="shortcut icon" href="{{ Hyde::relativeLink('media/favicon.ico') }}" type="image/x-icon">

--- a/packages/framework/resources/views/layouts/head.blade.php
+++ b/packages/framework/resources/views/layouts/head.blade.php
@@ -1,6 +1,6 @@
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
-<title>{{ $page->htmlTitle() }}</title>
+<title>{{ $page->pageTitle() }}</title>
 
 @if (file_exists(Hyde::mediaPath('favicon.ico'))) 
 <link rel="shortcut icon" href="{{ Hyde::relativeLink('media/favicon.ico') }}" type="image/x-icon">

--- a/packages/framework/src/Framework/Features/Metadata/PageMetadataBag.php
+++ b/packages/framework/src/Framework/Features/Metadata/PageMetadataBag.php
@@ -31,8 +31,8 @@ class PageMetadataBag extends MetadataBag
         }
 
         if ($page->has('title')) {
-            $this->add(Meta::name('twitter:title', $page->htmlTitle()));
-            $this->add(Meta::property('title', $page->htmlTitle()));
+            $this->add(Meta::name('twitter:title', $page->pageTitle()));
+            $this->add(Meta::property('title', $page->pageTitle()));
         }
 
         if ($page instanceof MarkdownPost) {

--- a/packages/framework/src/Framework/Features/Metadata/PageMetadataBag.php
+++ b/packages/framework/src/Framework/Features/Metadata/PageMetadataBag.php
@@ -31,8 +31,8 @@ class PageMetadataBag extends MetadataBag
         }
 
         if ($page->has('title')) {
-            $this->add(Meta::name('twitter:title', $page->pageTitle()));
-            $this->add(Meta::property('title', $page->pageTitle()));
+            $this->add(Meta::name('twitter:title', $page->title()));
+            $this->add(Meta::property('title', $page->title()));
         }
 
         if ($page instanceof MarkdownPost) {

--- a/packages/framework/src/Pages/Concerns/HydePage.php
+++ b/packages/framework/src/Pages/Concerns/HydePage.php
@@ -306,7 +306,7 @@ abstract class HydePage implements PageSchema
     /**
      * Get the page title to display in HTML tags like <title> and <meta> tags.
      */
-    public function pageTitle(): string
+    public function title(): string
     {
         return config('hyde.name', 'HydePHP').' - '.$this->title;
     }

--- a/packages/framework/src/Pages/Concerns/HydePage.php
+++ b/packages/framework/src/Pages/Concerns/HydePage.php
@@ -305,16 +305,6 @@ abstract class HydePage implements PageSchema
 
     /**
      * Get the page title to display in HTML tags like <title> and <meta> tags.
-     *
-     * @deprecated Use pageTitle() instead.
-     */
-    public function htmlTitle(): string
-    {
-        return $this->pageTitle();
-    }
-
-    /**
-     * Get the page title to display in HTML tags like <title> and <meta> tags.
      */
     public function pageTitle(): string
     {

--- a/packages/framework/src/Pages/Concerns/HydePage.php
+++ b/packages/framework/src/Pages/Concerns/HydePage.php
@@ -313,6 +313,14 @@ abstract class HydePage implements PageSchema
         return config('hyde.name', 'HydePHP').' - '.$this->title;
     }
 
+    /**
+     * Get the page title to display in HTML tags like <title> and <meta> tags.
+     */
+    public function pageTitle(): string
+    {
+        return config('hyde.name', 'HydePHP').' - '.$this->title;
+    }
+
     public function metadata(): PageMetadataBag
     {
         return $this->metadata;

--- a/packages/framework/src/Pages/Concerns/HydePage.php
+++ b/packages/framework/src/Pages/Concerns/HydePage.php
@@ -305,6 +305,8 @@ abstract class HydePage implements PageSchema
 
     /**
      * Get the page title to display in HTML tags like <title> and <meta> tags.
+     *
+     * @todo Rename to pageTitle()?
      */
     public function htmlTitle(): string
     {

--- a/packages/framework/src/Pages/Concerns/HydePage.php
+++ b/packages/framework/src/Pages/Concerns/HydePage.php
@@ -310,7 +310,7 @@ abstract class HydePage implements PageSchema
      */
     public function htmlTitle(): string
     {
-        return config('hyde.name', 'HydePHP').' - '.$this->title;
+        return $this->pageTitle();
     }
 
     /**

--- a/packages/framework/src/Pages/Concerns/HydePage.php
+++ b/packages/framework/src/Pages/Concerns/HydePage.php
@@ -306,7 +306,7 @@ abstract class HydePage implements PageSchema
     /**
      * Get the page title to display in HTML tags like <title> and <meta> tags.
      *
-     * @todo Rename to pageTitle()?
+     * @deprecated Use pageTitle() instead.
      */
     public function htmlTitle(): string
     {

--- a/packages/framework/tests/Feature/HydePageTest.php
+++ b/packages/framework/tests/Feature/HydePageTest.php
@@ -613,14 +613,14 @@ class HydePageTest extends TestCase
     public function test_html_title_returns_site_name_plus_page_title()
     {
         $make = MarkdownPage::make('', ['title' => 'Foo']);
-        $this->assertEquals('HydePHP - Foo', $make->pageTitle());
+        $this->assertEquals('HydePHP - Foo', $make->title());
     }
 
     public function test_html_title_uses_configured_site_name()
     {
         config(['hyde.name' => 'Foo Bar']);
         $markdownPage = new MarkdownPage('Foo');
-        $this->assertEquals('Foo Bar - Foo', $markdownPage->pageTitle());
+        $this->assertEquals('Foo Bar - Foo', $markdownPage->title());
     }
 
     public function test_body_helper_returns_markdown_document_body_in_markdown_pages()

--- a/packages/framework/tests/Feature/HydePageTest.php
+++ b/packages/framework/tests/Feature/HydePageTest.php
@@ -612,13 +612,15 @@ class HydePageTest extends TestCase
 
     public function test_html_title_returns_site_name_plus_page_title()
     {
-        $this->assertEquals('HydePHP - Foo', MarkdownPage::make('', ['title' => 'Foo'])->htmlTitle());
+        $make = MarkdownPage::make('', ['title' => 'Foo']);
+        $this->assertEquals('HydePHP - Foo', $make->pageTitle());
     }
 
     public function test_html_title_uses_configured_site_name()
     {
         config(['hyde.name' => 'Foo Bar']);
-        $this->assertEquals('Foo Bar - Foo', (new MarkdownPage('Foo'))->htmlTitle());
+        $markdownPage = new MarkdownPage('Foo');
+        $this->assertEquals('Foo Bar - Foo', $markdownPage->pageTitle());
     }
 
     public function test_body_helper_returns_markdown_document_body_in_markdown_pages()

--- a/packages/framework/tests/Unit/Pages/BaseHydePageUnitTest.php
+++ b/packages/framework/tests/Unit/Pages/BaseHydePageUnitTest.php
@@ -52,7 +52,7 @@ abstract class BaseHydePageUnitTest extends TestCase
 
     abstract public function testGetRouteKey();
 
-    abstract public function testPageTitle();
+    abstract public function testTitle();
 
     abstract public function testAll();
 

--- a/packages/framework/tests/Unit/Pages/BaseHydePageUnitTest.php
+++ b/packages/framework/tests/Unit/Pages/BaseHydePageUnitTest.php
@@ -52,7 +52,7 @@ abstract class BaseHydePageUnitTest extends TestCase
 
     abstract public function testGetRouteKey();
 
-    abstract public function testHtmlTitle();
+    abstract public function testPageTitle();
 
     abstract public function testAll();
 

--- a/packages/framework/tests/Unit/Pages/BladePageUnitTest.php
+++ b/packages/framework/tests/Unit/Pages/BladePageUnitTest.php
@@ -10,7 +10,6 @@ use Hyde\Framework\Features\Metadata\PageMetadataBag;
 use Hyde\Hyde;
 use Hyde\Markdown\Models\FrontMatter;
 use Hyde\Pages\BladePage;
-use Hyde\Pages\Concerns\HydePage;
 use Hyde\Support\Models\Route;
 
 require_once __DIR__.'/BaseHydePageUnitTest.php';

--- a/packages/framework/tests/Unit/Pages/BladePageUnitTest.php
+++ b/packages/framework/tests/Unit/Pages/BladePageUnitTest.php
@@ -10,6 +10,7 @@ use Hyde\Framework\Features\Metadata\PageMetadataBag;
 use Hyde\Hyde;
 use Hyde\Markdown\Models\FrontMatter;
 use Hyde\Pages\BladePage;
+use Hyde\Pages\Concerns\HydePage;
 use Hyde\Support\Models\Route;
 
 require_once __DIR__.'/BaseHydePageUnitTest.php';
@@ -130,9 +131,10 @@ class BladePageUnitTest extends BaseHydePageUnitTest
         $this->assertSame('foo', (new BladePage('foo'))->getRouteKey());
     }
 
-    public function testHtmlTitle()
+    public function testPageTitle()
     {
-        $this->assertSame('HydePHP - Foo', (new BladePage('foo'))->htmlTitle());
+        $bladePage = new BladePage('foo');
+        $this->assertSame('HydePHP - Foo', $bladePage->pageTitle());
     }
 
     public function testAll()

--- a/packages/framework/tests/Unit/Pages/BladePageUnitTest.php
+++ b/packages/framework/tests/Unit/Pages/BladePageUnitTest.php
@@ -130,10 +130,10 @@ class BladePageUnitTest extends BaseHydePageUnitTest
         $this->assertSame('foo', (new BladePage('foo'))->getRouteKey());
     }
 
-    public function testPageTitle()
+    public function testTitle()
     {
         $bladePage = new BladePage('foo');
-        $this->assertSame('HydePHP - Foo', $bladePage->pageTitle());
+        $this->assertSame('HydePHP - Foo', $bladePage->title());
     }
 
     public function testAll()

--- a/packages/framework/tests/Unit/Pages/DocumentationPageUnitTest.php
+++ b/packages/framework/tests/Unit/Pages/DocumentationPageUnitTest.php
@@ -10,7 +10,6 @@ use Hyde\Framework\Features\Metadata\PageMetadataBag;
 use Hyde\Hyde;
 use Hyde\Markdown\Models\FrontMatter;
 use Hyde\Markdown\Models\Markdown;
-use Hyde\Pages\Concerns\HydePage;
 use Hyde\Pages\DocumentationPage;
 use Hyde\Support\Models\Route;
 

--- a/packages/framework/tests/Unit/Pages/DocumentationPageUnitTest.php
+++ b/packages/framework/tests/Unit/Pages/DocumentationPageUnitTest.php
@@ -10,6 +10,7 @@ use Hyde\Framework\Features\Metadata\PageMetadataBag;
 use Hyde\Hyde;
 use Hyde\Markdown\Models\FrontMatter;
 use Hyde\Markdown\Models\Markdown;
+use Hyde\Pages\Concerns\HydePage;
 use Hyde\Pages\DocumentationPage;
 use Hyde\Support\Models\Route;
 
@@ -137,9 +138,10 @@ class DocumentationPageUnitTest extends BaseMarkdownPageUnitTest
         $this->assertSame('docs/foo', (new DocumentationPage('foo'))->getRouteKey());
     }
 
-    public function testHtmlTitle()
+    public function testPageTitle()
     {
-        $this->assertSame('HydePHP - Foo', (new DocumentationPage('foo'))->htmlTitle());
+        $documentationPage = new DocumentationPage('foo');
+        $this->assertSame('HydePHP - Foo', $documentationPage->pageTitle());
     }
 
     public function testAll()

--- a/packages/framework/tests/Unit/Pages/DocumentationPageUnitTest.php
+++ b/packages/framework/tests/Unit/Pages/DocumentationPageUnitTest.php
@@ -137,10 +137,10 @@ class DocumentationPageUnitTest extends BaseMarkdownPageUnitTest
         $this->assertSame('docs/foo', (new DocumentationPage('foo'))->getRouteKey());
     }
 
-    public function testPageTitle()
+    public function testTitle()
     {
         $documentationPage = new DocumentationPage('foo');
-        $this->assertSame('HydePHP - Foo', $documentationPage->pageTitle());
+        $this->assertSame('HydePHP - Foo', $documentationPage->title());
     }
 
     public function testAll()

--- a/packages/framework/tests/Unit/Pages/HtmlPageUnitTest.php
+++ b/packages/framework/tests/Unit/Pages/HtmlPageUnitTest.php
@@ -9,6 +9,7 @@ use Hyde\Framework\Factories\Concerns\CoreDataObject;
 use Hyde\Framework\Features\Metadata\PageMetadataBag;
 use Hyde\Hyde;
 use Hyde\Markdown\Models\FrontMatter;
+use Hyde\Pages\Concerns\HydePage;
 use Hyde\Pages\HtmlPage;
 use Hyde\Support\Models\Route;
 
@@ -164,9 +165,10 @@ class HtmlPageUnitTest extends BaseHydePageUnitTest
         $this->assertSame('foo', (new HtmlPage('foo'))->getRouteKey());
     }
 
-    public function testHtmlTitle()
+    public function testPageTitle()
     {
-        $this->assertSame('HydePHP - Foo', (new HtmlPage('foo'))->htmlTitle());
+        $htmlPage = new HtmlPage('foo');
+        $this->assertSame('HydePHP - Foo', $htmlPage->pageTitle());
     }
 
     public function testAll()

--- a/packages/framework/tests/Unit/Pages/HtmlPageUnitTest.php
+++ b/packages/framework/tests/Unit/Pages/HtmlPageUnitTest.php
@@ -164,10 +164,10 @@ class HtmlPageUnitTest extends BaseHydePageUnitTest
         $this->assertSame('foo', (new HtmlPage('foo'))->getRouteKey());
     }
 
-    public function testPageTitle()
+    public function testTitle()
     {
         $htmlPage = new HtmlPage('foo');
-        $this->assertSame('HydePHP - Foo', $htmlPage->pageTitle());
+        $this->assertSame('HydePHP - Foo', $htmlPage->title());
     }
 
     public function testAll()

--- a/packages/framework/tests/Unit/Pages/HtmlPageUnitTest.php
+++ b/packages/framework/tests/Unit/Pages/HtmlPageUnitTest.php
@@ -9,7 +9,6 @@ use Hyde\Framework\Factories\Concerns\CoreDataObject;
 use Hyde\Framework\Features\Metadata\PageMetadataBag;
 use Hyde\Hyde;
 use Hyde\Markdown\Models\FrontMatter;
-use Hyde\Pages\Concerns\HydePage;
 use Hyde\Pages\HtmlPage;
 use Hyde\Support\Models\Route;
 

--- a/packages/framework/tests/Unit/Pages/InMemoryPageUnitTest.php
+++ b/packages/framework/tests/Unit/Pages/InMemoryPageUnitTest.php
@@ -168,10 +168,10 @@ class InMemoryPageUnitTest extends BaseHydePageUnitTest
         $this->assertSame('foo', (new InMemoryPage('foo'))->getRouteKey());
     }
 
-    public function testPageTitle()
+    public function testTitle()
     {
         $inMemoryPage = new InMemoryPage('foo');
-        $this->assertSame('HydePHP - Foo', $inMemoryPage->pageTitle());
+        $this->assertSame('HydePHP - Foo', $inMemoryPage->title());
     }
 
     public function testAll()

--- a/packages/framework/tests/Unit/Pages/InMemoryPageUnitTest.php
+++ b/packages/framework/tests/Unit/Pages/InMemoryPageUnitTest.php
@@ -10,7 +10,6 @@ use Hyde\Framework\Factories\Concerns\CoreDataObject;
 use Hyde\Framework\Features\Metadata\PageMetadataBag;
 use Hyde\Hyde;
 use Hyde\Markdown\Models\FrontMatter;
-use Hyde\Pages\Concerns\HydePage;
 use Hyde\Pages\InMemoryPage;
 use Hyde\Support\Models\Route;
 

--- a/packages/framework/tests/Unit/Pages/InMemoryPageUnitTest.php
+++ b/packages/framework/tests/Unit/Pages/InMemoryPageUnitTest.php
@@ -10,6 +10,7 @@ use Hyde\Framework\Factories\Concerns\CoreDataObject;
 use Hyde\Framework\Features\Metadata\PageMetadataBag;
 use Hyde\Hyde;
 use Hyde\Markdown\Models\FrontMatter;
+use Hyde\Pages\Concerns\HydePage;
 use Hyde\Pages\InMemoryPage;
 use Hyde\Support\Models\Route;
 
@@ -168,9 +169,10 @@ class InMemoryPageUnitTest extends BaseHydePageUnitTest
         $this->assertSame('foo', (new InMemoryPage('foo'))->getRouteKey());
     }
 
-    public function testHtmlTitle()
+    public function testPageTitle()
     {
-        $this->assertSame('HydePHP - Foo', (new InMemoryPage('foo'))->htmlTitle());
+        $inMemoryPage = new InMemoryPage('foo');
+        $this->assertSame('HydePHP - Foo', $inMemoryPage->pageTitle());
     }
 
     public function testAll()

--- a/packages/framework/tests/Unit/Pages/MarkdownPageUnitTest.php
+++ b/packages/framework/tests/Unit/Pages/MarkdownPageUnitTest.php
@@ -165,10 +165,10 @@ class MarkdownPageUnitTest extends BaseMarkdownPageUnitTest
         $this->assertSame('foo', (new MarkdownPage('foo'))->getRouteKey());
     }
 
-    public function testPageTitle()
+    public function testTitle()
     {
         $markdownPage = new MarkdownPage('foo');
-        $this->assertSame('HydePHP - Foo', $markdownPage->pageTitle());
+        $this->assertSame('HydePHP - Foo', $markdownPage->title());
     }
 
     public function testAll()

--- a/packages/framework/tests/Unit/Pages/MarkdownPageUnitTest.php
+++ b/packages/framework/tests/Unit/Pages/MarkdownPageUnitTest.php
@@ -10,6 +10,7 @@ use Hyde\Framework\Features\Metadata\PageMetadataBag;
 use Hyde\Hyde;
 use Hyde\Markdown\Models\FrontMatter;
 use Hyde\Markdown\Models\Markdown;
+use Hyde\Pages\Concerns\HydePage;
 use Hyde\Pages\MarkdownPage;
 use Hyde\Support\Models\Route;
 
@@ -165,9 +166,10 @@ class MarkdownPageUnitTest extends BaseMarkdownPageUnitTest
         $this->assertSame('foo', (new MarkdownPage('foo'))->getRouteKey());
     }
 
-    public function testHtmlTitle()
+    public function testPageTitle()
     {
-        $this->assertSame('HydePHP - Foo', (new MarkdownPage('foo'))->htmlTitle());
+        $markdownPage = new MarkdownPage('foo');
+        $this->assertSame('HydePHP - Foo', $markdownPage->pageTitle());
     }
 
     public function testAll()

--- a/packages/framework/tests/Unit/Pages/MarkdownPageUnitTest.php
+++ b/packages/framework/tests/Unit/Pages/MarkdownPageUnitTest.php
@@ -10,7 +10,6 @@ use Hyde\Framework\Features\Metadata\PageMetadataBag;
 use Hyde\Hyde;
 use Hyde\Markdown\Models\FrontMatter;
 use Hyde\Markdown\Models\Markdown;
-use Hyde\Pages\Concerns\HydePage;
 use Hyde\Pages\MarkdownPage;
 use Hyde\Support\Models\Route;
 

--- a/packages/framework/tests/Unit/Pages/MarkdownPostUnitTest.php
+++ b/packages/framework/tests/Unit/Pages/MarkdownPostUnitTest.php
@@ -165,10 +165,10 @@ class MarkdownPostUnitTest extends BaseMarkdownPageUnitTest
         $this->assertSame('posts/foo', (new MarkdownPost('foo'))->getRouteKey());
     }
 
-    public function testPageTitle()
+    public function testTitle()
     {
         $markdownPost = new MarkdownPost('foo');
-        $this->assertSame('HydePHP - Foo', $markdownPost->pageTitle());
+        $this->assertSame('HydePHP - Foo', $markdownPost->title());
     }
 
     public function testAll()

--- a/packages/framework/tests/Unit/Pages/MarkdownPostUnitTest.php
+++ b/packages/framework/tests/Unit/Pages/MarkdownPostUnitTest.php
@@ -10,6 +10,7 @@ use Hyde\Framework\Features\Metadata\PageMetadataBag;
 use Hyde\Hyde;
 use Hyde\Markdown\Models\FrontMatter;
 use Hyde\Markdown\Models\Markdown;
+use Hyde\Pages\Concerns\HydePage;
 use Hyde\Pages\MarkdownPost;
 use Hyde\Support\Models\Route;
 
@@ -165,9 +166,10 @@ class MarkdownPostUnitTest extends BaseMarkdownPageUnitTest
         $this->assertSame('posts/foo', (new MarkdownPost('foo'))->getRouteKey());
     }
 
-    public function testHtmlTitle()
+    public function testPageTitle()
     {
-        $this->assertSame('HydePHP - Foo', (new MarkdownPost('foo'))->htmlTitle());
+        $markdownPost = new MarkdownPost('foo');
+        $this->assertSame('HydePHP - Foo', $markdownPost->pageTitle());
     }
 
     public function testAll()

--- a/packages/framework/tests/Unit/Pages/MarkdownPostUnitTest.php
+++ b/packages/framework/tests/Unit/Pages/MarkdownPostUnitTest.php
@@ -10,7 +10,6 @@ use Hyde\Framework\Features\Metadata\PageMetadataBag;
 use Hyde\Hyde;
 use Hyde\Markdown\Models\FrontMatter;
 use Hyde\Markdown\Models\Markdown;
-use Hyde\Pages\Concerns\HydePage;
 use Hyde\Pages\MarkdownPost;
 use Hyde\Support\Models\Route;
 

--- a/packages/framework/tests/Unit/Views/HeadComponentViewTest.php
+++ b/packages/framework/tests/Unit/Views/HeadComponentViewTest.php
@@ -35,7 +35,7 @@ class HeadComponentViewTest extends TestCase
     public function testTitleElementUsesPageTitle()
     {
         $page = $this->createMock(InMemoryPage::class);
-        $page->method('pageTitle')->willReturn('Foo Bar');
+        $page->method('title')->willReturn('Foo Bar');
         $this->mockPage($page);
 
         $this->assertStringContainsString('<title>Foo Bar</title>', $this->renderTestView());

--- a/packages/framework/tests/Unit/Views/HeadComponentViewTest.php
+++ b/packages/framework/tests/Unit/Views/HeadComponentViewTest.php
@@ -32,10 +32,10 @@ class HeadComponentViewTest extends TestCase
         $this->assertStringContainsString('<meta charset="utf-8">', $this->renderTestView());
     }
 
-    public function testTitleElementUsesPageHtmlTitle()
+    public function testTitleElementUsesPageTitle()
     {
         $page = $this->createMock(InMemoryPage::class);
-        $page->method('htmlTitle')->willReturn('Foo Bar');
+        $page->method('pageTitle')->willReturn('Foo Bar');
         $this->mockPage($page);
 
         $this->assertStringContainsString('<title>Foo Bar</title>', $this->renderTestView());

--- a/packages/ui-kit/docs/components-demo.blade.php
+++ b/packages/ui-kit/docs/components-demo.blade.php
@@ -3,7 +3,7 @@
 <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    <title>{{ $page->htmlTitle() }}</title>
+    <title>{{ $page->pageTitle() }}</title>
     @include('hyde::layouts.styles')
 </head>
 <body id="app" class="flex flex-col min-h-screen overflow-x-hidden dark:bg-gray-900 dark:text-white">

--- a/packages/ui-kit/docs/components-demo.blade.php
+++ b/packages/ui-kit/docs/components-demo.blade.php
@@ -3,7 +3,7 @@
 <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    <title>{{ $page->pageTitle() }}</title>
+    <title>{{ $page->title() }}</title>
     @include('hyde::layouts.styles')
 </head>
 <body id="app" class="flex flex-col min-h-screen overflow-x-hidden dark:bg-gray-900 dark:text-white">


### PR DESCRIPTION
Shortens the wierdly named helper methods. Thanks to Twitter for voting on the new method name! This will break any published views.

```blade
- <title>{{ $page->htmlTitle() }}</title>
+ <title>{{ $page->title() }}</title>
```
