### PR TITLE
Add build warning system

### DIFF
--- a/packages/framework/src/Console/Commands/BuildSiteCommand.php
+++ b/packages/framework/src/Console/Commands/BuildSiteCommand.php
@@ -164,6 +164,10 @@ class BuildSiteCommand extends Command
 
     protected function getExitCode(): int
     {
-        return $this->hasWarnings() && BuildWarnings::reportsWarningsAsExceptions() ? self::INVALID : Command::SUCCESS;
+        if ($this->hasWarnings() && BuildWarnings::reportsWarningsAsExceptions()) {
+            return self::INVALID;
+        }
+
+        return Command::SUCCESS;
     }
 }

--- a/packages/framework/src/Console/Commands/BuildSiteCommand.php
+++ b/packages/framework/src/Console/Commands/BuildSiteCommand.php
@@ -104,7 +104,7 @@ class BuildSiteCommand extends Command
 
     protected function printFinishMessage(float $timeStart): void
     {
-        if (BuildWarnings::hasWarnings() && BuildWarnings::reportsWarnings()) {
+        if ($this->hasWarnings()) {
             $this->newLine();
             $this->error('There were some warnings during the build process:');
             $this->newLine();
@@ -155,5 +155,10 @@ class BuildSiteCommand extends Command
     protected function canGenerateSearch(): bool
     {
         return Features::hasDocumentationSearch();
+    }
+
+    protected function hasWarnings(): bool
+    {
+        return BuildWarnings::hasWarnings() && BuildWarnings::reportsWarnings();
     }
 }

--- a/packages/framework/src/Console/Commands/BuildSiteCommand.php
+++ b/packages/framework/src/Console/Commands/BuildSiteCommand.php
@@ -55,7 +55,7 @@ class BuildSiteCommand extends Command
 
         $this->printFinishMessage($timeStart);
 
-        return Command::SUCCESS;
+        return $this->hasWarnings() && BuildWarnings::reportsWarningsAsExceptions() ? self::FAILURE : Command::SUCCESS;
     }
 
     protected function runPreBuildActions(): void

--- a/packages/framework/src/Console/Commands/BuildSiteCommand.php
+++ b/packages/framework/src/Console/Commands/BuildSiteCommand.php
@@ -55,7 +55,7 @@ class BuildSiteCommand extends Command
 
         $this->printFinishMessage($timeStart);
 
-        return $this->hasWarnings() && BuildWarnings::reportsWarningsAsExceptions() ? self::FAILURE : Command::SUCCESS;
+        return $this->hasWarnings() && BuildWarnings::reportsWarningsAsExceptions() ? self::INVALID : Command::SUCCESS;
     }
 
     protected function runPreBuildActions(): void

--- a/packages/framework/src/Console/Commands/BuildSiteCommand.php
+++ b/packages/framework/src/Console/Commands/BuildSiteCommand.php
@@ -108,7 +108,7 @@ class BuildSiteCommand extends Command
             $this->newLine();
             $this->error('There were some warnings during the build process:');
             $this->newLine();
-            BuildWarnings::writeWarningsToOutput($this->output);
+            BuildWarnings::writeWarningsToOutput($this->output, $this->output->isVerbose());
         }
 
         $executionTime = (microtime(true) - $timeStart);

--- a/packages/framework/src/Console/Commands/BuildSiteCommand.php
+++ b/packages/framework/src/Console/Commands/BuildSiteCommand.php
@@ -55,7 +55,7 @@ class BuildSiteCommand extends Command
 
         $this->printFinishMessage($timeStart);
 
-        return $this->hasWarnings() && BuildWarnings::reportsWarningsAsExceptions() ? self::INVALID : Command::SUCCESS;
+        return $this->getExitCode();
     }
 
     protected function runPreBuildActions(): void
@@ -160,5 +160,10 @@ class BuildSiteCommand extends Command
     protected function hasWarnings(): bool
     {
         return BuildWarnings::hasWarnings() && BuildWarnings::reportsWarnings();
+    }
+
+    protected function getExitCode(): int
+    {
+        return $this->hasWarnings() && BuildWarnings::reportsWarningsAsExceptions() ? self::INVALID : Command::SUCCESS;
     }
 }

--- a/packages/framework/src/Framework/Exceptions/BuildWarning.php
+++ b/packages/framework/src/Framework/Exceptions/BuildWarning.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Hyde\Framework\Exceptions;
 
 use RuntimeException;
-use Throwable;
 
 /**
  * @experimental Having a class like this extending an exception means it's easy to throw if enabled, however,
@@ -13,8 +12,5 @@ use Throwable;
  */
 class BuildWarning extends RuntimeException
 {
-    public function __construct(string $message = '', int $code = 0, ?Throwable $previous = null)
-    {
-        parent::__construct($message, $code, $previous);
-    }
+    //
 }

--- a/packages/framework/src/Framework/Exceptions/BuildWarning.php
+++ b/packages/framework/src/Framework/Exceptions/BuildWarning.php
@@ -13,12 +13,8 @@ use Throwable;
  */
 class BuildWarning extends RuntimeException
 {
-    protected string $location;
-
-    public function __construct(string $message = '', string $location = '', int $code = 0, ?Throwable $previous = null)
+    public function __construct(string $message = '', int $code = 0, ?Throwable $previous = null)
     {
         parent::__construct($message, $code, $previous);
-
-        $this->location = $location;
     }
 }

--- a/packages/framework/src/Framework/Exceptions/BuildWarning.php
+++ b/packages/framework/src/Framework/Exceptions/BuildWarning.php
@@ -21,9 +21,4 @@ class BuildWarning extends RuntimeException
 
         $this->location = $location;
     }
-
-    public function getLocation(): string
-    {
-        return $this->location;
-    }
 }

--- a/packages/framework/src/Support/BuildWarnings.php
+++ b/packages/framework/src/Support/BuildWarnings.php
@@ -32,6 +32,11 @@ class BuildWarnings
         return static::$instance;
     }
 
+    public static function clear(): void
+    {
+        static::getInstance()->warnings = [];
+    }
+
     public static function report(BuildWarning|string $warning): void
     {
         static::getInstance()->warnings[] = $warning instanceof BuildWarning ? $warning : new BuildWarning($warning);
@@ -56,11 +61,6 @@ class BuildWarnings
     public static function reportsWarningsAsExceptions(): bool
     {
         return Config::getBool('hyde.convert_build_warnings_to_exceptions', false);
-    }
-
-    public static function clear(): void
-    {
-        static::getInstance()->warnings = [];
     }
 
     public static function writeWarningsToOutput(OutputStyle $output, bool $verbose = false): void

--- a/packages/framework/src/Support/BuildWarnings.php
+++ b/packages/framework/src/Support/BuildWarnings.php
@@ -59,7 +59,7 @@ class BuildWarnings
             } else {
                 $output->writeln(sprintf(' %s. <comment>%s</comment>', $line + 1, $warning->getMessage()));
                 if ($warning->getLocation()) {
-                    $output->writeln(sprintf('    <fg=gray>%s</>', $warning->getLocation()));
+                    $output->writeln(sprintf('    <fg=gray>%s:%s</>', $warning->getFile(), $warning->getLine()));
                 }
             }
         }

