### PR TITLE
Breaking: Update schema interfaces to use a pseudo-generic array specifier

### DIFF
--- a/packages/framework/src/Markdown/Contracts/FrontMatter/BlogPostSchema.php
+++ b/packages/framework/src/Markdown/Contracts/FrontMatter/BlogPostSchema.php
@@ -16,8 +16,8 @@ interface BlogPostSchema extends FeaturedImageSchema
         'description'  => 'string',
         'category'     => 'string',
         'date'         => 'string',
-        'author'       => 'string|array|author',
-        'image'        => 'string|array|featured_image',
+        'author'       => 'string|array<self.author>',
+        'image'        => 'string|array<featured_image>',
     ];
 
     public const AUTHOR_SCHEMA = [

--- a/packages/framework/src/Markdown/Contracts/FrontMatter/BlogPostSchema.php
+++ b/packages/framework/src/Markdown/Contracts/FrontMatter/BlogPostSchema.php
@@ -16,7 +16,7 @@ interface BlogPostSchema extends FeaturedImageSchema
         'description'  => 'string',
         'category'     => 'string',
         'date'         => 'string',
-        'author'       => 'string|array<self.author>',
+        'author'       => 'string|array<blog_post.author>',
         'image'        => 'string|array<featured_image>',
     ];
 

--- a/packages/framework/src/Markdown/Contracts/FrontMatter/PageSchema.php
+++ b/packages/framework/src/Markdown/Contracts/FrontMatter/PageSchema.php
@@ -14,6 +14,6 @@ interface PageSchema extends NavigationSchema
     public const PAGE_SCHEMA = [
         'title'         => 'string',
         'canonicalUrl'  => 'string|url',
-        'navigation'    => 'array|navigation',
+        'navigation'    => 'array<navigation>',
     ];
 }

--- a/packages/framework/tests/Unit/SchemaContractsTest.php
+++ b/packages/framework/tests/Unit/SchemaContractsTest.php
@@ -23,7 +23,7 @@ class SchemaContractsTest extends TestCase
     {
         $this->assertEquals([
             'title'         => 'string',
-            'navigation'    => 'array|navigation',
+            'navigation'    => 'array<navigation>',
             'canonicalUrl'  => 'string|url',
         ], PageSchema::PAGE_SCHEMA);
 
@@ -39,8 +39,8 @@ class SchemaContractsTest extends TestCase
             'description'  => 'string',
             'category'     => 'string',
             'date'         => 'string',
-            'author'       => 'string|array|author',
-            'image'        => 'string|array|featured_image',
+            'author'       => 'string|array<self.author>',
+            'image'        => 'string|array<featured_image>',
         ], BlogPostSchema::MARKDOWN_POST_SCHEMA);
 
         $this->assertEquals([

--- a/packages/framework/tests/Unit/SchemaContractsTest.php
+++ b/packages/framework/tests/Unit/SchemaContractsTest.php
@@ -39,7 +39,7 @@ class SchemaContractsTest extends TestCase
             'description'  => 'string',
             'category'     => 'string',
             'date'         => 'string',
-            'author'       => 'string|array<self.author>',
+            'author'       => 'string|array<blog_post.author>',
             'image'        => 'string|array<featured_image>',
         ], BlogPostSchema::MARKDOWN_POST_SCHEMA);
 


### PR DESCRIPTION
### Abstract

Updates the syntax of the front matter schema arrays to change how subschemas are referenced. This is breaking as it modifies interfaces.

### Motivation & Examples

The previous format for referencing sub-schemas is a bit unclear. Take the following as an example:

```php
'string|array|featured_image'
```

To me, this looks like the property accepts three input types. But in fact, it only accepts two. String, OR an array conforming to the `FeaturedImage` subschema.

#### The new syntax looks as follows:

```php
'string|array<featured_image>'
```

I believe this makes it more clear that two types are accepted and due to the `|` operator it's one `OR` the other. And I think it signifies that the array is of the generic shape of `FeaturedImage`.

#### In-interface subschemas
For the `BlogPostSchema` interface that has a secondary constant for the author schema, this is referenced as `<blog_post.author>` (Interface name + constant name)