### PR TITLE
Breaking: Update schema interface syntax for union typed url-strings

### DIFF
--- a/packages/framework/src/Markdown/Contracts/FrontMatter/BlogPostSchema.php
+++ b/packages/framework/src/Markdown/Contracts/FrontMatter/BlogPostSchema.php
@@ -23,6 +23,6 @@ interface BlogPostSchema extends FeaturedImageSchema
     public const AUTHOR_SCHEMA = [
         'name'      => 'string',
         'username'  => 'string',
-        'website'   => 'string|url',
+        'website'   => 'string(url)',
     ];
 }

--- a/packages/framework/src/Markdown/Contracts/FrontMatter/PageSchema.php
+++ b/packages/framework/src/Markdown/Contracts/FrontMatter/PageSchema.php
@@ -13,7 +13,7 @@ interface PageSchema extends NavigationSchema
 {
     public const PAGE_SCHEMA = [
         'title'         => 'string',
-        'canonicalUrl'  => 'string|url',
+        'canonicalUrl'  => 'string(url)',
         'navigation'    => 'array<navigation>',
     ];
 }

--- a/packages/framework/tests/Unit/SchemaContractsTest.php
+++ b/packages/framework/tests/Unit/SchemaContractsTest.php
@@ -24,7 +24,7 @@ class SchemaContractsTest extends TestCase
         $this->assertEquals([
             'title'         => 'string',
             'navigation'    => 'array<navigation>',
-            'canonicalUrl'  => 'string|url',
+            'canonicalUrl'  => 'string(url)',
         ], PageSchema::PAGE_SCHEMA);
 
         $this->assertEquals([
@@ -46,7 +46,7 @@ class SchemaContractsTest extends TestCase
         $this->assertEquals([
             'name'      => 'string',
             'username'  => 'string',
-            'website'   => 'string|url',
+            'website'   => 'string(url)',
         ], BlogPostSchema::AUTHOR_SCHEMA);
 
         $this->assertEquals([


### PR DESCRIPTION
### Abstract

Similar to https://github.com/hydephp/develop/pull/1090, this change changes the `'string|url'` syntax to be `'string(url)'` to make it clearer that the auxiliary type is a specifier not an alternative standalone type.

It uses `(parentheses)` instead of `<generics>` to distinguish it from the subschema identifiers added in #1090. I also considered a pseudo type of `'url-string'` but I think this change is more easily machine-and-humanly modifiable.