--- a/packages/framework/src/Support/BuildWarnings.php
+++ b/packages/framework/src/Support/BuildWarnings.php
@@ -58,7 +58,7 @@ class BuildWarnings
                 app(ExceptionHandler::class)->renderForConsole($output, $warning);
             } else {
                 $output->writeln(sprintf(' %s. <comment>%s</comment>', $line + 1, $warning->getMessage()));
-                if ($warning->getLocation()) {
+                if ($verbose) {
                     $output->writeln(sprintf('    <fg=gray>%s:%s</>', $warning->getFile(), $warning->getLine()));
                 }
             }

--- a/packages/framework/src/Support/BuildWarnings.php
+++ b/packages/framework/src/Support/BuildWarnings.php
@@ -30,9 +30,9 @@ class BuildWarnings
         return static::$instance;
     }
 
-    public static function report(string $warning, string $location = ''): void
+    public static function report(string $warning): void
     {
-        static::getInstance()->add(new BuildWarning($warning, $location));
+        static::getInstance()->add(new BuildWarning($warning));
     }
 
     /** @return array<\Hyde\Framework\Exceptions\BuildWarning> */

--- a/packages/framework/src/Support/BuildWarnings.php
+++ b/packages/framework/src/Support/BuildWarnings.php
@@ -32,11 +32,6 @@ class BuildWarnings
         return static::$instance;
     }
 
-    public static function clear(): void
-    {
-        static::getInstance()->warnings = [];
-    }
-
     public static function report(BuildWarning|string $warning): void
     {
         static::getInstance()->warnings[] = $warning instanceof BuildWarning ? $warning : new BuildWarning($warning);
@@ -61,6 +56,11 @@ class BuildWarnings
     public static function reportsWarningsAsExceptions(): bool
     {
         return Config::getBool('hyde.convert_build_warnings_to_exceptions', false);
+    }
+
+    public static function clear(): void
+    {
+        static::getInstance()->warnings = [];
     }
 
     public static function writeWarningsToOutput(OutputStyle $output, bool $verbose = false): void

--- a/packages/framework/src/Support/BuildWarnings.php
+++ b/packages/framework/src/Support/BuildWarnings.php
@@ -56,11 +56,6 @@ class BuildWarnings
         return Config::getBool('hyde.convert_build_warnings_to_exceptions', false);
     }
 
-    public static function clear(): void
-    {
-        static::getInstance()->warnings = [];
-    }
-
     public static function writeWarningsToOutput(OutputStyle $output, bool $verbose = false): void
     {
         if (static::reportsWarningsAsExceptions()) {

--- a/packages/framework/src/Support/BuildWarnings.php
+++ b/packages/framework/src/Support/BuildWarnings.php
@@ -19,6 +19,7 @@ class BuildWarnings
 {
     protected static self $instance;
 
+    /** @var array<\Hyde\Framework\Exceptions\BuildWarning> */
     protected array $warnings = [];
 
     public static function getInstance(): static
@@ -35,6 +36,7 @@ class BuildWarnings
         static::getInstance()->add(new BuildWarning($warning, $location));
     }
 
+    /** @return array<\Hyde\Framework\Exceptions\BuildWarning> */
     public static function getWarnings(): array
     {
         return static::getInstance()->get();
@@ -65,6 +67,7 @@ class BuildWarnings
         $this->warnings[] = $warning;
     }
 
+    /** @return array<\Hyde\Framework\Exceptions\BuildWarning> */
     public function get(): array
     {
         return $this->warnings;

--- a/packages/framework/src/Support/BuildWarnings.php
+++ b/packages/framework/src/Support/BuildWarnings.php
@@ -18,18 +18,16 @@ use function sprintf;
  */
 class BuildWarnings
 {
-    protected static self $instance;
-
     /** @var array<\Hyde\Framework\Exceptions\BuildWarning> */
     protected array $warnings = [];
 
     public static function getInstance(): static
     {
-        if (! isset(static::$instance)) {
-            static::$instance = new static();
+        if (! app()->bound(static::class)) {
+            app()->singleton(static::class);
         }
 
-        return static::$instance;
+        return app(static::class);
     }
 
     public static function report(BuildWarning|string $warning): void

--- a/packages/framework/src/Support/BuildWarnings.php
+++ b/packages/framework/src/Support/BuildWarnings.php
@@ -51,7 +51,7 @@ class BuildWarnings
         return Config::getBool('hyde.log_warnings', true);
     }
 
-    public static function writeWarningsToOutput(OutputStyle $output): void
+    public static function writeWarningsToOutput(OutputStyle $output, bool $verbose = false): void
     {
         foreach (static::getWarnings() as $line => $warning) {
             if (static::reportsWarningsAsExceptions()) {

--- a/packages/framework/src/Support/BuildWarnings.php
+++ b/packages/framework/src/Support/BuildWarnings.php
@@ -53,6 +53,11 @@ class BuildWarnings
         return Config::getBool('hyde.log_warnings', true);
     }
 
+    public static function reportsWarningsAsExceptions(): bool
+    {
+        return Config::getBool('hyde.convert_build_warnings_to_exceptions', false);
+    }
+
     public static function clear(): void
     {
         static::getInstance()->warnings = [];
@@ -82,10 +87,5 @@ class BuildWarnings
         foreach (static::getWarnings() as $warning) {
             app(ExceptionHandler::class)->renderForConsole($output, $warning);
         }
-    }
-
-    public static function reportsWarningsAsExceptions(): bool
-    {
-        return Config::getBool('hyde.convert_build_warnings_to_exceptions', false);
     }
 }

--- a/packages/framework/src/Support/BuildWarnings.php
+++ b/packages/framework/src/Support/BuildWarnings.php
@@ -23,11 +23,11 @@ class BuildWarnings
 
     public static function getInstance(): static
     {
-        if (! app()->bound(static::class)) {
-            app()->singleton(static::class);
+        if (! app()->bound(self::class)) {
+            app()->singleton(self::class);
         }
 
-        return app(static::class);
+        return app(self::class);
     }
 
     public static function report(BuildWarning|string $warning): void

--- a/packages/framework/src/Support/BuildWarnings.php
+++ b/packages/framework/src/Support/BuildWarnings.php
@@ -84,8 +84,8 @@ class BuildWarnings
         return Config::getBool('hyde.convert_build_warnings_to_exceptions', false);
     }
 
-    public function clear(): void
+    public static function clear(): void
     {
-        $this->warnings = [];
+        static::getInstance()->warnings = [];
     }
 }

--- a/packages/framework/src/Support/BuildWarnings.php
+++ b/packages/framework/src/Support/BuildWarnings.php
@@ -58,12 +58,12 @@ class BuildWarnings
         foreach (static::getWarnings() as $line => $warning) {
             if (Config::getBool('hyde.convert_build_warnings_to_exceptions', false)) {
                 app(ExceptionHandler::class)->renderForConsole($output, $warning);
-                continue;
-            }
+            } else {
 
-            $output->writeln(sprintf(' %s. <comment>%s</comment>', $line + 1, $warning->getMessage()));
-            if ($warning->getLocation()) {
-                $output->writeln(sprintf('    <fg=gray>%s</>', $warning->getLocation()));
+                $output->writeln(sprintf(' %s. <comment>%s</comment>', $line + 1, $warning->getMessage()));
+                if ($warning->getLocation()) {
+                    $output->writeln(sprintf('    <fg=gray>%s</>', $warning->getLocation()));
+                }
             }
         }
     }

--- a/packages/framework/src/Support/BuildWarnings.php
+++ b/packages/framework/src/Support/BuildWarnings.php
@@ -84,7 +84,7 @@ class BuildWarnings
         }
     }
 
-    protected static function reportsWarningsAsExceptions(): bool
+    public static function reportsWarningsAsExceptions(): bool
     {
         return Config::getBool('hyde.convert_build_warnings_to_exceptions', false);
     }

--- a/packages/framework/src/Support/BuildWarnings.php
+++ b/packages/framework/src/Support/BuildWarnings.php
@@ -12,8 +12,6 @@ use Symfony\Component\Console\Style\OutputStyle;
 /**
  * @experimental
  *
- * @todo Add generics to increase type coverage
- *
  * @see \Hyde\Framework\Testing\Unit\BuildWarningsTest
  */
 class BuildWarnings

--- a/packages/framework/src/Support/BuildWarnings.php
+++ b/packages/framework/src/Support/BuildWarnings.php
@@ -53,6 +53,11 @@ class BuildWarnings
         return Config::getBool('hyde.log_warnings', true);
     }
 
