### PR TITLE
Expand first collapsed sidebar group for documentation index page

### DIFF
--- a/packages/framework/src/Framework/Features/Navigation/DocumentationSidebar.php
+++ b/packages/framework/src/Framework/Features/Navigation/DocumentationSidebar.php
@@ -50,7 +50,7 @@ class DocumentationSidebar extends BaseNavigationMenu
     public function isGroupActive(string $group): bool
     {
         return Str::slug(Render::getPage()->navigationMenuGroup()) === $group
-            || Render::getPage()->getRoute()->is(DocumentationPage::homeRouteName()) && $group === collect($this->getGroups())->first();
+            || Render::getPage()->getRoute()->is(DocumentationPage::homeRouteName()) && Render::getPage()->navigationMenuGroup() === 'other' && $group === collect($this->getGroups())->first();
     }
 
     protected static function shouldItemBeHidden(NavItem $item): bool

--- a/packages/framework/src/Framework/Features/Navigation/DocumentationSidebar.php
+++ b/packages/framework/src/Framework/Features/Navigation/DocumentationSidebar.php
@@ -49,8 +49,9 @@ class DocumentationSidebar extends BaseNavigationMenu
 
     public function isGroupActive(string $group): bool
     {
-        return Str::slug(Render::getPage()->navigationMenuGroup()) === $group
-            || Render::getPage()->getRoute()->is(DocumentationPage::homeRouteName()) && Render::getPage()->navigationMenuGroup() === 'other' && $group === collect($this->getGroups())->first();
+        $pageGroup = Render::getPage()->navigationMenuGroup();
+        return Str::slug($pageGroup) === $group
+            || Render::getPage()->getRoute()->is(DocumentationPage::homeRouteName()) && $pageGroup === 'other' && $group === collect($this->getGroups())->first();
     }
 
     protected static function shouldItemBeHidden(NavItem $item): bool

--- a/packages/framework/src/Framework/Features/Navigation/DocumentationSidebar.php
+++ b/packages/framework/src/Framework/Features/Navigation/DocumentationSidebar.php
@@ -49,7 +49,8 @@ class DocumentationSidebar extends BaseNavigationMenu
 
     public function isGroupActive(string $group): bool
     {
-        return Str::slug(Render::getPage()->navigationMenuGroup()) === $group || Render::getPage()->getRoute()->is(DocumentationPage::homeRouteName()) && $group === collect($this->getGroups())->first();
+        return Str::slug(Render::getPage()->navigationMenuGroup()) === $group
+            || Render::getPage()->getRoute()->is(DocumentationPage::homeRouteName()) && $group === collect($this->getGroups())->first();
     }
 
     protected static function shouldItemBeHidden(NavItem $item): bool

--- a/packages/framework/src/Framework/Features/Navigation/DocumentationSidebar.php
+++ b/packages/framework/src/Framework/Features/Navigation/DocumentationSidebar.php
@@ -58,12 +58,12 @@ class DocumentationSidebar extends BaseNavigationMenu
         return parent::shouldItemBeHidden($item) || $item->getRoute()?->is(DocumentationPage::homeRouteName());
     }
 
-    protected function isPageIndexPage(): bool
+    private function isPageIndexPage(): bool
     {
         return Render::getPage()->getRoute()->is(DocumentationPage::homeRouteName());
     }
 
-    protected function shouldIndexPageBeActive(string $group): bool
+    private function shouldIndexPageBeActive(string $group): bool
     {
         return Render::getPage()->navigationMenuGroup() === 'other' && $group === collect($this->getGroups())->first();
     }

--- a/packages/framework/src/Framework/Features/Navigation/DocumentationSidebar.php
+++ b/packages/framework/src/Framework/Features/Navigation/DocumentationSidebar.php
@@ -49,9 +49,8 @@ class DocumentationSidebar extends BaseNavigationMenu
 
     public function isGroupActive(string $group): bool
     {
-        $pageGroup = Render::getPage()->navigationMenuGroup();
-        return Str::slug($pageGroup) === $group
-            || Render::getPage()->getRoute()->is(DocumentationPage::homeRouteName()) && $pageGroup === 'other' && $group === collect($this->getGroups())->first();
+        return Str::slug(Render::getPage()->navigationMenuGroup()) === $group
+            || Render::getPage()->getRoute()->is(DocumentationPage::homeRouteName()) && Render::getPage()->navigationMenuGroup() === 'other' && $group === collect($this->getGroups())->first();
     }
 
     protected static function shouldItemBeHidden(NavItem $item): bool

