### PR TITLE
Breaking publication package renames

### DIFF
--- a/packages/publications/src/Actions/CreatesNewPublicationPage.php
+++ b/packages/publications/src/Actions/CreatesNewPublicationPage.php
@@ -24,21 +24,21 @@ class CreatesNewPublicationPage extends CreateAction
 {
     protected bool $force = false;
     protected Collection $fieldData;
-    protected PublicationType $pubType;
+    protected PublicationType $publicationType;
 
     /**
-     * @param  \Hyde\Publications\Models\PublicationType  $pubType
+     * @param  \Hyde\Publications\Models\PublicationType  $publicationType
      * @param  \Illuminate\Support\Collection<string, \Hyde\Publications\Models\PublicationFieldValue>  $fieldData
      * @param  bool  $force
      */
-    public function __construct(PublicationType $pubType, Collection $fieldData, bool $force = false)
+    public function __construct(PublicationType $publicationType, Collection $fieldData, bool $force = false)
     {
         $fieldData->prepend(new PublicationFieldValue(PublicationFieldTypes::Datetime, (string) Carbon::now()), '__createdAt');
 
-        $this->pubType = $pubType;
+        $this->publicationType = $publicationType;
         $this->fieldData = $fieldData;
         $this->force = $force;
-        $this->outputPath = "{$this->pubType->getDirectory()}/{$this->getFilename()}.md";
+        $this->outputPath = "{$this->publicationType->getDirectory()}/{$this->getFilename()}.md";
     }
 
     protected function handleCreate(): void
@@ -53,7 +53,7 @@ class CreatesNewPublicationPage extends CreateAction
 
     protected function getCanonicalValue(): string
     {
-        $canonicalFieldName = $this->pubType->canonicalField;
+        $canonicalFieldName = $this->publicationType->canonicalField;
         if ($canonicalFieldName === '__createdAt') {
             return $this->getFieldFromCollection('__createdAt')->getValue()->format('Y-m-d H:i:s');
         }

--- a/packages/publications/src/Actions/PublicationFieldValidator.php
+++ b/packages/publications/src/Actions/PublicationFieldValidator.php
@@ -44,7 +44,7 @@ class PublicationFieldValidator
     protected function makeDynamicRules(): array
     {
         if ($this->fieldDefinition->type == PublicationFieldTypes::Media) {
-            $mediaFiles = PublicationService::getMediaForPubType($this->publicationType);
+            $mediaFiles = PublicationService::getMediaForType($this->publicationType);
             $valueList = $mediaFiles->implode(',');
 
             return ["in:$valueList"];

--- a/packages/publications/src/Actions/PublicationSchemaValidator.php
+++ b/packages/publications/src/Actions/PublicationSchemaValidator.php
@@ -20,14 +20,14 @@ class PublicationSchemaValidator
     protected Validator $schemaValidator;
     protected array $fieldValidators = [];
 
-    public static function call(string $pubTypeName): static
+    public static function call(string $publicationTypeName): static
     {
-        return (new self($pubTypeName))->__invoke();
+        return (new self($publicationTypeName))->__invoke();
     }
 
-    public function __construct(string $pubTypeName)
+    public function __construct(string $publicationTypeName)
     {
-        $this->schema = json_decode(Filesystem::getContents("$pubTypeName/schema.json"));
+        $this->schema = json_decode(Filesystem::getContents("$publicationTypeName/schema.json"));
     }
 
     /** @return $this */

--- a/packages/publications/src/Actions/SeedsPublicationFiles.php
+++ b/packages/publications/src/Actions/SeedsPublicationFiles.php
@@ -30,7 +30,7 @@ use function ucfirst;
  */
 class SeedsPublicationFiles
 {
-    protected PublicationType $pubType;
+    protected PublicationType $publicationType;
     protected int $number = 1;
 
     protected array $matter;
@@ -39,7 +39,7 @@ class SeedsPublicationFiles
     public function __construct(PublicationType $pubType, int $number = 1)
     {
         $this->number = $number;
-        $this->pubType = $pubType;
+        $this->publicationType = $pubType;
     }
 
     public function create(): void
@@ -51,7 +51,7 @@ class SeedsPublicationFiles
             $this->generatePublicationData();
             $identifier = Str::slug(substr($this->canonicalValue, 0, 64));
 
-            $page = new PublicationPage($identifier, $this->matter, "## Write something awesome.\n\n{$this->randomMarkdownLines(rand(0, 16))}\n\n", $this->pubType);
+            $page = new PublicationPage($identifier, $this->matter, "## Write something awesome.\n\n{$this->randomMarkdownLines(rand(0, 16))}\n\n", $this->publicationType);
             $page->save();
         }
     }
@@ -59,7 +59,7 @@ class SeedsPublicationFiles
     protected function generatePublicationData(): void
     {
         $this->matter['__createdAt'] = Carbon::today()->subDays(rand(1, 360))->addSeconds(rand(0, 86400));
-        foreach ($this->pubType->getFields() as $field) {
+        foreach ($this->publicationType->getFields() as $field) {
             $this->matter[$field->name] = $this->generateFieldData($field);
             $this->getCanonicalFieldName($field);
         }
@@ -107,7 +107,7 @@ class SeedsPublicationFiles
     protected function getCanonicalFieldName(PublicationFieldDefinition $field): void
     {
         if ($this->canFieldTypeCanBeCanonical($field->type->value)) {
-            if ($field->name === $this->pubType->canonicalField) {
+            if ($field->name === $this->publicationType->canonicalField) {
                 $this->canonicalValue = $this->matter[$field->name];
             }
         }

--- a/packages/publications/src/Actions/SeedsPublicationFiles.php
+++ b/packages/publications/src/Actions/SeedsPublicationFiles.php
@@ -36,10 +36,10 @@ class SeedsPublicationFiles
     protected array $matter;
     protected string $canonicalValue;
 
-    public function __construct(PublicationType $pubType, int $number = 1)
+    public function __construct(PublicationType $publicationType, int $number = 1)
     {
         $this->number = $number;
-        $this->publicationType = $pubType;
+        $this->publicationType = $publicationType;
     }
 
     public function create(): void

--- a/packages/publications/src/Commands/MakePublicationCommand.php
+++ b/packages/publications/src/Commands/MakePublicationCommand.php
@@ -145,7 +145,7 @@ class MakePublicationCommand extends ValidatingCommand
     {
         $this->infoComment("Select file for image field [$field->name]");
 
-        $mediaFiles = PublicationService::getMediaForPubType($this->publicationType);
+        $mediaFiles = PublicationService::getMediaForType($this->publicationType);
         if ($mediaFiles->isEmpty()) {
             return $this->handleEmptyOptionsCollection($field, 'media file',
                 sprintf('No media files found in directory %s/%s/', Hyde::getMediaDirectory(),

--- a/packages/publications/src/Commands/SeedPublicationCommand.php
+++ b/packages/publications/src/Commands/SeedPublicationCommand.php
@@ -31,7 +31,7 @@ class SeedPublicationCommand extends ValidatingCommand
     {
         $this->title('Seeding new publications!');
 
-        $pubType = $this->getPubTypeSelection($this->getPublicationTypes());
+        $publicationType = $this->getPublicationTypeSelection($this->getPublicationTypes());
         $number = (int) ($this->argument('number') ?? $this->askWithValidation(
             'number',
             'How many publications would you like to generate',
@@ -45,41 +45,41 @@ class SeedPublicationCommand extends ValidatingCommand
         }
 
         $timeStart = microtime(true);
-        $seeder = new SeedsPublicationFiles($pubType, $number);
+        $seeder = new SeedsPublicationFiles($publicationType, $number);
         $seeder->create();
 
         $ms = round((microtime(true) - $timeStart) * 1000);
         $each = round($ms / $number, 2);
-        $this->info(sprintf("<comment>$number</comment> publication{$this->pluralize($number)} for <comment>$pubType->name</comment> created! <fg=gray>Took {$ms}ms%s",
+        $this->info(sprintf("<comment>$number</comment> publication{$this->pluralize($number)} for <comment>$publicationType->name</comment> created! <fg=gray>Took {$ms}ms%s",
                 ($number > 1) ? " ({$each}ms/each)</>" : ''));
 
         return Command::SUCCESS;
     }
 
     /**
-     * @param  \Illuminate\Support\Collection<string, \Hyde\Publications\Models\PublicationType>  $pubTypes
+     * @param  \Illuminate\Support\Collection<string, \Hyde\Publications\Models\PublicationType>  $publicationTypes
      * @return \Hyde\Publications\Models\PublicationType
      */
-    protected function getPubTypeSelection(Collection $pubTypes): PublicationType
+    protected function getPublicationTypeSelection(Collection $publicationTypes): PublicationType
     {
-        $pubTypeSelection = $this->argument('publicationType') ?? $pubTypes->keys()->get(
+        $publicationType = $this->argument('publicationType') ?? $publicationTypes->keys()->get(
             (int) $this->choice(
                 'Which publication type would you like to seed?',
-                $pubTypes->keys()->toArray()
+                $publicationTypes->keys()->toArray()
             )
         );
 
-        if ($pubTypes->has($pubTypeSelection)) {
+        if ($publicationTypes->has($publicationType)) {
             if ($this->argument('number')) {
-                $this->line("<info>Creating</info> [<comment>{$this->argument('number')}</comment>] <info>random publications for type</info> [<comment>$pubTypeSelection</comment>]");
+                $this->line("<info>Creating</info> [<comment>{$this->argument('number')}</comment>] <info>random publications for type</info> [<comment>$publicationType</comment>]");
             } else {
-                $this->line("<info>Creating random publications for type</info> [<comment>$pubTypeSelection</comment>]");
+                $this->line("<info>Creating random publications for type</info> [<comment>$publicationType</comment>]");
             }
 
-            return $pubTypes->get($pubTypeSelection);
+            return $publicationTypes->get($publicationType);
         }
 
-        throw new InvalidArgumentException("Unable to locate publication type [$pubTypeSelection]");
+        throw new InvalidArgumentException("Unable to locate publication type [$publicationType]");
     }
 
     /**
@@ -89,12 +89,12 @@ class SeedPublicationCommand extends ValidatingCommand
      */
     protected function getPublicationTypes(): Collection
     {
-        $pubTypes = PublicationService::getPublicationTypes();
-        if ($pubTypes->isEmpty()) {
+        $publicationTypes = PublicationService::getPublicationTypes();
+        if ($publicationTypes->isEmpty()) {
             throw new InvalidArgumentException('Unable to locate any publication types. Did you create any?');
         }
 
-        return $pubTypes;
+        return $publicationTypes;
     }
 
     protected function pluralize(int $count): string

--- a/packages/publications/src/Models/PublicationType.php
+++ b/packages/publications/src/Models/PublicationType.php
@@ -168,7 +168,7 @@ class PublicationType implements SerializableContract
     /** @return \Illuminate\Support\Collection<\Hyde\Publications\Models\PublicationPage> */
     public function getPublications(): Collection
     {
-        return PublicationService::getPublicationsForPubType($this);
+        return PublicationService::getPublicationsForType($this);
     }
 
     public function getPaginator(int $currentPageNumber = null): Paginator

--- a/packages/publications/src/PublicationService.php
+++ b/packages/publications/src/PublicationService.php
@@ -36,7 +36,7 @@ class PublicationService
     /**
      * Return all publications for a given publication type.
      */
-    public static function getPublicationsForPubType(PublicationType $pubType, ?string $sortField = null, ?bool $sortAscending = null): Collection
+    public static function getPublicationsForType(PublicationType $pubType, ?string $sortField = null, ?bool $sortAscending = null): Collection
     {
         /** @var Collection<PublicationPage> $publications */
         $publications = Collection::make(static::getPublicationFiles($pubType->getDirectory()))->map(function (string $file): PublicationPage {

--- a/packages/publications/src/PublicationService.php
+++ b/packages/publications/src/PublicationService.php
@@ -38,15 +38,15 @@ class PublicationService
      *
      * @return Collection<PublicationPage>
      */
-    public static function getPublicationsForType(PublicationType $pubType, ?string $sortField = null, ?bool $sortAscending = null): Collection
+    public static function getPublicationsForType(PublicationType $publicationType, ?string $sortField = null, ?bool $sortAscending = null): Collection
     {
         /** @var Collection<PublicationPage> $publications */
-        $publications = Collection::make(static::getPublicationFiles($pubType->getDirectory()))->map(function (string $file): PublicationPage {
+        $publications = Collection::make(static::getPublicationFiles($publicationType->getDirectory()))->map(function (string $file): PublicationPage {
             return static::parsePublicationFile(Hyde::pathToRelative($file));
         });
 
-        $sortAscending = $sortAscending !== null ? $sortAscending : $pubType->sortAscending;
-        $sortField = $sortField !== null ? $sortField : $pubType->sortField;
+        $sortAscending = $sortAscending !== null ? $sortAscending : $publicationType->sortAscending;
+        $sortField = $sortField !== null ? $sortField : $publicationType->sortField;
 
         return $publications->sortBy(function (PublicationPage $page) use ($sortField): mixed {
             return $page->matter($sortField);
@@ -56,9 +56,9 @@ class PublicationService
     /**
      * Return all media items for a given publication type.
      */
-    public static function getMediaForType(PublicationType $pubType): Collection
+    public static function getMediaForType(PublicationType $publicationType): Collection
     {
-        return Collection::make(static::getMediaFiles($pubType->getDirectory()))->map(function (string $file): string {
+        return Collection::make(static::getMediaFiles($publicationType->getDirectory()))->map(function (string $file): string {
             return Hyde::pathToRelative($file);
         });
     }
@@ -92,9 +92,9 @@ class PublicationService
     /**
      * Check whether a given publication type exists.
      */
-    public static function publicationTypeExists(string $pubTypeName): bool
+    public static function publicationTypeExists(string $publicationTypeName): bool
     {
-        return static::getPublicationTypes()->has(Str::slug($pubTypeName));
+        return static::getPublicationTypes()->has(Str::slug($publicationTypeName));
     }
 
     protected static function getSchemaFiles(): array

--- a/packages/publications/src/PublicationService.php
+++ b/packages/publications/src/PublicationService.php
@@ -54,7 +54,7 @@ class PublicationService
     /**
      * Return all media items for a given publication type.
      */
-    public static function getMediaForPubType(PublicationType $pubType): Collection
+    public static function getMediaForType(PublicationType $pubType): Collection
     {
         return Collection::make(static::getMediaFiles($pubType->getDirectory()))->map(function (string $file): string {
             return Hyde::pathToRelative($file);

--- a/packages/publications/src/PublicationsExtension.php
+++ b/packages/publications/src/PublicationsExtension.php
@@ -42,7 +42,7 @@ class PublicationsExtension extends HydeExtension
 
     protected static function discoverPublicationPagesForType(PublicationType $type, PageCollection $instance): void
     {
-        PublicationService::getPublicationsForPubType($type)->each(function (PublicationPage $publication) use (
+        PublicationService::getPublicationsForType($type)->each(function (PublicationPage $publication) use (
             $instance
         ): void {
             $instance->addPage($publication);

--- a/packages/publications/tests/Feature/PublicationServiceTest.php
+++ b/packages/publications/tests/Feature/PublicationServiceTest.php
@@ -55,7 +55,7 @@ class PublicationServiceTest extends TestCase
 
         $this->assertEquals(
             new Collection(),
-            PublicationService::getPublicationsForPubType(PublicationType::get('test-publication'))
+            PublicationService::getPublicationsForType(PublicationType::get('test-publication'))
         );
     }
 
@@ -68,7 +68,7 @@ class PublicationServiceTest extends TestCase
             new Collection([
                 PublicationService::parsePublicationFile('test-publication/foo.md'),
             ]),
-            PublicationService::getPublicationsForPubType(PublicationType::get('test-publication'))
+            PublicationService::getPublicationsForType(PublicationType::get('test-publication'))
         );
     }
 
@@ -79,7 +79,7 @@ class PublicationServiceTest extends TestCase
 
         $this->assertContainsOnlyInstancesOf(
             PublicationPage::class,
-            PublicationService::getPublicationsForPubType(PublicationType::get('test-publication'))
+            PublicationService::getPublicationsForType(PublicationType::get('test-publication'))
         );
     }
 
@@ -97,7 +97,7 @@ class PublicationServiceTest extends TestCase
                 PublicationService::parsePublicationFile('test-publication/two.md'),
                 PublicationService::parsePublicationFile('test-publication/three.md'),
             ]),
-            PublicationService::getPublicationsForPubType(PublicationType::get('test-publication'))
+            PublicationService::getPublicationsForType(PublicationType::get('test-publication'))
         );
     }
 
@@ -115,7 +115,7 @@ class PublicationServiceTest extends TestCase
                 PublicationService::parsePublicationFile('test-publication/two.md'),
                 PublicationService::parsePublicationFile('test-publication/one.md'),
             ]),
-            PublicationService::getPublicationsForPubType(PublicationType::get('test-publication'))
+            PublicationService::getPublicationsForType(PublicationType::get('test-publication'))
         );
     }
 
@@ -133,7 +133,7 @@ class PublicationServiceTest extends TestCase
                 PublicationService::parsePublicationFile('test-publication/two.md'),
                 PublicationService::parsePublicationFile('test-publication/three.md'),
             ]),
-            PublicationService::getPublicationsForPubType(PublicationType::get('test-publication'), 'readCount')
+            PublicationService::getPublicationsForType(PublicationType::get('test-publication'), 'readCount')
         );
     }
 
@@ -151,7 +151,7 @@ class PublicationServiceTest extends TestCase
                 PublicationService::parsePublicationFile('test-publication/two.md'),
                 PublicationService::parsePublicationFile('test-publication/one.md'),
             ]),
-            PublicationService::getPublicationsForPubType(PublicationType::get('test-publication'), 'readCount', false)
+            PublicationService::getPublicationsForType(PublicationType::get('test-publication'), 'readCount', false)
         );
     }
 
@@ -169,7 +169,7 @@ class PublicationServiceTest extends TestCase
                 PublicationService::parsePublicationFile('test-publication/three.md'),
                 PublicationService::parsePublicationFile('test-publication/two.md'),
             ]),
-            PublicationService::getPublicationsForPubType(PublicationType::get('test-publication'), 'invalid')
+            PublicationService::getPublicationsForType(PublicationType::get('test-publication'), 'invalid')
         );
     }
 

--- a/packages/publications/tests/Feature/PublicationServiceTest.php
+++ b/packages/publications/tests/Feature/PublicationServiceTest.php
@@ -179,7 +179,7 @@ class PublicationServiceTest extends TestCase
 
         $this->assertEquals(
             new Collection(),
-            PublicationService::getMediaForPubType(PublicationType::get('test-publication'))
+            PublicationService::getMediaForType(PublicationType::get('test-publication'))
         );
     }
 
@@ -193,7 +193,7 @@ class PublicationServiceTest extends TestCase
             new Collection([
                 '_media/test-publication/image.png',
             ]),
-            PublicationService::getMediaForPubType(PublicationType::get('test-publication'))
+            PublicationService::getMediaForType(PublicationType::get('test-publication'))
         );
 
         File::deleteDirectory(Hyde::path('_media/test-publication'));
@@ -210,7 +210,7 @@ class PublicationServiceTest extends TestCase
             new Collection([
                 '_assets/test-publication/image.png',
             ]),
-            PublicationService::getMediaForPubType(PublicationType::get('test-publication'))
+            PublicationService::getMediaForType(PublicationType::get('test-publication'))
         );
 
         File::deleteDirectory(Hyde::path('_assets/test-publication'));

--- a/packages/publications/tests/Feature/PublicationTypeTest.php
+++ b/packages/publications/tests/Feature/PublicationTypeTest.php
@@ -285,7 +285,7 @@ class PublicationTypeTest extends TestCase
     {
         $publicationType = new PublicationType(...$this->getTestData());
         $this->assertEquals(
-            PublicationService::getPublicationsForPubType($publicationType),
+            PublicationService::getPublicationsForType($publicationType),
             $publicationType->getPublications()
         );
     }


### PR DESCRIPTION
### Method renames

Renames the following methods to remove the Pub prefix as it's implied since the method belongs to the PublicationService.

- Renames method `PublicationService::getMediaForPubType` to `PublicationService::getMediaForType`
- Renames method `PublicationService::getPublicationsForPubType` to `PublicationService::getPublicationsForType`

### Expanding abbreviated variables

Expands `pubType` to `publicationType` for both local variables, class properties, constructor parameters, and internal helper methods, in the following classes:

- SeedsPublicationFiles
- SeedPublicationCommand
- PublicationService
- PublicationSchemaValidator
- CreatesNewPublicationPage