+    public static function clear(): void
+    {
+        static::getInstance()->warnings = [];
+    }
+
     public static function writeWarningsToOutput(OutputStyle $output, bool $verbose = false): void
     {
         if (static::reportsWarningsAsExceptions()) {
@@ -82,10 +87,5 @@ class BuildWarnings
     protected static function reportsWarningsAsExceptions(): bool
     {
         return Config::getBool('hyde.convert_build_warnings_to_exceptions', false);
-    }
-
-    public static function clear(): void
-    {
-        static::getInstance()->warnings = [];
     }
 }

--- a/packages/framework/src/Support/BuildWarnings.php
+++ b/packages/framework/src/Support/BuildWarnings.php
@@ -58,8 +58,8 @@ class BuildWarnings
                 app(ExceptionHandler::class)->renderForConsole($output, $warning);
             }
         } else {
-            foreach (static::getWarnings() as $line => $warning) {
-                $output->writeln(sprintf(' %s. <comment>%s</comment>', $line + 1, $warning->getMessage()));
+            foreach (static::getWarnings() as $number => $warning) {
+                $output->writeln(sprintf(' %s. <comment>%s</comment>', $number + 1, $warning->getMessage()));
                 if ($verbose) {
                     $output->writeln(sprintf('    <fg=gray>%s:%s</>', $warning->getFile(), $warning->getLine()));
                 }

--- a/packages/framework/src/Support/BuildWarnings.php
+++ b/packages/framework/src/Support/BuildWarnings.php
@@ -54,16 +54,9 @@ class BuildWarnings
     public static function writeWarningsToOutput(OutputStyle $output, bool $verbose = false): void
     {
         if (static::reportsWarningsAsExceptions()) {
-            foreach (static::getWarnings() as $warning) {
-                app(ExceptionHandler::class)->renderForConsole($output, $warning);
-            }
+            self::renderWarningsAsExceptions($output);
         } else {
-            foreach (static::getWarnings() as $number => $warning) {
-                $output->writeln(sprintf(' %s. <comment>%s</comment>', $number + 1, $warning->getMessage()));
-                if ($verbose) {
-                    $output->writeln(sprintf('    <fg=gray>%s:%s</>', $warning->getFile(), $warning->getLine()));
-                }
-            }
+            self::renderWarnings($output, $verbose);
         }
     }
 
@@ -86,5 +79,22 @@ class BuildWarnings
     protected static function reportsWarningsAsExceptions(): bool
     {
         return Config::getBool('hyde.convert_build_warnings_to_exceptions', false);
+    }
+
+    protected static function renderWarningsAsExceptions(OutputStyle $output): void
+    {
+        foreach (static::getWarnings() as $warning) {
+            app(ExceptionHandler::class)->renderForConsole($output, $warning);
+        }
+    }
+
+    protected static function renderWarnings(OutputStyle $output, bool $verbose): void
+    {
+        foreach (static::getWarnings() as $number => $warning) {
+            $output->writeln(sprintf(' %s. <comment>%s</comment>', $number + 1, $warning->getMessage()));
+            if ($verbose) {
+                $output->writeln(sprintf('    <fg=gray>%s:%s</>', $warning->getFile(), $warning->getLine()));
+            }
+        }
     }
 }

--- a/packages/framework/src/Support/BuildWarnings.php
+++ b/packages/framework/src/Support/BuildWarnings.php
@@ -60,7 +60,7 @@ class BuildWarnings
         }
     }
 
-    public function add(BuildWarning $warning): void
+    protected function add(BuildWarning $warning): void
     {
         $this->warnings[] = $warning;
     }

--- a/packages/framework/src/Support/BuildWarnings.php
+++ b/packages/framework/src/Support/BuildWarnings.php
@@ -56,7 +56,7 @@ class BuildWarnings
     public static function writeWarningsToOutput(OutputStyle $output): void
     {
         foreach (static::getWarnings() as $line => $warning) {
-            if (Config::getBool('hyde.convert_build_warnings_to_exceptions', false)) {
+            if (static::reportsWarningsAsExceptions()) {
                 app(ExceptionHandler::class)->renderForConsole($output, $warning);
             } else {
                 $output->writeln(sprintf(' %s. <comment>%s</comment>', $line + 1, $warning->getMessage()));
@@ -81,5 +81,10 @@ class BuildWarnings
     public function clear(): void
     {
         $this->warnings = [];
+    }
+
+    protected static function reportsWarningsAsExceptions(): bool
+    {
+        return Config::getBool('hyde.convert_build_warnings_to_exceptions', false);
     }
 }

--- a/packages/framework/src/Support/BuildWarnings.php
+++ b/packages/framework/src/Support/BuildWarnings.php
@@ -66,7 +66,7 @@ class BuildWarnings
     }
 
     /** @return array<\Hyde\Framework\Exceptions\BuildWarning> */
-    public function get(): array
+    protected function get(): array
     {
         return $this->warnings;
     }

--- a/packages/framework/src/Support/BuildWarnings.php
+++ b/packages/framework/src/Support/BuildWarnings.php
@@ -32,13 +32,13 @@ class BuildWarnings
 
     public static function report(BuildWarning|string $warning): void
     {
-        static::getInstance()->add($warning instanceof BuildWarning ? $warning : new BuildWarning($warning));
+        static::getInstance()->warnings[] = $warning instanceof BuildWarning ? $warning : new BuildWarning($warning);
     }
 
     /** @return array<\Hyde\Framework\Exceptions\BuildWarning> */
     public static function getWarnings(): array
     {
-        return static::getInstance()->get();
+        return static::getInstance()->warnings;
     }
 
     public static function hasWarnings(): bool
@@ -58,17 +58,6 @@ class BuildWarnings
         } else {
             self::renderWarnings($output, $verbose);
         }
-    }
-
-    protected function add(BuildWarning $warning): void
-    {
-        $this->warnings[] = $warning;
-    }
-
-    /** @return array<\Hyde\Framework\Exceptions\BuildWarning> */
-    protected function get(): array
-    {
-        return $this->warnings;
     }
 
     public function clear(): void

