### PR TITLE
Add experimental framework support for compiling the HydeCLI to a standalone application

### DIFF
--- a/packages/framework/src/Foundation/Kernel/Filesystem.php
+++ b/packages/framework/src/Foundation/Kernel/Filesystem.php
@@ -141,12 +141,7 @@ class Filesystem
     public function vendorPath(string $path = '', string $package = 'framework'): string
     {
         if (PharSupport::active() && ! is_dir($this->path('vendor'))) {
-            if ($package !== 'framework') {
-                throw new \RuntimeException('Cannot use vendorPath() outside of the framework package when running from a Phar archive.');
-            }
-
-            // Return relative link to the Phar archive contents.
-            return dirname(__DIR__, 3).'/'.unslash($path);
+            return PharSupport::vendorPath($path, $package);
         }
 
         return $this->path("vendor/hyde/$package/".unslash($path));

--- a/packages/framework/src/Foundation/Kernel/Filesystem.php
+++ b/packages/framework/src/Foundation/Kernel/Filesystem.php
@@ -6,6 +6,7 @@ namespace Hyde\Foundation\Kernel;
 
 use Hyde\Facades\Site;
 use Hyde\Foundation\HydeKernel;
+use Hyde\Foundation\PharSupport;
 use Hyde\Framework\Services\DiscoveryService;
 use Hyde\Hyde;
 use Hyde\Pages\BladePage;
@@ -139,7 +140,7 @@ class Filesystem
      */
     public function vendorPath(string $path = '', string $package = 'framework'): string
     {
-        if (\Phar::running() && ! is_dir($this->path('vendor'))) {
+        if (PharSupport::active() && ! is_dir($this->path('vendor'))) {
             if ($package !== 'framework') {
                 throw new \RuntimeException('Cannot use vendorPath() outside of the framework package when running from a Phar archive.');
             }

--- a/packages/framework/src/Foundation/Kernel/Filesystem.php
+++ b/packages/framework/src/Foundation/Kernel/Filesystem.php
@@ -139,6 +139,15 @@ class Filesystem
      */
     public function vendorPath(string $path = '', string $package = 'framework'): string
     {
+        if (\Phar::running() && ! is_dir($this->path('vendor'))) {
+            if ($package !== 'framework') {
+                throw new \RuntimeException('Cannot use vendorPath() outside of the framework package when running from a Phar archive.');
+            }
+
+            // Return relative link to the Phar archive contents.
+            return dirname(__DIR__, 3).'/'.unslash($path);
+        }
+
         return $this->path("vendor/hyde/$package/".unslash($path));
     }
 

--- a/packages/framework/src/Foundation/Kernel/Filesystem.php
+++ b/packages/framework/src/Foundation/Kernel/Filesystem.php
@@ -140,7 +140,7 @@ class Filesystem
      */
     public function vendorPath(string $path = '', string $package = 'framework'): string
     {
-        if (PharSupport::running() && ! is_dir($this->path('vendor'))) {
+        if (PharSupport::running() && ! PharSupport::hasVendorDirectory()) {
             return PharSupport::vendorPath($path, $package);
         }
 

--- a/packages/framework/src/Foundation/Kernel/Filesystem.php
+++ b/packages/framework/src/Foundation/Kernel/Filesystem.php
@@ -140,7 +140,7 @@ class Filesystem
      */
     public function vendorPath(string $path = '', string $package = 'framework'): string
     {
-        if (PharSupport::active() && ! is_dir($this->path('vendor'))) {
+        if (PharSupport::running() && ! is_dir($this->path('vendor'))) {
             return PharSupport::vendorPath($path, $package);
         }
 

--- a/packages/framework/src/Foundation/PharSupport.php
+++ b/packages/framework/src/Foundation/PharSupport.php
@@ -17,18 +17,24 @@ use BadMethodCallException;
  */
 class PharSupport
 {
-    protected static bool $mocksActive = false;
+    protected static array $mocks = [];
+
+    /** @internal Mock the Phar method state. */
+    public static function mock(string $method, bool $value): void
+    {
+        self::$mocks[$method] = $value;
+    }
+
+    /** @internal Clear all Phar method mocks. */
+    public static function clearMocks()
+    {
+        self::$mocks = [];
+    }
 
     /** Determine if the application is running in a Phar archive. */
     public static function active(): bool
     {
-        return self::$mocksActive || Phar::running() !== '';
-    }
-
-    /** @internal Mock the Phar active state. */
-    public static function mockActive(bool $active = true): void
-    {
-        self::$mocksActive = $active;
+        return self::$mocks['active'] ?? false || Phar::running() !== '';
     }
 
     public static function vendorPath(string $path = '', string $package = 'framework'): string

--- a/packages/framework/src/Foundation/PharSupport.php
+++ b/packages/framework/src/Foundation/PharSupport.php
@@ -49,6 +49,6 @@ class PharSupport
             throw new BadMethodCallException('Cannot use vendorPath() outside of the framework package when running from a Phar archive.');
         }
 
-        return unslash(dirname(__DIR__, 2).'/'.unslash($path));
+        return str_replace('/', DIRECTORY_SEPARATOR, unslash(dirname(__DIR__, 2).'/'.unslash($path)));
     }
 }

--- a/packages/framework/src/Foundation/PharSupport.php
+++ b/packages/framework/src/Foundation/PharSupport.php
@@ -12,6 +12,7 @@ use BadMethodCallException;
  * Provides experimental support for running the HydeCLI in a standalone Phar archive.
  *
  * @experimental
+ *
  * @internal
  *
  * @see \Hyde\Framework\Testing\Feature\PharSupportTest

--- a/packages/framework/src/Foundation/PharSupport.php
+++ b/packages/framework/src/Foundation/PharSupport.php
@@ -4,6 +4,9 @@ declare(strict_types=1);
 
 namespace Hyde\Foundation;
 
+/**
+ * Provides experimental support for running the HydeCLI in a standalone Phar archive.
+ */
 class PharSupport
 {
     //

--- a/packages/framework/src/Foundation/PharSupport.php
+++ b/packages/framework/src/Foundation/PharSupport.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Hyde\Foundation;
 
+use Phar;
+
 /**
  * Provides experimental support for running the HydeCLI in a standalone Phar archive.
  *
@@ -14,5 +16,9 @@ namespace Hyde\Foundation;
  */
 class PharSupport
 {
-    //
+    /** Determine if the application is running in a Phar archive. */
+    public static function active(): bool
+    {
+        return Phar::running() !== '';
+    }
 }

--- a/packages/framework/src/Foundation/PharSupport.php
+++ b/packages/framework/src/Foundation/PharSupport.php
@@ -29,4 +29,14 @@ class PharSupport
     {
         self::$mocksActive = $active;
     }
+
+    public static function vendorPath(string $path = '', string $package = 'framework'): string
+    {
+        if ($package !== 'framework') {
+            throw new \RuntimeException('Cannot use vendorPath() outside of the framework package when running from a Phar archive.');
+        }
+
+        // Return relative link to the Phar archive contents.
+        return dirname(__DIR__, 2).'/'.unslash($path);
+    }
 }

--- a/packages/framework/src/Foundation/PharSupport.php
+++ b/packages/framework/src/Foundation/PharSupport.php
@@ -16,9 +16,17 @@ use Phar;
  */
 class PharSupport
 {
+    private static bool $mocksActive = false;
+
     /** Determine if the application is running in a Phar archive. */
     public static function active(): bool
     {
-        return Phar::running() !== '';
+        return self::$mocksActive || Phar::running() !== '';
+    }
+
+    /** @internal Mock the Phar active state. */
+    public static function mockActive(bool $active): void
+    {
+        self::$mocksActive = $active;
     }
 }

--- a/packages/framework/src/Foundation/PharSupport.php
+++ b/packages/framework/src/Foundation/PharSupport.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Hyde\Foundation;
+
+class PharSupport
+{
+    //
+}

--- a/packages/framework/src/Foundation/PharSupport.php
+++ b/packages/framework/src/Foundation/PharSupport.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Hyde\Foundation;
 
 use Phar;
+use RuntimeException;
 
 /**
  * Provides experimental support for running the HydeCLI in a standalone Phar archive.
@@ -33,7 +34,7 @@ class PharSupport
     public static function vendorPath(string $path = '', string $package = 'framework'): string
     {
         if ($package !== 'framework') {
-            throw new \RuntimeException('Cannot use vendorPath() outside of the framework package when running from a Phar archive.');
+            throw new RuntimeException('Cannot use vendorPath() outside of the framework package when running from a Phar archive.');
         }
 
         // Return relative link to the Phar archive contents.

--- a/packages/framework/src/Foundation/PharSupport.php
+++ b/packages/framework/src/Foundation/PharSupport.php
@@ -32,9 +32,9 @@ class PharSupport
     }
 
     /** Determine if the application is running in a Phar archive. */
-    public static function active(): bool
+    public static function running(): bool
     {
-        return self::$mocks['active'] ?? Phar::running() !== '';
+        return self::$mocks['running'] ?? Phar::running() !== '';
     }
 
     public static function vendorPath(string $path = '', string $package = 'framework'): string

--- a/packages/framework/src/Foundation/PharSupport.php
+++ b/packages/framework/src/Foundation/PharSupport.php
@@ -31,7 +31,6 @@ class PharSupport
         self::$mocks = [];
     }
 
-    /** Determine if the application is running in a Phar archive. */
     public static function running(): bool
     {
         return self::$mocks['running'] ?? Phar::running() !== '';

--- a/packages/framework/src/Foundation/PharSupport.php
+++ b/packages/framework/src/Foundation/PharSupport.php
@@ -48,6 +48,6 @@ class PharSupport
             throw new BadMethodCallException('Cannot use vendorPath() outside of the framework package when running from a Phar archive.');
         }
 
-        return dirname(__DIR__, 2).'/'.unslash($path);
+        return unslash(dirname(__DIR__, 2).'/'.unslash($path));
     }
 }

--- a/packages/framework/src/Foundation/PharSupport.php
+++ b/packages/framework/src/Foundation/PharSupport.php
@@ -19,13 +19,13 @@ class PharSupport
 {
     protected static array $mocks = [];
 
-    /** @internal Mock the Phar method state. */
+    /** @internal */
     public static function mock(string $method, bool $value): void
     {
         self::$mocks[$method] = $value;
     }
 
-    /** @internal Clear all Phar method mocks. */
+    /** @internal */
     public static function clearMocks(): void
     {
         self::$mocks = [];

--- a/packages/framework/src/Foundation/PharSupport.php
+++ b/packages/framework/src/Foundation/PharSupport.php
@@ -49,6 +49,6 @@ class PharSupport
             throw new BadMethodCallException('Cannot use vendorPath() outside of the framework package when running from a Phar archive.');
         }
 
-        return rtrim(str_replace('/', DIRECTORY_SEPARATOR, unslash(dirname(__DIR__, 2).'/'.$path)), '/\\');
+        return rtrim(str_replace('/', DIRECTORY_SEPARATOR, rtrim(dirname(__DIR__, 2).'/'.$path, '/\\')), '/\\');
     }
 }

--- a/packages/framework/src/Foundation/PharSupport.php
+++ b/packages/framework/src/Foundation/PharSupport.php
@@ -8,6 +8,11 @@ use Hyde\Hyde;
 use Phar;
 use BadMethodCallException;
 
+use function dirname;
+use function is_dir;
+use function rtrim;
+use function str_replace;
+
 /**
  * Provides experimental support for running the HydeCLI in a standalone Phar archive.
  *

--- a/packages/framework/src/Foundation/PharSupport.php
+++ b/packages/framework/src/Foundation/PharSupport.php
@@ -26,7 +26,7 @@ class PharSupport
     }
 
     /** @internal Clear all Phar method mocks. */
-    public static function clearMocks()
+    public static function clearMocks(): void
     {
         self::$mocks = [];
     }

--- a/packages/framework/src/Foundation/PharSupport.php
+++ b/packages/framework/src/Foundation/PharSupport.php
@@ -17,7 +17,7 @@ use BadMethodCallException;
  */
 class PharSupport
 {
-    private static bool $mocksActive = false;
+    protected static bool $mocksActive = false;
 
     /** Determine if the application is running in a Phar archive. */
     public static function active(): bool

--- a/packages/framework/src/Foundation/PharSupport.php
+++ b/packages/framework/src/Foundation/PharSupport.php
@@ -23,6 +23,7 @@ use function str_replace;
  */
 class PharSupport
 {
+    /** @var array<string, bool> */
     protected static array $mocks = [];
 
     public static function mock(string $method, bool $value): void

--- a/packages/framework/src/Foundation/PharSupport.php
+++ b/packages/framework/src/Foundation/PharSupport.php
@@ -25,13 +25,11 @@ class PharSupport
 {
     protected static array $mocks = [];
 
-    /** @internal */
     public static function mock(string $method, bool $value): void
     {
         self::$mocks[$method] = $value;
     }
 
-    /** @internal */
     public static function clearMocks(): void
     {
         self::$mocks = [];

--- a/packages/framework/src/Foundation/PharSupport.php
+++ b/packages/framework/src/Foundation/PharSupport.php
@@ -34,7 +34,7 @@ class PharSupport
     /** Determine if the application is running in a Phar archive. */
     public static function active(): bool
     {
-        return self::$mocks['active'] ?? false || Phar::running() !== '';
+        return self::$mocks['active'] ?? Phar::running() !== '';
     }
 
     public static function vendorPath(string $path = '', string $package = 'framework'): string

--- a/packages/framework/src/Foundation/PharSupport.php
+++ b/packages/framework/src/Foundation/PharSupport.php
@@ -8,6 +8,7 @@ namespace Hyde\Foundation;
  * Provides experimental support for running the HydeCLI in a standalone Phar archive.
  *
  * @experimental
+ * @internal
  */
 class PharSupport
 {

--- a/packages/framework/src/Foundation/PharSupport.php
+++ b/packages/framework/src/Foundation/PharSupport.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Hyde\Foundation;
 
+use Hyde\Hyde;
 use Phar;
 use BadMethodCallException;
 
@@ -34,6 +35,11 @@ class PharSupport
     public static function running(): bool
     {
         return self::$mocks['running'] ?? Phar::running() !== '';
+    }
+
+    public static function hasVendorDirectory(): bool
+    {
+        return self::$mocks['hasVendorDirectory'] ?? is_dir(Hyde::path('vendor'));
     }
 
     public static function vendorPath(string $path = '', string $package = 'framework'): string

--- a/packages/framework/src/Foundation/PharSupport.php
+++ b/packages/framework/src/Foundation/PharSupport.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace Hyde\Foundation;
 
 use Phar;
-use RuntimeException;
+use BadMethodCallException;
 
 /**
  * Provides experimental support for running the HydeCLI in a standalone Phar archive.
@@ -34,7 +34,7 @@ class PharSupport
     public static function vendorPath(string $path = '', string $package = 'framework'): string
     {
         if ($package !== 'framework') {
-            throw new RuntimeException('Cannot use vendorPath() outside of the framework package when running from a Phar archive.');
+            throw new BadMethodCallException('Cannot use vendorPath() outside of the framework package when running from a Phar archive.');
         }
 
         return dirname(__DIR__, 2).'/'.unslash($path);

--- a/packages/framework/src/Foundation/PharSupport.php
+++ b/packages/framework/src/Foundation/PharSupport.php
@@ -49,6 +49,6 @@ class PharSupport
             throw new BadMethodCallException('Cannot use vendorPath() outside of the framework package when running from a Phar archive.');
         }
 
-        return str_replace('/', DIRECTORY_SEPARATOR, unslash(dirname(__DIR__, 2).'/'.unslash($path)));
+        return unslash(str_replace('/', DIRECTORY_SEPARATOR, unslash(dirname(__DIR__, 2).'/'.$path)));
     }
 }

--- a/packages/framework/src/Foundation/PharSupport.php
+++ b/packages/framework/src/Foundation/PharSupport.php
@@ -6,6 +6,8 @@ namespace Hyde\Foundation;
 
 /**
  * Provides experimental support for running the HydeCLI in a standalone Phar archive.
+ *
+ * @experimental
  */
 class PharSupport
 {

--- a/packages/framework/src/Foundation/PharSupport.php
+++ b/packages/framework/src/Foundation/PharSupport.php
@@ -26,7 +26,7 @@ class PharSupport
     }
 
     /** @internal Mock the Phar active state. */
-    public static function mockActive(bool $active): void
+    public static function mockActive(bool $active = true): void
     {
         self::$mocksActive = $active;
     }

--- a/packages/framework/src/Foundation/PharSupport.php
+++ b/packages/framework/src/Foundation/PharSupport.php
@@ -37,7 +37,6 @@ class PharSupport
             throw new RuntimeException('Cannot use vendorPath() outside of the framework package when running from a Phar archive.');
         }
 
-        // Return relative link to the Phar archive contents.
         return dirname(__DIR__, 2).'/'.unslash($path);
     }
 }

--- a/packages/framework/src/Foundation/PharSupport.php
+++ b/packages/framework/src/Foundation/PharSupport.php
@@ -9,6 +9,8 @@ namespace Hyde\Foundation;
  *
  * @experimental
  * @internal
+ *
+ * @see \Hyde\Framework\Testing\Feature\PharSupportTest
  */
 class PharSupport
 {

--- a/packages/framework/src/Foundation/PharSupport.php
+++ b/packages/framework/src/Foundation/PharSupport.php
@@ -7,7 +7,6 @@ namespace Hyde\Foundation;
 use Hyde\Hyde;
 use Phar;
 use BadMethodCallException;
-
 use function dirname;
 use function is_dir;
 use function rtrim;

--- a/packages/framework/src/Foundation/PharSupport.php
+++ b/packages/framework/src/Foundation/PharSupport.php
@@ -49,6 +49,6 @@ class PharSupport
             throw new BadMethodCallException('Cannot use vendorPath() outside of the framework package when running from a Phar archive.');
         }
 
-        return unslash(str_replace('/', DIRECTORY_SEPARATOR, unslash(dirname(__DIR__, 2).'/'.$path)));
+        return rtrim(str_replace('/', DIRECTORY_SEPARATOR, unslash(dirname(__DIR__, 2).'/'.$path)), '/\\');
     }
 }

--- a/packages/framework/tests/Feature/Foundation/FilesystemTest.php
+++ b/packages/framework/tests/Feature/Foundation/FilesystemTest.php
@@ -122,7 +122,7 @@ class FilesystemTest extends TestCase
     public function test_vendor_path_can_run_in_phar()
     {
         // Monorepo support for symlinked packages directory
-        $base = str_contains(realpath(Hyde::vendorPath()), 'packages') ? 'packages' : 'vendor/hyde';
+        $base = str_contains(realpath(Hyde::vendorPath() ?? ''), 'vendor') ? 'vendor/hyde' : 'packages';
 
         PharSupport::mock('running', true);
         PharSupport::mock('hasVendorDirectory', false);
@@ -135,7 +135,7 @@ class FilesystemTest extends TestCase
     public function test_vendor_path_can_run_in_phar_with_path_argument()
     {
         // Monorepo support for symlinked packages directory
-        $base = str_contains(realpath(Hyde::vendorPath()), 'packages') ? 'packages' : 'vendor/hyde';
+        $base = str_contains(realpath(Hyde::vendorPath() ?? ''), 'vendor') ? 'vendor/hyde' : 'packages';
 
         PharSupport::mock('running', true);
         PharSupport::mock('hasVendorDirectory', false);

--- a/packages/framework/tests/Feature/Foundation/FilesystemTest.php
+++ b/packages/framework/tests/Feature/Foundation/FilesystemTest.php
@@ -127,7 +127,7 @@ class FilesystemTest extends TestCase
         PharSupport::mock('running', true);
         PharSupport::mock('hasVendorDirectory', false);
 
-        $this->assertEquals(Hyde::path($base.'/framework'), $this->filesystem->vendorPath());
+        $this->assertEquals(str_replace('/', DIRECTORY_SEPARATOR, Hyde::path($base.'/framework')), $this->filesystem->vendorPath());
 
         PharSupport::clearMocks();
     }
@@ -140,7 +140,7 @@ class FilesystemTest extends TestCase
         PharSupport::mock('running', true);
         PharSupport::mock('hasVendorDirectory', false);
 
-        $this->assertEquals(Hyde::path($base.'/framework/file.php'), $this->filesystem->vendorPath('file.php'));
+        $this->assertEquals(str_replace('/', DIRECTORY_SEPARATOR, Hyde::path($base.'/framework/file.php')), $this->filesystem->vendorPath('file.php'));
 
         PharSupport::clearMocks();
     }

--- a/packages/framework/tests/Feature/Foundation/FilesystemTest.php
+++ b/packages/framework/tests/Feature/Foundation/FilesystemTest.php
@@ -121,26 +121,28 @@ class FilesystemTest extends TestCase
 
     public function test_vendor_path_can_run_in_phar()
     {
-        // Monorepo support for symlinked packages directory
-        $base = str_contains(realpath(Hyde::vendorPath() ?? ''), 'vendor') ? 'vendor/hyde' : 'packages';
-
         PharSupport::mock('running', true);
         PharSupport::mock('hasVendorDirectory', false);
 
-        $this->assertEquals(str_replace('/', DIRECTORY_SEPARATOR, Hyde::path($base.'/framework')), $this->filesystem->vendorPath());
+        $this->assertContains($this->filesystem->vendorPath(), [
+            // Monorepo support for symlinked packages directory
+            str_replace('/', DIRECTORY_SEPARATOR, Hyde::path('packages/framework')),
+            str_replace('/', DIRECTORY_SEPARATOR, Hyde::path('vendor/hyde/framework')),
+        ]);
 
         PharSupport::clearMocks();
     }
 
     public function test_vendor_path_can_run_in_phar_with_path_argument()
     {
-        // Monorepo support for symlinked packages directory
-        $base = str_contains(realpath(Hyde::vendorPath() ?? ''), 'vendor') ? 'vendor/hyde' : 'packages';
-
         PharSupport::mock('running', true);
         PharSupport::mock('hasVendorDirectory', false);
 
-        $this->assertEquals(str_replace('/', DIRECTORY_SEPARATOR, Hyde::path($base.'/framework/file.php')), $this->filesystem->vendorPath('file.php'));
+        $this->assertContains($this->filesystem->vendorPath('file.php'), [
+            // Monorepo support for symlinked packages directory
+            str_replace('/', DIRECTORY_SEPARATOR, Hyde::path('packages/framework/file.php')),
+            str_replace('/', DIRECTORY_SEPARATOR, Hyde::path('vendor/hyde/framework/file.php')),
+        ]);
 
         PharSupport::clearMocks();
     }

--- a/packages/framework/tests/Feature/Foundation/FilesystemTest.php
+++ b/packages/framework/tests/Feature/Foundation/FilesystemTest.php
@@ -125,6 +125,8 @@ class FilesystemTest extends TestCase
         PharSupport::mock('hasVendorDirectory', false);
 
         $this->assertEquals(Hyde::path('vendor/hyde/framework'), $this->filesystem->vendorPath());
+
+        PharSupport::clearMocks();
     }
 
     public function test_vendor_path_can_run_in_phar_with_path_argument()
@@ -133,6 +135,8 @@ class FilesystemTest extends TestCase
         PharSupport::mock('hasVendorDirectory', false);
 
         $this->assertEquals(Hyde::path('vendor/hyde/framework/file.php'), $this->filesystem->vendorPath('file.php'));
+
+        PharSupport::clearMocks();
     }
 
     public function test_vendor_path_can_run_in_phar_with_package_argument_but_throws()
