### PR TITLE
Add final InMemoryPage source path accessor override 

### DIFF
--- a/packages/framework/src/Pages/InMemoryPage.php
+++ b/packages/framework/src/Pages/InMemoryPage.php
@@ -144,6 +144,6 @@ class InMemoryPage extends HydePage
 
     final public function getSourcePath(): string
     {
-        return '';
+        return "__dynamic/{$this->getIdentifier()}";
     }
 }

--- a/packages/framework/src/Pages/InMemoryPage.php
+++ b/packages/framework/src/Pages/InMemoryPage.php
@@ -142,6 +142,7 @@ class InMemoryPage extends HydePage
         return $macro(...$parameters);
     }
 
+    /** @experimental */
     final public function getSourcePath(): string
     {
         return "__dynamic/{$this->getIdentifier()}";

--- a/packages/framework/src/Pages/InMemoryPage.php
+++ b/packages/framework/src/Pages/InMemoryPage.php
@@ -141,4 +141,9 @@ class InMemoryPage extends HydePage
 
         return $macro(...$parameters);
     }
+
+    public function getSourcePath(): string
+    {
+        return '';
+    }
 }

--- a/packages/framework/src/Pages/InMemoryPage.php
+++ b/packages/framework/src/Pages/InMemoryPage.php
@@ -142,7 +142,7 @@ class InMemoryPage extends HydePage
         return $macro(...$parameters);
     }
 
-    public function getSourcePath(): string
+    final public function getSourcePath(): string
     {
         return '';
     }

--- a/packages/framework/tests/Unit/Pages/InMemoryPageUnitTest.php
+++ b/packages/framework/tests/Unit/Pages/InMemoryPageUnitTest.php
@@ -81,7 +81,7 @@ class InMemoryPageUnitTest extends BaseHydePageUnitTest
     public function testGetSourcePath()
     {
         $this->assertSame(
-            'hello-world',
+            '__dynamic/hello-world',
             (new InMemoryPage('hello-world'))->getSourcePath()
         );
     }


### PR DESCRIPTION
InMemoryPages can, by definition, not have a source path. This PR adds a final method override to return an empty string `''` to force a consistent behaviour.