--- a/packages/framework/src/Support/BuildWarnings.php
+++ b/packages/framework/src/Support/BuildWarnings.php
@@ -6,6 +6,7 @@ namespace Hyde\Support;
 
 use Hyde\Facades\Config;
 use Hyde\Framework\Exceptions\BuildWarning;
+use Illuminate\Contracts\Debug\ExceptionHandler;
 use Symfony\Component\Console\Style\OutputStyle;
 
 /**
@@ -55,6 +56,11 @@ class BuildWarnings
     public static function writeWarningsToOutput(OutputStyle $output): void
     {
         foreach (static::getWarnings() as $line => $warning) {
+            if (Config::getBool('hyde.convert_build_warnings_to_exceptions', false)) {
+                app(ExceptionHandler::class)->renderForConsole($output, $warning);
+                continue;
+            }
+
             $output->writeln(sprintf(' %s. <comment>%s</comment>', $line + 1, $warning->getMessage()));
             if ($warning->getLocation()) {
                 $output->writeln(sprintf('    <fg=gray>%s</>', $warning->getLocation()));

--- a/packages/framework/src/Support/BuildWarnings.php
+++ b/packages/framework/src/Support/BuildWarnings.php
@@ -59,7 +59,6 @@ class BuildWarnings
             if (Config::getBool('hyde.convert_build_warnings_to_exceptions', false)) {
                 app(ExceptionHandler::class)->renderForConsole($output, $warning);
             } else {
-
                 $output->writeln(sprintf(' %s. <comment>%s</comment>', $line + 1, $warning->getMessage()));
                 if ($warning->getLocation()) {
                     $output->writeln(sprintf('    <fg=gray>%s</>', $warning->getLocation()));

--- a/packages/framework/src/Support/BuildWarnings.php
+++ b/packages/framework/src/Support/BuildWarnings.php
@@ -62,14 +62,14 @@ class BuildWarnings
         }
     }
 
-    public function clear(): void
+    protected static function renderWarnings(OutputStyle $output, bool $verbose): void
     {
-        $this->warnings = [];
-    }
-
-    protected static function reportsWarningsAsExceptions(): bool
-    {
-        return Config::getBool('hyde.convert_build_warnings_to_exceptions', false);
+        foreach (static::getWarnings() as $number => $warning) {
+            $output->writeln(sprintf(' %s. <comment>%s</comment>', $number + 1, $warning->getMessage()));
+            if ($verbose) {
+                $output->writeln(sprintf('    <fg=gray>%s:%s</>', $warning->getFile(), $warning->getLine()));
+            }
+        }
     }
 
     protected static function renderWarningsAsExceptions(OutputStyle $output): void
@@ -79,13 +79,13 @@ class BuildWarnings
         }
     }
 
-    protected static function renderWarnings(OutputStyle $output, bool $verbose): void
+    protected static function reportsWarningsAsExceptions(): bool
     {
-        foreach (static::getWarnings() as $number => $warning) {
-            $output->writeln(sprintf(' %s. <comment>%s</comment>', $number + 1, $warning->getMessage()));
-            if ($verbose) {
-                $output->writeln(sprintf('    <fg=gray>%s:%s</>', $warning->getFile(), $warning->getLine()));
-            }
-        }
+        return Config::getBool('hyde.convert_build_warnings_to_exceptions', false);
+    }
+
+    public function clear(): void
+    {
+        $this->warnings = [];
     }
 }

--- a/packages/framework/src/Support/BuildWarnings.php
+++ b/packages/framework/src/Support/BuildWarnings.php
@@ -54,7 +54,7 @@ class BuildWarnings
     public static function writeWarningsToOutput(OutputStyle $output, bool $verbose = false): void
     {
         if (static::reportsWarningsAsExceptions()) {
-            foreach (static::getWarnings() as $line => $warning) {
+            foreach (static::getWarnings() as $warning) {
                 app(ExceptionHandler::class)->renderForConsole($output, $warning);
             }
         } else {

--- a/packages/framework/src/Support/BuildWarnings.php
+++ b/packages/framework/src/Support/BuildWarnings.php
@@ -53,10 +53,12 @@ class BuildWarnings
 
     public static function writeWarningsToOutput(OutputStyle $output, bool $verbose = false): void
     {
-        foreach (static::getWarnings() as $line => $warning) {
-            if (static::reportsWarningsAsExceptions()) {
+        if (static::reportsWarningsAsExceptions()) {
+            foreach (static::getWarnings() as $line => $warning) {
                 app(ExceptionHandler::class)->renderForConsole($output, $warning);
-            } else {
+            }
+        } else {
+            foreach (static::getWarnings() as $line => $warning) {
                 $output->writeln(sprintf(' %s. <comment>%s</comment>', $line + 1, $warning->getMessage()));
                 if ($verbose) {
                     $output->writeln(sprintf('    <fg=gray>%s:%s</>', $warning->getFile(), $warning->getLine()));

--- a/packages/framework/src/Support/BuildWarnings.php
+++ b/packages/framework/src/Support/BuildWarnings.php
@@ -8,6 +8,8 @@ use Hyde\Facades\Config;
 use Hyde\Framework\Exceptions\BuildWarning;
 use Illuminate\Contracts\Debug\ExceptionHandler;
 use Symfony\Component\Console\Style\OutputStyle;
+use function app;
+use function sprintf;
 
 /**
  * @experimental

--- a/packages/framework/src/Support/BuildWarnings.php
+++ b/packages/framework/src/Support/BuildWarnings.php
@@ -30,9 +30,9 @@ class BuildWarnings
         return static::$instance;
     }
 
-    public static function report(string $warning): void
+    public static function report(BuildWarning|string $warning): void
     {
-        static::getInstance()->add(new BuildWarning($warning));
+        static::getInstance()->add($warning instanceof BuildWarning ? $warning : new BuildWarning($warning));
     }
 
     /** @return array<\Hyde\Framework\Exceptions\BuildWarning> */

--- a/packages/framework/tests/Feature/StaticSiteServiceTest.php
+++ b/packages/framework/tests/Feature/StaticSiteServiceTest.php
@@ -262,7 +262,6 @@ class StaticSiteServiceTest extends TestCase
         $this->artisan('build')
             ->expectsOutput('There were some warnings during the build process:')
             ->expectsOutput(' 1. This is a warning')
-            ->doesntExpectOutputToContain('BuildWarnings.php')
             ->assertExitCode(0);
     }
 

--- a/packages/framework/tests/Feature/StaticSiteServiceTest.php
+++ b/packages/framework/tests/Feature/StaticSiteServiceTest.php
@@ -251,7 +251,6 @@ class StaticSiteServiceTest extends TestCase
 
     public function test_without_warnings()
     {
-        BuildWarnings::clear();
         $this->artisan('build')
             ->doesntExpectOutput('There were some warnings during the build process:')
             ->assertExitCode(0);

--- a/packages/framework/tests/Feature/StaticSiteServiceTest.php
+++ b/packages/framework/tests/Feature/StaticSiteServiceTest.php
@@ -22,6 +22,7 @@ class StaticSiteServiceTest extends TestCase
         parent::setUp();
 
         $this->resetSite();
+        BuildWarnings::clear();
     }
 
     protected function tearDown(): void

