### PR TITLE
Polish the BuildTask API

### DIFF
--- a/docs/digging-deeper/advanced-customization.md
+++ b/docs/digging-deeper/advanced-customization.md
@@ -127,7 +127,7 @@ This will then output the following, where you can see that some extra output, i
 
 ### Full example
 
-You can also set the description, and an optional `then()` method to run after the main task has been executed. The then method is great if you want to display a status message.
+You can also set the message, and an optional `then()` method to run after the main task has been executed. The then method is great if you want to display a status message.
 
 ```php
 <?php
@@ -138,7 +138,7 @@ use Hyde\Framework\Features\BuildTasks\BuildTask;
 
 class ExampleTask extends BuildTask
 {
-    public static string $description = 'Say hello';
+    public static string $message = 'Say hello';
 
     public function run(): void
     {

--- a/packages/framework/src/Console/Commands/BuildRssFeedCommand.php
+++ b/packages/framework/src/Console/Commands/BuildRssFeedCommand.php
@@ -22,6 +22,6 @@ class BuildRssFeedCommand extends Command
 
     public function handle(): int
     {
-        return (new GenerateRssFeed($this->output))->handle() ?? Command::SUCCESS;
+        return (new GenerateRssFeed($this->output))->handle();
     }
 }

--- a/packages/framework/src/Console/Commands/BuildSearchCommand.php
+++ b/packages/framework/src/Console/Commands/BuildSearchCommand.php
@@ -22,6 +22,6 @@ class BuildSearchCommand extends Command
 
     public function handle(): int
     {
-        return (new GenerateSearch($this->output))->handle() ?? Command::SUCCESS;
+        return (new GenerateSearch($this->output))->handle();
     }
 }

--- a/packages/framework/src/Console/Commands/BuildSitemapCommand.php
+++ b/packages/framework/src/Console/Commands/BuildSitemapCommand.php
@@ -22,6 +22,6 @@ class BuildSitemapCommand extends Command
 
     public function handle(): int
     {
-        return (new GenerateSitemap($this->output))->handle() ?? Command::SUCCESS;
+        return (new GenerateSitemap($this->output))->handle();
     }
 }

--- a/packages/framework/src/Console/Commands/RebuildStaticPageCommand.php
+++ b/packages/framework/src/Console/Commands/RebuildStaticPageCommand.php
@@ -53,7 +53,7 @@ class RebuildStaticPageCommand extends Command
     {
         return new class($output, $path) extends BuildTask
         {
-            public static string $description = 'Rebuilding page';
+            public static string $message = 'Rebuilding page';
 
             protected string $path;
 

--- a/packages/framework/src/Console/Commands/RebuildStaticPageCommand.php
+++ b/packages/framework/src/Console/Commands/RebuildStaticPageCommand.php
@@ -41,7 +41,7 @@ class RebuildStaticPageCommand extends Command
             return Command::SUCCESS;
         }
 
-        return $this->makeBuildTask($this->output, $this->getNormalizedPathString())->handle() ?? Command::SUCCESS;
+        return $this->makeBuildTask($this->output, $this->getNormalizedPathString())->handle();
     }
 
     protected function getNormalizedPathString(): string

--- a/packages/framework/src/Framework/Features/BuildTasks/BuildTask.php
+++ b/packages/framework/src/Framework/Features/BuildTasks/BuildTask.php
@@ -8,6 +8,7 @@ use Hyde\Framework\Concerns\TracksExecutionTime;
 use Hyde\Hyde;
 use Illuminate\Console\Concerns\InteractsWithIO;
 use Illuminate\Console\OutputStyle;
+use Symfony\Component\Console\Command\Command;
 use Throwable;
 
 /**
@@ -20,7 +21,7 @@ abstract class BuildTask
 
     protected static string $message = 'Running generic build task';
 
-    protected int $exitCode = 0;
+    protected int $exitCode = Command::SUCCESS;
 
     /** @var \Illuminate\Console\OutputStyle|null */
     protected $output;

--- a/packages/framework/src/Framework/Features/BuildTasks/BuildTask.php
+++ b/packages/framework/src/Framework/Features/BuildTasks/BuildTask.php
@@ -20,10 +20,7 @@ abstract class BuildTask
 
     protected static string $message = 'Running generic build task';
 
-    /**
-     * @todo Consider setting default value to 0
-     */
-    protected ?int $exitCode = null;
+    protected ?int $exitCode = 0;
 
     /** @var \Illuminate\Console\OutputStyle|null */
     protected $output;

--- a/packages/framework/src/Framework/Features/BuildTasks/BuildTask.php
+++ b/packages/framework/src/Framework/Features/BuildTasks/BuildTask.php
@@ -31,7 +31,7 @@ abstract class BuildTask
         $this->output = $output;
     }
 
-    public function handle(): ?int
+    public function handle(): int
     {
         $this->write('<comment>'.$this->getDescription().'...</comment> ');
 

--- a/packages/framework/src/Framework/Features/BuildTasks/BuildTask.php
+++ b/packages/framework/src/Framework/Features/BuildTasks/BuildTask.php
@@ -18,8 +18,7 @@ abstract class BuildTask
     use InteractsWithIO;
     use TracksExecutionTime;
 
-    /** @todo Consider renaming to $message */
-    protected static string $description = 'Generic build task';
+    protected static string $message = 'Running generic build task';
 
     /**
      * @todo Consider setting default value to 0
@@ -62,7 +61,7 @@ abstract class BuildTask
 
     public function getDescription(): string
     {
-        return static::$description;
+        return static::$message;
     }
 
     public function write(string $message): void

--- a/packages/framework/src/Framework/Features/BuildTasks/BuildTask.php
+++ b/packages/framework/src/Framework/Features/BuildTasks/BuildTask.php
@@ -20,7 +20,7 @@ abstract class BuildTask
 
     protected static string $message = 'Running generic build task';
 
-    protected ?int $exitCode = 0;
+    protected int $exitCode = 0;
 
     /** @var \Illuminate\Console\OutputStyle|null */
     protected $output;

--- a/packages/framework/src/Framework/Features/BuildTasks/PostBuildTasks/GenerateBuildManifest.php
+++ b/packages/framework/src/Framework/Features/BuildTasks/PostBuildTasks/GenerateBuildManifest.php
@@ -17,7 +17,7 @@ use function Hyde\unixsum_file as unixsum_file1;
  */
 class GenerateBuildManifest extends BuildTask
 {
-    public static string $description = 'Generating build manifest';
+    public static string $message = 'Generating build manifest';
 
     public function __construct(?OutputStyle $output = null)
     {

--- a/packages/framework/src/Framework/Features/BuildTasks/PostBuildTasks/GenerateRssFeed.php
+++ b/packages/framework/src/Framework/Features/BuildTasks/PostBuildTasks/GenerateRssFeed.php
@@ -10,7 +10,7 @@ use Hyde\Hyde;
 
 class GenerateRssFeed extends BuildTask
 {
-    public static string $description = 'Generating RSS feed';
+    public static string $message = 'Generating RSS feed';
 
     public function run(): void
     {

--- a/packages/framework/src/Framework/Features/BuildTasks/PostBuildTasks/GenerateSearch.php
+++ b/packages/framework/src/Framework/Features/BuildTasks/PostBuildTasks/GenerateSearch.php
@@ -13,7 +13,7 @@ class GenerateSearch extends BuildTask
 {
     use InteractsWithDirectories;
 
-    public static string $description = 'Generating search index';
+    public static string $message = 'Generating search index';
 
     public function run(): void
     {

--- a/packages/framework/src/Framework/Features/BuildTasks/PostBuildTasks/GenerateSitemap.php
+++ b/packages/framework/src/Framework/Features/BuildTasks/PostBuildTasks/GenerateSitemap.php
@@ -10,7 +10,7 @@ use Hyde\Hyde;
 
 class GenerateSitemap extends BuildTask
 {
-    public static string $description = 'Generating sitemap';
+    public static string $message = 'Generating sitemap';
 
     public function run(): void
     {


### PR DESCRIPTION
Goes over the BuildTasks feature and their API. Contains breaking changes to any existing BuildTasks.

Notable and breaking changes:
- Breaking: Rename BuildTask::$description to BuildTask::$message
- Minor breaking: BuildTask::handle() no longer has nullable return type
- Minor breaking: BuildTask::$exitCode is no longer nullable
- May break things: Set default BuildTask exit code from null to 0
