### PR TITLE
Refactor the Hyde::path() helper to normalize already absolute paths

### DIFF
--- a/packages/framework/src/Console/Concerns/Command.php
+++ b/packages/framework/src/Console/Concerns/Command.php
@@ -84,7 +84,7 @@ abstract class Command extends BaseCommand
      */
     public static function fileLink(string $filepath, string $label = null): string
     {
-        $link = 'file://'.str_replace('\\', '/', realpath($filepath) ?: Hyde::path(Hyde::pathToRelative($filepath)));
+        $link = 'file://'.str_replace('\\', '/', realpath($filepath) ?: Hyde::path($filepath));
 
         return $label ? "<href=$link>$label</>" : $link;
     }

--- a/packages/framework/src/Foundation/Kernel/Filesystem.php
+++ b/packages/framework/src/Foundation/Kernel/Filesystem.php
@@ -61,7 +61,7 @@ class Filesystem
             return $this->getBasePath();
         }
 
-        $path = unslash($path);
+        $path = unslash($this->pathToRelative($path));
 
         return path_join($this->getBasePath(), $path);
     }

--- a/packages/framework/tests/Feature/Foundation/FilesystemTest.php
+++ b/packages/framework/tests/Feature/Foundation/FilesystemTest.php
@@ -91,6 +91,22 @@ class FilesystemTest extends TestCase
         $this->assertEquals('/foo/bar/file.php', $this->filesystem->path('\\/bar/file.php/'));
     }
 
+    public function test_path_method_resolves_already_absolute_paths()
+    {
+        Hyde::getInstance()->setBasePath('/foo');
+        $this->assertEquals('/foo/bar', $this->filesystem->path('/foo/bar'));
+    }
+
+    public function test_path_method_resolves_already_absolute_paths_using_helper()
+    {
+        $this->assertEquals($this->filesystem->path('foo'), $this->filesystem->path($this->filesystem->path('foo')));
+    }
+
+    public function test_path_method_resolves_already_absolute_paths_using_helper_with_trailing_slash()
+    {
+        $this->assertEquals($this->filesystem->path('foo'), $this->filesystem->path($this->filesystem->path('foo/')));
+    }
+
     public function test_vendor_path_method_exists()
     {
         $this->assertTrue(method_exists(Filesystem::class, 'vendorPath'));


### PR DESCRIPTION
### Refactor the Hyde::path() helper to normalize already absolute paths

Originally there has been two reasons for now doing this:

1. Paths should almost always already be relative
2. Performance concerns due to increased operations

After actually measuring this, I can confidently state that concern two is no concern at all. Firstly, performance is not that big of a concern in a static site generator, and secondly: after benchmarking this, it's clear that the method is lightning fast in either case.

### Benchmarks

| Input string           | Avg time (before) | Avg time (after) |
|------------------------|-------------------|------------------|
| ''                     | 0.001ms           | 0.001ms          |
| 'foo'                  | 0.002ms           | 0.003ms          |
| Hyde::path('foo')      | 0.004ms           | 0.006ms          |
| Hyde::path(Hyde::path) | 0.003ms           | 0.004ms          |

*Average time over 10 000 iterations
**Speed is unaffected by length and complexity of the input string

### Conclusion 

As you can see, the method is lightning fast in either case and will never be a bottleneck or even be noticeable. Even though it's a very frequently called method, since we can call it over 150 times per millisecond (with worst case performance) this just isn't a concern. The only difference is that it now also works with absolute paths.

Then only the first issue remains, and I think the improved leniency and thus beter DX is preferable here, thus the refactor.