@@ -142,6 +146,8 @@ class FilesystemTest extends TestCase
 
         $this->expectException(BadMethodCallException::class);
         $this->filesystem->vendorPath(package: 'realtime-compiler');
+
+        PharSupport::clearMocks();
     }
 
     public function test_copy_method()

--- a/packages/framework/tests/Feature/Foundation/FilesystemTest.php
+++ b/packages/framework/tests/Feature/Foundation/FilesystemTest.php
@@ -121,20 +121,26 @@ class FilesystemTest extends TestCase
 
     public function test_vendor_path_can_run_in_phar()
     {
+        // Monorepo support for symlinked packages directory
+        $base = str_contains(realpath(Hyde::vendorPath()), 'packages') ? 'packages' : 'vendor/hyde';
+
         PharSupport::mock('running', true);
         PharSupport::mock('hasVendorDirectory', false);
 
-        $this->assertEquals(Hyde::path('vendor/hyde/framework'), $this->filesystem->vendorPath());
+        $this->assertEquals(Hyde::path($base.'/framework'), $this->filesystem->vendorPath());
 
         PharSupport::clearMocks();
     }
 
     public function test_vendor_path_can_run_in_phar_with_path_argument()
     {
+        // Monorepo support for symlinked packages directory
+        $base = str_contains(realpath(Hyde::vendorPath()), 'packages') ? 'packages' : 'vendor/hyde';
+
         PharSupport::mock('running', true);
         PharSupport::mock('hasVendorDirectory', false);
 
-        $this->assertEquals(Hyde::path('vendor/hyde/framework/file.php'), $this->filesystem->vendorPath('file.php'));
+        $this->assertEquals(Hyde::path($base.'/framework/file.php'), $this->filesystem->vendorPath('file.php'));
 
         PharSupport::clearMocks();
     }

