### PR TITLE
Only attempt file discovery for discoverable page classes

### DIFF
--- a/packages/framework/src/Foundation/Kernel/FileCollection.php
+++ b/packages/framework/src/Foundation/Kernel/FileCollection.php
@@ -58,7 +58,9 @@ final class FileCollection extends BaseFoundationCollection
     protected function runDiscovery(): self
     {
         foreach ($this->kernel->getRegisteredPageClasses() as $pageClass) {
-            $this->discoverFilesFor($pageClass);
+            if ($pageClass::isDiscoverable()) {
+                $this->discoverFilesFor($pageClass);
+            }
         }
 
         $this->runExtensionCallbacks();

--- a/packages/framework/src/Foundation/Kernel/FileCollection.php
+++ b/packages/framework/src/Foundation/Kernel/FileCollection.php
@@ -57,6 +57,7 @@ final class FileCollection extends BaseFoundationCollection
 
     protected function runDiscovery(): self
     {
+        /** @var class-string<\Hyde\Pages\Concerns\HydePage> $pageClass */
         foreach ($this->kernel->getRegisteredPageClasses() as $pageClass) {
             if ($pageClass::isDiscoverable()) {
                 $this->discoverFilesFor($pageClass);


### PR DESCRIPTION
This issue was somehow surfaced after upgrading to Laravel 10, and presented itself in the `publications-feature` branch (since that extension registers an `InMemoryPage`). Nonetheless, I consider it a bug as discovery should not be attempted for non-discoverable page classes.