### PR TITLE
Add Hyde::mediaLink argument to enable source media file existence validation

### DIFF
--- a/packages/framework/src/Foundation/Concerns/ForwardsHyperlinks.php
+++ b/packages/framework/src/Foundation/Concerns/ForwardsHyperlinks.php
@@ -21,9 +21,9 @@ trait ForwardsHyperlinks
         return $this->hyperlinks->relativeLink($destination);
     }
 
-    public function mediaLink(string $destination): string
+    public function mediaLink(string $destination, bool $validate = false): string
     {
-        return $this->hyperlinks->mediaLink($destination);
+        return $this->hyperlinks->mediaLink($destination, $validate);
     }
 
     public function image(string $name, bool $preferQualifiedUrl = false): string

--- a/packages/framework/src/Foundation/Concerns/ForwardsHyperlinks.php
+++ b/packages/framework/src/Foundation/Concerns/ForwardsHyperlinks.php
@@ -21,7 +21,7 @@ trait ForwardsHyperlinks
         return $this->hyperlinks->relativeLink($destination);
     }
 
-    public function mediaLink(string $destination, bool $validate = true): string
+    public function mediaLink(string $destination, bool $validate = false): string
     {
         return $this->hyperlinks->mediaLink($destination, $validate);
     }

--- a/packages/framework/src/Foundation/Concerns/ForwardsHyperlinks.php
+++ b/packages/framework/src/Foundation/Concerns/ForwardsHyperlinks.php
@@ -21,7 +21,7 @@ trait ForwardsHyperlinks
         return $this->hyperlinks->relativeLink($destination);
     }
 
-    public function mediaLink(string $destination, bool $validate = false): string
+    public function mediaLink(string $destination, bool $validate = true): string
     {
         return $this->hyperlinks->mediaLink($destination, $validate);
     }

--- a/packages/framework/src/Foundation/Kernel/Hyperlinks.php
+++ b/packages/framework/src/Foundation/Kernel/Hyperlinks.php
@@ -88,6 +88,8 @@ class Hyperlinks
      *
      * If true is passed as the second argument, and a base URL is set,
      * the image will be returned with a qualified absolute URL.
