### PR TITLE
Breaking: Merge blog post featured image source front matter properties

### DIFF
--- a/docs/creating-content/blog-posts.md
+++ b/docs/creating-content/blog-posts.md
@@ -186,11 +186,11 @@ will override all the values in the `authors` config entry.
 ### Image
 
 ```yaml
-image: image.jpg # Expanded by Hyde to `_media/image.jpg` and is resolved automatically
-image: https://cdn.example.com/image.jpg # Full URL starting with `http(s)://`)
+image: image.jpg # Expanded by Hyde to `_media/image.jpg` and is resolved automatically to the correct URL for the built site
+image: https://cdn.example.com/image.jpg # Full URL starting with `http(s)://`) or `//` (protocol-relative)
 image:
-  path: image.jpg
-  url: https://cdn.example.com/image.jpg # Takes precedence over `path`
+  source: image.jpg # Same as above
+  source: https://cdn.example.com/image.jpg # Same as above
   description: "Alt text for image"
   title: "Tooltip title"
   copyright: "Copyright (c) 2022"
@@ -200,7 +200,10 @@ image:
   author: "John Doe"
 ```
 
-When supplying an image with a local image path, the image is expected to be stored in the `_media/` directory.
+When supplying an image source with a local image path, the image is expected to be stored in the `_media/` directory.
+Like all other media files, it will be copied to `_site/media/` when the site is built, so Hyde will resolve links accordingly.
+
+When supplying an image with a full URL, the image source will be used as-is, and no additional processing is done.
 
 The image will be used as the cover image, and any array data is constructed into a dynamic fluent caption,
 and injected into post and page metadata.

--- a/packages/framework/src/Framework/Factories/FeaturedImageFactory.php
+++ b/packages/framework/src/Framework/Factories/FeaturedImageFactory.php
@@ -81,9 +81,7 @@ class FeaturedImageFactory extends Concerns\PageDataFactory implements FeaturedI
 
         if ($this->getStringMatter('image.source') !== null) {
             return $this->getStringMatter('image.source');
-        }
 
-        if ($this->getStringMatter('image.source') !== null) {
             return $this->normalizeLocalImagePath($this->getStringMatter('image.source'));
         }
 

--- a/packages/framework/src/Framework/Factories/FeaturedImageFactory.php
+++ b/packages/framework/src/Framework/Factories/FeaturedImageFactory.php
@@ -83,8 +83,8 @@ class FeaturedImageFactory extends Concerns\PageDataFactory implements FeaturedI
             return $this->getStringMatter('image.source');
         }
 
-        if ($this->getStringMatter('image.path') !== null) {
-            return $this->normalizeLocalImagePath($this->getStringMatter('image.path'));
+        if ($this->getStringMatter('image.source') !== null) {
+            return $this->normalizeLocalImagePath($this->getStringMatter('image.source'));
         }
 
         // Todo, we might want to add a note about which file caused the error.

--- a/packages/framework/src/Framework/Factories/FeaturedImageFactory.php
+++ b/packages/framework/src/Framework/Factories/FeaturedImageFactory.php
@@ -79,8 +79,8 @@ class FeaturedImageFactory extends Concerns\PageDataFactory implements FeaturedI
             return self::normalizeLocalImagePath($this->getStringMatter('image'));
         }
 
-        if ($this->getStringMatter('image.url') !== null) {
-            return $this->getStringMatter('image.url');
+        if ($this->getStringMatter('image.source') !== null) {
+            return $this->getStringMatter('image.source');
         }
 
         if ($this->getStringMatter('image.path') !== null) {

--- a/packages/framework/src/Framework/Factories/FeaturedImageFactory.php
+++ b/packages/framework/src/Framework/Factories/FeaturedImageFactory.php
@@ -80,7 +80,9 @@ class FeaturedImageFactory extends Concerns\PageDataFactory implements FeaturedI
         }
 
         if ($this->getStringMatter('image.source') !== null) {
-            return $this->getStringMatter('image.source');
+            if (str_starts_with($this->getStringMatter('image.source'), 'http')) {
+                return $this->getStringMatter('image.source');
+            }
 
             return $this->normalizeLocalImagePath($this->getStringMatter('image.source'));
         }

--- a/packages/framework/src/Framework/Features/Blogging/Models/FeaturedImage.php
+++ b/packages/framework/src/Framework/Features/Blogging/Models/FeaturedImage.php
@@ -36,7 +36,10 @@ use Stringable;
  */
 abstract class FeaturedImage implements Stringable, FeaturedImageSchema
 {
+    /** @deprecated Can be implicitly determined by source prefix */
     protected final const TYPE_LOCAL = 'local';
+
+    /** @deprecated Can be implicitly determined by source prefix */
     protected final const TYPE_REMOTE = 'remote';
 
     /** @var self::TYPE_* */

--- a/packages/framework/src/Framework/Features/Blogging/Models/FeaturedImage.php
+++ b/packages/framework/src/Framework/Features/Blogging/Models/FeaturedImage.php
@@ -42,7 +42,11 @@ abstract class FeaturedImage implements Stringable, FeaturedImageSchema
     /** @deprecated Can be implicitly determined by source prefix */
     protected final const TYPE_REMOTE = 'remote';
 
-    /** @var self::TYPE_* */
+    /**
+     * @deprecated Can be implicitly determined by source prefix
+     *
+     * @var self::TYPE_*
+     */
     protected readonly string $type;
     protected readonly string $source;
 

--- a/packages/framework/src/Framework/Features/Blogging/Models/LocalFeaturedImage.php
+++ b/packages/framework/src/Framework/Features/Blogging/Models/LocalFeaturedImage.php
@@ -30,13 +30,6 @@ class LocalFeaturedImage extends FeaturedImage
         return Str::after($source, Hyde::getMediaDirectory().'/');
     }
 
-    /** @deprecated */
-    public function getSource(): string
-    {
-        // Return value is always resolvable from a compiled page in the _site directory.
-        return Hyde::mediaLink($this->source);
-    }
-
     public function getContentLength(): int
     {
         return filesize($this->validatedStoragePath());

--- a/packages/framework/src/Framework/Features/Blogging/Models/RemoteFeaturedImage.php
+++ b/packages/framework/src/Framework/Features/Blogging/Models/RemoteFeaturedImage.php
@@ -20,12 +20,6 @@ class RemoteFeaturedImage extends FeaturedImage
         return $source;
     }
 
-    /** @deprecated */
-    public function getSource(): string
-    {
-        return $this->source;
-    }
-
     public function getContentLength(): int
     {
         $headers = Http::withHeaders([

--- a/packages/framework/src/Markdown/Contracts/FrontMatter/SubSchemas/FeaturedImageSchema.php
+++ b/packages/framework/src/Markdown/Contracts/FrontMatter/SubSchemas/FeaturedImageSchema.php
@@ -11,7 +11,7 @@ namespace Hyde\Markdown\Contracts\FrontMatter\SubSchemas;
 interface FeaturedImageSchema
 {
     public const FEATURED_IMAGE_SCHEMA = [
-        'source'         => 'string',
+        'source'         => 'string', // Filename in _media/ or a remote URL
         'path'           => 'string', // @deprecated
         'url'            => 'string', // @deprecated
         'description'    => 'string',

--- a/packages/framework/src/Markdown/Contracts/FrontMatter/SubSchemas/FeaturedImageSchema.php
+++ b/packages/framework/src/Markdown/Contracts/FrontMatter/SubSchemas/FeaturedImageSchema.php
@@ -12,7 +12,7 @@ interface FeaturedImageSchema
 {
     public const FEATURED_IMAGE_SCHEMA = [
         'path'           => 'string',
-        'url'            => 'string', // Takes precedence over path
+        'url'            => 'string',
         'description'    => 'string',
         'title'          => 'string',
         'copyright'      => 'string',

--- a/packages/framework/src/Markdown/Contracts/FrontMatter/SubSchemas/FeaturedImageSchema.php
+++ b/packages/framework/src/Markdown/Contracts/FrontMatter/SubSchemas/FeaturedImageSchema.php
@@ -12,7 +12,7 @@ interface FeaturedImageSchema
 {
     public const FEATURED_IMAGE_SCHEMA = [
         'path'           => 'string', // @deprecated
-        'url'            => 'string',
+        'url'            => 'string', // @deprecated
         'description'    => 'string',
         'title'          => 'string',
         'copyright'      => 'string',

--- a/packages/framework/src/Markdown/Contracts/FrontMatter/SubSchemas/FeaturedImageSchema.php
+++ b/packages/framework/src/Markdown/Contracts/FrontMatter/SubSchemas/FeaturedImageSchema.php
@@ -12,7 +12,6 @@ interface FeaturedImageSchema
 {
     public const FEATURED_IMAGE_SCHEMA = [
         'source'         => 'string', // Filename in _media/ or a remote URL
-        'path'           => 'string', // @deprecated
         'url'            => 'string', // @deprecated
         'description'    => 'string',
         'title'          => 'string',

--- a/packages/framework/src/Markdown/Contracts/FrontMatter/SubSchemas/FeaturedImageSchema.php
+++ b/packages/framework/src/Markdown/Contracts/FrontMatter/SubSchemas/FeaturedImageSchema.php
@@ -12,7 +12,6 @@ interface FeaturedImageSchema
 {
     public const FEATURED_IMAGE_SCHEMA = [
         'source'         => 'string', // Filename in _media/ or a remote URL
-        'url'            => 'string', // @deprecated
         'description'    => 'string',
         'title'          => 'string',
         'copyright'      => 'string',

--- a/packages/framework/src/Markdown/Contracts/FrontMatter/SubSchemas/FeaturedImageSchema.php
+++ b/packages/framework/src/Markdown/Contracts/FrontMatter/SubSchemas/FeaturedImageSchema.php
@@ -11,7 +11,7 @@ namespace Hyde\Markdown\Contracts\FrontMatter\SubSchemas;
 interface FeaturedImageSchema
 {
     public const FEATURED_IMAGE_SCHEMA = [
-        'path'           => 'string',
+        'path'           => 'string', // @deprecated
         'url'            => 'string',
         'description'    => 'string',
         'title'          => 'string',

--- a/packages/framework/src/Markdown/Contracts/FrontMatter/SubSchemas/FeaturedImageSchema.php
+++ b/packages/framework/src/Markdown/Contracts/FrontMatter/SubSchemas/FeaturedImageSchema.php
@@ -11,6 +11,7 @@ namespace Hyde\Markdown\Contracts\FrontMatter\SubSchemas;
 interface FeaturedImageSchema
 {
     public const FEATURED_IMAGE_SCHEMA = [
+        'source'         => 'string',
         'path'           => 'string', // @deprecated
         'url'            => 'string', // @deprecated
         'description'    => 'string',

--- a/packages/framework/tests/Feature/FeaturedImageFactoryTest.php
+++ b/packages/framework/tests/Feature/FeaturedImageFactoryTest.php
@@ -50,11 +50,11 @@ class FeaturedImageFactoryTest extends TestCase
     public function testMakeMethodCreatesLocalImageWhenPathIsSet()
     {
         $image = $this->makeFromArray([
-            'image.source' => 'source',
+            'image.source' => 'foo',
         ]);
 
         $this->assertInstanceOf(LocalFeaturedImage::class, $image);
-        $this->assertSame('media/source', $image->getSource());
+        $this->assertSame('media/foo', $image->getSource());
     }
 
     public function testMakeMethodThrowsExceptionIfNoPathInformationIsSet()

--- a/packages/framework/tests/Feature/FeaturedImageFactoryTest.php
+++ b/packages/framework/tests/Feature/FeaturedImageFactoryTest.php
@@ -22,7 +22,7 @@ class FeaturedImageFactoryTest extends TestCase
     {
         $array = [
             'image.path' => 'path',
-            'image.url' => 'url',
+            'image.source' => 'source',
             'image.description' => 'description',
             'image.title' => 'title',
             'image.copyright' => 'copyright',
@@ -33,7 +33,7 @@ class FeaturedImageFactoryTest extends TestCase
         ];
 
         $expected = [
-            'source' => 'url',
+            'source' => 'source',
             'altText' => 'description',
             'titleText' => 'title',
             'authorName' => 'author',
@@ -61,22 +61,22 @@ class FeaturedImageFactoryTest extends TestCase
     public function testMakeMethodCreatesRemoteImageWhenUrlIsSet()
     {
         $image = $this->makeFromArray([
-            'image.url' => 'url',
+            'image.source' => 'source',
         ]);
 
         $this->assertInstanceOf(RemoteFeaturedImage::class, $image);
-        $this->assertSame('url', $image->getSource());
+        $this->assertSame('source', $image->getSource());
     }
 
     public function testMakeMethodCreatesRemoteImageWhenBothUrlAndPathIsSet()
     {
         $image = $this->makeFromArray([
-            'image.url' => 'url',
+            'image.source' => 'source',
             'image.path' => 'path',
         ]);
 
         $this->assertInstanceOf(RemoteFeaturedImage::class, $image);
-        $this->assertSame('url', $image->getSource());
+        $this->assertSame('source', $image->getSource());
     }
 
     public function testMakeMethodThrowsExceptionIfNoPathInformationIsSet()

--- a/packages/framework/tests/Feature/FeaturedImageFactoryTest.php
+++ b/packages/framework/tests/Feature/FeaturedImageFactoryTest.php
@@ -22,7 +22,6 @@ class FeaturedImageFactoryTest extends TestCase
     {
         $array = [
             'image.source' => 'source',
-            'image.source' => 'source',
             'image.description' => 'description',
             'image.title' => 'title',
             'image.copyright' => 'copyright',
@@ -56,27 +55,6 @@ class FeaturedImageFactoryTest extends TestCase
 
         $this->assertInstanceOf(LocalFeaturedImage::class, $image);
         $this->assertSame('media/source', $image->getSource());
-    }
-
-    public function testMakeMethodCreatesRemoteImageWhenUrlIsSet()
-    {
-        $image = $this->makeFromArray([
-            'image.source' => 'source',
-        ]);
-
-        $this->assertInstanceOf(RemoteFeaturedImage::class, $image);
-        $this->assertSame('source', $image->getSource());
-    }
-
-    public function testMakeMethodCreatesRemoteImageWhenBothUrlAndPathIsSet()
-    {
-        $image = $this->makeFromArray([
-            'image.source' => 'source',
-            'image.source' => 'source',
-        ]);
-
-        $this->assertInstanceOf(RemoteFeaturedImage::class, $image);
-        $this->assertSame('source', $image->getSource());
     }
 
     public function testMakeMethodThrowsExceptionIfNoPathInformationIsSet()

--- a/packages/framework/tests/Feature/FeaturedImageFactoryTest.php
+++ b/packages/framework/tests/Feature/FeaturedImageFactoryTest.php
@@ -21,7 +21,7 @@ class FeaturedImageFactoryTest extends TestCase
     public function testWithDataFromSchema()
     {
         $array = [
-            'image.path' => 'path',
+            'image.source' => 'source',
             'image.source' => 'source',
             'image.description' => 'description',
             'image.title' => 'title',
@@ -51,11 +51,11 @@ class FeaturedImageFactoryTest extends TestCase
     public function testMakeMethodCreatesLocalImageWhenPathIsSet()
     {
         $image = $this->makeFromArray([
-            'image.path' => 'path',
+            'image.source' => 'source',
         ]);
 
         $this->assertInstanceOf(LocalFeaturedImage::class, $image);
-        $this->assertSame('media/path', $image->getSource());
+        $this->assertSame('media/source', $image->getSource());
     }
 
     public function testMakeMethodCreatesRemoteImageWhenUrlIsSet()
@@ -72,7 +72,7 @@ class FeaturedImageFactoryTest extends TestCase
     {
         $image = $this->makeFromArray([
             'image.source' => 'source',
-            'image.path' => 'path',
+            'image.source' => 'source',
         ]);
 
         $this->assertInstanceOf(RemoteFeaturedImage::class, $image);
@@ -113,9 +113,9 @@ class FeaturedImageFactoryTest extends TestCase
         $this->assertSourceIsSame('media/foo', ['image' => 'media/foo']);
         $this->assertSourceIsSame('media/foo', ['image' => '_media/foo']);
 
-        $this->assertSourceIsSame('media/foo', ['image' => ['path' => 'foo']]);
-        $this->assertSourceIsSame('media/foo', ['image' => ['path' => 'media/foo']]);
-        $this->assertSourceIsSame('media/foo', ['image' => ['path' => '_media/foo']]);
+        $this->assertSourceIsSame('media/foo', ['image' => ['source' => 'foo']]);
+        $this->assertSourceIsSame('media/foo', ['image' => ['source' => 'media/foo']]);
+        $this->assertSourceIsSame('media/foo', ['image' => ['source' => '_media/foo']]);
     }
 
     public function testImagePathsAreNormalizedForCustomizedMediaDirectory()
@@ -126,9 +126,9 @@ class FeaturedImageFactoryTest extends TestCase
         $this->assertSourceIsSame('assets/foo', ['image' => 'assets/foo']);
         $this->assertSourceIsSame('assets/foo', ['image' => '_assets/foo']);
 
-        $this->assertSourceIsSame('assets/foo', ['image' => ['path' => 'foo']]);
-        $this->assertSourceIsSame('assets/foo', ['image' => ['path' => 'assets/foo']]);
-        $this->assertSourceIsSame('assets/foo', ['image' => ['path' => '_assets/foo']]);
+        $this->assertSourceIsSame('assets/foo', ['image' => ['source' => 'foo']]);
+        $this->assertSourceIsSame('assets/foo', ['image' => ['source' => 'assets/foo']]);
+        $this->assertSourceIsSame('assets/foo', ['image' => ['source' => '_assets/foo']]);
     }
 
     public function testImagePathsAreNormalizedForCustomizedMediaDirectoryWithoutUnderscore()
@@ -139,9 +139,9 @@ class FeaturedImageFactoryTest extends TestCase
         $this->assertSourceIsSame('assets/foo', ['image' => 'assets/foo']);
         $this->assertSourceIsSame('assets/foo', ['image' => 'assets/foo']);
 
-        $this->assertSourceIsSame('assets/foo', ['image' => ['path' => 'foo']]);
-        $this->assertSourceIsSame('assets/foo', ['image' => ['path' => 'assets/foo']]);
-        $this->assertSourceIsSame('assets/foo', ['image' => ['path' => 'assets/foo']]);
+        $this->assertSourceIsSame('assets/foo', ['image' => ['source' => 'foo']]);
+        $this->assertSourceIsSame('assets/foo', ['image' => ['source' => 'assets/foo']]);
+        $this->assertSourceIsSame('assets/foo', ['image' => ['source' => 'assets/foo']]);
     }
 
     protected function makeFromArray(array $matter): FeaturedImage

--- a/packages/framework/tests/Feature/FeaturedImageTest.php
+++ b/packages/framework/tests/Feature/FeaturedImageTest.php
@@ -186,11 +186,10 @@ class FeaturedImageTest extends TestCase
         $this->assertEquals('https/foo', $image->getSource());
     }
 
-    /** @deprecated */
     public function testCanConstructRemoteFeaturedImageWithInvalidSource()
     {
         $image = new RemoteFeaturedImage('foo', ...$this->defaultArguments());
-        $this->assertEquals('media/foo', $image->getSource());
+        $this->assertEquals('foo', $image->getSource());
     }
 
     public function testFeaturedImageGetContentLengthWithRemoteSource()
@@ -235,8 +234,8 @@ class FeaturedImageTest extends TestCase
         $this->assertEquals('media/foo', FeaturedImageFactory::make(new FrontMatter(['image.path' => 'media/foo']))->getSource());
         $this->assertEquals('media/foo', FeaturedImageFactory::make(new FrontMatter(['image.path' => '_media/foo']))->getSource());
 
-        // TODO $this->assertEquals('foo', FeaturedImageFactory::make(new FrontMatter(['image.url' => 'foo']))->getSource());
-        // TODO $this->assertEquals('//foo', FeaturedImageFactory::make(new FrontMatter(['image.url' => '//foo']))->getSource());
+        $this->assertEquals('foo', FeaturedImageFactory::make(new FrontMatter(['image.url' => 'foo']))->getSource());
+        $this->assertEquals('//foo', FeaturedImageFactory::make(new FrontMatter(['image.url' => '//foo']))->getSource());
         $this->assertEquals('http', FeaturedImageFactory::make(new FrontMatter(['image.url' => 'http']))->getSource());
 
         $this->assertEquals('media/foo', FeaturedImageFactory::make(new FrontMatter(['image' => 'foo']))->getSource());

--- a/packages/framework/tests/Feature/FeaturedImageTest.php
+++ b/packages/framework/tests/Feature/FeaturedImageTest.php
@@ -230,13 +230,13 @@ class FeaturedImageTest extends TestCase
     {
         $this->assertEquals('media/foo', (new LocalFeaturedImage('_media/foo', ...$this->defaultArguments()))->getSource());
 
-        $this->assertEquals('media/foo', FeaturedImageFactory::make(new FrontMatter(['image.path' => 'foo']))->getSource());
-        $this->assertEquals('media/foo', FeaturedImageFactory::make(new FrontMatter(['image.path' => 'media/foo']))->getSource());
-        $this->assertEquals('media/foo', FeaturedImageFactory::make(new FrontMatter(['image.path' => '_media/foo']))->getSource());
+        $this->assertEquals('media/foo', FeaturedImageFactory::make(new FrontMatter(['image.source' => 'foo']))->getSource());
+        $this->assertEquals('media/foo', FeaturedImageFactory::make(new FrontMatter(['image.source' => 'media/foo']))->getSource());
+        $this->assertEquals('media/foo', FeaturedImageFactory::make(new FrontMatter(['image.source' => '_media/foo']))->getSource());
 
-        $this->assertEquals('foo', FeaturedImageFactory::make(new FrontMatter(['image.url' => 'foo']))->getSource());
-        $this->assertEquals('//foo', FeaturedImageFactory::make(new FrontMatter(['image.url' => '//foo']))->getSource());
-        $this->assertEquals('http', FeaturedImageFactory::make(new FrontMatter(['image.url' => 'http']))->getSource());
+        $this->assertEquals('media/foo', FeaturedImageFactory::make(new FrontMatter(['image.source' => 'foo']))->getSource());
+        // TODO $this->assertEquals('//foo', FeaturedImageFactory::make(new FrontMatter(['image.source' => '//foo']))->getSource());
+        // FIXME $this->assertEquals('http', FeaturedImageFactory::make(new FrontMatter(['image.source' => 'http']))->getSource());
 
         $this->assertEquals('media/foo', FeaturedImageFactory::make(new FrontMatter(['image' => 'foo']))->getSource());
         $this->assertEquals('http', FeaturedImageFactory::make(new FrontMatter(['image' => 'http']))->getSource());

--- a/packages/framework/tests/Feature/FeaturedImageTest.php
+++ b/packages/framework/tests/Feature/FeaturedImageTest.php
@@ -186,10 +186,11 @@ class FeaturedImageTest extends TestCase
         $this->assertEquals('https/foo', $image->getSource());
     }
 
+    /** @deprecated */
     public function testCanConstructRemoteFeaturedImageWithInvalidSource()
     {
         $image = new RemoteFeaturedImage('foo', ...$this->defaultArguments());
-        $this->assertEquals('foo', $image->getSource());
+        $this->assertEquals('media/foo', $image->getSource());
     }
 
     public function testFeaturedImageGetContentLengthWithRemoteSource()
@@ -234,8 +235,8 @@ class FeaturedImageTest extends TestCase
         $this->assertEquals('media/foo', FeaturedImageFactory::make(new FrontMatter(['image.path' => 'media/foo']))->getSource());
         $this->assertEquals('media/foo', FeaturedImageFactory::make(new FrontMatter(['image.path' => '_media/foo']))->getSource());
 
-        $this->assertEquals('foo', FeaturedImageFactory::make(new FrontMatter(['image.url' => 'foo']))->getSource());
-        $this->assertEquals('//foo', FeaturedImageFactory::make(new FrontMatter(['image.url' => '//foo']))->getSource());
+        // TODO $this->assertEquals('foo', FeaturedImageFactory::make(new FrontMatter(['image.url' => 'foo']))->getSource());
+        // TODO $this->assertEquals('//foo', FeaturedImageFactory::make(new FrontMatter(['image.url' => '//foo']))->getSource());
         $this->assertEquals('http', FeaturedImageFactory::make(new FrontMatter(['image.url' => 'http']))->getSource());
 
         $this->assertEquals('media/foo', FeaturedImageFactory::make(new FrontMatter(['image' => 'foo']))->getSource());

--- a/packages/framework/tests/Feature/FeaturedImageTest.php
+++ b/packages/framework/tests/Feature/FeaturedImageTest.php
@@ -230,13 +230,13 @@ class FeaturedImageTest extends TestCase
     {
         $this->assertEquals('media/foo', (new LocalFeaturedImage('_media/foo', ...$this->defaultArguments()))->getSource());
 
-        $this->assertEquals('media/foo', FeaturedImageFactory::make(new FrontMatter(['image.source' => 'foo']))->getSource());
-        $this->assertEquals('media/foo', FeaturedImageFactory::make(new FrontMatter(['image.source' => 'media/foo']))->getSource());
-        $this->assertEquals('media/foo', FeaturedImageFactory::make(new FrontMatter(['image.source' => '_media/foo']))->getSource());
+        $this->assertEquals('media/foo', FeaturedImageFactory::make(new FrontMatter(['image.path' => 'foo']))->getSource());
+        $this->assertEquals('media/foo', FeaturedImageFactory::make(new FrontMatter(['image.path' => 'media/foo']))->getSource());
+        $this->assertEquals('media/foo', FeaturedImageFactory::make(new FrontMatter(['image.path' => '_media/foo']))->getSource());
 
-        $this->assertEquals('media/foo', FeaturedImageFactory::make(new FrontMatter(['image.source' => 'foo']))->getSource());
-        // TODO $this->assertEquals('//foo', FeaturedImageFactory::make(new FrontMatter(['image.source' => '//foo']))->getSource());
-        // FIXME $this->assertEquals('http', FeaturedImageFactory::make(new FrontMatter(['image.source' => 'http']))->getSource());
+        $this->assertEquals('foo', FeaturedImageFactory::make(new FrontMatter(['image.url' => 'foo']))->getSource());
+        $this->assertEquals('//foo', FeaturedImageFactory::make(new FrontMatter(['image.url' => '//foo']))->getSource());
+        $this->assertEquals('http', FeaturedImageFactory::make(new FrontMatter(['image.url' => 'http']))->getSource());
 
         $this->assertEquals('media/foo', FeaturedImageFactory::make(new FrontMatter(['image' => 'foo']))->getSource());
         $this->assertEquals('http', FeaturedImageFactory::make(new FrontMatter(['image' => 'http']))->getSource());

--- a/packages/framework/tests/Feature/FeaturedImageTest.php
+++ b/packages/framework/tests/Feature/FeaturedImageTest.php
@@ -236,7 +236,7 @@ class FeaturedImageTest extends TestCase
 
         $this->assertEquals('media/foo', FeaturedImageFactory::make(new FrontMatter(['image.source' => 'foo']))->getSource());
         // TODO $this->assertEquals('//foo', FeaturedImageFactory::make(new FrontMatter(['image.source' => '//foo']))->getSource());
-        // FIXME $this->assertEquals('http', FeaturedImageFactory::make(new FrontMatter(['image.source' => 'http']))->getSource());
+        $this->assertEquals('http', FeaturedImageFactory::make(new FrontMatter(['image.source' => 'http']))->getSource());
 
         $this->assertEquals('media/foo', FeaturedImageFactory::make(new FrontMatter(['image' => 'foo']))->getSource());
         $this->assertEquals('http', FeaturedImageFactory::make(new FrontMatter(['image' => 'http']))->getSource());

--- a/packages/framework/tests/Feature/FeaturedImageTest.php
+++ b/packages/framework/tests/Feature/FeaturedImageTest.php
@@ -235,7 +235,7 @@ class FeaturedImageTest extends TestCase
         $this->assertEquals('media/foo', FeaturedImageFactory::make(new FrontMatter(['image.source' => '_media/foo']))->getSource());
 
         $this->assertEquals('media/foo', FeaturedImageFactory::make(new FrontMatter(['image.source' => 'foo']))->getSource());
-        $this->assertEquals('//foo', FeaturedImageFactory::make(new FrontMatter(['image.source' => '//foo']))->getSource());
+        // TODO $this->assertEquals('//foo', FeaturedImageFactory::make(new FrontMatter(['image.source' => '//foo']))->getSource());
         $this->assertEquals('http', FeaturedImageFactory::make(new FrontMatter(['image.source' => 'http']))->getSource());
 
         $this->assertEquals('media/foo', FeaturedImageFactory::make(new FrontMatter(['image' => 'foo']))->getSource());

--- a/packages/framework/tests/Feature/FeaturedImageTest.php
+++ b/packages/framework/tests/Feature/FeaturedImageTest.php
@@ -230,13 +230,13 @@ class FeaturedImageTest extends TestCase
     {
         $this->assertEquals('media/foo', (new LocalFeaturedImage('_media/foo', ...$this->defaultArguments()))->getSource());
 
-        $this->assertEquals('media/foo', FeaturedImageFactory::make(new FrontMatter(['image.path' => 'foo']))->getSource());
-        $this->assertEquals('media/foo', FeaturedImageFactory::make(new FrontMatter(['image.path' => 'media/foo']))->getSource());
-        $this->assertEquals('media/foo', FeaturedImageFactory::make(new FrontMatter(['image.path' => '_media/foo']))->getSource());
+        $this->assertEquals('media/foo', FeaturedImageFactory::make(new FrontMatter(['image.source' => 'foo']))->getSource());
+        $this->assertEquals('media/foo', FeaturedImageFactory::make(new FrontMatter(['image.source' => 'media/foo']))->getSource());
+        $this->assertEquals('media/foo', FeaturedImageFactory::make(new FrontMatter(['image.source' => '_media/foo']))->getSource());
 
-        $this->assertEquals('foo', FeaturedImageFactory::make(new FrontMatter(['image.url' => 'foo']))->getSource());
-        $this->assertEquals('//foo', FeaturedImageFactory::make(new FrontMatter(['image.url' => '//foo']))->getSource());
-        $this->assertEquals('http', FeaturedImageFactory::make(new FrontMatter(['image.url' => 'http']))->getSource());
+        $this->assertEquals('media/foo', FeaturedImageFactory::make(new FrontMatter(['image.source' => 'foo']))->getSource());
+        $this->assertEquals('//foo', FeaturedImageFactory::make(new FrontMatter(['image.source' => '//foo']))->getSource());
+        $this->assertEquals('http', FeaturedImageFactory::make(new FrontMatter(['image.source' => 'http']))->getSource());
 
         $this->assertEquals('media/foo', FeaturedImageFactory::make(new FrontMatter(['image' => 'foo']))->getSource());
         $this->assertEquals('http', FeaturedImageFactory::make(new FrontMatter(['image' => 'http']))->getSource());

--- a/packages/framework/tests/Feature/FeaturedImageTest.php
+++ b/packages/framework/tests/Feature/FeaturedImageTest.php
@@ -186,12 +186,6 @@ class FeaturedImageTest extends TestCase
         $this->assertEquals('https/foo', $image->getSource());
     }
 
-    public function testCanConstructRemoteFeaturedImageWithInvalidSource()
-    {
-        $image = new RemoteFeaturedImage('foo', ...$this->defaultArguments());
-        $this->assertEquals('foo', $image->getSource());
-    }
-
     public function testFeaturedImageGetContentLengthWithRemoteSource()
     {
         Http::fake(function () {

--- a/packages/framework/tests/Feature/FeaturedImageTest.php
+++ b/packages/framework/tests/Feature/FeaturedImageTest.php
@@ -236,7 +236,7 @@ class FeaturedImageTest extends TestCase
 
         $this->assertEquals('media/foo', FeaturedImageFactory::make(new FrontMatter(['image.source' => 'foo']))->getSource());
         // TODO $this->assertEquals('//foo', FeaturedImageFactory::make(new FrontMatter(['image.source' => '//foo']))->getSource());
-        $this->assertEquals('http', FeaturedImageFactory::make(new FrontMatter(['image.source' => 'http']))->getSource());
+        // FIXME $this->assertEquals('http', FeaturedImageFactory::make(new FrontMatter(['image.source' => 'http']))->getSource());
 
         $this->assertEquals('media/foo', FeaturedImageFactory::make(new FrontMatter(['image' => 'foo']))->getSource());
         $this->assertEquals('http', FeaturedImageFactory::make(new FrontMatter(['image' => 'http']))->getSource());

--- a/packages/framework/tests/Feature/MarkdownPostTest.php
+++ b/packages/framework/tests/Feature/MarkdownPostTest.php
@@ -59,7 +59,7 @@ class MarkdownPostTest extends TestCase
     {
         $post = new MarkdownPost(matter: FrontMatter::fromArray([
             'image' => [
-                'url' => 'https://example.com/image.jpg',
+                'source' => 'https://example.com/image.jpg',
             ],
         ]));
 
@@ -101,7 +101,7 @@ class MarkdownPostTest extends TestCase
 
     public function test_featured_image_can_be_constructed_returns_image_object_with_supplied_data_when_matter_is_array()
     {
-        $page = MarkdownPost::make(matter: ['image' => ['path' => 'foo.png', 'title' => 'bar']]);
+        $page = MarkdownPost::make(matter: ['image' => ['source' => 'foo.png', 'title' => 'bar']]);
         $image = $page->image;
         $this->assertInstanceOf(FeaturedImage::class, $image);
         $this->assertEquals('media/foo.png', $image->getSource());

--- a/packages/framework/tests/Feature/MetadataTest.php
+++ b/packages/framework/tests/Feature/MetadataTest.php
@@ -421,7 +421,7 @@ class MetadataTest extends TestCase
     {
         $page = MarkdownPost::make(matter: [
             'image' => [
-                'path' => 'foo.jpg',
+                'source' => 'foo.jpg',
             ],
         ]);
 
@@ -432,7 +432,7 @@ class MetadataTest extends TestCase
     {
         $page = MarkdownPost::make(matter: [
             'image' => [
-                'url' => 'https://example.com/foo.jpg',
+                'source' => 'https://example.com/foo.jpg',
             ],
         ]);
 

--- a/packages/framework/tests/Unit/SchemaContractsTest.php
+++ b/packages/framework/tests/Unit/SchemaContractsTest.php
@@ -51,7 +51,6 @@ class SchemaContractsTest extends TestCase
 
         $this->assertEquals([
             'source'         => 'string',
-            'url'            => 'string',
             'description'    => 'string',
             'title'          => 'string',
             'copyright'      => 'string',

--- a/packages/framework/tests/Unit/SchemaContractsTest.php
+++ b/packages/framework/tests/Unit/SchemaContractsTest.php
@@ -50,6 +50,7 @@ class SchemaContractsTest extends TestCase
         ], BlogPostSchema::AUTHOR_SCHEMA);
 
         $this->assertEquals([
+            'source'         => 'string',
             'path'           => 'string',
             'url'            => 'string',
             'description'    => 'string',

--- a/packages/framework/tests/Unit/SchemaContractsTest.php
+++ b/packages/framework/tests/Unit/SchemaContractsTest.php
@@ -51,7 +51,6 @@ class SchemaContractsTest extends TestCase
 
         $this->assertEquals([
             'source'         => 'string',
-            'path'           => 'string',
             'url'            => 'string',
             'description'    => 'string',
             'title'          => 'string',

--- a/packages/framework/tests/Unit/Views/FeaturedImageViewTest.php
+++ b/packages/framework/tests/Unit/Views/FeaturedImageViewTest.php
@@ -23,7 +23,7 @@ class FeaturedImageViewTest extends TestCase
     public function test_the_view()
     {
         $component = $this->renderComponent([
-            'image.path' => 'foo.jpg',
+            'image.source' => 'foo.jpg',
             'image.description' => 'This is an image',
             'image.title' => 'FeaturedImage Title',
             'image.author' => 'John Doe',
@@ -264,7 +264,7 @@ class FeaturedImageViewTest extends TestCase
         return str_replace([' ', "\r", "\n"], '', $string);
     }
 
-    protected function renderComponent(FeaturedImage|array $data = ['image.path'=>'foo']): string
+    protected function renderComponent(FeaturedImage|array $data = ['image.source'=>'foo']): string
     {
         $image = $data instanceof FeaturedImage ? $data : $this->make($data);
 
@@ -280,7 +280,7 @@ class FeaturedImageViewTest extends TestCase
         $this->file("_media/$path");
 
         return FeaturedImageFactory::make(FrontMatter::fromArray(array_merge(
-            ['image.path' => $path],
+            ['image.source' => $path],
             $data,
         )));
     }


### PR DESCRIPTION
## Abstract

Implements the proposed change in https://github.com/hydephp/develop/pull/1093#issuecomment-1439109372 to simplify the API by merging `image.path` and `image.url` into a single `image.source` (or just the `image` one when not using array) property that determines local/remote state depending on whether it starts with `http` or `//`. 

Although this is a breaking change, I believe it is worth it. This change also aligns with the internal data structure, where both input options are stored in the `$source` property. Furthermore, we no longer need to specify that one property overrides the other.

In other words, both `image.url` and `image.path` are now `image.source`, which equals the behaviour of when using `image: somestring`

## Comparison

### Flat syntax: Before & After

No change here.

```yaml
image: image.jpg
```
```yaml
image: https://cdn.example.com/image.jpg
```

### Array syntax: Before

```yaml
image:
  path: image.jpg
```
```yaml
image: 
  url: https://cdn.example.com/image.jpg
```

### Array syntax: After

```yaml
image:
  source: image.jpg
```
```yaml
image: 
  source: https://cdn.example.com/image.jpg
```