--- a/packages/framework/tests/Feature/Foundation/FilesystemTest.php
+++ b/packages/framework/tests/Feature/Foundation/FilesystemTest.php
@@ -117,6 +117,7 @@ class FilesystemTest extends TestCase
         $this->assertFileExists(Hyde::vendorPath('composer.json', 'realtime-compiler'));
     }
 
+    // TODO Test vendorPath can run in Phar
     public function test_copy_method()
     {
         touch(Hyde::path('foo'));

--- a/packages/framework/tests/Feature/Foundation/FilesystemTest.php
+++ b/packages/framework/tests/Feature/Foundation/FilesystemTest.php
@@ -133,31 +133,6 @@ class FilesystemTest extends TestCase
         PharSupport::clearMocks();
     }
 
-    public function test_vendor_path_can_run_in_phar_with_path_argument()
-    {
-        PharSupport::mock('running', true);
-        PharSupport::mock('hasVendorDirectory', false);
-
-        $this->assertContains($this->filesystem->vendorPath('file.php'), [
-            // Monorepo support for symlinked packages directory
-            str_replace('/', DIRECTORY_SEPARATOR, Hyde::path('packages/framework/file.php')),
-            str_replace('/', DIRECTORY_SEPARATOR, Hyde::path('vendor/hyde/framework/file.php')),
-        ]);
-
-        PharSupport::clearMocks();
-    }
-
-    public function test_vendor_path_can_run_in_phar_with_package_argument_but_throws()
-    {
-        PharSupport::mock('running', true);
-        PharSupport::mock('hasVendorDirectory', false);
-
-        $this->expectException(BadMethodCallException::class);
-        $this->filesystem->vendorPath(package: 'realtime-compiler');
-
-        PharSupport::clearMocks();
-    }
-
     public function test_copy_method()
     {
         touch(Hyde::path('foo'));

--- a/packages/framework/tests/Feature/Foundation/FilesystemTest.php
+++ b/packages/framework/tests/Feature/Foundation/FilesystemTest.php
@@ -4,7 +4,9 @@ declare(strict_types=1);
 
 namespace Hyde\Framework\Testing\Feature\Foundation;
 
+use BadMethodCallException;
 use Hyde\Foundation\Kernel\Filesystem;
+use Hyde\Foundation\PharSupport;
 use Hyde\Hyde;
 use Hyde\Pages\BladePage;
 use Hyde\Pages\DocumentationPage;
@@ -117,7 +119,31 @@ class FilesystemTest extends TestCase
         $this->assertFileExists(Hyde::vendorPath('composer.json', 'realtime-compiler'));
     }
 
