### PR TITLE
Update test to account for time drift

### DIFF
--- a/packages/framework/tests/Feature/TracksExecutionTimeTest.php
+++ b/packages/framework/tests/Feature/TracksExecutionTimeTest.php
@@ -21,7 +21,8 @@ class TracksExecutionTimeTest extends TestCase
 
         $this->assertTrue($class->isset('timeStart'));
         $this->assertIsFloat($class->timeStart);
-        $this->assertSame(round(microtime(true)), round($class->timeStart));
+        // Assert that the difference between the two is less than 1 second to account for time drift (causes 1/10 000 tests to fail)
+        $this->assertLessThan(1, abs((microtime(true)) - ($class->timeStart)));
     }
 
     public function test_stopClock()


### PR DESCRIPTION
This covers an extreme edge case causing tests to very rarely fail. Since the time difference between starting and stopping the clock is about 0.00048 seconds, or less than half a millisecond, this means the clock can switchover to a new second during this time.

This means that about when running the test around 1400 times, there is a 50% chance of this to occur. Given the scale we run tests on this means this issue is likely to happen again. 

```math
0.5 = (0.99952)^n
ln(0.5) = n * ln(0.99952)
n = ln(0.5) / ln(0.99952) ≈ 1438.96
```
So this PR fixes this by checking the time diff instead of rounded equality.