### PR TITLE
Fix bug inconsistent front matter serialization for empty publication field input

### DIFF
--- a/packages/publications/src/Commands/MakePublicationCommand.php
+++ b/packages/publications/src/Commands/MakePublicationCommand.php
@@ -182,7 +182,7 @@ class MakePublicationCommand extends ValidatingCommand
     {
         $selection = $this->askForFieldData($field->name, $field->getRules());
         if (empty($selection)) {
-            return null;
+            return new PublicationFieldValue($field->type, $selection);
         }
 
         return new PublicationFieldValue($field->type, $selection);


### PR DESCRIPTION
This means that skipped fields will still be included in the saved output even if they're empty.

Fixes https://github.com/hydephp/publications/issues/6