### PR TITLE
Aggressively simplify the featured image classes

### DIFF
--- a/docs/creating-content/blog-posts.md
+++ b/docs/creating-content/blog-posts.md
@@ -186,11 +186,11 @@ will override all the values in the `authors` config entry.
 ### Image
 
 ```yaml
-image: image.jpg # Expanded by Hyde to `_media/image.jpg` and is resolved automatically
-image: https://cdn.example.com/image.jpg # Full URL starting with `http(s)://`)
+image: image.jpg # Expanded by Hyde to `_media/image.jpg` and is resolved automatically to the correct URL for the built site
+image: https://cdn.example.com/image.jpg # Full URL starting with `http(s)://`) or `//` (protocol-relative)
 image:
-  path: image.jpg
-  url: https://cdn.example.com/image.jpg # Takes precedence over `path`
+  source: image.jpg # Same as above
+  source: https://cdn.example.com/image.jpg # Same as above
   description: "Alt text for image"
   title: "Tooltip title"
   copyright: "Copyright (c) 2022"
@@ -200,7 +200,10 @@ image:
   author: "John Doe"
 ```
 
-When supplying an image with a local image path, the image is expected to be stored in the `_media/` directory.
+When supplying an image source with a local image path, the image is expected to be stored in the `_media/` directory.
+Like all other media files, it will be copied to `_site/media/` when the site is built, so Hyde will resolve links accordingly.
+
+When supplying an image with a full URL, the image source will be used as-is, and no additional processing is done.
 
 The image will be used as the cover image, and any array data is constructed into a dynamic fluent caption,
 and injected into post and page metadata.

--- a/packages/framework/src/Framework/Factories/FeaturedImageFactory.php
+++ b/packages/framework/src/Framework/Factories/FeaturedImageFactory.php
@@ -5,8 +5,6 @@ declare(strict_types=1);
 namespace Hyde\Framework\Factories;
 
 use Hyde\Framework\Features\Blogging\Models\FeaturedImage;
-use Hyde\Framework\Features\Blogging\Models\LocalFeaturedImage;
-use Hyde\Framework\Features\Blogging\Models\RemoteFeaturedImage;
 use Hyde\Hyde;
 use Hyde\Markdown\Contracts\FrontMatter\SubSchemas\FeaturedImageSchema;
 use Hyde\Markdown\Models\FrontMatter;
@@ -62,11 +60,7 @@ class FeaturedImageFactory extends Concerns\PageDataFactory implements FeaturedI
     {
         $data = (new static($matter))->toArray();
 
-        if (self::isRemote($matter)) {
-            return new RemoteFeaturedImage(...$data);
-        }
-
-        return new LocalFeaturedImage(...$data);
+        return new FeaturedImage(...$data);
     }
 
     protected function makeSource(): string

--- a/packages/framework/src/Framework/Factories/FeaturedImageFactory.php
+++ b/packages/framework/src/Framework/Factories/FeaturedImageFactory.php
@@ -30,13 +30,13 @@ class FeaturedImageFactory extends Concerns\PageDataFactory implements FeaturedI
         private readonly FrontMatter $matter,
     ) {
         $this->source = $this->makeSource();
-        $this->altText = $this->makeAltText();
-        $this->titleText = $this->makeTitleText();
-        $this->authorName = $this->makeAuthorName();
-        $this->authorUrl = $this->makeAuthorUrl();
-        $this->copyrightText = $this->makeCopyrightText();
-        $this->licenseName = $this->makeLicenseName();
-        $this->licenseUrl = $this->makeLicenseUrl();
+        $this->altText = $this->getStringMatter('image.description');
+        $this->titleText = $this->getStringMatter('image.title');
+        $this->authorName = $this->getStringMatter('image.author');
+        $this->authorUrl = $this->getStringMatter('image.attributionUrl');
+        $this->copyrightText = $this->getStringMatter('image.copyright');
+        $this->licenseName = $this->getStringMatter('image.license');
+        $this->licenseUrl = $this->getStringMatter('image.licenseUrl');
     }
 
     /**
@@ -78,41 +78,6 @@ class FeaturedImageFactory extends Concerns\PageDataFactory implements FeaturedI
         }
 
         return self::normalizeLocalImagePath($value);
-    }
-
-    protected function makeAltText(): ?string
-    {
-        return $this->getStringMatter('image.description');
-    }
-
-    protected function makeTitleText(): ?string
-    {
-        return $this->getStringMatter('image.title');
-    }
-
-    protected function makeAuthorName(): ?string
-    {
-        return $this->getStringMatter('image.author');
-    }
-
-    protected function makeAuthorUrl(): ?string
-    {
-        return $this->getStringMatter('image.attributionUrl');
-    }
-
-    protected function makeCopyrightText(): ?string
-    {
-        return $this->getStringMatter('image.copyright');
-    }
-
-    protected function makeLicenseName(): ?string
-    {
-        return $this->getStringMatter('image.license');
-    }
-
-    protected function makeLicenseUrl(): ?string
-    {
-        return $this->getStringMatter('image.licenseUrl');
     }
 
     protected static function normalizeLocalImagePath(string $path): string

--- a/packages/framework/src/Framework/Factories/FeaturedImageFactory.php
+++ b/packages/framework/src/Framework/Factories/FeaturedImageFactory.php
@@ -125,15 +125,6 @@ class FeaturedImageFactory extends Concerns\PageDataFactory implements FeaturedI
         return unslash($path);
     }
 
-    protected static function isRemote(FrontMatter $matter): bool
-    {
-        if (is_string($matter->get('image')) && str_starts_with($matter->get('image'), 'http')) {
-            return true;
-        }
-
-        return $matter->get('image.url') !== null;
-    }
-
     protected function getStringMatter(string $key): ?string
     {
         return is_string($this->matter->get($key)) ? $this->matter->get($key) : null;

--- a/packages/framework/src/Framework/Factories/FeaturedImageFactory.php
+++ b/packages/framework/src/Framework/Factories/FeaturedImageFactory.php
@@ -139,12 +139,11 @@ class FeaturedImageFactory extends Concerns\PageDataFactory implements FeaturedI
 
     protected static function isRemote(FrontMatter $matter): bool
     {
-        $value = $matter->get('image') ?? $matter->get('image.source');
-        if (is_string($value) && str_starts_with($value, 'http')) {
+        if (is_string($matter->get('image')) && str_starts_with($matter->get('image'), 'http')) {
             return true;
         }
 
-        return $value !== null;
+        return $matter->get('image.url') !== null;
     }
 
     protected function getStringMatter(string $key): ?string

--- a/packages/framework/src/Framework/Factories/FeaturedImageFactory.php
+++ b/packages/framework/src/Framework/Factories/FeaturedImageFactory.php
@@ -72,6 +72,8 @@ class FeaturedImageFactory extends Concerns\PageDataFactory implements FeaturedI
     protected function makeSource(): string
     {
         $flatValue = $this->getStringMatter('image');
+        $arrayValue = $this->getStringMatter('image.source');
+
         if (is_string($flatValue)) {
             if (str_starts_with($flatValue, 'http')) {
                 return $flatValue;
@@ -80,7 +82,6 @@ class FeaturedImageFactory extends Concerns\PageDataFactory implements FeaturedI
             return self::normalizeLocalImagePath($flatValue);
         }
 
-        $arrayValue = $this->getStringMatter('image.source');
         if ($arrayValue !== null) {
             if (str_starts_with($arrayValue, 'http')) {
                 return $arrayValue;

--- a/packages/framework/src/Framework/Factories/FeaturedImageFactory.php
+++ b/packages/framework/src/Framework/Factories/FeaturedImageFactory.php
@@ -71,20 +71,22 @@ class FeaturedImageFactory extends Concerns\PageDataFactory implements FeaturedI
 
     protected function makeSource(): string
     {
-        if (is_string($this->getStringMatter('image'))) {
-            if (str_starts_with($this->getStringMatter('image'), 'http')) {
-                return $this->getStringMatter('image');
+        $flatValue = $this->getStringMatter('image');
+        if (is_string($flatValue)) {
+            if (str_starts_with($flatValue, 'http')) {
+                return $flatValue;
             }
 
-            return self::normalizeLocalImagePath($this->getStringMatter('image'));
+            return self::normalizeLocalImagePath($flatValue);
         }
 
-        if ($this->getStringMatter('image.source') !== null) {
-            if (str_starts_with($this->getStringMatter('image.source'), 'http')) {
-                return $this->getStringMatter('image.source');
+        $arrayValue = $this->getStringMatter('image.source');
+        if ($arrayValue !== null) {
+            if (str_starts_with($arrayValue, 'http')) {
+                return $arrayValue;
             }
 
-            return $this->normalizeLocalImagePath($this->getStringMatter('image.source'));
+            return $this->normalizeLocalImagePath($arrayValue);
         }
 
         // Todo, we might want to add a note about which file caused the error.

--- a/packages/framework/src/Framework/Factories/FeaturedImageFactory.php
+++ b/packages/framework/src/Framework/Factories/FeaturedImageFactory.php
@@ -122,7 +122,7 @@ class FeaturedImageFactory extends Concerns\PageDataFactory implements FeaturedI
         $path = Str::after($path, Hyde::getMediaDirectory());
         $path = Str::after($path, Hyde::getMediaOutputDirectory());
 
-        return unslash($path);
+        return str_starts_with($path, '//') ? $path : unslash($path);
     }
 
     protected function getStringMatter(string $key): ?string

--- a/packages/framework/src/Framework/Factories/FeaturedImageFactory.php
+++ b/packages/framework/src/Framework/Factories/FeaturedImageFactory.php
@@ -67,7 +67,7 @@ class FeaturedImageFactory extends Concerns\PageDataFactory implements FeaturedI
     {
         $value = $this->getStringMatter('image') ?? $this->getStringMatter('image.source');
 
-        if (is_null($value)) {
+        if (empty($value)) {
             // Todo, we might want to add a note about which file caused the error.
             // We could also check for these before calling the factory, and just ignore the image if it's not valid.
             throw new RuntimeException('No featured image source was found');

--- a/packages/framework/src/Framework/Factories/FeaturedImageFactory.php
+++ b/packages/framework/src/Framework/Factories/FeaturedImageFactory.php
@@ -139,11 +139,12 @@ class FeaturedImageFactory extends Concerns\PageDataFactory implements FeaturedI
 
     protected static function isRemote(FrontMatter $matter): bool
     {
-        if (is_string($matter->get('image')) && str_starts_with($matter->get('image'), 'http')) {
+        $value = $matter->get('image') ?? $matter->get('image.source');
+        if (is_string($value) && str_starts_with($value, 'http')) {
             return true;
         }
 
-        return $matter->get('image.url') !== null;
+        return $value !== null;
     }
 
     protected function getStringMatter(string $key): ?string

--- a/packages/framework/src/Framework/Factories/FeaturedImageFactory.php
+++ b/packages/framework/src/Framework/Factories/FeaturedImageFactory.php
@@ -71,8 +71,8 @@ class FeaturedImageFactory extends Concerns\PageDataFactory implements FeaturedI
 
     protected function makeSource(): string
     {
-        $flatValue = $this->getStringMatter('image');
-        $arrayValue = $this->getStringMatter('image.source');
+        $flatValue = $this->getStringMatter('image') ?? $this->getStringMatter('image.source');
+        $arrayValue = $flatValue;
 
         if (is_string($flatValue)) {
             if (str_starts_with($flatValue, 'http')) {

--- a/packages/framework/src/Framework/Factories/FeaturedImageFactory.php
+++ b/packages/framework/src/Framework/Factories/FeaturedImageFactory.php
@@ -73,7 +73,7 @@ class FeaturedImageFactory extends Concerns\PageDataFactory implements FeaturedI
             throw new RuntimeException('No featured image source was found');
         }
 
-        if (str_starts_with($value, 'http')) {
+        if (FeaturedImage::isRemote($value)) {
             return $value;
         }
 

--- a/packages/framework/src/Framework/Factories/FeaturedImageFactory.php
+++ b/packages/framework/src/Framework/Factories/FeaturedImageFactory.php
@@ -79,12 +79,12 @@ class FeaturedImageFactory extends Concerns\PageDataFactory implements FeaturedI
             return self::normalizeLocalImagePath($this->getStringMatter('image'));
         }
 
-        if ($this->getStringMatter('image.url') !== null) {
-            return $this->getStringMatter('image.url');
-        }
+        if ($this->getStringMatter('image.source') !== null) {
+            if (str_starts_with($this->getStringMatter('image.source'), 'http')) {
+                return $this->getStringMatter('image.source');
+            }
 
-        if ($this->getStringMatter('image.path') !== null) {
-            return $this->normalizeLocalImagePath($this->getStringMatter('image.path'));
+            return $this->normalizeLocalImagePath($this->getStringMatter('image.source'));
         }
 
         // Todo, we might want to add a note about which file caused the error.

--- a/packages/framework/src/Framework/Factories/FeaturedImageFactory.php
+++ b/packages/framework/src/Framework/Factories/FeaturedImageFactory.php
@@ -82,14 +82,6 @@ class FeaturedImageFactory extends Concerns\PageDataFactory implements FeaturedI
             return self::normalizeLocalImagePath($flatValue);
         }
 
-        if ($arrayValue !== null) {
-            if (str_starts_with($arrayValue, 'http')) {
-                return $arrayValue;
-            }
-
-            return $this->normalizeLocalImagePath($arrayValue);
-        }
-
         // Todo, we might want to add a note about which file caused the error.
         // We could also check for these before calling the factory, and just ignore the image if it's not valid.
         throw new RuntimeException('No featured image source was found');

--- a/packages/framework/src/Framework/Factories/FeaturedImageFactory.php
+++ b/packages/framework/src/Framework/Factories/FeaturedImageFactory.php
@@ -71,14 +71,14 @@ class FeaturedImageFactory extends Concerns\PageDataFactory implements FeaturedI
 
     protected function makeSource(): string
     {
-        $flatValue = $this->getStringMatter('image') ?? $this->getStringMatter('image.source');
+        $value = $this->getStringMatter('image') ?? $this->getStringMatter('image.source');
 
-        if (is_string($flatValue)) {
-            if (str_starts_with($flatValue, 'http')) {
-                return $flatValue;
+        if (is_string($value)) {
+            if (str_starts_with($value, 'http')) {
+                return $value;
             }
 
-            return self::normalizeLocalImagePath($flatValue);
+            return self::normalizeLocalImagePath($value);
         }
 
         // Todo, we might want to add a note about which file caused the error.

--- a/packages/framework/src/Framework/Factories/FeaturedImageFactory.php
+++ b/packages/framework/src/Framework/Factories/FeaturedImageFactory.php
@@ -67,17 +67,17 @@ class FeaturedImageFactory extends Concerns\PageDataFactory implements FeaturedI
     {
         $value = $this->getStringMatter('image') ?? $this->getStringMatter('image.source');
 
-        if (is_string($value)) {
-            if (str_starts_with($value, 'http')) {
-                return $value;
-            }
-
-            return self::normalizeLocalImagePath($value);
+        if (is_null($value)) {
+            // Todo, we might want to add a note about which file caused the error.
+            // We could also check for these before calling the factory, and just ignore the image if it's not valid.
+            throw new RuntimeException('No featured image source was found');
         }
 
-        // Todo, we might want to add a note about which file caused the error.
-        // We could also check for these before calling the factory, and just ignore the image if it's not valid.
-        throw new RuntimeException('No featured image source was found');
+        if (str_starts_with($value, 'http')) {
+            return $value;
+        }
+
+        return self::normalizeLocalImagePath($value);
     }
 
     protected function makeAltText(): ?string

--- a/packages/framework/src/Framework/Factories/FeaturedImageFactory.php
+++ b/packages/framework/src/Framework/Factories/FeaturedImageFactory.php
@@ -72,7 +72,6 @@ class FeaturedImageFactory extends Concerns\PageDataFactory implements FeaturedI
     protected function makeSource(): string
     {
         $flatValue = $this->getStringMatter('image') ?? $this->getStringMatter('image.source');
-        $arrayValue = $flatValue;
 
         if (is_string($flatValue)) {
             if (str_starts_with($flatValue, 'http')) {

--- a/packages/framework/src/Framework/Features/Blogging/Models/FeaturedImage.php
+++ b/packages/framework/src/Framework/Features/Blogging/Models/FeaturedImage.php
@@ -100,7 +100,7 @@ abstract class FeaturedImage implements Stringable, FeaturedImageSchema
         return $metadata;
     }
 
-    public function __call(string $name, array $arguments)
+    public function __call(string $name, array $arguments): mixed
     {
         if (Str::startsWith($name, 'get')) {
             $property = Str::camel(Str::after($name, 'get'));

--- a/packages/framework/src/Framework/Features/Blogging/Models/FeaturedImage.php
+++ b/packages/framework/src/Framework/Features/Blogging/Models/FeaturedImage.php
@@ -105,13 +105,17 @@ abstract class FeaturedImage implements Stringable, FeaturedImageSchema
         if (Str::startsWith($name, 'has')) {
             $property = Str::camel(Str::after($name, 'has'));
 
-            return $this->$property !== null;
+            if (property_exists($this, $property)) {
+                return $this->$property !== null;
+            }
         }
 
         if (Str::startsWith($name, 'get')) {
             $property = Str::camel(Str::after($name, 'get'));
 
-            return $this->$property ?? null;
+            if (property_exists($this, $property)) {
+                return $this->$property ?? null;
+            }
         }
 
         throw new BadMethodCallException("Method '$name' does not exist on ".static::class);

--- a/packages/framework/src/Framework/Features/Blogging/Models/FeaturedImage.php
+++ b/packages/framework/src/Framework/Features/Blogging/Models/FeaturedImage.php
@@ -88,6 +88,14 @@ abstract class FeaturedImage implements Stringable, FeaturedImageSchema
     /** Called from constructor to allow child classes to validate and transform the value as needed before assignment. */
     protected function setSource(string $source): string
     {
+        if ($this->type === self::TYPE_LOCAL) {
+            // We could also validate the file exists here if we want.
+            // We might also want to just send a warning. But for now,
+            // we'll just trim any leading media path prefixes.
+
+            return Str::after($source, Hyde::getMediaDirectory().'/');
+        }
+
         return $source;
     }
 

--- a/packages/framework/src/Framework/Features/Blogging/Models/FeaturedImage.php
+++ b/packages/framework/src/Framework/Features/Blogging/Models/FeaturedImage.php
@@ -85,7 +85,6 @@ abstract class FeaturedImage implements Stringable, FeaturedImageSchema
         return $this->source;
     }
 
-    /** Called from constructor to allow child classes to validate and transform the value as needed before assignment. */
     protected function setSource(string $source): string
     {
         if ($this->type === self::TYPE_LOCAL) {

--- a/packages/framework/src/Framework/Features/Blogging/Models/FeaturedImage.php
+++ b/packages/framework/src/Framework/Features/Blogging/Models/FeaturedImage.php
@@ -136,26 +136,74 @@ class FeaturedImage implements Stringable, FeaturedImageSchema
         return $metadata;
     }
 
-    /** @deprecated Original behaviour can be refactored to use protected ->get/->has forwarding */
-    public function __call(string $name, array $arguments): null|bool|string
+    public function getAltText(): ?string
     {
-        if (Str::startsWith($name, 'get')) {
-            $property = Str::camel(Str::after($name, 'get'));
+        return $this->altText;
+    }
 
-            if (property_exists($this, $property)) {
-                return $this->$property ?? null;
-            }
-        }
+    public function getTitleText(): ?string
+    {
+        return $this->titleText;
+    }
 
-        if (Str::startsWith($name, 'has')) {
-            $property = Str::camel(Str::after($name, 'has'));
+    public function getAuthorName(): ?string
+    {
+        return $this->authorName;
+    }
 
-            if (property_exists($this, $property)) {
-                return $this->$property !== null;
-            }
-        }
+    public function getAuthorUrl(): ?string
+    {
+        return $this->authorUrl;
+    }
 
-        throw new BadMethodCallException(sprintf("Method '$name' does not exist on %s", static::class));
+    public function getCopyrightText(): ?string
+    {
+        return $this->copyrightText;
+    }
+
+    public function getLicenseName(): ?string
+    {
+        return $this->licenseName;
+    }
+
+    public function getLicenseUrl(): ?string
+    {
+        return $this->licenseUrl;
+    }
+
+    public function hasAltText(): bool
+    {
+        return $this->altText !== null;
+    }
+
+    public function hasTitleText(): bool
+    {
+        return $this->titleText !== null;
+    }
+
+    public function hasAuthorName(): bool
+    {
+        return $this->authorName !== null;
+    }
+
+    public function hasAuthorUrl(): bool
+    {
+        return $this->authorUrl !== null;
+    }
+
+    public function hasCopyrightText(): bool
+    {
+        return $this->copyrightText !== null;
+    }
+
+    public function hasLicenseName(): bool
+    {
+        return $this->licenseName !== null;
+    }
+
+    public function hasLicenseUrl(): bool
+    {
+        return $this->licenseUrl !== null;
     }
 
     protected function getContentLengthForLocalImage(): int

--- a/packages/framework/src/Framework/Features/Blogging/Models/FeaturedImage.php
+++ b/packages/framework/src/Framework/Features/Blogging/Models/FeaturedImage.php
@@ -10,14 +10,12 @@ use Hyde\Hyde;
 use Hyde\Markdown\Contracts\FrontMatter\SubSchemas\FeaturedImageSchema;
 use Illuminate\Support\Facades\Http;
 use Illuminate\Support\Str;
-use BadMethodCallException;
 use Stringable;
 use function array_flip;
 use function array_key_exists;
 use function file_exists;
 use function filesize;
 use function key;
-use function property_exists;
 use function sprintf;
 
 /**

--- a/packages/framework/src/Framework/Features/Blogging/Models/FeaturedImage.php
+++ b/packages/framework/src/Framework/Features/Blogging/Models/FeaturedImage.php
@@ -96,7 +96,10 @@ abstract class FeaturedImage implements Stringable, FeaturedImageSchema
         return $source;
     }
 
-    abstract public function getContentLength(): int;
+    public function getContentLength(): int
+    {
+        return 0;
+    }
 
     /** @return self::TYPE_* */
     public function getType(): string

--- a/packages/framework/src/Framework/Features/Blogging/Models/FeaturedImage.php
+++ b/packages/framework/src/Framework/Features/Blogging/Models/FeaturedImage.php
@@ -36,10 +36,17 @@ use Stringable;
  */
 abstract class FeaturedImage implements Stringable, FeaturedImageSchema
 {
+    /** @deprecated Can be implicitly determined by source prefix */
     protected final const TYPE_LOCAL = 'local';
+
+    /** @deprecated Can be implicitly determined by source prefix */
     protected final const TYPE_REMOTE = 'remote';
 
-    /** @var self::TYPE_* */
+    /**
+     * @deprecated Can be implicitly determined by source prefix
+     *
+     * @var self::TYPE_*
+     */
     protected readonly string $type;
     protected readonly string $source;
 

--- a/packages/framework/src/Framework/Features/Blogging/Models/FeaturedImage.php
+++ b/packages/framework/src/Framework/Features/Blogging/Models/FeaturedImage.php
@@ -138,72 +138,82 @@ class FeaturedImage implements Stringable, FeaturedImageSchema
 
     public function getAltText(): ?string
     {
-        return $this->altText;
+        return $this->get('altText');
     }
 
     public function getTitleText(): ?string
     {
-        return $this->titleText;
+        return $this->get('titleText');
     }
 
     public function getAuthorName(): ?string
     {
-        return $this->authorName;
+        return $this->get('authorName');
     }
 
     public function getAuthorUrl(): ?string
     {
-        return $this->authorUrl;
+        return $this->get('authorUrl');
     }
 
     public function getCopyrightText(): ?string
     {
-        return $this->copyrightText;
+        return $this->get('copyrightText');
     }
 
     public function getLicenseName(): ?string
     {
-        return $this->licenseName;
+        return $this->get('licenseName');
     }
 
     public function getLicenseUrl(): ?string
     {
-        return $this->licenseUrl;
+        return $this->get('licenseUrl');
     }
 
     public function hasAltText(): bool
     {
-        return $this->altText !== null;
+        return $this->has('altText');
     }
 
     public function hasTitleText(): bool
     {
-        return $this->titleText !== null;
+        return $this->has('titleText');
     }
 
     public function hasAuthorName(): bool
     {
-        return $this->authorName !== null;
+        return $this->has('authorName');
     }
 
     public function hasAuthorUrl(): bool
     {
-        return $this->authorUrl !== null;
+        return $this->has('authorUrl');
     }
 
     public function hasCopyrightText(): bool
     {
-        return $this->copyrightText !== null;
+        return $this->has('copyrightText');
     }
 
     public function hasLicenseName(): bool
     {
-        return $this->licenseName !== null;
+        return $this->has('licenseName');
     }
 
     public function hasLicenseUrl(): bool
     {
-        return $this->licenseUrl !== null;
+        return $this->has('licenseUrl');
+    }
+
+    protected function get(string $property): ?string
+    {
+        return $this->$property ?? null;
+    }
+
+    protected function has(string $property): bool
+    {
+        return $this->$property !== null;
     }
 
     protected function getContentLengthForLocalImage(): int

--- a/packages/framework/src/Framework/Features/Blogging/Models/FeaturedImage.php
+++ b/packages/framework/src/Framework/Features/Blogging/Models/FeaturedImage.php
@@ -14,7 +14,11 @@ use BadMethodCallException;
 use Stringable;
 use function array_flip;
 use function array_key_exists;
+use function file_exists;
+use function filesize;
 use function key;
+use function property_exists;
+use function sprintf;
 
 /**
  * Object representation of a blog post's featured image.

--- a/packages/framework/src/Framework/Features/Blogging/Models/FeaturedImage.php
+++ b/packages/framework/src/Framework/Features/Blogging/Models/FeaturedImage.php
@@ -100,13 +100,7 @@ abstract class FeaturedImage implements Stringable, FeaturedImageSchema
     public function getContentLength(): int
     {
         if ($this->type === self::TYPE_LOCAL) {
-            $storagePath = Hyde::mediaPath($this->source);
-
-            if (! file_exists($storagePath)) {
-                throw new FileNotFoundException(sprintf('Image at %s does not exist', Hyde::pathToRelative($storagePath)));
-            }
-
-            return filesize($storagePath);
+            return $this->getContentLengthForLocalImage();
         }
 
         return 0;
@@ -160,5 +154,16 @@ abstract class FeaturedImage implements Stringable, FeaturedImageSchema
         }
 
         throw new BadMethodCallException(sprintf("Method '$name' does not exist on %s", static::class));
+    }
+
+    protected function getContentLengthForLocalImage(): int
+    {
+        $storagePath = Hyde::mediaPath($this->source);
+
+        if (!file_exists($storagePath)) {
+            throw new FileNotFoundException(sprintf('Image at %s does not exist', Hyde::pathToRelative($storagePath)));
+        }
+
+        return filesize($storagePath);
     }
 }

--- a/packages/framework/src/Framework/Features/Blogging/Models/FeaturedImage.php
+++ b/packages/framework/src/Framework/Features/Blogging/Models/FeaturedImage.php
@@ -150,6 +150,7 @@ class FeaturedImage implements Stringable, FeaturedImageSchema
         return $metadata;
     }
 
+    /** @deprecated Original behaviour can be refactored to use protected ->get/->has forwarding */
     public function __call(string $name, array $arguments): null|bool|string
     {
         if (Str::startsWith($name, 'get')) {

--- a/packages/framework/src/Framework/Features/Blogging/Models/FeaturedImage.php
+++ b/packages/framework/src/Framework/Features/Blogging/Models/FeaturedImage.php
@@ -160,7 +160,7 @@ abstract class FeaturedImage implements Stringable, FeaturedImageSchema
     {
         $storagePath = Hyde::mediaPath($this->source);
 
-        if (!file_exists($storagePath)) {
+        if (! file_exists($storagePath)) {
             throw new FileNotFoundException(sprintf('Image at %s does not exist', Hyde::pathToRelative($storagePath)));
         }
 

--- a/packages/framework/src/Framework/Features/Blogging/Models/FeaturedImage.php
+++ b/packages/framework/src/Framework/Features/Blogging/Models/FeaturedImage.php
@@ -17,6 +17,21 @@ use Stringable;
  * it is named "FeaturedImage" as it's only usage within Hyde
  * is for the featured image of a Markdown blog post.
  *
+ * @method getAltText(): ?string
+ * @method getTitleText(): ?string
+ * @method getAuthorName(): ?string
+ * @method getAuthorUrl(): ?string
+ * @method getCopyrightText(): ?string
+ * @method getLicenseName(): ?string
+ * @method getLicenseUrl(): ?string
+ * @method hasAltText(): bool
+ * @method hasTitleText(): bool
+ * @method hasAuthorName(): bool
+ * @method hasAuthorUrl(): bool
+ * @method hasCopyrightText(): bool
+ * @method hasLicenseName(): bool
+ * @method hasLicenseUrl(): bool
+ *
  * @see \Hyde\Framework\Factories\FeaturedImageFactory
  */
 abstract class FeaturedImage implements Stringable, FeaturedImageSchema

--- a/packages/framework/src/Framework/Features/Blogging/Models/FeaturedImage.php
+++ b/packages/framework/src/Framework/Features/Blogging/Models/FeaturedImage.php
@@ -88,9 +88,7 @@ abstract class FeaturedImage implements Stringable, FeaturedImageSchema
     protected function setSource(string $source): string
     {
         if ($this->type === self::TYPE_LOCAL) {
-            // We could also validate the file exists here if we want.
-            // We might also want to just send a warning. But for now,
-            // we'll just trim any leading media path prefixes.
+            // Normalize away any leading media path prefixes.
 
             return Str::after($source, Hyde::getMediaDirectory().'/');
         }

--- a/packages/framework/src/Framework/Features/Blogging/Models/FeaturedImage.php
+++ b/packages/framework/src/Framework/Features/Blogging/Models/FeaturedImage.php
@@ -102,19 +102,19 @@ abstract class FeaturedImage implements Stringable, FeaturedImageSchema
 
     public function __call(string $name, array $arguments)
     {
-        if (Str::startsWith($name, 'has')) {
-            $property = Str::camel(Str::after($name, 'has'));
-
-            if (property_exists($this, $property)) {
-                return $this->$property !== null;
-            }
-        }
-
         if (Str::startsWith($name, 'get')) {
             $property = Str::camel(Str::after($name, 'get'));
 
             if (property_exists($this, $property)) {
                 return $this->$property ?? null;
+            }
+        }
+
+        if (Str::startsWith($name, 'has')) {
+            $property = Str::camel(Str::after($name, 'has'));
+
+            if (property_exists($this, $property)) {
+                return $this->$property !== null;
             }
         }
 

--- a/packages/framework/src/Framework/Features/Blogging/Models/FeaturedImage.php
+++ b/packages/framework/src/Framework/Features/Blogging/Models/FeaturedImage.php
@@ -199,7 +199,7 @@ class FeaturedImage implements Stringable, FeaturedImageSchema
         return 0;
     }
 
-    protected function isRemote(string $source): bool
+    public static function isRemote(string $source): bool
     {
         return str_starts_with($source, 'http') || str_starts_with($source, '//');
     }

--- a/packages/framework/src/Framework/Features/Blogging/Models/FeaturedImage.php
+++ b/packages/framework/src/Framework/Features/Blogging/Models/FeaturedImage.php
@@ -77,7 +77,7 @@ class FeaturedImage implements Stringable, FeaturedImageSchema
         protected readonly ?string $licenseName = null,
         protected readonly ?string $licenseUrl = null
     ) {
-        $this->type = str_starts_with($source, 'http') ? self::TYPE_REMOTE : self::TYPE_LOCAL;
+        $this->type = $this->isRemote($source) ? self::TYPE_REMOTE : self::TYPE_LOCAL;
         $this->source = $this->setSource($source);
     }
 
@@ -197,5 +197,10 @@ class FeaturedImage implements Stringable, FeaturedImageSchema
         // Here we could throw an exception if we want to be strict about this, or add a warning.
 
         return 0;
+    }
+
+    protected function isRemote(string $source): bool
+    {
+        return str_starts_with($source, 'http');
     }
 }

--- a/packages/framework/src/Framework/Features/Blogging/Models/FeaturedImage.php
+++ b/packages/framework/src/Framework/Features/Blogging/Models/FeaturedImage.php
@@ -44,7 +44,7 @@ use function sprintf;
  *
  * @see \Hyde\Framework\Factories\FeaturedImageFactory
  */
-abstract class FeaturedImage implements Stringable, FeaturedImageSchema
+class FeaturedImage implements Stringable, FeaturedImageSchema
 {
     /**
      * A featured image object, for a file stored locally.

--- a/packages/framework/src/Framework/Features/Blogging/Models/FeaturedImage.php
+++ b/packages/framework/src/Framework/Features/Blogging/Models/FeaturedImage.php
@@ -111,7 +111,7 @@ abstract class FeaturedImage implements Stringable, FeaturedImageSchema
         if (Str::startsWith($name, 'get')) {
             $property = Str::camel(Str::after($name, 'get'));
 
-            return $this->$property;
+            return $this->$property ?? null;
         }
 
         throw new BadMethodCallException("Method '$name' does not exist on ".static::class);

--- a/packages/framework/src/Framework/Features/Blogging/Models/FeaturedImage.php
+++ b/packages/framework/src/Framework/Features/Blogging/Models/FeaturedImage.php
@@ -118,6 +118,6 @@ abstract class FeaturedImage implements Stringable, FeaturedImageSchema
             }
         }
 
-        throw new BadMethodCallException("Method '$name' does not exist on ".static::class);
+        throw new BadMethodCallException(sprintf("Method '$name' does not exist on %s", static::class));
     }
 }

--- a/packages/framework/src/Framework/Features/Blogging/Models/FeaturedImage.php
+++ b/packages/framework/src/Framework/Features/Blogging/Models/FeaturedImage.php
@@ -201,6 +201,6 @@ class FeaturedImage implements Stringable, FeaturedImageSchema
 
     protected function isRemote(string $source): bool
     {
-        return str_starts_with($source, 'http');
+        return str_starts_with($source, 'http') || str_starts_with($source, '//');
     }
 }

--- a/packages/framework/src/Framework/Features/Blogging/Models/FeaturedImage.php
+++ b/packages/framework/src/Framework/Features/Blogging/Models/FeaturedImage.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Hyde\Framework\Features\Blogging\Models;
 
+use Hyde\Framework\Exceptions\FileNotFoundException;
 use Hyde\Hyde;
 use Hyde\Markdown\Contracts\FrontMatter\SubSchemas\FeaturedImageSchema;
 use Illuminate\Support\Str;
@@ -98,6 +99,16 @@ abstract class FeaturedImage implements Stringable, FeaturedImageSchema
 
     public function getContentLength(): int
     {
+        if ($this->type === self::TYPE_LOCAL) {
+            $storagePath = Hyde::mediaPath($this->source);
+
+            if (! file_exists($storagePath)) {
+                throw new FileNotFoundException(sprintf('Image at %s does not exist', Hyde::pathToRelative($storagePath)));
+            }
+
+            return filesize($storagePath);
+        }
+
         return 0;
     }
 

--- a/packages/framework/src/Framework/Features/Blogging/Models/FeaturedImage.php
+++ b/packages/framework/src/Framework/Features/Blogging/Models/FeaturedImage.php
@@ -64,6 +64,7 @@ class FeaturedImage implements Stringable, FeaturedImageSchema
 
     /** @var self::TYPE_* */
     protected readonly string $type;
+
     protected readonly string $source;
 
     public function __construct(

--- a/packages/framework/src/Framework/Features/Blogging/Models/FeaturedImage.php
+++ b/packages/framework/src/Framework/Features/Blogging/Models/FeaturedImage.php
@@ -138,37 +138,37 @@ class FeaturedImage implements Stringable, FeaturedImageSchema
 
     public function getAltText(): ?string
     {
-        return $this->get('altText');
+        return $this->altText;
     }
 
     public function getTitleText(): ?string
     {
-        return $this->get('titleText');
+        return $this->titleText;
     }
 
     public function getAuthorName(): ?string
     {
-        return $this->get('authorName');
+        return $this->authorName;
     }
 
     public function getAuthorUrl(): ?string
     {
-        return $this->get('authorUrl');
+        return $this->authorUrl;
     }
 
     public function getCopyrightText(): ?string
     {
-        return $this->get('copyrightText');
+        return $this->copyrightText;
     }
 
     public function getLicenseName(): ?string
     {
-        return $this->get('licenseName');
+        return $this->licenseName;
     }
 
     public function getLicenseUrl(): ?string
     {
-        return $this->get('licenseUrl');
+        return $this->licenseUrl;
     }
 
     public function hasAltText(): bool
@@ -204,11 +204,6 @@ class FeaturedImage implements Stringable, FeaturedImageSchema
     public function hasLicenseUrl(): bool
     {
         return $this->has('licenseUrl');
-    }
-
-    protected function get(string $property): ?string
-    {
-        return $this->$property ?? null;
     }
 
     protected function has(string $property): bool

--- a/packages/framework/src/Framework/Features/Blogging/Models/FeaturedImage.php
+++ b/packages/framework/src/Framework/Features/Blogging/Models/FeaturedImage.php
@@ -100,7 +100,7 @@ abstract class FeaturedImage implements Stringable, FeaturedImageSchema
         return $metadata;
     }
 
-    public function __call(string $name, array $arguments): mixed
+    public function __call(string $name, array $arguments): null|bool|string
     {
         if (Str::startsWith($name, 'get')) {
             $property = Str::camel(Str::after($name, 'get'));

--- a/packages/framework/src/Framework/Features/Blogging/Models/FeaturedImage.php
+++ b/packages/framework/src/Framework/Features/Blogging/Models/FeaturedImage.php
@@ -51,7 +51,7 @@ class FeaturedImage implements Stringable, FeaturedImageSchema
     protected readonly string $source;
 
     public function __construct(
-        string $source = null,
+        string $source,
         protected readonly ?string $altText = null,
         protected readonly ?string $titleText = null,
         protected readonly ?string $authorName = null,

--- a/packages/framework/src/Framework/Features/Blogging/Models/FeaturedImage.php
+++ b/packages/framework/src/Framework/Features/Blogging/Models/FeaturedImage.php
@@ -89,7 +89,6 @@ class FeaturedImage implements Stringable, FeaturedImageSchema
     {
         if ($this->type === self::TYPE_LOCAL) {
             // Normalize away any leading media path prefixes.
-
             return Str::after($source, Hyde::getMediaDirectory().'/');
         }
 

--- a/packages/framework/src/Framework/Features/Blogging/Models/FeaturedImage.php
+++ b/packages/framework/src/Framework/Features/Blogging/Models/FeaturedImage.php
@@ -46,7 +46,20 @@ use function sprintf;
  */
 abstract class FeaturedImage implements Stringable, FeaturedImageSchema
 {
+    /**
+     * A featured image object, for a file stored locally.
+     *
+     * The internal data structure forces the image source to reference a file in the _media directory,
+     * and thus that is what is required for the input. However, when outputting data, the data will
+     * be used for the _site/media directory, so it will provide data relative to the site root.
+     *
+     * The source information is stored in $this->source, which is a file in the _media directory.
+     */
     protected final const TYPE_LOCAL = 'local';
+
+    /**
+     * A featured image object, for a file stored remotely.
+     */
     protected final const TYPE_REMOTE = 'remote';
 
     /** @var self::TYPE_* */

--- a/packages/framework/src/Framework/Features/Blogging/Models/FeaturedImage.php
+++ b/packages/framework/src/Framework/Features/Blogging/Models/FeaturedImage.php
@@ -49,11 +49,7 @@ abstract class FeaturedImage implements Stringable, FeaturedImageSchema
     protected final const TYPE_LOCAL = 'local';
     protected final const TYPE_REMOTE = 'remote';
 
-    /**
-     * @deprecated Can be implicitly determined by source prefix
-     *
-     * @var self::TYPE_*
-     */
+    /** @var self::TYPE_* */
     protected readonly string $type;
     protected readonly string $source;
 

--- a/packages/framework/src/Framework/Features/Blogging/Models/FeaturedImage.php
+++ b/packages/framework/src/Framework/Features/Blogging/Models/FeaturedImage.php
@@ -46,10 +46,7 @@ use function sprintf;
  */
 abstract class FeaturedImage implements Stringable, FeaturedImageSchema
 {
-    /** @deprecated Can be implicitly determined by source prefix */
     protected final const TYPE_LOCAL = 'local';
-
-    /** @deprecated Can be implicitly determined by source prefix */
     protected final const TYPE_REMOTE = 'remote';
 
     /**

--- a/packages/framework/src/Framework/Features/Blogging/Models/FeaturedImage.php
+++ b/packages/framework/src/Framework/Features/Blogging/Models/FeaturedImage.php
@@ -27,21 +27,6 @@ use function sprintf;
  * it is named "FeaturedImage" as it's only usage within Hyde
  * is for the featured image of a Markdown blog post.
  *
- * @method getAltText(): ?string
- * @method getTitleText(): ?string
- * @method getAuthorName(): ?string
- * @method getAuthorUrl(): ?string
- * @method getCopyrightText(): ?string
- * @method getLicenseName(): ?string
- * @method getLicenseUrl(): ?string
- * @method hasAltText(): bool
- * @method hasTitleText(): bool
- * @method hasAuthorName(): bool
- * @method hasAuthorUrl(): bool
- * @method hasCopyrightText(): bool
- * @method hasLicenseName(): bool
- * @method hasLicenseUrl(): bool
- *
  * @see \Hyde\Framework\Factories\FeaturedImageFactory
  */
 class FeaturedImage implements Stringable, FeaturedImageSchema

--- a/packages/framework/src/Framework/Features/Blogging/Models/LocalFeaturedImage.php
+++ b/packages/framework/src/Framework/Features/Blogging/Models/LocalFeaturedImage.php
@@ -30,13 +30,6 @@ class LocalFeaturedImage extends FeaturedImage
         return Str::after($source, Hyde::getMediaDirectory().'/');
     }
 
-    /** @deprecated */
-    public function getSource(): string
-    {
-        // Return value is always resolvable from a compiled page in the _site directory.
-        return Hyde::mediaLink($this->source);
-    }
-
     public function getContentLength(): int
     {
         return filesize($this->validatedStoragePath());

--- a/packages/framework/src/Framework/Features/Blogging/Models/LocalFeaturedImage.php
+++ b/packages/framework/src/Framework/Features/Blogging/Models/LocalFeaturedImage.php
@@ -25,17 +25,14 @@ class LocalFeaturedImage extends FeaturedImage
         return filesize($this->validatedStoragePath());
     }
 
-    protected function storagePath(): string
-    {
-        return Hyde::mediaPath($this->source);
-    }
-
     protected function validatedStoragePath(): string
     {
-        if (! file_exists($this->storagePath())) {
-            throw new FileNotFoundException(sprintf('Image at %s does not exist', Hyde::pathToRelative($this->storagePath())));
+        $storagePath = Hyde::mediaPath($this->source);
+
+        if (! file_exists($storagePath)) {
+            throw new FileNotFoundException(sprintf('Image at %s does not exist', Hyde::pathToRelative($storagePath)));
         }
 
-        return $this->storagePath();
+        return $storagePath;
     }
 }

--- a/packages/framework/src/Framework/Features/Blogging/Models/LocalFeaturedImage.php
+++ b/packages/framework/src/Framework/Features/Blogging/Models/LocalFeaturedImage.php
@@ -22,17 +22,12 @@ class LocalFeaturedImage extends FeaturedImage
 {
     public function getContentLength(): int
     {
-        return filesize($this->validatedStoragePath());
-    }
-
-    protected function validatedStoragePath(): string
-    {
         $storagePath = Hyde::mediaPath($this->source);
 
         if (! file_exists($storagePath)) {
             throw new FileNotFoundException(sprintf('Image at %s does not exist', Hyde::pathToRelative($storagePath)));
         }
 
-        return $storagePath;
+        return filesize($storagePath);
     }
 }

--- a/packages/framework/src/Framework/Features/Blogging/Models/LocalFeaturedImage.php
+++ b/packages/framework/src/Framework/Features/Blogging/Models/LocalFeaturedImage.php
@@ -30,6 +30,13 @@ class LocalFeaturedImage extends FeaturedImage
         return Str::after($source, Hyde::getMediaDirectory().'/');
     }
 
+    /** @deprecated */
+    public function getSource(): string
+    {
+        // Return value is always resolvable from a compiled page in the _site directory.
+        return Hyde::mediaLink($this->source);
+    }
+
     public function getContentLength(): int
     {
         return filesize($this->validatedStoragePath());

--- a/packages/framework/src/Framework/Features/Blogging/Models/LocalFeaturedImage.php
+++ b/packages/framework/src/Framework/Features/Blogging/Models/LocalFeaturedImage.php
@@ -4,8 +4,3 @@ declare(strict_types=1);
 
 namespace Hyde\Framework\Features\Blogging\Models;
 
-/** @deprecated Will be merged into FeaturedImage.php */
-class LocalFeaturedImage extends FeaturedImage
-{
-    //
-}

--- a/packages/framework/src/Framework/Features/Blogging/Models/LocalFeaturedImage.php
+++ b/packages/framework/src/Framework/Features/Blogging/Models/LocalFeaturedImage.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Hyde\Framework\Features\Blogging\Models;
 
-
 /**
  * A featured image object, for a file stored locally.
  *

--- a/packages/framework/src/Framework/Features/Blogging/Models/LocalFeaturedImage.php
+++ b/packages/framework/src/Framework/Features/Blogging/Models/LocalFeaturedImage.php
@@ -1,6 +1,0 @@
-<?php
-
-declare(strict_types=1);
-
-namespace Hyde\Framework\Features\Blogging\Models;
-

--- a/packages/framework/src/Framework/Features/Blogging/Models/LocalFeaturedImage.php
+++ b/packages/framework/src/Framework/Features/Blogging/Models/LocalFeaturedImage.php
@@ -4,8 +4,6 @@ declare(strict_types=1);
 
 namespace Hyde\Framework\Features\Blogging\Models;
 
-use Hyde\Framework\Exceptions\FileNotFoundException;
-use Hyde\Hyde;
 
 /**
  * A featured image object, for a file stored locally.
@@ -20,14 +18,5 @@ use Hyde\Hyde;
  */
 class LocalFeaturedImage extends FeaturedImage
 {
-    public function getContentLength(): int
-    {
-        $storagePath = Hyde::mediaPath($this->source);
-
-        if (! file_exists($storagePath)) {
-            throw new FileNotFoundException(sprintf('Image at %s does not exist', Hyde::pathToRelative($storagePath)));
-        }
-
-        return filesize($storagePath);
-    }
+    //
 }

--- a/packages/framework/src/Framework/Features/Blogging/Models/LocalFeaturedImage.php
+++ b/packages/framework/src/Framework/Features/Blogging/Models/LocalFeaturedImage.php
@@ -4,17 +4,7 @@ declare(strict_types=1);
 
 namespace Hyde\Framework\Features\Blogging\Models;
 
-/**
- * A featured image object, for a file stored locally.
- *
- * @deprecated Will be merged into FeaturedImage.php
- *
- * The internal data structure forces the image source to reference a file in the _media directory,
- * and thus that is what is required for the input. However, when outputting data, the data will
- * be used for the _site/media directory, so it will provide data relative to the site root.
- *
- * The source information is stored in $this->source, which is a file in the _media directory.
- */
+/** @deprecated Will be merged into FeaturedImage.php */
 class LocalFeaturedImage extends FeaturedImage
 {
     //

--- a/packages/framework/src/Framework/Features/Blogging/Models/LocalFeaturedImage.php
+++ b/packages/framework/src/Framework/Features/Blogging/Models/LocalFeaturedImage.php
@@ -6,7 +6,6 @@ namespace Hyde\Framework\Features\Blogging\Models;
 
 use Hyde\Framework\Exceptions\FileNotFoundException;
 use Hyde\Hyde;
-use Illuminate\Support\Str;
 
 /**
  * A featured image object, for a file stored locally.
@@ -21,15 +20,6 @@ use Illuminate\Support\Str;
  */
 class LocalFeaturedImage extends FeaturedImage
 {
-    protected function setSource(string $source): string
-    {
-        // We could also validate the file exists here if we want.
-        // We might also want to just send a warning. But for now,
-        // we'll just trim any leading media path prefixes.
-
-        return Str::after($source, Hyde::getMediaDirectory().'/');
-    }
-
     public function getContentLength(): int
     {
         return filesize($this->validatedStoragePath());

--- a/packages/framework/src/Framework/Features/Blogging/Models/RemoteFeaturedImage.php
+++ b/packages/framework/src/Framework/Features/Blogging/Models/RemoteFeaturedImage.php
@@ -20,6 +20,12 @@ class RemoteFeaturedImage extends FeaturedImage
         return $source;
     }
 
+    /** @deprecated */
+    public function getSource(): string
+    {
+        return $this->source;
+    }
+
     public function getContentLength(): int
     {
         $headers = Http::withHeaders([

--- a/packages/framework/src/Framework/Features/Blogging/Models/RemoteFeaturedImage.php
+++ b/packages/framework/src/Framework/Features/Blogging/Models/RemoteFeaturedImage.php
@@ -20,12 +20,6 @@ class RemoteFeaturedImage extends FeaturedImage
         return $source;
     }
 
-    /** @deprecated */
-    public function getSource(): string
-    {
-        return $this->source;
-    }
-
     public function getContentLength(): int
     {
         $headers = Http::withHeaders([

--- a/packages/framework/src/Framework/Features/Blogging/Models/RemoteFeaturedImage.php
+++ b/packages/framework/src/Framework/Features/Blogging/Models/RemoteFeaturedImage.php
@@ -4,27 +4,8 @@ declare(strict_types=1);
 
 namespace Hyde\Framework\Features\Blogging\Models;
 
-use function array_flip;
-use function array_key_exists;
-use Hyde\Facades\Config;
-use Illuminate\Support\Facades\Http;
-use function key;
-
 /** @deprecated Will be merged into FeaturedImage.php */
 class RemoteFeaturedImage extends FeaturedImage
 {
-    public function getContentLength(): int
-    {
-        $headers = Http::withHeaders([
-            'User-Agent' => Config::getString('hyde.http_user_agent', 'RSS Request Client'),
-        ])->head($this->getSource())->headers();
-
-        if (array_key_exists('Content-Length', $headers)) {
-            return (int) key(array_flip($headers['Content-Length']));
-        }
-
-        // Here we could throw an exception if we want to be strict about this, or add a warning.
-
-        return 0;
-    }
+    //
 }

--- a/packages/framework/src/Framework/Features/Blogging/Models/RemoteFeaturedImage.php
+++ b/packages/framework/src/Framework/Features/Blogging/Models/RemoteFeaturedImage.php
@@ -1,6 +1,0 @@
-<?php
-
-declare(strict_types=1);
-
-namespace Hyde\Framework\Features\Blogging\Models;
-

--- a/packages/framework/src/Framework/Features/Blogging/Models/RemoteFeaturedImage.php
+++ b/packages/framework/src/Framework/Features/Blogging/Models/RemoteFeaturedImage.php
@@ -13,13 +13,6 @@ use function key;
 /** @deprecated Will be merged into FeaturedImage.php */
 class RemoteFeaturedImage extends FeaturedImage
 {
-    protected function setSource(string $source): string
-    {
-        // Here we can validate the source URL if we want.
-
-        return $source;
-    }
-
     public function getContentLength(): int
     {
         $headers = Http::withHeaders([

--- a/packages/framework/src/Framework/Features/Blogging/Models/RemoteFeaturedImage.php
+++ b/packages/framework/src/Framework/Features/Blogging/Models/RemoteFeaturedImage.php
@@ -4,8 +4,3 @@ declare(strict_types=1);
 
 namespace Hyde\Framework\Features\Blogging\Models;
 
-/** @deprecated Will be merged into FeaturedImage.php */
-class RemoteFeaturedImage extends FeaturedImage
-{
-    //
-}

--- a/packages/framework/src/Markdown/Contracts/FrontMatter/SubSchemas/FeaturedImageSchema.php
+++ b/packages/framework/src/Markdown/Contracts/FrontMatter/SubSchemas/FeaturedImageSchema.php
@@ -11,8 +11,7 @@ namespace Hyde\Markdown\Contracts\FrontMatter\SubSchemas;
 interface FeaturedImageSchema
 {
     public const FEATURED_IMAGE_SCHEMA = [
-        'path'           => 'string',
-        'url'            => 'string', // Takes precedence over path
+        'source'         => 'string', // Filename in _media/ or a remote URL
         'description'    => 'string',
         'title'          => 'string',
         'copyright'      => 'string',

--- a/packages/framework/tests/Feature/FeaturedImageFactoryTest.php
+++ b/packages/framework/tests/Feature/FeaturedImageFactoryTest.php
@@ -21,8 +21,7 @@ class FeaturedImageFactoryTest extends TestCase
     public function testWithDataFromSchema()
     {
         $array = [
-            'image.path' => 'path',
-            'image.url' => 'url',
+            'image.source' => 'source',
             'image.description' => 'description',
             'image.title' => 'title',
             'image.copyright' => 'copyright',
@@ -33,7 +32,7 @@ class FeaturedImageFactoryTest extends TestCase
         ];
 
         $expected = [
-            'source' => 'url',
+            'source' => 'source',
             'altText' => 'description',
             'titleText' => 'title',
             'authorName' => 'author',
@@ -51,32 +50,11 @@ class FeaturedImageFactoryTest extends TestCase
     public function testMakeMethodCreatesLocalImageWhenPathIsSet()
     {
         $image = $this->makeFromArray([
-            'image.path' => 'path',
+            'image.source' => 'foo',
         ]);
 
         $this->assertInstanceOf(LocalFeaturedImage::class, $image);
-        $this->assertSame('media/path', $image->getSource());
-    }
-
-    public function testMakeMethodCreatesRemoteImageWhenUrlIsSet()
-    {
-        $image = $this->makeFromArray([
-            'image.url' => 'url',
-        ]);
-
-        $this->assertInstanceOf(RemoteFeaturedImage::class, $image);
-        $this->assertSame('url', $image->getSource());
-    }
-
-    public function testMakeMethodCreatesRemoteImageWhenBothUrlAndPathIsSet()
-    {
-        $image = $this->makeFromArray([
-            'image.url' => 'url',
-            'image.path' => 'path',
-        ]);
-
-        $this->assertInstanceOf(RemoteFeaturedImage::class, $image);
-        $this->assertSame('url', $image->getSource());
+        $this->assertSame('media/foo', $image->getSource());
     }
 
     public function testMakeMethodThrowsExceptionIfNoPathInformationIsSet()
@@ -113,9 +91,9 @@ class FeaturedImageFactoryTest extends TestCase
         $this->assertSourceIsSame('media/foo', ['image' => 'media/foo']);
         $this->assertSourceIsSame('media/foo', ['image' => '_media/foo']);
 
-        $this->assertSourceIsSame('media/foo', ['image' => ['path' => 'foo']]);
-        $this->assertSourceIsSame('media/foo', ['image' => ['path' => 'media/foo']]);
-        $this->assertSourceIsSame('media/foo', ['image' => ['path' => '_media/foo']]);
+        $this->assertSourceIsSame('media/foo', ['image' => ['source' => 'foo']]);
+        $this->assertSourceIsSame('media/foo', ['image' => ['source' => 'media/foo']]);
+        $this->assertSourceIsSame('media/foo', ['image' => ['source' => '_media/foo']]);
     }
 
     public function testImagePathsAreNormalizedForCustomizedMediaDirectory()
@@ -126,9 +104,9 @@ class FeaturedImageFactoryTest extends TestCase
         $this->assertSourceIsSame('assets/foo', ['image' => 'assets/foo']);
         $this->assertSourceIsSame('assets/foo', ['image' => '_assets/foo']);
 
-        $this->assertSourceIsSame('assets/foo', ['image' => ['path' => 'foo']]);
-        $this->assertSourceIsSame('assets/foo', ['image' => ['path' => 'assets/foo']]);
-        $this->assertSourceIsSame('assets/foo', ['image' => ['path' => '_assets/foo']]);
+        $this->assertSourceIsSame('assets/foo', ['image' => ['source' => 'foo']]);
+        $this->assertSourceIsSame('assets/foo', ['image' => ['source' => 'assets/foo']]);
+        $this->assertSourceIsSame('assets/foo', ['image' => ['source' => '_assets/foo']]);
     }
 
     public function testImagePathsAreNormalizedForCustomizedMediaDirectoryWithoutUnderscore()
@@ -139,9 +117,9 @@ class FeaturedImageFactoryTest extends TestCase
         $this->assertSourceIsSame('assets/foo', ['image' => 'assets/foo']);
         $this->assertSourceIsSame('assets/foo', ['image' => 'assets/foo']);
 
-        $this->assertSourceIsSame('assets/foo', ['image' => ['path' => 'foo']]);
-        $this->assertSourceIsSame('assets/foo', ['image' => ['path' => 'assets/foo']]);
-        $this->assertSourceIsSame('assets/foo', ['image' => ['path' => 'assets/foo']]);
+        $this->assertSourceIsSame('assets/foo', ['image' => ['source' => 'foo']]);
+        $this->assertSourceIsSame('assets/foo', ['image' => ['source' => 'assets/foo']]);
+        $this->assertSourceIsSame('assets/foo', ['image' => ['source' => 'assets/foo']]);
     }
 
     protected function makeFromArray(array $matter): FeaturedImage

--- a/packages/framework/tests/Feature/FeaturedImageFactoryTest.php
+++ b/packages/framework/tests/Feature/FeaturedImageFactoryTest.php
@@ -6,8 +6,6 @@ namespace Hyde\Framework\Testing\Feature;
 
 use Hyde\Framework\Factories\FeaturedImageFactory;
 use Hyde\Framework\Features\Blogging\Models\FeaturedImage;
-use Hyde\Framework\Features\Blogging\Models\LocalFeaturedImage;
-use Hyde\Framework\Features\Blogging\Models\RemoteFeaturedImage;
 use Hyde\Hyde;
 use Hyde\Markdown\Models\FrontMatter;
 use Hyde\Testing\TestCase;
@@ -47,13 +45,13 @@ class FeaturedImageFactoryTest extends TestCase
         $this->assertSame($expected, $factory->toArray());
     }
 
-    public function testMakeMethodCreatesLocalImageWhenPathIsSet()
+    public function testMakeMethodCreatesImageWhenPathIsSet()
     {
         $image = $this->makeFromArray([
             'image.source' => 'foo',
         ]);
 
-        $this->assertInstanceOf(LocalFeaturedImage::class, $image);
+        $this->assertInstanceOf(FeaturedImage::class, $image);
         $this->assertSame('media/foo', $image->getSource());
     }
 
@@ -71,7 +69,7 @@ class FeaturedImageFactoryTest extends TestCase
             'image' => 'foo',
         ]);
 
-        $this->assertInstanceOf(LocalFeaturedImage::class, $image);
+        $this->assertInstanceOf(FeaturedImage::class, $image);
         $this->assertSame('media/foo', $image->getSource());
     }
 
@@ -81,7 +79,7 @@ class FeaturedImageFactoryTest extends TestCase
             'image' => 'https://example.com/foo',
         ]);
 
-        $this->assertInstanceOf(RemoteFeaturedImage::class, $image);
+        $this->assertInstanceOf(FeaturedImage::class, $image);
         $this->assertSame('https://example.com/foo', $image->getSource());
     }
 

--- a/packages/framework/tests/Feature/FeaturedImageTest.php
+++ b/packages/framework/tests/Feature/FeaturedImageTest.php
@@ -186,11 +186,10 @@ class FeaturedImageTest extends TestCase
         $this->assertEquals('https/foo', $image->getSource());
     }
 
-    /** @deprecated */
     public function testCanConstructRemoteFeaturedImageWithInvalidSource()
     {
         $image = new RemoteFeaturedImage('foo', ...$this->defaultArguments());
-        $this->assertEquals('media/foo', $image->getSource());
+        $this->assertEquals('foo', $image->getSource());
     }
 
     public function testFeaturedImageGetContentLengthWithRemoteSource()
@@ -235,8 +234,8 @@ class FeaturedImageTest extends TestCase
         $this->assertEquals('media/foo', FeaturedImageFactory::make(new FrontMatter(['image.path' => 'media/foo']))->getSource());
         $this->assertEquals('media/foo', FeaturedImageFactory::make(new FrontMatter(['image.path' => '_media/foo']))->getSource());
 
-        // TODO $this->assertEquals('foo', FeaturedImageFactory::make(new FrontMatter(['image.url' => 'foo']))->getSource());
-        // TODO $this->assertEquals('//foo', FeaturedImageFactory::make(new FrontMatter(['image.url' => '//foo']))->getSource());
+        $this->assertEquals('foo', FeaturedImageFactory::make(new FrontMatter(['image.url' => 'foo']))->getSource());
+        $this->assertEquals('//foo', FeaturedImageFactory::make(new FrontMatter(['image.url' => '//foo']))->getSource());
         $this->assertEquals('http', FeaturedImageFactory::make(new FrontMatter(['image.url' => 'http']))->getSource());
 
         $this->assertEquals('media/foo', FeaturedImageFactory::make(new FrontMatter(['image' => 'foo']))->getSource());

--- a/packages/framework/tests/Feature/FeaturedImageTest.php
+++ b/packages/framework/tests/Feature/FeaturedImageTest.php
@@ -222,7 +222,7 @@ class FeaturedImageTest extends TestCase
         $this->assertEquals('media/foo', FeaturedImageFactory::make(new FrontMatter(['image.source' => '_media/foo']))->getSource());
 
         $this->assertEquals('media/foo', FeaturedImageFactory::make(new FrontMatter(['image.source' => 'foo']))->getSource());
-        // TODO $this->assertEquals('//foo', FeaturedImageFactory::make(new FrontMatter(['image.source' => '//foo']))->getSource());
+        $this->assertEquals('//foo', FeaturedImageFactory::make(new FrontMatter(['image.source' => '//foo']))->getSource());
         $this->assertEquals('http', FeaturedImageFactory::make(new FrontMatter(['image.source' => 'http']))->getSource());
 
         $this->assertEquals('media/foo', FeaturedImageFactory::make(new FrontMatter(['image' => 'foo']))->getSource());

--- a/packages/framework/tests/Feature/FeaturedImageTest.php
+++ b/packages/framework/tests/Feature/FeaturedImageTest.php
@@ -186,12 +186,6 @@ class FeaturedImageTest extends TestCase
         $this->assertEquals('https/foo', $image->getSource());
     }
 
-    public function testCanConstructRemoteFeaturedImageWithInvalidSource()
-    {
-        $image = new RemoteFeaturedImage('foo', ...$this->defaultArguments());
-        $this->assertEquals('foo', $image->getSource());
-    }
-
     public function testFeaturedImageGetContentLengthWithRemoteSource()
     {
         Http::fake(function () {
@@ -230,13 +224,13 @@ class FeaturedImageTest extends TestCase
     {
         $this->assertEquals('media/foo', (new LocalFeaturedImage('_media/foo', ...$this->defaultArguments()))->getSource());
 
-        $this->assertEquals('media/foo', FeaturedImageFactory::make(new FrontMatter(['image.path' => 'foo']))->getSource());
-        $this->assertEquals('media/foo', FeaturedImageFactory::make(new FrontMatter(['image.path' => 'media/foo']))->getSource());
-        $this->assertEquals('media/foo', FeaturedImageFactory::make(new FrontMatter(['image.path' => '_media/foo']))->getSource());
+        $this->assertEquals('media/foo', FeaturedImageFactory::make(new FrontMatter(['image.source' => 'foo']))->getSource());
+        $this->assertEquals('media/foo', FeaturedImageFactory::make(new FrontMatter(['image.source' => 'media/foo']))->getSource());
+        $this->assertEquals('media/foo', FeaturedImageFactory::make(new FrontMatter(['image.source' => '_media/foo']))->getSource());
 
-        $this->assertEquals('foo', FeaturedImageFactory::make(new FrontMatter(['image.url' => 'foo']))->getSource());
-        $this->assertEquals('//foo', FeaturedImageFactory::make(new FrontMatter(['image.url' => '//foo']))->getSource());
-        $this->assertEquals('http', FeaturedImageFactory::make(new FrontMatter(['image.url' => 'http']))->getSource());
+        $this->assertEquals('media/foo', FeaturedImageFactory::make(new FrontMatter(['image.source' => 'foo']))->getSource());
+        // TODO $this->assertEquals('//foo', FeaturedImageFactory::make(new FrontMatter(['image.source' => '//foo']))->getSource());
+        $this->assertEquals('http', FeaturedImageFactory::make(new FrontMatter(['image.source' => 'http']))->getSource());
 
         $this->assertEquals('media/foo', FeaturedImageFactory::make(new FrontMatter(['image' => 'foo']))->getSource());
         $this->assertEquals('http', FeaturedImageFactory::make(new FrontMatter(['image' => 'http']))->getSource());

--- a/packages/framework/tests/Feature/FeaturedImageTest.php
+++ b/packages/framework/tests/Feature/FeaturedImageTest.php
@@ -245,7 +245,7 @@ class FeaturedImageTest extends TestCase
     public function testMagicCallResolverWithNonExistentGetProperty()
     {
         $this->expectException(BadMethodCallException::class);
-        $this->expectExceptionMessage("Method 'getFoo' does not exist on " . NullImage::class);
+        $this->expectExceptionMessage("Method 'getFoo' does not exist on ".NullImage::class);
 
         /** @noinspection PhpUndefinedMethodInspection */
         (new NullImage())->getFoo();
@@ -254,7 +254,7 @@ class FeaturedImageTest extends TestCase
     public function testMagicCallResolverWithNonExistentHasProperty()
     {
         $this->expectException(BadMethodCallException::class);
-        $this->expectExceptionMessage("Method 'hasFoo' does not exist on " . NullImage::class);
+        $this->expectExceptionMessage("Method 'hasFoo' does not exist on ".NullImage::class);
 
         /** @noinspection PhpUndefinedMethodInspection */
         (new NullImage())->hasFoo();
@@ -263,7 +263,7 @@ class FeaturedImageTest extends TestCase
     public function testMagicCallResolverWithNonExistentMethodPrefix()
     {
         $this->expectException(BadMethodCallException::class);
-        $this->expectExceptionMessage("Method 'foo' does not exist on " . NullImage::class);
+        $this->expectExceptionMessage("Method 'foo' does not exist on ".NullImage::class);
 
         /** @noinspection PhpUndefinedMethodInspection */
         (new NullImage())->foo();

--- a/packages/framework/tests/Feature/FeaturedImageTest.php
+++ b/packages/framework/tests/Feature/FeaturedImageTest.php
@@ -186,10 +186,11 @@ class FeaturedImageTest extends TestCase
         $this->assertEquals('https/foo', $image->getSource());
     }
 
+    /** @deprecated */
     public function testCanConstructRemoteFeaturedImageWithInvalidSource()
     {
         $image = new RemoteFeaturedImage('foo', ...$this->defaultArguments());
-        $this->assertEquals('foo', $image->getSource());
+        $this->assertEquals('media/foo', $image->getSource());
     }
 
     public function testFeaturedImageGetContentLengthWithRemoteSource()
@@ -234,8 +235,8 @@ class FeaturedImageTest extends TestCase
         $this->assertEquals('media/foo', FeaturedImageFactory::make(new FrontMatter(['image.path' => 'media/foo']))->getSource());
         $this->assertEquals('media/foo', FeaturedImageFactory::make(new FrontMatter(['image.path' => '_media/foo']))->getSource());
 
-        $this->assertEquals('foo', FeaturedImageFactory::make(new FrontMatter(['image.url' => 'foo']))->getSource());
-        $this->assertEquals('//foo', FeaturedImageFactory::make(new FrontMatter(['image.url' => '//foo']))->getSource());
+        // TODO $this->assertEquals('foo', FeaturedImageFactory::make(new FrontMatter(['image.url' => 'foo']))->getSource());
+        // TODO $this->assertEquals('//foo', FeaturedImageFactory::make(new FrontMatter(['image.url' => '//foo']))->getSource());
         $this->assertEquals('http', FeaturedImageFactory::make(new FrontMatter(['image.url' => 'http']))->getSource());
 
         $this->assertEquals('media/foo', FeaturedImageFactory::make(new FrontMatter(['image' => 'foo']))->getSource());

--- a/packages/framework/tests/Feature/FeaturedImageTest.php
+++ b/packages/framework/tests/Feature/FeaturedImageTest.php
@@ -16,6 +16,11 @@ use Illuminate\Support\Facades\Http;
  */
 class FeaturedImageTest extends TestCase
 {
+    public function testCanConstruct()
+    {
+        $this->assertInstanceOf(FeaturedImage::class, new FeaturedImage('foo'));
+    }
+
     public function testGetAltText()
     {
         $this->assertNull((new NullImage)->getAltText());

--- a/packages/framework/tests/Feature/FeaturedImageTest.php
+++ b/packages/framework/tests/Feature/FeaturedImageTest.php
@@ -8,14 +8,12 @@ use BadMethodCallException;
 use Hyde\Framework\Exceptions\FileNotFoundException;
 use Hyde\Framework\Factories\FeaturedImageFactory;
 use Hyde\Framework\Features\Blogging\Models\FeaturedImage;
-use Hyde\Framework\Features\Blogging\Models\RemoteFeaturedImage;
 use Hyde\Markdown\Models\FrontMatter;
 use Hyde\Testing\TestCase;
 use Illuminate\Support\Facades\Http;
 
 /**
  * @covers \Hyde\Framework\Features\Blogging\Models\FeaturedImage
- * @covers \Hyde\Framework\Features\Blogging\Models\RemoteFeaturedImage
  */
 class FeaturedImageTest extends TestCase
 {
@@ -165,19 +163,17 @@ class FeaturedImageTest extends TestCase
         $this->assertEquals(0, $image->getContentLength());
     }
 
-    public function testCanConstructRemoteFeaturedImage()
+    public function testCanConstructFeaturedImageWithRemoteSource()
     {
-        $image = new RemoteFeaturedImage('http/foo', ...$this->defaultArguments());
-        $this->assertInstanceOf(RemoteFeaturedImage::class, $image);
+        $image = new FeaturedImage('http/foo', ...$this->defaultArguments());
         $this->assertInstanceOf(FeaturedImage::class, $image);
 
         $this->assertEquals('http/foo', $image->getSource());
     }
 
-    public function testCanConstructRemoteFeaturedImageWithHttps()
+    public function testCanConstructFeaturedImageWithHttps()
     {
-        $image = new RemoteFeaturedImage('https/foo', ...$this->defaultArguments());
-        $this->assertInstanceOf(RemoteFeaturedImage::class, $image);
+        $image = new FeaturedImage('https/foo', ...$this->defaultArguments());
         $this->assertInstanceOf(FeaturedImage::class, $image);
 
         $this->assertEquals('https/foo', $image->getSource());
@@ -191,7 +187,7 @@ class FeaturedImageTest extends TestCase
             ]);
         });
 
-        $image = new RemoteFeaturedImage('https://hyde.test/static/image.png', ...$this->defaultArguments());
+        $image = new FeaturedImage('https://hyde.test/static/image.png', ...$this->defaultArguments());
         $this->assertEquals(16, $image->getContentLength());
     }
 
@@ -201,7 +197,7 @@ class FeaturedImageTest extends TestCase
             return Http::response(null, 404);
         });
 
-        $image = new RemoteFeaturedImage('https://hyde.test/static/image.png', ...$this->defaultArguments());
+        $image = new FeaturedImage('https://hyde.test/static/image.png', ...$this->defaultArguments());
         $this->assertEquals(0, $image->getContentLength());
     }
 
@@ -213,7 +209,7 @@ class FeaturedImageTest extends TestCase
             ]);
         });
 
-        $image = new RemoteFeaturedImage('https://hyde.test/static/image.png', ...$this->defaultArguments());
+        $image = new FeaturedImage('https://hyde.test/static/image.png', ...$this->defaultArguments());
         $this->assertEquals(0, $image->getContentLength());
     }
 

--- a/packages/framework/tests/Feature/FeaturedImageTest.php
+++ b/packages/framework/tests/Feature/FeaturedImageTest.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Hyde\Framework\Testing\Feature;
 
-use BadMethodCallException;
 use Hyde\Framework\Exceptions\FileNotFoundException;
 use Hyde\Framework\Factories\FeaturedImageFactory;
 use Hyde\Framework\Features\Blogging\Models\FeaturedImage;
@@ -227,33 +226,6 @@ class FeaturedImageTest extends TestCase
 
         $this->assertEquals('media/foo', FeaturedImageFactory::make(new FrontMatter(['image' => 'foo']))->getSource());
         $this->assertEquals('http', FeaturedImageFactory::make(new FrontMatter(['image' => 'http']))->getSource());
-    }
-
-    public function testMagicCallResolverWithNonExistentGetProperty()
-    {
-        $this->expectException(BadMethodCallException::class);
-        $this->expectExceptionMessage("Method 'getFoo' does not exist on ".NullImage::class);
-
-        /** @noinspection PhpUndefinedMethodInspection */
-        (new NullImage())->getFoo();
-    }
-
-    public function testMagicCallResolverWithNonExistentHasProperty()
-    {
-        $this->expectException(BadMethodCallException::class);
-        $this->expectExceptionMessage("Method 'hasFoo' does not exist on ".NullImage::class);
-
-        /** @noinspection PhpUndefinedMethodInspection */
-        (new NullImage())->hasFoo();
-    }
-
-    public function testMagicCallResolverWithNonExistentMethodPrefix()
-    {
-        $this->expectException(BadMethodCallException::class);
-        $this->expectExceptionMessage("Method 'foo' does not exist on ".NullImage::class);
-
-        /** @noinspection PhpUndefinedMethodInspection */
-        (new NullImage())->foo();
     }
 
     protected function defaultArguments(): array

--- a/packages/framework/tests/Feature/FeaturedImageTest.php
+++ b/packages/framework/tests/Feature/FeaturedImageTest.php
@@ -8,7 +8,6 @@ use BadMethodCallException;
 use Hyde\Framework\Exceptions\FileNotFoundException;
 use Hyde\Framework\Factories\FeaturedImageFactory;
 use Hyde\Framework\Features\Blogging\Models\FeaturedImage;
-use Hyde\Framework\Features\Blogging\Models\LocalFeaturedImage;
 use Hyde\Framework\Features\Blogging\Models\RemoteFeaturedImage;
 use Hyde\Markdown\Models\FrontMatter;
 use Hyde\Testing\TestCase;
@@ -16,7 +15,6 @@ use Illuminate\Support\Facades\Http;
 
 /**
  * @covers \Hyde\Framework\Features\Blogging\Models\FeaturedImage
- * @covers \Hyde\Framework\Features\Blogging\Models\LocalFeaturedImage
  * @covers \Hyde\Framework\Features\Blogging\Models\RemoteFeaturedImage
  */
 class FeaturedImageTest extends TestCase
@@ -142,10 +140,9 @@ class FeaturedImageTest extends TestCase
         $this->assertEquals(0, (new FilledImage)->getContentLength());
     }
 
-    public function testCanConstructLocalFeaturedImage()
+    public function testCanConstructFeaturedImage()
     {
-        $image = new LocalFeaturedImage('_media/foo', ...$this->defaultArguments());
-        $this->assertInstanceOf(LocalFeaturedImage::class, $image);
+        $image = new FeaturedImage('_media/foo', ...$this->defaultArguments());
         $this->assertInstanceOf(FeaturedImage::class, $image);
 
         $this->assertEquals('media/foo', $image->getSource());
@@ -155,7 +152,7 @@ class FeaturedImageTest extends TestCase
     {
         $this->file('_media/foo', 'image');
 
-        $image = new LocalFeaturedImage('_media/foo', ...$this->defaultArguments());
+        $image = new FeaturedImage('_media/foo', ...$this->defaultArguments());
         $this->assertEquals(5, $image->getContentLength());
     }
 
@@ -164,7 +161,7 @@ class FeaturedImageTest extends TestCase
         $this->expectException(FileNotFoundException::class);
         $this->expectExceptionMessage('Image at _media/foo does not exist');
 
-        $image = new LocalFeaturedImage('_media/foo', ...$this->defaultArguments());
+        $image = new FeaturedImage('_media/foo', ...$this->defaultArguments());
         $this->assertEquals(0, $image->getContentLength());
     }
 
@@ -222,7 +219,7 @@ class FeaturedImageTest extends TestCase
 
     public function testGetSourceMethod()
     {
-        $this->assertEquals('media/foo', (new LocalFeaturedImage('_media/foo', ...$this->defaultArguments()))->getSource());
+        $this->assertEquals('media/foo', (new FeaturedImage('_media/foo', ...$this->defaultArguments()))->getSource());
 
         $this->assertEquals('media/foo', FeaturedImageFactory::make(new FrontMatter(['image.source' => 'foo']))->getSource());
         $this->assertEquals('media/foo', FeaturedImageFactory::make(new FrontMatter(['image.source' => 'media/foo']))->getSource());

--- a/packages/framework/tests/Feature/MarkdownPostTest.php
+++ b/packages/framework/tests/Feature/MarkdownPostTest.php
@@ -59,7 +59,7 @@ class MarkdownPostTest extends TestCase
     {
         $post = new MarkdownPost(matter: FrontMatter::fromArray([
             'image' => [
-                'url' => 'https://example.com/image.jpg',
+                'source' => 'https://example.com/image.jpg',
             ],
         ]));
 
@@ -101,7 +101,7 @@ class MarkdownPostTest extends TestCase
 
     public function test_featured_image_can_be_constructed_returns_image_object_with_supplied_data_when_matter_is_array()
     {
-        $page = MarkdownPost::make(matter: ['image' => ['path' => 'foo.png', 'title' => 'bar']]);
+        $page = MarkdownPost::make(matter: ['image' => ['source' => 'foo.png', 'title' => 'bar']]);
         $image = $page->image;
         $this->assertInstanceOf(FeaturedImage::class, $image);
         $this->assertEquals('media/foo.png', $image->getSource());

--- a/packages/framework/tests/Feature/MetadataTest.php
+++ b/packages/framework/tests/Feature/MetadataTest.php
@@ -421,7 +421,7 @@ class MetadataTest extends TestCase
     {
         $page = MarkdownPost::make(matter: [
             'image' => [
-                'path' => 'foo.jpg',
+                'source' => 'foo.jpg',
             ],
         ]);
 
@@ -432,7 +432,7 @@ class MetadataTest extends TestCase
     {
         $page = MarkdownPost::make(matter: [
             'image' => [
-                'url' => 'https://example.com/foo.jpg',
+                'source' => 'https://example.com/foo.jpg',
             ],
         ]);
 

--- a/packages/framework/tests/Unit/SchemaContractsTest.php
+++ b/packages/framework/tests/Unit/SchemaContractsTest.php
@@ -50,8 +50,7 @@ class SchemaContractsTest extends TestCase
         ], BlogPostSchema::AUTHOR_SCHEMA);
 
         $this->assertEquals([
-            'path'           => 'string',
-            'url'            => 'string',
+            'source'         => 'string',
             'description'    => 'string',
             'title'          => 'string',
             'copyright'      => 'string',

--- a/packages/framework/tests/Unit/Views/FeaturedImageViewTest.php
+++ b/packages/framework/tests/Unit/Views/FeaturedImageViewTest.php
@@ -23,7 +23,7 @@ class FeaturedImageViewTest extends TestCase
     public function test_the_view()
     {
         $component = $this->renderComponent([
-            'image.path' => 'foo.jpg',
+            'image.source' => 'foo.jpg',
             'image.description' => 'This is an image',
             'image.title' => 'FeaturedImage Title',
             'image.author' => 'John Doe',
@@ -264,7 +264,7 @@ class FeaturedImageViewTest extends TestCase
         return str_replace([' ', "\r", "\n"], '', $string);
     }
 
-    protected function renderComponent(FeaturedImage|array $data = ['image.path'=>'foo']): string
+    protected function renderComponent(FeaturedImage|array $data = ['image.source'=>'foo']): string
     {
         $image = $data instanceof FeaturedImage ? $data : $this->make($data);
 
@@ -280,7 +280,7 @@ class FeaturedImageViewTest extends TestCase
         $this->file("_media/$path");
 
         return FeaturedImageFactory::make(FrontMatter::fromArray(array_merge(
-            ['image.path' => $path],
+            ['image.source' => $path],
             $data,
         )));
     }

--- a/tests/fixtures/_posts/typography-front-matter.md
+++ b/tests/fixtures/_posts/typography-front-matter.md
@@ -8,7 +8,7 @@ author:
 date: Nov 7, 2021
 updated: July 30, 2022
 image:
-  url: https://hydephp.com/media/fixture-1.jpg
+  source: https://hydephp.com/media/fixture-1.jpg
   description: Alt text
   title: Tooltip
   license: "the Unsplash License"


### PR DESCRIPTION
This provides a nice feature, but there's honestly not enough reason to use three classes for such a scoped feature. Hence this (obviously breaking) refactor to aggressively simplify these classes, merging in the two child classes into the base abstract class.