--- a/packages/framework/tests/Feature/StaticSiteServiceTest.php
+++ b/packages/framework/tests/Feature/StaticSiteServiceTest.php
@@ -263,7 +263,7 @@ class StaticSiteServiceTest extends TestCase
         $this->artisan('build')
             ->expectsOutput('There were some warnings during the build process:')
             ->expectsOutput(' 1. This is a warning')
-            ->doesntExpectOutputToContain('BuildWarnings.php:')
+            ->doesntExpectOutputToContain('BuildWarnings.php')
             ->assertExitCode(0);
     }
 
@@ -274,7 +274,7 @@ class StaticSiteServiceTest extends TestCase
         $this->artisan('build --verbose')
             ->expectsOutput('There were some warnings during the build process:')
             ->expectsOutput(' 1. This is a warning')
-            ->expectsOutputToContain('BuildWarnings.php:')
+            ->expectsOutputToContain('BuildWarnings.php')
             ->assertExitCode(0);
     }
 

--- a/packages/framework/tests/Feature/StaticSiteServiceTest.php
+++ b/packages/framework/tests/Feature/StaticSiteServiceTest.php
@@ -251,6 +251,7 @@ class StaticSiteServiceTest extends TestCase
 
     public function test_without_warnings()
     {
+        BuildWarnings::clear();
         $this->artisan('build')
             ->doesntExpectOutput('There were some warnings during the build process:')
             ->assertExitCode(0);

--- a/packages/framework/tests/Feature/StaticSiteServiceTest.php
+++ b/packages/framework/tests/Feature/StaticSiteServiceTest.php
@@ -7,6 +7,7 @@ namespace Hyde\Framework\Testing\Feature;
 use Hyde\Facades\Filesystem;
 use Hyde\Facades\Site;
 use Hyde\Hyde;
+use Hyde\Support\BuildWarnings;
 use Hyde\Testing\TestCase;
 use Illuminate\Support\Facades\File;
 
@@ -244,5 +245,56 @@ class StaticSiteServiceTest extends TestCase
 
         $this->assertFileExists(Hyde::path('foo/keep.html'));
         File::deleteDirectory(Hyde::path('foo'));
+    }
+
+    public function test_without_warnings()
+    {
+        $this->artisan('build')
+            ->doesntExpectOutput('There were some warnings during the build process:')
+            ->assertExitCode(0);
+    }
+
+    public function test_with_warnings()
+    {
+        BuildWarnings::report('This is a warning');
+
+        $this->artisan('build')
+            ->expectsOutput('There were some warnings during the build process:')
+            ->expectsOutput(' 1. This is a warning')
+            ->doesntExpectOutputToContain('BuildWarnings.php')
+            ->assertExitCode(0);
+    }
+
+    public function test_with_warnings_and_verbose()
+    {
+        BuildWarnings::report('This is a warning');
+
+        $this->artisan('build --verbose')
+            ->expectsOutput('There were some warnings during the build process:')
+            ->expectsOutput(' 1. This is a warning')
+            ->expectsOutputToContain('BuildWarnings.php')
+            ->assertExitCode(0);
+    }
+
+    public function test_with_warnings_but_warnings_are_disabled()
+    {
+        config(['hyde.log_warnings' => false]);
+        BuildWarnings::report('This is a warning');
+
+        $this->artisan('build')
+            ->doesntExpectOutput('There were some warnings during the build process:')
+            ->assertExitCode(0);
+    }
+
+    public function test_with_warnings_converted_to_exceptions()
+    {
+        config(['hyde.convert_build_warnings_to_exceptions' => true]);
+        BuildWarnings::report('This is a warning');
+
+        $this->artisan('build')
+            ->expectsOutput('There were some warnings during the build process:')
+            ->expectsOutputToContain('Hyde\Framework\Exceptions\BuildWarning')
+            ->doesntExpectOutput(' 1. This is a warning')
+            ->assertExitCode(1);
     }
 }

--- a/packages/framework/tests/Feature/StaticSiteServiceTest.php
+++ b/packages/framework/tests/Feature/StaticSiteServiceTest.php
@@ -22,7 +22,6 @@ class StaticSiteServiceTest extends TestCase
         parent::setUp();
 
         $this->resetSite();
-        BuildWarnings::clear();
     }
 
     protected function tearDown(): void

--- a/packages/framework/tests/Feature/StaticSiteServiceTest.php
+++ b/packages/framework/tests/Feature/StaticSiteServiceTest.php
@@ -27,6 +27,7 @@ class StaticSiteServiceTest extends TestCase
     protected function tearDown(): void
     {
         File::cleanDirectory(Hyde::path('_site'));
+        BuildWarnings::clear();
 
         parent::tearDown();
     }

--- a/packages/framework/tests/Feature/StaticSiteServiceTest.php
+++ b/packages/framework/tests/Feature/StaticSiteServiceTest.php
@@ -295,6 +295,6 @@ class StaticSiteServiceTest extends TestCase
             ->expectsOutput('There were some warnings during the build process:')
             ->expectsOutputToContain('Hyde\Framework\Exceptions\BuildWarning')
             ->doesntExpectOutput(' 1. This is a warning')
-            ->assertExitCode(1);
+            ->assertExitCode(2);
     }
 }

--- a/packages/framework/tests/Feature/StaticSiteServiceTest.php
+++ b/packages/framework/tests/Feature/StaticSiteServiceTest.php
@@ -262,7 +262,7 @@ class StaticSiteServiceTest extends TestCase
         $this->artisan('build')
             ->expectsOutput('There were some warnings during the build process:')
             ->expectsOutput(' 1. This is a warning')
-            ->doesntExpectOutputToContain('BuildWarnings.php')
+            ->doesntExpectOutputToContain('BuildWarnings.php:')
             ->assertExitCode(0);
     }
 
@@ -273,7 +273,7 @@ class StaticSiteServiceTest extends TestCase
         $this->artisan('build --verbose')
             ->expectsOutput('There were some warnings during the build process:')
             ->expectsOutput(' 1. This is a warning')
-            ->expectsOutputToContain('BuildWarnings.php')
+            ->expectsOutputToContain('BuildWarnings.php:')
             ->assertExitCode(0);
     }
 

--- a/packages/framework/tests/Feature/StaticSiteServiceTest.php
+++ b/packages/framework/tests/Feature/StaticSiteServiceTest.php
@@ -27,7 +27,6 @@ class StaticSiteServiceTest extends TestCase
     protected function tearDown(): void
     {
         File::cleanDirectory(Hyde::path('_site'));
-        BuildWarnings::clear();
 
         parent::tearDown();
     }

--- a/packages/framework/tests/Unit/BuildWarningsTest.php
+++ b/packages/framework/tests/Unit/BuildWarningsTest.php
@@ -117,8 +117,10 @@ class BuildWarningsTest extends UnitTestCase
             $handler = Mockery::mock(ExceptionHandler::class);
             $handler->shouldReceive('renderForConsole')->once()->withArgs(function ($output, $warning) {
                 $this->assertEquals(new BuildWarning('This is a warning'), $warning);
+
                 return $output instanceof OutputStyle && $warning instanceof BuildWarning;
             });