-    // TODO Test vendorPath can run in Phar
+    public function test_vendor_path_can_run_in_phar()
+    {
+        PharSupport::mock('running', true);
+        PharSupport::mock('hasVendorDirectory', false);
+
+        $this->assertEquals(Hyde::path('vendor/hyde/framework'), $this->filesystem->vendorPath());
+    }
+
+    public function test_vendor_path_can_run_in_phar_with_path_argument()
+    {
+        PharSupport::mock('running', true);
+        PharSupport::mock('hasVendorDirectory', false);
+
+        $this->assertEquals(Hyde::path('vendor/hyde/framework/file.php'), $this->filesystem->vendorPath('file.php'));
+    }
+
+    public function test_vendor_path_can_run_in_phar_with_package_argument_but_throws()
+    {
+        PharSupport::mock('running', true);
+        PharSupport::mock('hasVendorDirectory', false);
+
+        $this->expectException(BadMethodCallException::class);
+        $this->filesystem->vendorPath(package: 'realtime-compiler');
+    }
+
     public function test_copy_method()
     {
         touch(Hyde::path('foo'));

--- a/packages/framework/tests/Feature/Foundation/FilesystemTest.php
+++ b/packages/framework/tests/Feature/Foundation/FilesystemTest.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Hyde\Framework\Testing\Feature\Foundation;
 
-use BadMethodCallException;
 use Hyde\Foundation\Kernel\Filesystem;
 use Hyde\Foundation\PharSupport;
 use Hyde\Hyde;

--- a/packages/framework/tests/Feature/PharSupportTest.php
+++ b/packages/framework/tests/Feature/PharSupportTest.php
@@ -31,4 +31,17 @@ class PharSupportTest extends TestCase
         PharSupport::mock('running', false);
         $this->assertFalse(PharSupport::running());
     }
