### PR TITLE
Add a `InMemoryPag::hasMacro()` helper method

### DIFF
--- a/packages/framework/src/Pages/InMemoryPage.php
+++ b/packages/framework/src/Pages/InMemoryPage.php
@@ -90,7 +90,7 @@ class InMemoryPage extends HydePage
      */
     public function compile(): string
     {
-        if (isset($this->macros['compile'])) {
+        if ($this->hasMacro('compile')) {
             return $this->__call('compile', []);
         }
 
@@ -120,11 +120,19 @@ class InMemoryPage extends HydePage
     }
 
     /**
+     * Determine if a macro with the given name is registered for the instance.
+     */
+    public function hasMacro(string $method): bool
+    {
+        return isset($this->macros[$method]);
+    }
+
+    /**
      * Dynamically handle macro calls to the class.
      */
     public function __call(string $method, array $parameters): mixed
     {
-        if (! isset($this->macros[$method])) {
+        if (! $this->hasMacro($method)) {
             throw new BadMethodCallException(sprintf(
                 'Method %s::%s does not exist.', static::class, $method
             ));

--- a/packages/framework/tests/Unit/Pages/InMemoryPageTest.php
+++ b/packages/framework/tests/Unit/Pages/InMemoryPageTest.php
@@ -132,4 +132,16 @@ class InMemoryPageTest extends TestCase
         /** @noinspection PhpUndefinedMethodInspection */
         $page->foo();
     }
+
+    public function testHasMacro()
+    {
+        $page = InMemoryPage::make('foo');
+
+        $page->macro('foo', function () {
+            return 'bar';
+        });
+
+        $this->assertTrue($page->hasMacro('foo'));
+        $this->assertFalse($page->hasMacro('bar'));
+    }
 }


### PR DESCRIPTION
Adds a simple helper method to determine if an InMemoryPage instance has a macro of the given name registered.