+
             return $handler;
         });
 

--- a/packages/framework/tests/Unit/BuildWarningsTest.php
+++ b/packages/framework/tests/Unit/BuildWarningsTest.php
@@ -42,9 +42,23 @@ class BuildWarningsTest extends UnitTestCase
         $this->assertFalse(BuildWarnings::hasWarnings());
     }
 
+    public function testHasWarningWithWarnings()
+    {
+        BuildWarnings::report('This is a warning');
+
+        $this->assertTrue(BuildWarnings::hasWarnings());
+    }
+
     public function testGetWarnings()
     {
         $this->assertSame([], BuildWarnings::getWarnings());
+    }
+
+    public function testGetWarningsWithWarnings()
+    {
+        BuildWarnings::report('This is a warning');
+
+        $this->assertEquals([new BuildWarning('This is a warning')], BuildWarnings::getWarnings());
     }
 
     public function testReport()

--- a/packages/framework/tests/Unit/BuildWarningsTest.php
+++ b/packages/framework/tests/Unit/BuildWarningsTest.php
@@ -113,14 +113,6 @@ class BuildWarningsTest extends UnitTestCase
         $this->assertFalse(BuildWarnings::reportsWarningsAsExceptions());
     }
 
-    public function testClear()
-    {
-        BuildWarnings::report(new BuildWarning('This is a warning'));
-        BuildWarnings::clear();
-
-        $this->assertFalse(BuildWarnings::hasWarnings());
-    }
-
     public function testWriteWarningsToOutput()
     {
         BuildWarnings::report('This is a warning');

--- a/packages/framework/tests/Unit/BuildWarningsTest.php
+++ b/packages/framework/tests/Unit/BuildWarningsTest.php
@@ -22,7 +22,7 @@ class BuildWarningsTest extends UnitTestCase
 {
     protected function tearDown(): void
     {
-        BuildWarnings::clear();
+        app()->forgetInstance(BuildWarnings::class);
 
         parent::tearDown();
     }

--- a/packages/framework/tests/Unit/BuildWarningsTest.php
+++ b/packages/framework/tests/Unit/BuildWarningsTest.php
@@ -85,11 +85,12 @@ class BuildWarningsTest extends UnitTestCase
         BuildWarnings::report('This is a warning');
 
         $output = Mockery::mock(OutputStyle::class);
-        $output->shouldReceive('writeln')->with(' 1. <comment>This is a warning</comment>');
+        $output->shouldReceive('writeln')->once()->withArgs(function (string $string) {
+            $this->assertSame(' 1. <comment>This is a warning</comment>', $string);
+            return true;
+        });
 
         BuildWarnings::writeWarningsToOutput($output);
-
-        $this->assertTrue(true);
     }
 
     public function testWriteWarningsToOutputWithLocation()
@@ -97,15 +98,16 @@ class BuildWarningsTest extends UnitTestCase
         BuildWarnings::report('This is a warning', 'path/to/file.md');
 
         $output = Mockery::mock(OutputStyle::class);
-        $output->shouldReceive('writeln')->with(' 1. <comment>This is a warning</comment>');
+        $output->shouldReceive('writeln')->once()->withArgs(function (string $string) {
+            $this->assertSame(' 1. <comment>This is a warning</comment>', $string);
+            return true;
+        });
         $output->shouldReceive('writeln')->once()->withArgs(function (string $string) {
             $this->assertStringContainsString('BuildWarnings.php', $string);
             return true;
         });
 
         BuildWarnings::writeWarningsToOutput($output, true);
-
-        $this->assertTrue(true);
     }
 
     public function testWriteWarningsToOutputWithConvertingBuildWarningsToExceptions()

--- a/packages/framework/tests/Unit/BuildWarningsTest.php
+++ b/packages/framework/tests/Unit/BuildWarningsTest.php
@@ -27,11 +27,6 @@ class BuildWarningsTest extends UnitTestCase
         parent::tearDown();
     }
 
-    public function testCanConstructBuildWarning()
-    {
-        $this->assertInstanceOf(BuildWarning::class, new BuildWarning('This is a warning'));
-    }
-
     public function testGetInstance()
     {
         $this->assertInstanceOf(BuildWarnings::class, BuildWarnings::getInstance());
@@ -158,6 +153,11 @@ class BuildWarningsTest extends UnitTestCase
         $instance->report(new BuildWarning('This is a warning'));
         $instance->clear();
         $this->assertFalse($instance->hasWarnings());
+    }
+
+    public function testCanConstructBuildWarning()
+    {
+        $this->assertInstanceOf(BuildWarning::class, new BuildWarning('This is a warning'));
     }
 
     protected static function mockConfig(array $items = []): void

--- a/packages/framework/tests/Unit/BuildWarningsTest.php
+++ b/packages/framework/tests/Unit/BuildWarningsTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Hyde\Framework\Testing\Unit;
 
+use Closure;
 use Hyde\Framework\Exceptions\BuildWarning;
 use Hyde\Support\BuildWarnings;
 use Hyde\Testing\UnitTestCase;
@@ -77,11 +78,9 @@ class BuildWarningsTest extends UnitTestCase
         BuildWarnings::report('This is a warning');
 
         $output = Mockery::mock(OutputStyle::class);
-        $output->shouldReceive('writeln')->once()->withArgs(function (string $string) {
-            $this->assertSame(' 1. <comment>This is a warning</comment>', $string);
-
-            return true;
-        });
+        $output->shouldReceive('writeln')->once()->withArgs(
+            $this->runAssertSame(' 1. <comment>This is a warning</comment>')
+        );
 
         BuildWarnings::writeWarningsToOutput($output);
     }
@@ -91,11 +90,9 @@ class BuildWarningsTest extends UnitTestCase
         BuildWarnings::report('This is a warning');
 
         $output = Mockery::mock(OutputStyle::class);
-        $output->shouldReceive('writeln')->once()->withArgs(function (string $string) {
-            $this->assertSame(' 1. <comment>This is a warning</comment>', $string);
-
-            return true;
-        });
+        $output->shouldReceive('writeln')->once()->withArgs(
+            $this->runAssertSame(' 1. <comment>This is a warning</comment>')
+        );
         $output->shouldReceive('writeln')->once()->withArgs(function (string $string) {
             $this->assertStringContainsString('BuildWarnings.php', $string);
 
@@ -157,5 +154,14 @@ class BuildWarningsTest extends UnitTestCase
         app()->bind('config', fn () => new Repository($items));
 
         Config::swap(app('config'));
+    }
+
+    protected function runAssertSame(string $expected): Closure
+    {
+        return function (string $string) use ($expected) {
+            $this->assertSame($expected, $string);
+
+            return true;
+        };
     }
 }

--- a/packages/framework/tests/Unit/BuildWarningsTest.php
+++ b/packages/framework/tests/Unit/BuildWarningsTest.php
@@ -98,7 +98,7 @@ class BuildWarningsTest extends UnitTestCase
 
         $output = Mockery::mock(OutputStyle::class);
         $output->shouldReceive('writeln')->with(' 1. <comment>This is a warning</comment>');
