### PR TITLE
Internal: Update unit tests

### DIFF
--- a/packages/framework/tests/Unit/BaseFoundationCollectionTest.php
+++ b/packages/framework/tests/Unit/BaseFoundationCollectionTest.php
@@ -6,15 +6,17 @@ namespace Hyde\Framework\Testing\Unit;
 
 use Hyde\Foundation\Concerns\BaseFoundationCollection;
 use Hyde\Foundation\HydeKernel;
-use Hyde\Testing\TestCase;
+use Hyde\Testing\UnitTestCase;
 
 /**
  * @covers \Hyde\Foundation\Concerns\BaseFoundationCollection
  */
-class BaseFoundationCollectionTest extends TestCase
+class BaseFoundationCollectionTest extends UnitTestCase
 {
     public function test_init()
     {
+        $this->needsKernel();
+
         $booted = BaseFoundationCollectionTestClass::init(HydeKernel::getInstance())->boot();
 
         $this->assertInstanceOf(BaseFoundationCollection::class, $booted);

--- a/packages/framework/tests/Unit/BlogPostFrontMatterIsOptionalTest.php
+++ b/packages/framework/tests/Unit/BlogPostFrontMatterIsOptionalTest.php
@@ -4,9 +4,11 @@ declare(strict_types=1);
 
 namespace Hyde\Framework\Testing\Unit;
 
+use Hyde\Framework\Actions\StaticPageBuilder;
 use Hyde\Hyde;
+use Hyde\Pages\BladePage;
+use Hyde\Pages\MarkdownPost;
 use Hyde\Testing\TestCase;
-use Illuminate\Support\Facades\Artisan;
 
 class BlogPostFrontMatterIsOptionalTest extends TestCase
 {
@@ -14,7 +16,7 @@ class BlogPostFrontMatterIsOptionalTest extends TestCase
     {
         file_put_contents(Hyde::path('_posts/test-post.md'), '# My New Post');
 
-        Artisan::call('rebuild _posts/test-post.md');
+        new StaticPageBuilder(MarkdownPost::get('test-post'), true);
 
         $this->assertFileExists(Hyde::path('_site/posts/test-post.html'));
 
@@ -31,7 +33,7 @@ class BlogPostFrontMatterIsOptionalTest extends TestCase
             Hyde::path('_pages/feed-test.blade.php')
         );
 
-        Artisan::call('rebuild _pages/feed-test.blade.php');
+        new StaticPageBuilder(BladePage::get('feed-test'), true);
 
         $this->assertFileExists(Hyde::path('_site/feed-test.html'));
 

--- a/packages/framework/tests/Unit/BuildOutputDirectoryCanBeChangedTest.php
+++ b/packages/framework/tests/Unit/BuildOutputDirectoryCanBeChangedTest.php
@@ -22,6 +22,7 @@ class BuildOutputDirectoryCanBeChangedTest extends TestCase
 
         Site::setOutputDirectory('_site/build');
 
+        $this->withoutMockingConsoleOutput();
         $this->artisan('build');
 
         $this->assertFileExists(Hyde::path('_site/build/posts/test-post.html'));

--- a/packages/framework/tests/Unit/EnsureCommandsFollowNamingConventionTest.php
+++ b/packages/framework/tests/Unit/EnsureCommandsFollowNamingConventionTest.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Hyde\Framework\Testing\Unit;
 
-use Hyde\Testing\TestCase;
+use PHPUnit\Framework\TestCase;
 
 class EnsureCommandsFollowNamingConventionTest extends TestCase
 {

--- a/packages/framework/tests/Unit/FrontMatterModelTest.php
+++ b/packages/framework/tests/Unit/FrontMatterModelTest.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace Hyde\Framework\Testing\Unit;
 
 use Hyde\Markdown\Models\FrontMatter;
-use Hyde\Testing\TestCase;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @covers \Hyde\Markdown\Models\FrontMatter

--- a/packages/framework/tests/Unit/MarkdownFacadeTest.php
+++ b/packages/framework/tests/Unit/MarkdownFacadeTest.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace Hyde\Framework\Testing\Unit;
 
 use Hyde\Markdown\Models\Markdown;
-use Hyde\Testing\TestCase;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Class MarkdownConverterTest.

--- a/packages/framework/tests/Unit/RelativeLinksAcrossPagesRetainsIntegrityTest.php
+++ b/packages/framework/tests/Unit/RelativeLinksAcrossPagesRetainsIntegrityTest.php
@@ -92,7 +92,6 @@ class RelativeLinksAcrossPagesRetainsIntegrityTest extends TestCase
         $service->transferMediaAssets();
         $service->compileStaticPages();
 
-
         $this->assertSee('root', [
             '<link rel="stylesheet" href="media/app.css">',
             '<a href="index.html"',

--- a/packages/framework/tests/Unit/RelativeLinksAcrossPagesRetainsIntegrityTest.php
+++ b/packages/framework/tests/Unit/RelativeLinksAcrossPagesRetainsIntegrityTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Hyde\Framework\Testing\Unit;
 
+use Hyde\Framework\Actions\CreatesNewMarkdownPostFile;
 use function config;
 use Hyde\Framework\Concerns\InteractsWithDirectories;
 use Hyde\Hyde;
@@ -30,8 +31,7 @@ class RelativeLinksAcrossPagesRetainsIntegrityTest extends TestCase
         $this->file('_docs/index.md');
         $this->file('_docs/docs.md');
 
-        $this->mockConsoleOutput = false;
-        $this->artisan('make:post -n');
+        (new CreatesNewMarkdownPostFile('My New Post', null, null, null))->save();
     }
 
     protected function tearDown(): void

--- a/packages/framework/tests/Unit/RouteNotFoundExceptionTest.php
+++ b/packages/framework/tests/Unit/RouteNotFoundExceptionTest.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace Hyde\Framework\Testing\Unit;
 
 use Hyde\Framework\Exceptions\RouteNotFoundException;
-use Hyde\Testing\TestCase;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @covers \Hyde\Framework\Exceptions\RouteNotFoundException

--- a/packages/framework/tests/Unit/SchemaContractsTest.php
+++ b/packages/framework/tests/Unit/SchemaContractsTest.php
@@ -21,20 +21,20 @@ class SchemaContractsTest extends TestCase
 {
     public function testSchemasAreNotAccidentallyChanged()
     {
-        $this->assertEquals([
+        $this->assertSame([
             'title'         => 'string',
             'navigation'    => 'array<navigation>',
             'canonicalUrl'  => 'string(url)',
         ], PageSchema::PAGE_SCHEMA);
 
-        $this->assertEquals([
+        $this->assertSame([
             'label'     => 'string',
             'group'     => 'string',
             'hidden'    => 'bool',
             'priority'  => 'int',
         ], NavigationSchema::NAVIGATION_SCHEMA);
 
-        $this->assertEquals([
+        $this->assertSame([
             'title'        => 'string',
             'description'  => 'string',
             'category'     => 'string',
@@ -43,13 +43,13 @@ class SchemaContractsTest extends TestCase
             'image'        => 'string|array<featured_image>',
         ], BlogPostSchema::MARKDOWN_POST_SCHEMA);
 
-        $this->assertEquals([
+        $this->assertSame([
             'name'      => 'string',
             'username'  => 'string',
             'website'   => 'string(url)',
         ], BlogPostSchema::AUTHOR_SCHEMA);
 
-        $this->assertEquals([
+        $this->assertSame([
             'source'         => 'string',
             'description'    => 'string',
             'title'          => 'string',

--- a/packages/framework/tests/Unit/SchemaContractsTest.php
+++ b/packages/framework/tests/Unit/SchemaContractsTest.php
@@ -23,8 +23,8 @@ class SchemaContractsTest extends TestCase
     {
         $this->assertSame([
             'title'         => 'string',
-            'navigation'    => 'array<navigation>',
             'canonicalUrl'  => 'string(url)',
+            'navigation'    => 'array<navigation>',
         ], PageSchema::PAGE_SCHEMA);
 
         $this->assertSame([

--- a/packages/framework/tests/Unit/SerializableContractTest.php
+++ b/packages/framework/tests/Unit/SerializableContractTest.php
@@ -5,10 +5,10 @@ declare(strict_types=1);
 namespace Hyde\Framework\Testing\Unit;
 
 use Hyde\Support\Contracts\SerializableContract;
-use Hyde\Testing\TestCase;
 use Illuminate\Contracts\Support\Arrayable;
 use Illuminate\Contracts\Support\Jsonable;
 use JsonSerializable;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @see \Hyde\Support\Contracts\SerializableContract

--- a/packages/framework/tests/Unit/SerializableTest.php
+++ b/packages/framework/tests/Unit/SerializableTest.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace Hyde\Framework\Testing\Unit;
 
 use Hyde\Support\Concerns\Serializable;
-use Hyde\Testing\TestCase;
+use PHPUnit\Framework\TestCase;
 use JsonSerializable;
 
 /**

--- a/packages/framework/tests/Unit/UnsupportedPageTypeExceptionTest.php
+++ b/packages/framework/tests/Unit/UnsupportedPageTypeExceptionTest.php
@@ -5,7 +5,8 @@ declare(strict_types=1);
 namespace Hyde\Framework\Testing\Unit;
 
 use Hyde\Framework\Exceptions\UnsupportedPageTypeException;
-use Hyde\Testing\TestCase;
+use PHPUnit\Framework\TestCase;
+
 
 /**
  * @covers \Hyde\Framework\Exceptions\UnsupportedPageTypeException

--- a/packages/framework/tests/Unit/UnsupportedPageTypeExceptionTest.php
+++ b/packages/framework/tests/Unit/UnsupportedPageTypeExceptionTest.php
@@ -7,7 +7,6 @@ namespace Hyde\Framework\Testing\Unit;
 use Hyde\Framework\Exceptions\UnsupportedPageTypeException;
 use PHPUnit\Framework\TestCase;
 
-
 /**
  * @covers \Hyde\Framework\Exceptions\UnsupportedPageTypeException
  */

--- a/packages/testing/src/UnitTestCase.php
+++ b/packages/testing/src/UnitTestCase.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Hyde\Testing;
+
+class UnitTestCase
+{
+    //
+}

--- a/packages/testing/src/UnitTestCase.php
+++ b/packages/testing/src/UnitTestCase.php
@@ -9,8 +9,18 @@ use PHPUnit\Framework\TestCase as BaseTestCase;
 
 abstract class UnitTestCase extends BaseTestCase
 {
+    protected static bool $hasSetUpKernel = false;
+
+    protected function needsKernel(): void
+    {
+        if (! self::$hasSetUpKernel) {
+            $this->setupKernel();
+        }
+    }
+
     protected function setupKernel(): void
     {
         HydeKernel::setInstance(new HydeKernel());
+        self::$hasSetUpKernel = true;
     }
 }

--- a/packages/testing/src/UnitTestCase.php
+++ b/packages/testing/src/UnitTestCase.php
@@ -4,7 +4,9 @@ declare(strict_types=1);
 
 namespace Hyde\Testing;
 
-class UnitTestCase extends \PHPUnit\Framework\TestCase
+use PHPUnit\Framework\TestCase as BaseTestCase;
+
+class UnitTestCase extends BaseTestCase
 {
     //
 }

--- a/packages/testing/src/UnitTestCase.php
+++ b/packages/testing/src/UnitTestCase.php
@@ -4,9 +4,13 @@ declare(strict_types=1);
 
 namespace Hyde\Testing;
 
+use Hyde\Foundation\HydeKernel;
 use PHPUnit\Framework\TestCase as BaseTestCase;
 
 abstract class UnitTestCase extends BaseTestCase
 {
-    //
+    protected function setupKernel(): void
+    {
+        HydeKernel::setInstance(new HydeKernel());
+    }
 }

--- a/packages/testing/src/UnitTestCase.php
+++ b/packages/testing/src/UnitTestCase.php
@@ -6,7 +6,7 @@ namespace Hyde\Testing;
 
 use PHPUnit\Framework\TestCase as BaseTestCase;
 
-class UnitTestCase extends BaseTestCase
+abstract class UnitTestCase extends BaseTestCase
 {
     //
 }

--- a/packages/testing/src/UnitTestCase.php
+++ b/packages/testing/src/UnitTestCase.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Hyde\Testing;
 
-class UnitTestCase
+class UnitTestCase extends \PHPUnit\Framework\TestCase
 {
     //
 }


### PR DESCRIPTION
Refactors and updates unit tests, making the entire unit test suite be about 500ms faster which accounts to about one minute less CI time each day on average which according to calculations made by ChatGPT will save about 200 grams of CO2 emissions per year.