--- a/packages/framework/src/Framework/Features/Navigation/DocumentationSidebar.php
+++ b/packages/framework/src/Framework/Features/Navigation/DocumentationSidebar.php
@@ -49,7 +49,7 @@ class DocumentationSidebar extends BaseNavigationMenu
 
     public function isGroupActive(string $group): bool
     {
-        return Str::slug(Render::getPage()->navigationMenuGroup()) === $group;
+        return Str::slug(Render::getPage()->navigationMenuGroup()) === $group || Render::getPage()->getRoute()->is(DocumentationPage::home()) && $group === collect($this->getGroups())->first();
     }
 
     protected static function shouldItemBeHidden(NavItem $item): bool

--- a/packages/framework/src/Framework/Features/Navigation/DocumentationSidebar.php
+++ b/packages/framework/src/Framework/Features/Navigation/DocumentationSidebar.php
@@ -50,11 +50,21 @@ class DocumentationSidebar extends BaseNavigationMenu
     public function isGroupActive(string $group): bool
     {
         return Str::slug(Render::getPage()->navigationMenuGroup()) === $group
-            || Render::getPage()->getRoute()->is(DocumentationPage::homeRouteName()) && Render::getPage()->navigationMenuGroup() === 'other' && $group === collect($this->getGroups())->first();
+            || $this->isPageIndexPage() && $this->shouldIndexPageBeActive($group);
     }
 
     protected static function shouldItemBeHidden(NavItem $item): bool
     {
         return parent::shouldItemBeHidden($item) || $item->getRoute()?->is(DocumentationPage::homeRouteName());
+    }
+
+    protected function isPageIndexPage(): bool
+    {
+        return Render::getPage()->getRoute()->is(DocumentationPage::homeRouteName());
+    }
+
+    protected function shouldIndexPageBeActive(string $group): bool
+    {
+        return Render::getPage()->navigationMenuGroup() === 'other' && $group === collect($this->getGroups())->first();
     }
 }

--- a/packages/framework/src/Framework/Features/Navigation/DocumentationSidebar.php
+++ b/packages/framework/src/Framework/Features/Navigation/DocumentationSidebar.php
@@ -49,7 +49,7 @@ class DocumentationSidebar extends BaseNavigationMenu
 
     public function isGroupActive(string $group): bool
     {
-        return Str::slug(Render::getPage()->navigationMenuGroup()) === $group || Render::getPage()->getRoute()->is(DocumentationPage::home()) && $group === collect($this->getGroups())->first();
+        return Str::slug(Render::getPage()->navigationMenuGroup()) === $group || Render::getPage()->getRoute()->is(DocumentationPage::homeRouteName()) && $group === collect($this->getGroups())->first();
     }
 
     protected static function shouldItemBeHidden(NavItem $item): bool

--- a/packages/framework/tests/Feature/Services/DocumentationSidebarTest.php
+++ b/packages/framework/tests/Feature/Services/DocumentationSidebarTest.php
@@ -297,6 +297,32 @@ class DocumentationSidebarTest extends TestCase
         $this->assertTrue(DocumentationSidebar::create()->isGroupActive('foo-bar'));
     }
 