-        $output->shouldReceive('writeln')->withArgs(function (string $string) {
+        $output->shouldReceive('writeln')->once()->withArgs(function (string $string) {
             $this->assertStringContainsString('BuildWarnings.php', $string);
             return true;
         });

--- a/packages/framework/tests/Unit/BuildWarningsTest.php
+++ b/packages/framework/tests/Unit/BuildWarningsTest.php
@@ -88,7 +88,7 @@ class BuildWarningsTest extends UnitTestCase
 
     public function testWriteWarningsToOutputWithLocation()
     {
-        BuildWarnings::report('This is a warning', 'path/to/file.md');
+        BuildWarnings::report('This is a warning');
 
         $output = Mockery::mock(OutputStyle::class);
         $output->shouldReceive('writeln')->once()->withArgs(function (string $string) {

--- a/packages/framework/tests/Unit/BuildWarningsTest.php
+++ b/packages/framework/tests/Unit/BuildWarningsTest.php
@@ -86,7 +86,7 @@ class BuildWarningsTest extends UnitTestCase
         BuildWarnings::writeWarningsToOutput($output);
     }
 
-    public function testWriteWarningsToOutputWithLocation()
+    public function testWriteWarningsToOutputWithVerboseOutput()
     {
         BuildWarnings::report('This is a warning');
 

--- a/packages/framework/tests/Unit/BuildWarningsTest.php
+++ b/packages/framework/tests/Unit/BuildWarningsTest.php
@@ -132,14 +132,6 @@ class BuildWarningsTest extends UnitTestCase
         BuildWarnings::writeWarningsToOutput($output);
     }
 
-    public function testGet()
-    {
-        $instance = BuildWarnings::getInstance();
-
-        $instance->report($warning = new BuildWarning('This is a warning'));
-        $this->assertSame([$warning], $instance->get());
-    }
-
     public function testClear()
     {
         $instance = BuildWarnings::getInstance();

--- a/packages/framework/tests/Unit/BuildWarningsTest.php
+++ b/packages/framework/tests/Unit/BuildWarningsTest.php
@@ -148,11 +148,9 @@ class BuildWarningsTest extends UnitTestCase
 
     public function testClear()
     {
-        $instance = BuildWarnings::getInstance();
-
-        $instance->report(new BuildWarning('This is a warning'));
-        $instance::clear();
-        $this->assertFalse($instance->hasWarnings());
+        BuildWarnings::report(new BuildWarning('This is a warning'));
+        BuildWarnings::clear();
+        $this->assertFalse(BuildWarnings::hasWarnings());
     }
 
     public function testCanConstructBuildWarning()

--- a/packages/framework/tests/Unit/BuildWarningsTest.php
+++ b/packages/framework/tests/Unit/BuildWarningsTest.php
@@ -54,14 +54,6 @@ class BuildWarningsTest extends UnitTestCase
         $this->assertEquals([new BuildWarning('This is a warning')], BuildWarnings::getWarnings());
     }
 
-    public function testReportWithLocation()
-    {
-        BuildWarnings::report('This is a warning', 'path/to/file.md');
-
-        $this->assertTrue(BuildWarnings::hasWarnings());
-        $this->assertEquals([new BuildWarning('This is a warning', 'path/to/file.md')], BuildWarnings::getWarnings());
-    }
-
     public function testReportsWarningsDefaultsToTrue()
     {
         self::mockConfig();

--- a/packages/framework/tests/Unit/BuildWarningsTest.php
+++ b/packages/framework/tests/Unit/BuildWarningsTest.php
@@ -22,7 +22,7 @@ class BuildWarningsTest extends UnitTestCase
 {
     protected function tearDown(): void
     {
-        BuildWarnings::getInstance()->clear();
+        BuildWarnings::clear();
 
         parent::tearDown();
     }
@@ -151,7 +151,7 @@ class BuildWarningsTest extends UnitTestCase
         $instance = BuildWarnings::getInstance();
 
         $instance->report(new BuildWarning('This is a warning'));
-        $instance->clear();
+        $instance::clear();
         $this->assertFalse($instance->hasWarnings());
     }
 

--- a/packages/framework/tests/Unit/BuildWarningsTest.php
+++ b/packages/framework/tests/Unit/BuildWarningsTest.php
@@ -95,6 +95,14 @@ class BuildWarningsTest extends UnitTestCase
         $this->assertFalse(BuildWarnings::reportsWarnings());
     }
 
+    public function testClear()
+    {
+        BuildWarnings::report(new BuildWarning('This is a warning'));
+        BuildWarnings::clear();
+
+        $this->assertFalse(BuildWarnings::hasWarnings());
+    }
+
     public function testWriteWarningsToOutput()
     {
         BuildWarnings::report('This is a warning');
@@ -144,14 +152,6 @@ class BuildWarningsTest extends UnitTestCase
         });
 
         BuildWarnings::writeWarningsToOutput($output);
-    }
-
-    public function testClear()
-    {
-        BuildWarnings::report(new BuildWarning('This is a warning'));
-        BuildWarnings::clear();
-
-        $this->assertFalse(BuildWarnings::hasWarnings());
     }
 
     public function testCanConstructBuildWarning()

--- a/packages/framework/tests/Unit/BuildWarningsTest.php
+++ b/packages/framework/tests/Unit/BuildWarningsTest.php
@@ -79,7 +79,7 @@ class BuildWarningsTest extends UnitTestCase
 
         $output = Mockery::mock(OutputStyle::class);
         $output->shouldReceive('writeln')->once()->withArgs(
-            $this->runAssertSame(' 1. <comment>This is a warning</comment>')
+            $this->assertArgumentIs(' 1. <comment>This is a warning</comment>')
         );
 
         BuildWarnings::writeWarningsToOutput($output);
@@ -91,7 +91,7 @@ class BuildWarningsTest extends UnitTestCase
 
         $output = Mockery::mock(OutputStyle::class);
         $output->shouldReceive('writeln')->once()->withArgs(
-            $this->runAssertSame(' 1. <comment>This is a warning</comment>')
+            $this->assertArgumentIs(' 1. <comment>This is a warning</comment>')
         );
         $output->shouldReceive('writeln')->once()->withArgs(function (string $string) {
             $this->assertStringContainsString('BuildWarnings.php', $string);
@@ -156,7 +156,7 @@ class BuildWarningsTest extends UnitTestCase
         Config::swap(app('config'));
     }
 
-    protected function runAssertSame(string $expected): Closure
+    protected function assertArgumentIs(string $expected): Closure
     {
         return function (string $string) use ($expected) {
             $this->assertSame($expected, $string);

--- a/packages/framework/tests/Unit/BuildWarningsTest.php
+++ b/packages/framework/tests/Unit/BuildWarningsTest.php
@@ -95,6 +95,24 @@ class BuildWarningsTest extends UnitTestCase
         $this->assertFalse(BuildWarnings::reportsWarnings());
     }
 
+    public function testReportsWarningsAsExceptionsDefaultsToFalse()
+    {
+        self::mockConfig();
+        $this->assertFalse(BuildWarnings::reportsWarningsAsExceptions());
+    }
+
+    public function testReportsWarningsAsExceptionsReturnsTrueWhenTrue()
+    {
+        self::mockConfig(['hyde.convert_build_warnings_to_exceptions' => true]);
+        $this->assertTrue(BuildWarnings::reportsWarningsAsExceptions());
+    }
+
+    public function testReportsWarningsAsExceptionsReturnsFalseWhenFalse()
+    {
+        self::mockConfig(['hyde.convert_build_warnings_to_exceptions' => false]);
+        $this->assertFalse(BuildWarnings::reportsWarningsAsExceptions());
+    }
+
     public function testClear()
     {
         BuildWarnings::report(new BuildWarning('This is a warning'));

--- a/packages/framework/tests/Unit/BuildWarningsTest.php
+++ b/packages/framework/tests/Unit/BuildWarningsTest.php
@@ -150,6 +150,7 @@ class BuildWarningsTest extends UnitTestCase
     {
         BuildWarnings::report(new BuildWarning('This is a warning'));
         BuildWarnings::clear();
+
         $this->assertFalse(BuildWarnings::hasWarnings());
     }
 

--- a/packages/framework/tests/Unit/BuildWarningsTest.php
+++ b/packages/framework/tests/Unit/BuildWarningsTest.php
@@ -55,6 +55,14 @@ class BuildWarningsTest extends UnitTestCase
         $this->assertEquals([new BuildWarning('This is a warning')], BuildWarnings::getWarnings());
     }
 
+    public function testReportWithBuildWarningObject()
+    {
+        BuildWarnings::report($warning = new BuildWarning('This is a warning'));
+
+        $this->assertTrue(BuildWarnings::hasWarnings());
+        $this->assertSame([$warning], BuildWarnings::getWarnings());
+    }
+
     public function testReportsWarningsDefaultsToTrue()
     {
         self::mockConfig();

--- a/packages/framework/tests/Unit/BuildWarningsTest.php
+++ b/packages/framework/tests/Unit/BuildWarningsTest.php
@@ -87,6 +87,7 @@ class BuildWarningsTest extends UnitTestCase
         $output = Mockery::mock(OutputStyle::class);
         $output->shouldReceive('writeln')->once()->withArgs(function (string $string) {
             $this->assertSame(' 1. <comment>This is a warning</comment>', $string);
+
             return true;
         });
 
@@ -100,10 +101,12 @@ class BuildWarningsTest extends UnitTestCase
         $output = Mockery::mock(OutputStyle::class);
         $output->shouldReceive('writeln')->once()->withArgs(function (string $string) {
             $this->assertSame(' 1. <comment>This is a warning</comment>', $string);
+
             return true;
         });
         $output->shouldReceive('writeln')->once()->withArgs(function (string $string) {
             $this->assertStringContainsString('BuildWarnings.php', $string);
+
             return true;
         });
 

--- a/packages/framework/tests/Unit/BuildWarningsTest.php
+++ b/packages/framework/tests/Unit/BuildWarningsTest.php
@@ -132,19 +132,11 @@ class BuildWarningsTest extends UnitTestCase
         BuildWarnings::writeWarningsToOutput($output);
     }
 
-    public function testAdd()
-    {
-        $instance = BuildWarnings::getInstance();
-
-        $instance->add(new BuildWarning('This is a warning'));
-        $this->assertTrue($instance->hasWarnings());
-    }
-
     public function testGet()
     {
         $instance = BuildWarnings::getInstance();
 
-        $instance->add($warning = new BuildWarning('This is a warning'));
+        $instance->report($warning = new BuildWarning('This is a warning'));
         $this->assertSame([$warning], $instance->get());
     }
 
@@ -152,7 +144,7 @@ class BuildWarningsTest extends UnitTestCase
     {
         $instance = BuildWarnings::getInstance();
 
-        $instance->add(new BuildWarning('This is a warning'));
+        $instance->report(new BuildWarning('This is a warning'));
         $instance->clear();
         $this->assertFalse($instance->hasWarnings());
     }

--- a/packages/framework/tests/Unit/BuildWarningsTest.php
+++ b/packages/framework/tests/Unit/BuildWarningsTest.php
@@ -27,6 +27,11 @@ class BuildWarningsTest extends UnitTestCase
         parent::tearDown();
     }
 
+    public function testCanConstructBuildWarning()
+    {
+        $this->assertInstanceOf(BuildWarning::class, new BuildWarning('This is a warning'));
+    }
+
     public function testGetInstance()
     {
         $this->assertInstanceOf(BuildWarnings::class, BuildWarnings::getInstance());

--- a/packages/framework/tests/Unit/BuildWarningsTest.php
+++ b/packages/framework/tests/Unit/BuildWarningsTest.php
@@ -98,9 +98,12 @@ class BuildWarningsTest extends UnitTestCase
 
         $output = Mockery::mock(OutputStyle::class);
         $output->shouldReceive('writeln')->with(' 1. <comment>This is a warning</comment>');
-        $output->shouldReceive('writeln')->with('    <fg=gray>path/to/file.md</>');
+        $output->shouldReceive('writeln')->withArgs(function (string $string) {
+            $this->assertStringContainsString('BuildWarnings.php', $string);
+            return true;
+        });
 
-        BuildWarnings::writeWarningsToOutput($output);
+        BuildWarnings::writeWarningsToOutput($output, true);
 
         $this->assertTrue(true);
     }


### PR DESCRIPTION
## Description

Adds an experimental system for us to buffer warnings that don't usually warrant a site build to fail (though there is an option to do just that) but that we want to alert the user about.

### Changes Made

- Added experimental system to buffer warnings that don't warrant a site build to fail.
- Add a helper to display where the warning took place. (Enabled when verbose)
- Add an option to make the site build fail when certain warnings occur

## Screenshots

### Console output

Here's how it looks now:

![image](https://user-images.githubusercontent.com/95144705/221406285-cfca57fc-ecc1-4b35-b1e6-e3f9e4f649be.png)


### Console output with verbose

![image](https://user-images.githubusercontent.com/95144705/221406359-caf47137-0893-4532-9a0b-0bd0dd322fac.png)


When output is set to verbose, it will display where the warning took place as it's not that helpful to say "hey here's a warning but we won't tell you where".

### Console output as exceptions

![image](https://user-images.githubusercontent.com/95144705/221406548-c2398b43-4880-41e8-8698-2e899c5b5687.png)

Exceptions can be enabled to get a full stack trace + exit with code 2.

## Usage

### Adding warnings

To add a warning, use the `BuildWarnings::report` method. You can either pass a string, or a `BuildWarning` object (this is recommended as it gives a better stracktrace)

```php
use Hyde\Support\BuildWarnings;
use Hyde\Framework\Exceptions\BuildWarning;

BuildWarnings::report('An image was referenced in a page, but not found in the media folder.');
BuildWarnings::report(new BuildWarning('A remote image returned a 404 status code. Are you sure the URL is correct?'));
```

### Displaying warnings

The warnings are automatically shown when running the site build command. If the verbose flag is set, the location where the warning was triggered will also be shown. There is also a config option which will report warnings as exceptions and fail the site command.