### PR TITLE
Refactor page creation actions

### DIFF
--- a/packages/framework/src/Framework/Actions/CreatesNewMarkdownPostFile.php
+++ b/packages/framework/src/Framework/Actions/CreatesNewMarkdownPostFile.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace Hyde\Framework\Actions;
 
 use Hyde\Framework\Exceptions\FileConflictException;
-use Hyde\Hyde;
+use Hyde\Facades\Filesystem;
 use Hyde\Pages\MarkdownPost;
 use Illuminate\Support\Str;
 
@@ -69,7 +69,7 @@ class CreatesNewMarkdownPostFile
     {
         $page = new MarkdownPost($this->identifier, $this->toArray(), "\n## Write something awesome.\n\n");
 
-        if ($force !== true && file_exists(Hyde::path($page->getSourcePath()))) {
+        if ($force !== true && Filesystem::exists($page->getSourcePath())) {
             throw new FileConflictException($page->getSourcePath());
         }
 

--- a/packages/framework/src/Framework/Actions/CreatesNewMarkdownPostFile.php
+++ b/packages/framework/src/Framework/Actions/CreatesNewMarkdownPostFile.php
@@ -35,7 +35,6 @@ class CreatesNewMarkdownPostFile
      * @param  string|null  $category  The Primary Post Category.
      * @param  string|null  $author  The Username of the Author.
      * @param  string|null  $date  The Publishing Date.
-     * @param  string|null  $identifier  The Post Identifier.
      */
     public function __construct(
         string $title,
@@ -43,7 +42,6 @@ class CreatesNewMarkdownPostFile
         ?string $category,
         ?string $author,
         ?string $date = null,
-        ?string $identifier = null
     ) {
         $this->title = $title;
         $this->description = $description ?? 'A short description used in previews and SEO';

--- a/packages/framework/src/Framework/Actions/CreatesNewMarkdownPostFile.php
+++ b/packages/framework/src/Framework/Actions/CreatesNewMarkdownPostFile.php
@@ -49,6 +49,7 @@ class CreatesNewMarkdownPostFile
         $this->description = $description ?? 'A short description used in previews and SEO';
         $this->category = $category ?? 'blog';
         $this->author = $author ?? 'default';
+
         if ($date === null) {
             $this->date = date('Y-m-d H:i');
         }

--- a/packages/framework/src/Framework/Actions/CreatesNewMarkdownPostFile.php
+++ b/packages/framework/src/Framework/Actions/CreatesNewMarkdownPostFile.php
@@ -73,9 +73,7 @@ class CreatesNewMarkdownPostFile
             throw new FileConflictException($page->getSourcePath());
         }
 
-        $page->save();
-
-        return $page->getSourcePath();
+        return $page->save()->getSourcePath();
     }
 
     /**

--- a/packages/framework/src/Framework/Actions/CreatesNewMarkdownPostFile.php
+++ b/packages/framework/src/Framework/Actions/CreatesNewMarkdownPostFile.php
@@ -35,12 +35,7 @@ class CreatesNewMarkdownPostFile
      * @param  string|null  $category  The Primary Post Category.
      * @param  string|null  $author  The Username of the Author.
      */
-    public function __construct(
-        string $title,
-        ?string $description,
-        ?string $category,
-        ?string $author,
-    ) {
+    public function __construct(string $title, ?string $description, ?string $category, ?string $author) {
         $this->title = $title;
         $this->description = $description ?? 'A short description used in previews and SEO';
         $this->category = $category ?? 'blog';

--- a/packages/framework/src/Framework/Actions/CreatesNewMarkdownPostFile.php
+++ b/packages/framework/src/Framework/Actions/CreatesNewMarkdownPostFile.php
@@ -61,11 +61,11 @@ class CreatesNewMarkdownPostFile
      * Save the class object to a Markdown file.
      *
      * @param  bool  $force  Should the file be created even if a file with the same path already exists?
-     * @return string|false Returns the path to the file if successful, or false if the file could not be saved.
+     * @return string Returns the path to the created file.
      *
      * @throws FileConflictException if a file with the same identifier already exists and the force flag is not set.
      */
-    public function save(bool $force = false): string|false
+    public function save(bool $force = false): string
     {
         $path = Hyde::path(MarkdownPost::sourcePath($this->identifier));
 
@@ -76,7 +76,9 @@ class CreatesNewMarkdownPostFile
         $contents = (new ConvertsArrayToFrontMatter)->execute($this->toArray()).
             "\n## Write something awesome.\n\n";
 
-        return file_put_contents($path, $contents) ? $path : false;
+        file_put_contents($path, $contents);
+
+        return $path;
     }
 
     /**

--- a/packages/framework/src/Framework/Actions/CreatesNewMarkdownPostFile.php
+++ b/packages/framework/src/Framework/Actions/CreatesNewMarkdownPostFile.php
@@ -67,16 +67,15 @@ class CreatesNewMarkdownPostFile
      */
     public function save(bool $force = false): string
     {
-        $path = Hyde::path(MarkdownPost::sourcePath($this->identifier));
+        $page = new MarkdownPost($this->identifier, $this->toArray(), "\n## Write something awesome.\n\n");
 
-        if ($force !== true && file_exists($path)) {
-            throw new FileConflictException($path);
+        if ($force !== true && file_exists(Hyde::path($page->getSourcePath()))) {
+            throw new FileConflictException($page->getSourcePath());
         }
 
-        $page = new MarkdownPost($this->identifier, $this->toArray(), "\n## Write something awesome.\n\n");
         $page->save();
 
-        return $path;
+        return $page->getSourcePath();
     }
 
     /**

--- a/packages/framework/src/Framework/Actions/CreatesNewMarkdownPostFile.php
+++ b/packages/framework/src/Framework/Actions/CreatesNewMarkdownPostFile.php
@@ -50,12 +50,8 @@ class CreatesNewMarkdownPostFile
         $this->category = $category ?? 'blog';
         $this->author = $author ?? 'default';
 
-        if ($date === null) {
-            $this->date = date('Y-m-d H:i');
-        }
-        if ($identifier === null) {
-            $this->identifier = Str::slug($title);
-        }
+        $this->date = date('Y-m-d H:i');
+        $this->identifier = Str::slug($title);
     }
 
     /**

--- a/packages/framework/src/Framework/Actions/CreatesNewMarkdownPostFile.php
+++ b/packages/framework/src/Framework/Actions/CreatesNewMarkdownPostFile.php
@@ -73,10 +73,8 @@ class CreatesNewMarkdownPostFile
             throw new FileConflictException($path);
         }
 
-        $contents = (new ConvertsArrayToFrontMatter)->execute($this->toArray()).
-            "\n## Write something awesome.\n\n";
-
-        file_put_contents($path, $contents);
+        $page = new MarkdownPost($this->identifier, $this->toArray(), "\n## Write something awesome.\n\n");
+        $page->save();
 
         return $path;
     }

--- a/packages/framework/src/Framework/Actions/CreatesNewMarkdownPostFile.php
+++ b/packages/framework/src/Framework/Actions/CreatesNewMarkdownPostFile.php
@@ -34,14 +34,12 @@ class CreatesNewMarkdownPostFile
      * @param  string|null  $description  The Post Meta Description.
      * @param  string|null  $category  The Primary Post Category.
      * @param  string|null  $author  The Username of the Author.
-     * @param  string|null  $date  The Publishing Date.
      */
     public function __construct(
         string $title,
         ?string $description,
         ?string $category,
         ?string $author,
-        ?string $date = null,
     ) {
         $this->title = $title;
         $this->description = $description ?? 'A short description used in previews and SEO';

--- a/packages/framework/src/Framework/Actions/CreatesNewMarkdownPostFile.php
+++ b/packages/framework/src/Framework/Actions/CreatesNewMarkdownPostFile.php
@@ -56,7 +56,7 @@ class CreatesNewMarkdownPostFile
      */
     public function save(bool $force = false): string
     {
-        $page = new MarkdownPost($this->identifier, $this->toArray(), "\n## Write something awesome.\n\n");
+        $page = new MarkdownPost($this->identifier, $this->toArray(), "## Write something awesome.\n\n");
 
         if ($force !== true && Filesystem::exists($page->getSourcePath())) {
             throw new FileConflictException($page->getSourcePath());

--- a/packages/framework/src/Framework/Actions/CreatesNewMarkdownPostFile.php
+++ b/packages/framework/src/Framework/Actions/CreatesNewMarkdownPostFile.php
@@ -56,7 +56,7 @@ class CreatesNewMarkdownPostFile
      */
     public function save(bool $force = false): string
     {
-        $page = new MarkdownPost($this->identifier, $this->toArray(), "## Write something awesome.");
+        $page = new MarkdownPost($this->identifier, $this->toArray(), '## Write something awesome.');
 
         if ($force !== true && Filesystem::exists($page->getSourcePath())) {
             throw new FileConflictException($page->getSourcePath());

--- a/packages/framework/src/Framework/Actions/CreatesNewMarkdownPostFile.php
+++ b/packages/framework/src/Framework/Actions/CreatesNewMarkdownPostFile.php
@@ -56,7 +56,7 @@ class CreatesNewMarkdownPostFile
      */
     public function save(bool $force = false): string
     {
-        $page = new MarkdownPost($this->identifier, $this->toArray(), "## Write something awesome.\n\n");
+        $page = new MarkdownPost($this->identifier, $this->toArray(), "## Write something awesome.");
 
         if ($force !== true && Filesystem::exists($page->getSourcePath())) {
             throw new FileConflictException($page->getSourcePath());

--- a/packages/framework/src/Framework/Actions/CreatesNewMarkdownPostFile.php
+++ b/packages/framework/src/Framework/Actions/CreatesNewMarkdownPostFile.php
@@ -35,7 +35,8 @@ class CreatesNewMarkdownPostFile
      * @param  string|null  $category  The Primary Post Category.
      * @param  string|null  $author  The Username of the Author.
      */
-    public function __construct(string $title, ?string $description, ?string $category, ?string $author) {
+    public function __construct(string $title, ?string $description, ?string $category, ?string $author)
+    {
         $this->title = $title;
         $this->description = $description ?? 'A short description used in previews and SEO';
         $this->category = $category ?? 'blog';

--- a/packages/framework/src/Framework/Actions/CreatesNewPageSourceFile.php
+++ b/packages/framework/src/Framework/Actions/CreatesNewPageSourceFile.php
@@ -128,7 +128,7 @@ class CreatesNewPageSourceFile
 
     protected function failIfFileCannotBeSaved(string $path): void
     {
-        if (! $this->force && file_exists($path)) {
+        if ($this->force !== true && file_exists($path)) {
             throw new FileConflictException($path);
         }
     }

--- a/packages/framework/src/Framework/Actions/CreatesNewPageSourceFile.php
+++ b/packages/framework/src/Framework/Actions/CreatesNewPageSourceFile.php
@@ -30,7 +30,7 @@ class CreatesNewPageSourceFile
     protected string $slug;
     protected string $outputPath;
     protected string $subDir = '';
-    protected bool $force = false;
+    protected bool $force;
 
     public function __construct(string $title, string $type = MarkdownPage::class, bool $force = false)
     {

--- a/packages/framework/src/Framework/Actions/CreatesNewPageSourceFile.php
+++ b/packages/framework/src/Framework/Actions/CreatesNewPageSourceFile.php
@@ -80,6 +80,8 @@ class CreatesNewPageSourceFile
 
     protected function createPage(string $type): void
     {
+        $this->failIfFileCannotBeSaved($this->outputPath);
+
         match ($type) {
             BladePage::class => $this->createBladeFile(),
             MarkdownPage::class => $this->createMarkdownFile(),
@@ -90,7 +92,6 @@ class CreatesNewPageSourceFile
     protected function createBladeFile(): void
     {
         $this->needsParentDirectory($this->outputPath);
-        $this->failIfFileCannotBeSaved($this->outputPath);
 
         file_put_contents($this->outputPath, Hyde::normalizeNewlines(<<<BLADE
             @extends('hyde::layouts.app')
@@ -109,15 +110,11 @@ class CreatesNewPageSourceFile
 
     protected function createMarkdownFile(): void
     {
-        $this->failIfFileCannotBeSaved($this->outputPath);
-
         (new MarkdownPage($this->formatIdentifier(), ['title' => $this->title], "# $this->title"))->save();
     }
 
     protected function createDocumentationFile(): void
     {
-        $this->failIfFileCannotBeSaved($this->outputPath);
-
         (new DocumentationPage($this->formatIdentifier(), [], "# $this->title\n"))->save();
     }
 

--- a/packages/framework/src/Framework/Actions/CreatesNewPageSourceFile.php
+++ b/packages/framework/src/Framework/Actions/CreatesNewPageSourceFile.php
@@ -106,12 +106,16 @@ class CreatesNewPageSourceFile
 
     protected function createMarkdownFile(): void
     {
-        $this->newCreateFile(MarkdownPage::class, ['title' => $this->title], "# $this->title");
+        $this->failIfFileCannotBeSaved($this->outputPath);
+
+        (new MarkdownPage($this->formatIdentifier(), ['title' => $this->title], "# $this->title"))->save();
     }
 
     protected function createDocumentationFile(): void
     {
-        $this->newCreateFile(DocumentationPage::class, [],"# $this->title\n");
+        $this->failIfFileCannotBeSaved($this->outputPath);
+
+        (new DocumentationPage($this->formatIdentifier(), [], "# $this->title\n"))->save();
     }
 
     protected function formatIdentifier(): string
@@ -144,13 +148,5 @@ class CreatesNewPageSourceFile
         $this->prepareOutputDirectory();
 
         file_put_contents($this->outputPath, Hyde::normalizeNewlines($contents));
-    }
-
-    /** @param  class-string<\Hyde\Pages\Concerns\BaseMarkdownPage>  $class */
-    protected function newCreateFile(string $class, array $matter, string $markdown): void
-    {
-        $this->failIfFileCannotBeSaved($this->outputPath);
-
-        (new $class($this->formatIdentifier(), $matter, $markdown))->save();
     }
 }

--- a/packages/framework/src/Framework/Actions/CreatesNewPageSourceFile.php
+++ b/packages/framework/src/Framework/Actions/CreatesNewPageSourceFile.php
@@ -106,12 +106,12 @@ class CreatesNewPageSourceFile
 
     protected function createMarkdownFile(): void
     {
-        $this->createFile("---\ntitle: $this->title\n---\n\n# $this->title\n");
+        $this->newCreateFile(MarkdownPage::class, ['title' => $this->title], "# $this->title");
     }
 
     protected function createDocumentationFile(): void
     {
-        $this->createFile("# $this->title\n");
+        $this->newCreateFile(DocumentationPage::class, [],"# $this->title\n");
     }
 
     protected function formatIdentifier(): string
@@ -144,5 +144,13 @@ class CreatesNewPageSourceFile
         $this->prepareOutputDirectory();
 
         file_put_contents($this->outputPath, Hyde::normalizeNewlines($contents));
+    }
+
+    /** @param  class-string<\Hyde\Pages\Concerns\BaseMarkdownPage>  $class */
+    protected function newCreateFile(string $class, array $matter, string $markdown): void
+    {
+        $this->failIfFileCannotBeSaved($this->outputPath);
+
+        (new $class($this->formatIdentifier(), $matter, $markdown))->save();
     }
 }

--- a/packages/framework/src/Framework/Actions/CreatesNewPageSourceFile.php
+++ b/packages/framework/src/Framework/Actions/CreatesNewPageSourceFile.php
@@ -89,7 +89,9 @@ class CreatesNewPageSourceFile
 
     protected function createBladeFile(): void
     {
-        $this->createFile(<<<BLADE
+        $this->prepareOutputDirectory();
+
+        file_put_contents($this->outputPath, Hyde::normalizeNewlines(<<<BLADE
             @extends('hyde::layouts.app')
             @section('content')
             @php(\$title = "$this->title")
@@ -101,7 +103,7 @@ class CreatesNewPageSourceFile
             @endsection
 
             BLADE
-        );
+        ));
     }
 
     protected function createMarkdownFile(): void
@@ -141,12 +143,5 @@ class CreatesNewPageSourceFile
     {
         $this->needsParentDirectory($this->outputPath);
         $this->failIfFileCannotBeSaved($this->outputPath);
-    }
-
-    protected function createFile(string $contents): void
-    {
-        $this->prepareOutputDirectory();
-
-        file_put_contents($this->outputPath, Hyde::normalizeNewlines($contents));
     }
 }

--- a/packages/framework/src/Framework/Actions/CreatesNewPageSourceFile.php
+++ b/packages/framework/src/Framework/Actions/CreatesNewPageSourceFile.php
@@ -89,7 +89,8 @@ class CreatesNewPageSourceFile
 
     protected function createBladeFile(): void
     {
-        $this->prepareOutputDirectory();
+        $this->needsParentDirectory($this->outputPath);
+        $this->failIfFileCannotBeSaved($this->outputPath);
 
         file_put_contents($this->outputPath, Hyde::normalizeNewlines(<<<BLADE
             @extends('hyde::layouts.app')
@@ -137,11 +138,5 @@ class CreatesNewPageSourceFile
         if ($this->force !== true && file_exists($path)) {
             throw new FileConflictException($path);
         }
-    }
-
-    protected function prepareOutputDirectory(): void
-    {
-        $this->needsParentDirectory($this->outputPath);
-        $this->failIfFileCannotBeSaved($this->outputPath);
     }
 }

--- a/packages/framework/src/Framework/Actions/CreatesNewPageSourceFile.php
+++ b/packages/framework/src/Framework/Actions/CreatesNewPageSourceFile.php
@@ -27,7 +27,7 @@ class CreatesNewPageSourceFile
     use InteractsWithDirectories;
 
     protected string $title;
-    protected string $slug;
+    protected string $filename;
     protected string $outputPath;
     protected string $subDir = '';
     protected bool $force;
@@ -37,7 +37,7 @@ class CreatesNewPageSourceFile
         $this->validateType($type);
 
         $this->title = $this->parseTitle($title);
-        $this->slug = $this->parseSlug($title);
+        $this->filename = $this->fileName($title);
         $this->force = $force;
 
         $this->outputPath = $this->makeOutputPath($type);
@@ -55,7 +55,7 @@ class CreatesNewPageSourceFile
         return Str::afterLast($title, '/');
     }
 
-    protected function parseSlug(string $title): string
+    protected function fileName(string $title): string
     {
         // If title contains a slash, it's a subdirectory
         if (str_contains($title, '/')) {
@@ -116,7 +116,7 @@ class CreatesNewPageSourceFile
 
     protected function formatIdentifier(): string
     {
-        return "$this->subDir/$this->slug";
+        return "$this->subDir/$this->filename";
     }
 
     protected function validateType(string $pageClass): void

--- a/packages/framework/src/Framework/Actions/CreatesNewPageSourceFile.php
+++ b/packages/framework/src/Framework/Actions/CreatesNewPageSourceFile.php
@@ -128,7 +128,7 @@ class CreatesNewPageSourceFile
 
     protected function failIfFileCannotBeSaved(string $path): void
     {
-        if (file_exists($path) && ! $this->force) {
+        if (! $this->force && file_exists($path)) {
             throw new FileConflictException($path);
         }
     }

--- a/packages/framework/src/Framework/Actions/CreatesNewPageSourceFile.php
+++ b/packages/framework/src/Framework/Actions/CreatesNewPageSourceFile.php
@@ -115,7 +115,7 @@ class CreatesNewPageSourceFile
 
     protected function createDocumentationFile(): void
     {
-        (new DocumentationPage($this->formatIdentifier(), [], "# $this->title\n"))->save();
+        (new DocumentationPage($this->formatIdentifier(), [], "# $this->title"))->save();
     }
 
     protected function formatIdentifier(): string

--- a/packages/framework/src/Framework/Actions/CreatesNewPageSourceFile.php
+++ b/packages/framework/src/Framework/Actions/CreatesNewPageSourceFile.php
@@ -72,9 +72,9 @@ class CreatesNewPageSourceFile
         return unslash('/'.rtrim(Str::beforeLast($title, '/').'/', '/\\'));
     }
 
+    /** @param class-string<\Hyde\Pages\Concerns\HydePage> $pageClass */
     protected function makeOutputPath(string $pageClass): string
     {
-        /** @var \Hyde\Pages\Concerns\HydePage $pageClass */
         return Hyde::path($pageClass::sourcePath($this->formatIdentifier()));
     }
 

--- a/packages/framework/src/Pages/Concerns/BaseMarkdownPage.php
+++ b/packages/framework/src/Pages/Concerns/BaseMarkdownPage.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Hyde\Pages\Concerns;
 
-use Hyde\Hyde;
 use Hyde\Facades\Filesystem;
 use Hyde\Markdown\Contracts\MarkdownDocumentContract;
 use Hyde\Markdown\Models\FrontMatter;
@@ -62,7 +61,7 @@ abstract class BaseMarkdownPage extends HydePage implements MarkdownDocumentCont
     {
         Filesystem::ensureDirectoryExists(dirname($this->getSourcePath()));
 
-        file_put_contents(Hyde::path($this->getSourcePath()), ltrim("$this->matter\n$this->markdown"));
+        Filesystem::putContents($this->getSourcePath(), ltrim("$this->matter\n$this->markdown"));
 
         return $this;
     }

--- a/packages/framework/src/Pages/Concerns/BaseMarkdownPage.php
+++ b/packages/framework/src/Pages/Concerns/BaseMarkdownPage.php
@@ -61,7 +61,7 @@ abstract class BaseMarkdownPage extends HydePage implements MarkdownDocumentCont
     {
         Filesystem::ensureDirectoryExists(dirname($this->getSourcePath()));
 
-        Filesystem::putContents($this->getSourcePath(), ltrim(trim("$this->matter\n$this->markdown") . "\n"));
+        Filesystem::putContents($this->getSourcePath(), ltrim(trim("$this->matter\n$this->markdown")."\n"));
 
         return $this;
     }

--- a/packages/framework/src/Pages/Concerns/BaseMarkdownPage.php
+++ b/packages/framework/src/Pages/Concerns/BaseMarkdownPage.php
@@ -61,7 +61,7 @@ abstract class BaseMarkdownPage extends HydePage implements MarkdownDocumentCont
     {
         Filesystem::ensureDirectoryExists(dirname($this->getSourcePath()));
 
-        Filesystem::putContents($this->getSourcePath(), trim("$this->matter\n$this->markdown") . "\n");
+        Filesystem::putContents($this->getSourcePath(), ltrim(trim("$this->matter\n$this->markdown") . "\n"));
 
         return $this;
     }

--- a/packages/framework/src/Pages/Concerns/BaseMarkdownPage.php
+++ b/packages/framework/src/Pages/Concerns/BaseMarkdownPage.php
@@ -60,7 +60,7 @@ abstract class BaseMarkdownPage extends HydePage implements MarkdownDocumentCont
      */
     public function save(): static
     {
-        Filesystem::ensureDirectoryExists(static::sourceDirectory());
+        Filesystem::ensureDirectoryExists(dirname($this->getSourcePath()));
 
         file_put_contents(Hyde::path($this->getSourcePath()), ltrim("$this->matter\n$this->markdown"));
 

--- a/packages/framework/src/Pages/Concerns/BaseMarkdownPage.php
+++ b/packages/framework/src/Pages/Concerns/BaseMarkdownPage.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Hyde\Pages\Concerns;
 
 use Hyde\Hyde;
+use Hyde\Facades\Filesystem;
 use Hyde\Markdown\Contracts\MarkdownDocumentContract;
 use Hyde\Markdown\Models\FrontMatter;
 use Hyde\Markdown\Models\Markdown;
@@ -59,6 +60,8 @@ abstract class BaseMarkdownPage extends HydePage implements MarkdownDocumentCont
      */
     public function save(): static
     {
+        Filesystem::ensureDirectoryExists(static::sourceDirectory());
+
         file_put_contents(Hyde::path($this->getSourcePath()), ltrim("$this->matter\n$this->markdown"));
 
         return $this;

--- a/packages/framework/src/Pages/Concerns/BaseMarkdownPage.php
+++ b/packages/framework/src/Pages/Concerns/BaseMarkdownPage.php
@@ -61,7 +61,7 @@ abstract class BaseMarkdownPage extends HydePage implements MarkdownDocumentCont
     {
         Filesystem::ensureDirectoryExists(dirname($this->getSourcePath()));
 
-        Filesystem::putContents($this->getSourcePath(), ltrim("$this->matter\n$this->markdown"));
+        Filesystem::putContents($this->getSourcePath(), trim("$this->matter\n$this->markdown") . "\n");
 
         return $this;
     }

--- a/packages/framework/tests/Feature/Actions/CreatesNewPageSourceFileTest.php
+++ b/packages/framework/tests/Feature/Actions/CreatesNewPageSourceFileTest.php
@@ -56,6 +56,32 @@ class CreatesNewPageSourceFileTest extends TestCase
         Filesystem::unlink('_pages/foo.md');
     }
 
+    public function test_exception_is_thrown_for_conflicting_blade_pages()
+    {
+        $this->file('_pages/foo.blade.php', 'foo');
+
+        $this->expectException(FileConflictException::class);
+        $this->expectExceptionMessage('File already exists: '.Hyde::path('_pages/foo.blade.php'));
+        $this->expectExceptionCode(409);
+
+        new CreatesNewPageSourceFile('foo', BladePage::class);
+        $this->assertSame('foo', file_get_contents(Hyde::path('_pages/foo.blade.php')));
+        Filesystem::unlink('_pages/foo.blade.php');
+    }
+
+    public function test_exception_is_thrown_for_conflicting_documentation_pages()
+    {
+        $this->file('_docs/foo.md', 'foo');
+
+        $this->expectException(FileConflictException::class);
+        $this->expectExceptionMessage('File already exists: '.Hyde::path('_docs/foo.md'));
+        $this->expectExceptionCode(409);
+
+        new CreatesNewPageSourceFile('foo', DocumentationPage::class);
+        $this->assertSame('foo', file_get_contents(Hyde::path('_docs/foo.md')));
+        Filesystem::unlink('_docs/foo.md');
+    }
+    
     public function test_that_a_markdown_file_can_be_created_and_contains_expected_content()
     {
         Filesystem::unlink('_pages/test-page.md');

--- a/packages/framework/tests/Feature/Actions/CreatesNewPageSourceFileTest.php
+++ b/packages/framework/tests/Feature/Actions/CreatesNewPageSourceFileTest.php
@@ -81,7 +81,7 @@ class CreatesNewPageSourceFileTest extends TestCase
         $this->assertSame('foo', file_get_contents(Hyde::path('_docs/foo.md')));
         Filesystem::unlink('_docs/foo.md');
     }
-    
+
     public function test_that_a_markdown_file_can_be_created_and_contains_expected_content()
     {
         Filesystem::unlink('_pages/test-page.md');

--- a/packages/framework/tests/Feature/Actions/CreatesNewPageSourceFileTest.php
+++ b/packages/framework/tests/Feature/Actions/CreatesNewPageSourceFileTest.php
@@ -64,7 +64,7 @@ class CreatesNewPageSourceFileTest extends TestCase
         $this->assertFileExists(Hyde::path('_pages/test-page.md'));
 
         $this->assertSame(
-            "---\ntitle: Test Page\n---\n\n# Test Page\n",
+            "---\ntitle: 'Test Page'\n---\n\n# Test Page\n",
             file_get_contents(Hyde::path('_pages/test-page.md'))
         );
         Filesystem::unlink('_pages/test-page.md');

--- a/packages/framework/tests/Feature/HydePageTest.php
+++ b/packages/framework/tests/Feature/HydePageTest.php
@@ -1015,6 +1015,20 @@ class HydePageTest extends TestCase
         Filesystem::deleteDirectory('foo');
     }
 
+    public function test_save_method_creates_source_directory_recursively_if_it_does_not_exist()
+    {
+        $this->assertDirectoryDoesNotExist(Hyde::path('foo'));
+
+        $page = new MissingSourceDirectoryMarkdownPage('bar/baz');
+        $page->save();
+
+        $this->assertDirectoryExists(Hyde::path('foo'));
+        $this->assertDirectoryExists(Hyde::path('foo/bar'));
+        $this->assertFileExists(Hyde::path('foo/bar/baz.md'));
+
+        Filesystem::deleteDirectory('foo');
+    }
+
     public function test_markdown_posts_can_be_saved()
     {
         $post = new MarkdownPost('foo');

--- a/packages/framework/tests/Feature/HydePageTest.php
+++ b/packages/framework/tests/Feature/HydePageTest.php
@@ -7,6 +7,7 @@ namespace Hyde\Framework\Testing\Feature;
 use Hyde\Foundation\HydeCoreExtension;
 use Hyde\Framework\Exceptions\FileNotFoundException;
 use Hyde\Hyde;
+use Hyde\Facades\Filesystem;
 use Hyde\Markdown\Models\Markdown;
 use Hyde\Pages\BladePage;
 use Hyde\Pages\Concerns\BaseMarkdownPage;
@@ -1001,6 +1002,19 @@ class HydePageTest extends TestCase
         Hyde::unlink('_pages/foo.md');
     }
 
+    public function test_save_method_creates_source_directory_if_it_does_not_exist()
+    {
+        $this->assertDirectoryDoesNotExist(Hyde::path('foo'));
+
+        $page = new MissingSourceDirectoryMarkdownPage('bar');
+        $page->save();
+
+        $this->assertDirectoryExists(Hyde::path('foo'));
+        $this->assertFileExists(Hyde::path('foo/bar.md'));
+
+        Filesystem::deleteDirectory('foo');
+    }
+
     public function test_markdown_posts_can_be_saved()
     {
         $post = new MarkdownPost('foo');
@@ -1239,4 +1253,9 @@ class DiscoverablePageWithInvalidSourceDirectory extends HydePage
     {
         return '';
     }
+}
+
+class MissingSourceDirectoryMarkdownPage extends BaseMarkdownPage
+{
+    public static string $sourceDirectory = 'foo';
 }

--- a/packages/framework/tests/Feature/HydePageTest.php
+++ b/packages/framework/tests/Feature/HydePageTest.php
@@ -948,7 +948,7 @@ class HydePageTest extends TestCase
     public function test_save_method_converts_front_matter_array_to_yaml_block()
     {
         MarkdownPage::make('foo', matter: ['foo' => 'bar'])->save();
-        $this->assertEquals("---\nfoo: bar\n---\n\n",
+        $this->assertEquals("---\nfoo: bar\n---\n",
             file_get_contents(Hyde::path('_pages/foo.md'))
         );
         Hyde::unlink('_pages/foo.md');
@@ -957,7 +957,7 @@ class HydePageTest extends TestCase
     public function test_save_method_writes_page_body_to_file()
     {
         MarkdownPage::make('foo', markdown: 'foo')->save();
-        $this->assertEquals('foo',
+        $this->assertEquals("foo\n",
             file_get_contents(Hyde::path('_pages/foo.md'))
         );
         Hyde::unlink('_pages/foo.md');
@@ -966,7 +966,7 @@ class HydePageTest extends TestCase
     public function test_save_method_writes_page_body_to_file_with_front_matter()
     {
         MarkdownPage::make('foo', matter: ['foo' => 'bar'], markdown: 'foo bar')->save();
-        $this->assertEquals("---\nfoo: bar\n---\n\nfoo bar",
+        $this->assertEquals("---\nfoo: bar\n---\n\nfoo bar\n",
             file_get_contents(Hyde::path('_pages/foo.md'))
         );
         Hyde::unlink('_pages/foo.md');
@@ -978,7 +978,7 @@ class HydePageTest extends TestCase
         $page->save();
 
         $this->assertFileExists(Hyde::path('_pages/foo.md'));
-        $this->assertSame('', file_get_contents(Hyde::path('_pages/foo.md')));
+        $this->assertSame("\n", file_get_contents(Hyde::path('_pages/foo.md')));
 
         Hyde::unlink('_pages/foo.md');
     }
@@ -988,7 +988,7 @@ class HydePageTest extends TestCase
         $page = new MarkdownPage('foo', markdown: 'bar');
         $page->save();
 
-        $this->assertSame('bar', file_get_contents(Hyde::path('_pages/foo.md')));
+        $this->assertSame("bar\n", file_get_contents(Hyde::path('_pages/foo.md')));
 
         /** @var BaseMarkdownPage $parsed */
         $parsed = MarkdownPage::all()->getPage('_pages/foo.md');
@@ -997,7 +997,7 @@ class HydePageTest extends TestCase
         $parsed->markdown = new Markdown('baz');
         $parsed->save();
 
-        $this->assertSame('baz', file_get_contents(Hyde::path('_pages/foo.md')));
+        $this->assertSame("baz\n", file_get_contents(Hyde::path('_pages/foo.md')));
 
         Hyde::unlink('_pages/foo.md');
     }

--- a/packages/framework/tests/Feature/HydePageTest.php
+++ b/packages/framework/tests/Feature/HydePageTest.php
@@ -978,7 +978,7 @@ class HydePageTest extends TestCase
         $page->save();
 
         $this->assertFileExists(Hyde::path('_pages/foo.md'));
-        $this->assertSame("\n", file_get_contents(Hyde::path('_pages/foo.md')));
+        $this->assertSame('', file_get_contents(Hyde::path('_pages/foo.md')));
 
         Hyde::unlink('_pages/foo.md');
     }


### PR DESCRIPTION
These files have been around since pretty much the start of Hyde, so they deserve another round of polishing before the 1.0 release to refactor to use newer helpers and anything else as needed.

Major changes:
- Refactor: Change `CreatesNewMarkdownPostFile` action to save file by creating a new object then saving it
- Refactor: Change `CreatesNewPageSourceFile` action to save Markdown files by creating new objects then saving then
- Bugfix: Update `BaseMarkdownPage::save` method to create parent directory if needed
- Breaking: Constructor parameters `$date` and `$identifier` in `CreatesNewMarkdownPostFile` have been removed as they are always null within the application (only affects if anyone has used this class outside of the framework, which is discouraged at this time)
- Change: Append a single newline to saved Markdown file as files should always have a trailing newline