+
+    public function testHasVendorDirectory()
+    {
+        $this->assertTrue(PharSupport::hasVendorDirectory());
+    }
+
+    public function testMockHasVendorDirectory()
+    {
+        PharSupport::mock('hasVendorDirectory', true);
+        $this->assertTrue(PharSupport::hasVendorDirectory());
+        PharSupport::mock('hasVendorDirectory', false);
+        $this->assertFalse(PharSupport::hasVendorDirectory());
+    }
 }

--- a/packages/framework/tests/Feature/PharSupportTest.php
+++ b/packages/framework/tests/Feature/PharSupportTest.php
@@ -12,5 +12,8 @@ use Hyde\Testing\TestCase;
  */
 class PharSupportTest extends TestCase
 {
-    //
+    public function testActive()
+    {
+        $this->assertFalse(PharSupport::active());
+    }
 }

--- a/packages/framework/tests/Feature/PharSupportTest.php
+++ b/packages/framework/tests/Feature/PharSupportTest.php
@@ -49,23 +49,17 @@ class PharSupportTest extends TestCase
 
     public function test_vendor_path_can_run_in_phar()
     {
-        // Monorepo support for symlinked packages directory
-        $base = str_contains(realpath(Hyde::vendorPath() ?? ''), 'vendor') ? 'vendor/hyde' : 'packages';
-
         PharSupport::mock('running', true);
         PharSupport::mock('hasVendorDirectory', false);
 
-        $this->assertEquals(str_replace('/', DIRECTORY_SEPARATOR, Hyde::path($base.'/framework')), Hyde::vendorPath());
+        $this->assertEquals(str_replace('/', DIRECTORY_SEPARATOR, Hyde::path($this->getBaseVendorPath().'/framework')), Hyde::vendorPath());
     }
 
     public function test_vendor_path_can_run_in_phar_with_path_argument()
     {
-        // Monorepo support for symlinked packages directory
-        $base = str_contains(realpath(Hyde::vendorPath() ?? ''), 'vendor') ? 'vendor/hyde' : 'packages';
-
         PharSupport::mock('running', true);
         PharSupport::mock('hasVendorDirectory', false);
-        $this->assertEquals(str_replace('/', DIRECTORY_SEPARATOR, Hyde::path($base.'/framework/file.php')), Hyde::vendorPath('file.php'));
+        $this->assertEquals(str_replace('/', DIRECTORY_SEPARATOR, Hyde::path($this->getBaseVendorPath().'/framework/file.php')), Hyde::vendorPath('file.php'));
     }
 
     public function test_vendor_path_can_run_in_phar_with_package_argument_but_throws()
