### PR TITLE
Update Hyde::formatLink helper to trim all index.html suffixes when using pretty URLs

### DIFF
--- a/packages/framework/src/Foundation/Kernel/Hyperlinks.php
+++ b/packages/framework/src/Foundation/Kernel/Hyperlinks.php
@@ -29,7 +29,7 @@ class Hyperlinks
     /**
      * Format a web link to an HTML file, allowing for pretty URLs, if enabled.
      *
-     * @see \Hyde\Framework\Testing\Unit\Foundation\HyperlinkformatLinkTest
+     * @see \Hyde\Framework\Testing\Unit\Foundation\HyperlinkFormatHtmlPathTest
      */
     public function formatLink(string $destination): string
     {

--- a/packages/framework/src/Foundation/Kernel/Hyperlinks.php
+++ b/packages/framework/src/Foundation/Kernel/Hyperlinks.php
@@ -7,7 +7,6 @@ namespace Hyde\Foundation\Kernel;
 use Hyde\Foundation\HydeKernel;
 use Hyde\Framework\Exceptions\BaseUrlNotSetException;
 use Hyde\Framework\Exceptions\FileNotFoundException;
-use Hyde\Pages\DocumentationPage;
 use Illuminate\Support\Str;
 
 /**
@@ -39,8 +38,8 @@ class Hyperlinks
                     return '/';
                 }
 
-                if ($destination === DocumentationPage::outputDirectory().'/index.html') {
-                    return DocumentationPage::outputDirectory().'/';
+                if (str_ends_with($destination, 'index.html')) {
+                    return substr($destination, 0, -10);
                 }
 
                 return substr($destination, 0, -5);

--- a/packages/framework/src/Foundation/Kernel/Hyperlinks.php
+++ b/packages/framework/src/Foundation/Kernel/Hyperlinks.php
@@ -34,12 +34,8 @@ class Hyperlinks
     {
         if (config('hyde.pretty_urls', false) === true) {
             if (str_ends_with($destination, '.html')) {
-                if ($destination === 'index.html') {
-                    return '/';
-                }
-
                 if (str_ends_with($destination, 'index.html')) {
-                    return substr($destination, 0, -10);
+                    return substr($destination, 0, -10) ?: '/';
                 }
 
                 return substr($destination, 0, -5);

--- a/packages/framework/src/Foundation/Kernel/Hyperlinks.php
+++ b/packages/framework/src/Foundation/Kernel/Hyperlinks.php
@@ -34,8 +34,12 @@ class Hyperlinks
     {
         if (config('hyde.pretty_urls', false) === true) {
             if (str_ends_with($destination, '.html')) {
+                if ($destination === 'index.html') {
+                    return '/';
+                }
+
                 if (str_ends_with($destination, 'index.html')) {
-                    return substr($destination, 0, -10) ?: '/';
+                    return substr($destination, 0, -10);
                 }
 
                 return substr($destination, 0, -5);

--- a/packages/framework/tests/Unit/Foundation/HyperlinkFormatHtmlPathTest.php
+++ b/packages/framework/tests/Unit/Foundation/HyperlinkFormatHtmlPathTest.php
@@ -5,91 +5,97 @@ declare(strict_types=1);
 namespace Hyde\Framework\Testing\Unit\Foundation;
 
 use Hyde\Hyde;
-use Hyde\Testing\TestCase;
+use Hyde\Testing\UnitTestCase;
 
 /**
  * @covers \Hyde\Foundation\Kernel\Hyperlinks::formatLink
  */
-class HyperlinkFormatHtmlPathTest extends TestCase
+class HyperlinkFormatHtmlPathTest extends UnitTestCase
 {
+    public static function setUpBeforeClass(): void
+    {
+        self::needsKernel();
+        self::mockConfig();
+    }
+
     public function test_helper_returns_string_as_is_if_pretty_urls_is_not_true()
     {
-        config(['hyde.pretty_urls' => false]);
+        self::mockConfig(['hyde.pretty_urls' => false]);
 
         $this->assertEquals('foo/bar.html', Hyde::formatLink('foo/bar.html'));
     }
 
     public function test_helper_returns_pretty_url_if_pretty_urls_is_true()
     {
-        config(['hyde.pretty_urls' => true]);
+        self::mockConfig(['hyde.pretty_urls' => true]);
 
         $this->assertEquals('foo/bar', Hyde::formatLink('foo/bar.html'));
     }
 
     public function test_non_pretty_urls_is_default_value_when_config_is_not_set()
     {
-        config(['hyde.pretty_urls' => null]);
+        self::mockConfig(['hyde.pretty_urls' => null]);
 
         $this->assertEquals('foo/bar.html', Hyde::formatLink('foo/bar.html'));
     }
 
     public function test_helper_respects_absolute_urls()
     {
-        config(['hyde.pretty_urls' => false]);
+        self::mockConfig(['hyde.pretty_urls' => false]);
         $this->assertEquals('/foo/bar.html', Hyde::formatLink('/foo/bar.html'));
     }
 
     public function test_helper_respects_pretty_absolute_urls()
     {
-        config(['hyde.pretty_urls' => true]);
+        self::mockConfig(['hyde.pretty_urls' => true]);
         $this->assertEquals('/foo/bar', Hyde::formatLink('/foo/bar.html'));
     }
 
     public function test_helper_respects_relative_urls()
     {
-        config(['hyde.pretty_urls' => false]);
+        self::mockConfig(['hyde.pretty_urls' => false]);
         $this->assertEquals('../foo/bar.html', Hyde::formatLink('../foo/bar.html'));
     }
 
     public function test_helper_respects_pretty_relative_urls()
     {
-        config(['hyde.pretty_urls' => true]);
+        self::mockConfig(['hyde.pretty_urls' => true]);
         $this->assertEquals('../foo/bar', Hyde::formatLink('../foo/bar.html'));
     }
 
     public function test_non_html_links_are_not_modified()
     {
-        config(['hyde.pretty_urls' => true]);
+        self::mockConfig(['hyde.pretty_urls' => true]);
         $this->assertEquals('/foo/bar.jpg', Hyde::formatLink('/foo/bar.jpg'));
     }
 
     public function test_helper_respects_absolute_urls_with_pretty_urls_enabled()
     {
-        config(['hyde.pretty_urls' => true]);
+        self::mockConfig(['hyde.pretty_urls' => true]);
         $this->assertEquals('/foo/bar.jpg', Hyde::formatLink('/foo/bar.jpg'));
     }
 
     public function test_helper_rewrites_index_when_using_pretty_urls()
     {
-        config(['hyde.pretty_urls' => true]);
+        self::mockConfig(['hyde.pretty_urls' => true]);
         $this->assertEquals('/', Hyde::formatLink('index.html'));
     }
 
     public function test_helper_does_not_rewrite_index_when_not_using_pretty_urls()
     {
-        config(['hyde.pretty_urls' => false]);
+        self::mockConfig(['hyde.pretty_urls' => false]);
         $this->assertEquals('index.html', Hyde::formatLink('index.html'));
     }
 
     public function test_helper_rewrites_documentation_page_index_when_using_pretty_urls()
     {
-        config(['hyde.pretty_urls' => true]);
+        self::mockConfig(['hyde.pretty_urls' => true]);
         $this->assertEquals('docs/', Hyde::formatLink('docs/index.html'));
     }
 
     public function test_helper_does_not_rewrite_documentation_page_index_when_not_using_pretty_urls()
     {
-        config(['hyde.pretty_urls' => false]);
+        self::mockConfig(['hyde.pretty_urls' => false]);
         $this->assertEquals('docs/index.html', Hyde::formatLink('docs/index.html'));
     }
 }

--- a/packages/framework/tests/Unit/Foundation/HyperlinkFormatHtmlPathTest.php
+++ b/packages/framework/tests/Unit/Foundation/HyperlinkFormatHtmlPathTest.php
@@ -98,4 +98,16 @@ class HyperlinkFormatHtmlPathTest extends UnitTestCase
         self::mockConfig(['hyde.pretty_urls' => false]);
         $this->assertEquals('docs/index.html', Hyde::formatLink('docs/index.html'));
     }
+
+    public function test_helpers_rewrites_arbitrary_nested_index_pages_when_using_pretty_urls()
+    {
+        self::mockConfig(['hyde.pretty_urls' => true]);
+        $this->assertEquals('foo/bar/', Hyde::formatLink('foo/bar/index.html'));
+    }
+
+    public function test_helpers_does_not_rewrite_arbitrary_nested_index_pages_when_not_using_pretty_urls()
+    {
+        self::mockConfig(['hyde.pretty_urls' => false]);
+        $this->assertEquals('foo/bar/index.html', Hyde::formatLink('foo/bar/index.html'));
+    }
 }


### PR DESCRIPTION
Updates the Hyde::formatLink helper to trim all index.html suffixes when using pretty URLs.

This means `Hyde::formatLink('foo/bar/index.html')` now returns `'foo/bar/'` instead of 'foo/bar/index.html'.

This makes it more in line with how both standard index and documentation pages were rewritten, providing a more consistent and broadly usable result.