### PR TITLE
Change visibility of FrontMatter::$data array to protected

### DIFF
--- a/packages/framework/src/Markdown/Models/FrontMatter.php
+++ b/packages/framework/src/Markdown/Models/FrontMatter.php
@@ -29,7 +29,7 @@ class FrontMatter implements Stringable, SerializableContract
 {
     use Serializable;
 
-    public array $data;
+    protected array $data;
 
     public function __construct(array $matter = [])
     {

--- a/packages/framework/tests/Unit/FrontMatterModelTest.php
+++ b/packages/framework/tests/Unit/FrontMatterModelTest.php
@@ -27,14 +27,14 @@ class FrontMatterModelTest extends TestCase
     public function test_constructor_arguments_are_assigned()
     {
         $matter = new FrontMatter(['foo' => 'bar']);
-        $this->assertEquals(['foo' => 'bar'], $matter->data);
+        $this->assertEquals(['foo' => 'bar'], $matter->toArray());
     }
 
     public function test_static_from_array_method_creates_new_front_matter_model()
     {
         $matter = FrontMatter::fromArray(['foo' => 'bar']);
         $this->assertInstanceOf(FrontMatter::class, $matter);
-        $this->assertEquals(['foo' => 'bar'], $matter->data);
+        $this->assertEquals(['foo' => 'bar'], $matter->toArray());
     }
 
     public function test_to_string_magic_method_converts_model_array_into_yaml_front_matter()


### PR DESCRIPTION
This class already has a very nice public API to work with, so there's really no reason for this to be public.

In addition to accessors with support for fallbacks, the exact same $data property can be retrieved using the ->toArray method.