+    public function test_is_group_active_returns_true_first_group_of_index_page()
+    {
+        $this->makePage('index');
+        $this->makePage('foo', ['navigation.group' => 'foo']);
+        $this->makePage('bar', ['navigation.group' => 'bar']);
+        $this->makePage('baz', ['navigation.group' => 'baz']);
+
+        Render::setPage(DocumentationPage::get('index'));
+        $this->assertTrue(DocumentationSidebar::create()->isGroupActive('bar'));
+        $this->assertFalse(DocumentationSidebar::create()->isGroupActive('foo'));
+        $this->assertFalse(DocumentationSidebar::create()->isGroupActive('baz'));
+    }
+
+    public function test_is_group_active_returns_true_first_sorted_group_of_index_page()
+    {
+        $this->makePage('index');
+        $this->makePage('foo', ['navigation.group' => 'foo', 'navigation.priority' => 1]);
+        $this->makePage('bar', ['navigation.group' => 'bar', 'navigation.priority' => 2]);
+        $this->makePage('baz', ['navigation.group' => 'baz', 'navigation.priority' => 3]);
+
+        Render::setPage(DocumentationPage::get('index'));
+        $this->assertTrue(DocumentationSidebar::create()->isGroupActive('foo'));
+        $this->assertFalse(DocumentationSidebar::create()->isGroupActive('bar'));
+        $this->assertFalse(DocumentationSidebar::create()->isGroupActive('baz'));
+    }
+
     protected function createTestFiles(int $count = 5): void
     {
         for ($i = 0; $i < $count; $i++) {

--- a/packages/framework/tests/Feature/Services/DocumentationSidebarTest.php
+++ b/packages/framework/tests/Feature/Services/DocumentationSidebarTest.php
@@ -323,6 +323,14 @@ class DocumentationSidebarTest extends TestCase
         $this->assertFalse(DocumentationSidebar::create()->isGroupActive('baz'));
     }
 
+    public function test_is_group_active_for_index_page_with_no_groups()
+    {
+        $this->makePage('index');
+
+        Render::setPage(DocumentationPage::get('index'));
+        $this->assertFalse(DocumentationSidebar::create()->isGroupActive('foo'));
+    }
+
     protected function createTestFiles(int $count = 5): void
     {
         for ($i = 0; $i < $count; $i++) {

--- a/packages/framework/tests/Feature/Services/DocumentationSidebarTest.php
+++ b/packages/framework/tests/Feature/Services/DocumentationSidebarTest.php
@@ -323,6 +323,19 @@ class DocumentationSidebarTest extends TestCase
         $this->assertFalse(DocumentationSidebar::create()->isGroupActive('baz'));
     }
 
+    public function test_automatic_index_page_group_expansion_respects_custom_navigation_menu_settings()
+    {
+        $this->makePage('index', ['navigation.group' => 'baz']);
+        $this->makePage('foo', ['navigation.group' => 'foo', 'navigation.priority' => 1]);
+        $this->makePage('bar', ['navigation.group' => 'bar', 'navigation.priority' => 2]);
+        $this->makePage('baz', ['navigation.group' => 'baz', 'navigation.priority' => 3]);
+
+        Render::setPage(DocumentationPage::get('index'));
+        $this->assertFalse(DocumentationSidebar::create()->isGroupActive('foo'));
+        $this->assertFalse(DocumentationSidebar::create()->isGroupActive('bar'));
+        $this->assertTrue(DocumentationSidebar::create()->isGroupActive('baz'));
+    }
+
     public function test_is_group_active_for_index_page_with_no_groups()
     {
         $this->makePage('index');


### PR DESCRIPTION
### Abstract
Updates the navigation group isActive logic so that the first navigation group of a collapsed sidebar is considered active when on the documentation page, even if the index page does not have a specified navigation group. This automatic state is not applied if the index page has a navigation menu group set in its front matter. Fixes https://github.com/hydephp/develop/issues/1083

### Comparison
| Before                                                                                                                                               | After                                                                                                                                                    |
|------------------------------------------------------------------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------|
| ![hydephp github io_develop_master_dev-docs_](https://user-images.githubusercontent.com/95144705/220333376-82a20e60-955f-45ba-97d8-0688c07e78fc.png) | ![hydephp github io_develop_master_dev-docs_ (1)](https://user-images.githubusercontent.com/95144705/220333366-dac96ab3-754d-407a-a5d9-67e3ca0c9fdc.png) |


**Sidenote:** Man I love fluent method chains!

```php
Render::getPage()->getRoute()->is(DocumentationPage::homeRouteName());
```


