### PR TITLE
Make public InteractsWithDirectories trait methods protected

### DIFF
--- a/packages/framework/src/Framework/Concerns/InteractsWithDirectories.php
+++ b/packages/framework/src/Framework/Concerns/InteractsWithDirectories.php
@@ -16,7 +16,7 @@ trait InteractsWithDirectories
      *
      * @param  string  $directory  relative file path to the directory
      */
-    public static function needsDirectory(string $directory): void
+    protected static function needsDirectory(string $directory): void
     {
         if (! Filesystem::exists($directory)) {
             Filesystem::makeDirectory($directory, recursive: true);
@@ -28,7 +28,7 @@ trait InteractsWithDirectories
      *
      * @param  array<string>  $directories  array with relative file paths to the directories
      */
-    public static function needsDirectories(array $directories): void
+    protected static function needsDirectories(array $directories): void
     {
         foreach ($directories as $directory) {
             static::needsDirectory($directory);
@@ -38,7 +38,7 @@ trait InteractsWithDirectories
     /**
      * Ensure the supplied file's parent directory exists by creating it if it does not.
      */
-    public static function needsParentDirectory(string $file, int $levels = 1): void
+    protected static function needsParentDirectory(string $file, int $levels = 1): void
     {
         static::needsDirectory(dirname($file, $levels));
     }


### PR DESCRIPTION
This trait is intended to provide helpers for the class using it, not to add to its public API. So there should be no reason for these methods to be public.