@@ -75,5 +69,11 @@ class PharSupportTest extends TestCase
 
         $this->expectException(BadMethodCallException::class);
         Hyde::vendorPath(package: 'realtime-compiler');
+    }
+
+    protected function getBaseVendorPath(): string
+    {
+        // Monorepo support for symlinked packages directory
+        return str_contains(realpath(Hyde::vendorPath() ?? ''), 'vendor') ? 'vendor/hyde' : 'packages';
     }
 }

--- a/packages/framework/tests/Feature/PharSupportTest.php
+++ b/packages/framework/tests/Feature/PharSupportTest.php
@@ -4,7 +4,9 @@ declare(strict_types=1);
 
 namespace Hyde\Framework\Testing\Feature;
 
+use BadMethodCallException;
 use Hyde\Foundation\PharSupport;
+use Hyde\Hyde;
 use Hyde\Testing\TestCase;
 
 /**
@@ -43,5 +45,38 @@ class PharSupportTest extends TestCase
         $this->assertTrue(PharSupport::hasVendorDirectory());
         PharSupport::mock('hasVendorDirectory', false);
         $this->assertFalse(PharSupport::hasVendorDirectory());
+    }
+
+    public function test_vendor_path_can_run_in_phar()
+    {
+        PharSupport::mock('running', true);
+        PharSupport::mock('hasVendorDirectory', false);
+
+        $this->assertContains(Hyde::vendorPath(), [
+            // Monorepo support for symlinked packages directory
+            str_replace('/', DIRECTORY_SEPARATOR, Hyde::path('packages/framework')),
+            str_replace('/', DIRECTORY_SEPARATOR, Hyde::path('vendor/hyde/framework')),
+        ]);
+    }
+
+    public function test_vendor_path_can_run_in_phar_with_path_argument()
+    {
+        PharSupport::mock('running', true);
+        PharSupport::mock('hasVendorDirectory', false);
+
+        $this->assertContains(Hyde::vendorPath('file.php'), [
+            // Monorepo support for symlinked packages directory
+            str_replace('/', DIRECTORY_SEPARATOR, Hyde::path('packages/framework/file.php')),
+            str_replace('/', DIRECTORY_SEPARATOR, Hyde::path('vendor/hyde/framework/file.php')),
+        ]);
+    }
+
+    public function test_vendor_path_can_run_in_phar_with_package_argument_but_throws()
+    {
+        PharSupport::mock('running', true);
+        PharSupport::mock('hasVendorDirectory', false);
+
+        $this->expectException(BadMethodCallException::class);
+        Hyde::vendorPath(package: 'realtime-compiler');
     }
 }

--- a/packages/framework/tests/Feature/PharSupportTest.php
+++ b/packages/framework/tests/Feature/PharSupportTest.php
@@ -49,26 +49,23 @@ class PharSupportTest extends TestCase
 
     public function test_vendor_path_can_run_in_phar()
     {
+        // Monorepo support for symlinked packages directory
+        $base = str_contains(realpath(Hyde::vendorPath() ?? ''), 'vendor') ? 'vendor/hyde' : 'packages';
+
         PharSupport::mock('running', true);
         PharSupport::mock('hasVendorDirectory', false);
 
-        $this->assertContains(Hyde::vendorPath(), [
-            // Monorepo support for symlinked packages directory
-            str_replace('/', DIRECTORY_SEPARATOR, Hyde::path('packages/framework')),
-            str_replace('/', DIRECTORY_SEPARATOR, Hyde::path('vendor/hyde/framework')),
-        ]);
+        $this->assertEquals(str_replace('/', DIRECTORY_SEPARATOR, Hyde::path($base.'/framework')), Hyde::vendorPath());
     }
 
     public function test_vendor_path_can_run_in_phar_with_path_argument()
     {
+        // Monorepo support for symlinked packages directory
+        $base = str_contains(realpath(Hyde::vendorPath() ?? ''), 'vendor') ? 'vendor/hyde' : 'packages';
+
         PharSupport::mock('running', true);
         PharSupport::mock('hasVendorDirectory', false);
-
-        $this->assertContains(Hyde::vendorPath('file.php'), [
-            // Monorepo support for symlinked packages directory
-            str_replace('/', DIRECTORY_SEPARATOR, Hyde::path('packages/framework/file.php')),
-            str_replace('/', DIRECTORY_SEPARATOR, Hyde::path('vendor/hyde/framework/file.php')),
-        ]);
+        $this->assertEquals(str_replace('/', DIRECTORY_SEPARATOR, Hyde::path($base.'/framework/file.php')), Hyde::vendorPath('file.php'));
     }
 
     public function test_vendor_path_can_run_in_phar_with_package_argument_but_throws()

--- a/packages/framework/tests/Feature/PharSupportTest.php
+++ b/packages/framework/tests/Feature/PharSupportTest.php
@@ -21,14 +21,14 @@ class PharSupportTest extends TestCase
 
     public function testActive()
     {
-        $this->assertFalse(PharSupport::active());
+        $this->assertFalse(PharSupport::running());
     }
 
     public function testMockActive()
     {
-        PharSupport::mock('active', true);
-        $this->assertTrue(PharSupport::active());
-        PharSupport::mock('active', false);
-        $this->assertFalse(PharSupport::active());
+        PharSupport::mock('running', true);
+        $this->assertTrue(PharSupport::running());
+        PharSupport::mock('running', false);
+        $this->assertFalse(PharSupport::running());
     }
 }

--- a/packages/framework/tests/Feature/PharSupportTest.php
+++ b/packages/framework/tests/Feature/PharSupportTest.php
@@ -52,14 +52,14 @@ class PharSupportTest extends TestCase
         PharSupport::mock('running', true);
         PharSupport::mock('hasVendorDirectory', false);
 
-        $this->assertEquals(str_replace('/', DIRECTORY_SEPARATOR, Hyde::path($this->getBaseVendorPath().'/framework')), Hyde::vendorPath());
+        $this->assertEquals(str_replace('/', DIRECTORY_SEPARATOR, Hyde::path("{$this->getBaseVendorPath()}/framework")), Hyde::vendorPath());
     }
 
     public function test_vendor_path_can_run_in_phar_with_path_argument()
     {
         PharSupport::mock('running', true);
         PharSupport::mock('hasVendorDirectory', false);
-        $this->assertEquals(str_replace('/', DIRECTORY_SEPARATOR, Hyde::path($this->getBaseVendorPath().'/framework/file.php')), Hyde::vendorPath('file.php'));
+        $this->assertEquals(str_replace('/', DIRECTORY_SEPARATOR, Hyde::path("{$this->getBaseVendorPath()}/framework/file.php")), Hyde::vendorPath('file.php'));
     }
 
     public function test_vendor_path_can_run_in_phar_with_package_argument_but_throws()

--- a/packages/framework/tests/Feature/PharSupportTest.php
+++ b/packages/framework/tests/Feature/PharSupportTest.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Hyde\Framework\Testing\Feature;
+
+use Hyde\Foundation\PharSupport;
+use Hyde\Testing\TestCase;
+
+/**
+ * @covers \Hyde\Foundation\PharSupport
+ */
+class PharSupportTest extends TestCase
+{
+    //
+}

