### PR TITLE
Update dynamic title generation for index pages to use parent basename

### DIFF
--- a/packages/framework/src/Framework/Factories/HydePageDataFactory.php
+++ b/packages/framework/src/Framework/Factories/HydePageDataFactory.php
@@ -78,6 +78,7 @@ class HydePageDataFactory extends Concerns\PageDataFactory implements PageSchema
     {
         return $this->matter('title')
             ?? $this->findTitleFromMarkdownHeadings()
+            ?? $this->findTitleFromParentIdentifier()
             ?? Hyde::makeTitle(basename($this->identifier));
     }
 
@@ -89,6 +90,15 @@ class HydePageDataFactory extends Concerns\PageDataFactory implements PageSchema
                     return trim(substr($line, 2), ' ');
                 }
             }
+        }
+
+        return null;
+    }
+
+    private function findTitleFromParentIdentifier(): ?string
+    {
+        if (str_contains($this->identifier, '/') && str_ends_with($this->identifier, '/index')) {
+            return Hyde::makeTitle(basename(dirname($this->identifier)));
         }
 
         return null;

--- a/packages/framework/tests/Unit/HydePageDataFactoryTest.php
+++ b/packages/framework/tests/Unit/HydePageDataFactoryTest.php
@@ -66,6 +66,16 @@ class HydePageDataFactoryTest extends UnitTestCase
         $this->assertSame('Bar', $this->factoryFromPage(new MarkdownPage('foo/bar'))->toArray()['title']);
     }
 
+    public function testIndexPageTitlesCanBeCreatedFromParentIdentifierBasename()
+    {
+        $this->assertSame('Foo', $this->factoryFromPage(new MarkdownPage('foo/index'))->toArray()['title']);
+    }
+
+    public function testIndexPageTitlesCanBeCreatedFromNestedParentIdentifierBasename()
+    {
+        $this->assertSame('Bar', $this->factoryFromPage(new MarkdownPage('foo/bar/index'))->toArray()['title']);
+    }
+
     public function testCanCreateCanonicalUrlUsingBaseUrlFromConfig()
     {
         self::mockConfig(['hyde' => [


### PR DESCRIPTION
## Description

This PR updates the dynamic title generation for index pages to use the parent basename as the page title. This adresses issue https://github.com/hydephp/develop/issues/1107.

The existing codebase was rewriting the titles of index and docs/index pages, unless explicitly set. The new internal method `findTitleFromParentIdentifier()` has been added to retrieve the title of the parent identifier, which is called from the existing `findTitleForPage()` method when a title is not explicitly set or found from the markdown headings.

This is because almost no time do index pages need to be named "index", so updating this making them easier to navigate and understand.

## Changes Made

- Added `findTitleFromParentIdentifier()` method to retrieve title from parent identifier.
- Updated `findTitleForPage()` method to call `findTitleFromParentIdentifier()` when title is not explicitly set or found from markdown headings.

## How to Test

To test this change, you can follow these steps:

1. Create an index page that does not have a custom title set (e.g., `foo/index.md`)
2. Run the application and navigate to the created index page.
3. Verify that the page title is set to the parent basename (e.g., "Foo").

Of course unit tests have been added to the suite as well.

## Related Issues

Closes https://github.com/hydephp/develop/pull/1109
