### PR TITLE
Update FileConflictException message to turn absolute paths to relative

### DIFF
--- a/packages/framework/src/Framework/Exceptions/FileConflictException.php
+++ b/packages/framework/src/Framework/Exceptions/FileConflictException.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Hyde\Framework\Exceptions;
 
 use Exception;
+use Hyde\Hyde;
 
 class FileConflictException extends Exception
 {
@@ -16,7 +17,7 @@ class FileConflictException extends Exception
 
     public function __construct(?string $path = null, ?string $message = null)
     {
-        $this->message = $message ?? ($path ? sprintf('File already exists: %s', $path) : $this->message);
+        $this->message = $message ?? ($path ? sprintf('File already exists: %s', Hyde::pathToRelative($path)) : $this->message);
 
         parent::__construct($this->message, $this->code);
     }

--- a/packages/framework/src/Framework/Exceptions/FileConflictException.php
+++ b/packages/framework/src/Framework/Exceptions/FileConflictException.php
@@ -16,7 +16,7 @@ class FileConflictException extends Exception
 
     public function __construct(?string $path = null, ?string $message = null)
     {
-        $this->message = $message ?? ($path ? "File already exists: $path" : $this->message);
+        $this->message = $message ?? ($path ? sprintf('File already exists: %s', $path) : $this->message);
 
         parent::__construct($this->message, $this->code);
     }

--- a/packages/framework/tests/Feature/Actions/CreatesNewPageSourceFileTest.php
+++ b/packages/framework/tests/Feature/Actions/CreatesNewPageSourceFileTest.php
@@ -39,7 +39,7 @@ class CreatesNewPageSourceFileTest extends TestCase
         $this->file('_pages/foo.md', 'foo');
 
         $this->expectException(FileConflictException::class);
-        $this->expectExceptionMessage('File already exists: '.Hyde::path('_pages/foo.md'));
+        $this->expectExceptionMessage('File already exists: _pages/foo.md');
         $this->expectExceptionCode(409);
 
         new CreatesNewPageSourceFile('foo');

--- a/packages/framework/tests/Feature/Actions/CreatesNewPageSourceFileTest.php
+++ b/packages/framework/tests/Feature/Actions/CreatesNewPageSourceFileTest.php
@@ -61,7 +61,7 @@ class CreatesNewPageSourceFileTest extends TestCase
         $this->file('_pages/foo.blade.php', 'foo');
 
         $this->expectException(FileConflictException::class);
-        $this->expectExceptionMessage('File already exists: '.Hyde::path('_pages/foo.blade.php'));
+        $this->expectExceptionMessage('File already exists: _pages/foo.blade.php');
         $this->expectExceptionCode(409);
 
         new CreatesNewPageSourceFile('foo', BladePage::class);
@@ -74,7 +74,7 @@ class CreatesNewPageSourceFileTest extends TestCase
         $this->file('_docs/foo.md', 'foo');
 
         $this->expectException(FileConflictException::class);
-        $this->expectExceptionMessage('File already exists: '.Hyde::path('_docs/foo.md'));
+        $this->expectExceptionMessage('File already exists: _docs/foo.md');
         $this->expectExceptionCode(409);
 
         new CreatesNewPageSourceFile('foo', DocumentationPage::class);

--- a/packages/framework/tests/Feature/Commands/MakePageCommandTest.php
+++ b/packages/framework/tests/Feature/Commands/MakePageCommandTest.php
@@ -98,7 +98,7 @@ class MakePageCommandTest extends TestCase
         file_put_contents($this->markdownPath, 'This should not be overwritten');
 
         $this->expectException(FileConflictException::class);
-        $this->expectExceptionMessage("File already exists: $this->markdownPath");
+        $this->expectExceptionMessage('File already exists: _pages/foo-test-page.md');
         $this->expectExceptionCode(409);
         $this->artisan('make:page "foo test page"')->assertExitCode(409);
 

--- a/packages/framework/tests/Unit/FileConflictExceptionTest.php
+++ b/packages/framework/tests/Unit/FileConflictExceptionTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Hyde\Framework\Testing\Unit;
 
+use Hyde\Foundation\HydeKernel;
 use Hyde\Framework\Exceptions\FileConflictException;
 use PHPUnit\Framework\TestCase;
 
@@ -12,5 +13,41 @@ use PHPUnit\Framework\TestCase;
  */
 class FileConflictExceptionTest extends TestCase
 {
-    //
+    public function test_it_can_be_instantiated()
+    {
+        $this->assertInstanceOf(FileConflictException::class, new FileConflictException());
+    }
+
+    public function test_it_can_be_thrown()
+    {
+        $this->expectException(FileConflictException::class);
+
+        throw new FileConflictException();
+    }
+
+    public function test_exception_code()
+    {
+        $this->assertSame(409, (new FileConflictException())->getCode());
+    }
+
+    public function test_exception_message()
+    {
+        $this->assertSame('A file already exists at this path.', (new FileConflictException())->getMessage());
+    }
+
+    public function test_exception_message_with_path()
+    {
+        HydeKernel::setInstance(new HydeKernel('my-base-path'));
+        $this->assertSame('File already exists: path/to/file', (new FileConflictException('path/to/file'))->getMessage());
+    }
+
+    public function test_exception_message_with_custom_message()
+    {
+        $this->assertSame('Custom message', (new FileConflictException(null, 'Custom message'))->getMessage());
+    }
+
+    public function test_exception_message_with_custom_message_and_path()
+    {
+        $this->assertSame('Custom message', (new FileConflictException('foo', 'Custom message'))->getMessage());
+    }
 }

--- a/packages/framework/tests/Unit/FileConflictExceptionTest.php
+++ b/packages/framework/tests/Unit/FileConflictExceptionTest.php
@@ -41,6 +41,12 @@ class FileConflictExceptionTest extends TestCase
         $this->assertSame('File already exists: path/to/file', (new FileConflictException('path/to/file'))->getMessage());
     }
 
+    public function test_exception_message_with_absolute_path()
+    {
+        HydeKernel::setInstance(new HydeKernel('my-base-path'));
+        $this->assertSame('File already exists: path/to/file', (new FileConflictException('my-base-path/path/to/file'))->getMessage());
+    }
+
     public function test_exception_message_with_custom_message()
     {
         $this->assertSame('Custom message', (new FileConflictException(null, 'Custom message'))->getMessage());

--- a/packages/framework/tests/Unit/FileConflictExceptionTest.php
+++ b/packages/framework/tests/Unit/FileConflictExceptionTest.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace Hyde\Framework\Testing\Unit;
 
 use Hyde\Framework\Exceptions\FileConflictException;
-use Hyde\Testing\TestCase;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @covers \Hyde\Framework\Exceptions\FileConflictException

--- a/packages/framework/tests/Unit/FileConflictExceptionTest.php
+++ b/packages/framework/tests/Unit/FileConflictExceptionTest.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Hyde\Framework\Testing\Unit;
+
+use Hyde\Framework\Exceptions\FileConflictException;
+use Hyde\Testing\TestCase;
+
+/**
+ * @covers \Hyde\Framework\Exceptions\FileConflictException
+ */
+class FileConflictExceptionTest extends TestCase
+{
+    //
+}


### PR DESCRIPTION
Updates the `FileConflictException` message to turn absolute paths to relative. This may break output that depends on the output. Some tests will need to be updated. Also adds a unit test for the exception class.