+     *
+     * @todo Rename to asset? Or just merge with mediaLink?
      */
     public function image(string $name, bool $preferQualifiedUrl = false): string
     {

--- a/packages/framework/src/Foundation/Kernel/Hyperlinks.php
+++ b/packages/framework/src/Foundation/Kernel/Hyperlinks.php
@@ -75,7 +75,7 @@ class Hyperlinks
     /**
      * Gets a relative web link to the given file stored in the _site/media folder.
      *
-     * @todo Add default option that throws if file is not present in _site/media (or just) _media?
+     * @todo Add default option that throws if file is not present in _media?
      */
     public function mediaLink(string $destination): string
     {

--- a/packages/framework/src/Foundation/Kernel/Hyperlinks.php
+++ b/packages/framework/src/Foundation/Kernel/Hyperlinks.php
@@ -6,6 +6,7 @@ namespace Hyde\Foundation\Kernel;
 
 use Hyde\Foundation\HydeKernel;
 use Hyde\Framework\Exceptions\BaseUrlNotSetException;
+use Hyde\Framework\Exceptions\FileNotFoundException;
 use Hyde\Pages\DocumentationPage;
 use Illuminate\Support\Str;
 
@@ -75,10 +76,15 @@ class Hyperlinks
     /**
      * Gets a relative web link to the given file stored in the _site/media folder.
      *
-     * @todo Add default option that throws if file is not present in _media?
+     * An exception will be thrown if the file does not exist in the _media directory,
+     * and the second argument is set to true.
      */
-    public function mediaLink(string $destination): string
+    public function mediaLink(string $destination, bool $validate = false): string
     {
+        if ($validate && ! file_exists($sourcePath = $this->kernel->getMediaDirectory()."/$destination")) {
+            throw new FileNotFoundException($sourcePath);
+        }
+
         return $this->relativeLink($this->kernel->getMediaOutputDirectory()."/$destination");
     }
 

--- a/packages/framework/src/Foundation/Kernel/Hyperlinks.php
+++ b/packages/framework/src/Foundation/Kernel/Hyperlinks.php
@@ -79,7 +79,7 @@ class Hyperlinks
      * An exception will be thrown if the file does not exist in the _media directory,
      * and the second argument is set to true.
      */
-    public function mediaLink(string $destination, bool $validate = false): string
+    public function mediaLink(string $destination, bool $validate = true): string
     {
         if ($validate && ! file_exists($sourcePath = "{$this->kernel->getMediaDirectory()}/$destination")) {
             throw new FileNotFoundException($sourcePath);

--- a/packages/framework/src/Foundation/Kernel/Hyperlinks.php
+++ b/packages/framework/src/Foundation/Kernel/Hyperlinks.php
@@ -79,7 +79,7 @@ class Hyperlinks
      * An exception will be thrown if the file does not exist in the _media directory,
      * and the second argument is set to true.
      */
-    public function mediaLink(string $destination, bool $validate = true): string
+    public function mediaLink(string $destination, bool $validate = false): string
     {
         if ($validate && ! file_exists($sourcePath = "{$this->kernel->getMediaDirectory()}/$destination")) {
             throw new FileNotFoundException($sourcePath);

--- a/packages/framework/src/Foundation/Kernel/Hyperlinks.php
+++ b/packages/framework/src/Foundation/Kernel/Hyperlinks.php
@@ -81,11 +81,11 @@ class Hyperlinks
      */
     public function mediaLink(string $destination, bool $validate = false): string
     {
-        if ($validate && ! file_exists($sourcePath = $this->kernel->getMediaDirectory()."/$destination")) {
+        if ($validate && ! file_exists($sourcePath = "{$this->kernel->getMediaDirectory()}/$destination")) {
             throw new FileNotFoundException($sourcePath);
         }
 
-        return $this->relativeLink($this->kernel->getMediaOutputDirectory()."/$destination");
+        return $this->relativeLink("{$this->kernel->getMediaOutputDirectory()}/$destination");
     }
 
     /**

--- a/packages/framework/src/Hyde.php
+++ b/packages/framework/src/Hyde.php
@@ -38,7 +38,7 @@ use Illuminate\Support\HtmlString;
  * @method static string siteMediaPath(string $path = '')
  * @method static string formatLink(string $destination)
  * @method static string relativeLink(string $destination)
- * @method static string mediaLink(string $destination)
+ * @method static string mediaLink(string $destination, bool $validate = false)
  * @method static string image(string $name, bool $preferQualifiedUrl = false)
  * @method static string url(string $path = '')
  * @method static string makeTitle(string $value)

--- a/packages/framework/src/Hyde.php
+++ b/packages/framework/src/Hyde.php
@@ -38,7 +38,7 @@ use Illuminate\Support\HtmlString;
  * @method static string siteMediaPath(string $path = '')
  * @method static string formatLink(string $destination)
  * @method static string relativeLink(string $destination)
- * @method static string mediaLink(string $destination, bool $validate = true)
+ * @method static string mediaLink(string $destination, bool $validate = false)
  * @method static string image(string $name, bool $preferQualifiedUrl = false)
  * @method static string url(string $path = '')
  * @method static string makeTitle(string $value)

--- a/packages/framework/src/Hyde.php
+++ b/packages/framework/src/Hyde.php
@@ -38,7 +38,7 @@ use Illuminate\Support\HtmlString;
  * @method static string siteMediaPath(string $path = '')
  * @method static string formatLink(string $destination)
  * @method static string relativeLink(string $destination)
- * @method static string mediaLink(string $destination, bool $validate = false)
+ * @method static string mediaLink(string $destination, bool $validate = true)
  * @method static string image(string $name, bool $preferQualifiedUrl = false)
  * @method static string url(string $path = '')
  * @method static string makeTitle(string $value)

--- a/packages/framework/tests/Feature/Foundation/HyperlinksTest.php
+++ b/packages/framework/tests/Feature/Foundation/HyperlinksTest.php
@@ -6,6 +6,7 @@ namespace Hyde\Framework\Testing\Feature\Foundation;
 
 use Hyde\Foundation\HydeKernel;
 use Hyde\Foundation\Kernel\Hyperlinks;
+use Hyde\Framework\Exceptions\FileNotFoundException;
 use Hyde\Hyde;
 use Hyde\Testing\TestCase;
 
@@ -89,5 +90,17 @@ class HyperlinksTest extends TestCase
     {
         Hyde::setMediaDirectory('_assets');
         $this->assertSame('assets/foo', $this->class->mediaLink('foo'));
+    }
+
+    public function test_media_link_helper_with_validation_and_existing_file()
+    {
+        $this->file('_media/foo');
+        $this->assertSame('media/foo', $this->class->mediaLink('foo', true));
+    }
+
+    public function test_media_link_helper_with_validation_and_non_existing_file()
+    {
+        $this->expectException(FileNotFoundException::class);
+        $this->class->mediaLink('foo', true);
     }
 }


### PR DESCRIPTION
Adds an argument to the Hyde::mediaLink helper that will enable a validation that will throw an exception if the file could not be found in the configured _media directory.