--- a/packages/framework/tests/Feature/PharSupportTest.php
+++ b/packages/framework/tests/Feature/PharSupportTest.php
@@ -30,6 +30,7 @@ class PharSupportTest extends TestCase
     {
         PharSupport::mock('running', true);
         $this->assertTrue(PharSupport::running());
+
         PharSupport::mock('running', false);
         $this->assertFalse(PharSupport::running());
     }
@@ -43,6 +44,7 @@ class PharSupportTest extends TestCase
     {
         PharSupport::mock('hasVendorDirectory', true);
         $this->assertTrue(PharSupport::hasVendorDirectory());
+
         PharSupport::mock('hasVendorDirectory', false);
         $this->assertFalse(PharSupport::hasVendorDirectory());
     }
@@ -59,6 +61,7 @@ class PharSupportTest extends TestCase
     {
         PharSupport::mock('running', true);
         PharSupport::mock('hasVendorDirectory', false);
+
         $this->assertEquals($this->replaceSlashes(Hyde::path("{$this->getBaseVendorPath()}/framework/file.php")), Hyde::vendorPath('file.php'));
     }
 
@@ -68,6 +71,7 @@ class PharSupportTest extends TestCase
         PharSupport::mock('hasVendorDirectory', false);
 
         $this->expectException(BadMethodCallException::class);
+
         Hyde::vendorPath(package: 'realtime-compiler');
     }
 

--- a/packages/framework/tests/Feature/PharSupportTest.php
+++ b/packages/framework/tests/Feature/PharSupportTest.php
@@ -52,14 +52,14 @@ class PharSupportTest extends TestCase
         PharSupport::mock('running', true);
         PharSupport::mock('hasVendorDirectory', false);
 
-        $this->assertEquals(str_replace('/', DIRECTORY_SEPARATOR, Hyde::path("{$this->getBaseVendorPath()}/framework")), Hyde::vendorPath());
+        $this->assertEquals($this->replaceSlashes(Hyde::path("{$this->getBaseVendorPath()}/framework")), Hyde::vendorPath());
     }
 
     public function test_vendor_path_can_run_in_phar_with_path_argument()
     {
         PharSupport::mock('running', true);
         PharSupport::mock('hasVendorDirectory', false);
-        $this->assertEquals(str_replace('/', DIRECTORY_SEPARATOR, Hyde::path("{$this->getBaseVendorPath()}/framework/file.php")), Hyde::vendorPath('file.php'));
+        $this->assertEquals($this->replaceSlashes(Hyde::path("{$this->getBaseVendorPath()}/framework/file.php")), Hyde::vendorPath('file.php'));
     }
 
     public function test_vendor_path_can_run_in_phar_with_package_argument_but_throws()
@@ -75,5 +75,10 @@ class PharSupportTest extends TestCase
     {
         // Monorepo support for symlinked packages directory
         return str_contains(realpath(Hyde::vendorPath() ?? ''), 'vendor') ? 'vendor/hyde' : 'packages';
+    }
+
+    protected function replaceSlashes(string $path): string
+    {
+        return str_replace('/', DIRECTORY_SEPARATOR, $path);
     }
 }

--- a/packages/framework/tests/Feature/PharSupportTest.php
+++ b/packages/framework/tests/Feature/PharSupportTest.php
@@ -19,7 +19,7 @@ class PharSupportTest extends TestCase
 
     public function testMockActive()
     {
-        PharSupport::mockActive(true);
+        PharSupport::mockActive();
         $this->assertTrue(PharSupport::active());
         PharSupport::mockActive(false);
         $this->assertFalse(PharSupport::active());

--- a/packages/framework/tests/Feature/PharSupportTest.php
+++ b/packages/framework/tests/Feature/PharSupportTest.php
@@ -12,6 +12,13 @@ use Hyde\Testing\TestCase;
  */
 class PharSupportTest extends TestCase
 {
+    public function tearDown(): void
+    {
+        PharSupport::clearMocks();
+
+        parent::tearDown();
+    }
+
     public function testActive()
     {
         $this->assertFalse(PharSupport::active());
@@ -19,9 +26,9 @@ class PharSupportTest extends TestCase
 
     public function testMockActive()
     {
-        PharSupport::mockActive();
+        PharSupport::mock('active', true);
         $this->assertTrue(PharSupport::active());
-        PharSupport::mockActive(false);
+        PharSupport::mock('active', false);
         $this->assertFalse(PharSupport::active());
     }
 }

--- a/packages/framework/tests/Feature/PharSupportTest.php
+++ b/packages/framework/tests/Feature/PharSupportTest.php
@@ -16,4 +16,12 @@ class PharSupportTest extends TestCase
     {
         $this->assertFalse(PharSupport::active());
     }
+
+    public function testMockActive()
+    {
+        PharSupport::mockActive(true);
+        $this->assertTrue(PharSupport::active());
+        PharSupport::mockActive(false);
+        $this->assertFalse(PharSupport::active());
+    }
 }


### PR DESCRIPTION
Adds a `PharSupport` helper class to get and mock the Phar state. Also refactors the `vendorPath` helper to properly support running in vendorless Phars.