### PR TITLE
Add configuration option for the realtime compiler server host

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,6 +4,6 @@ SITE_URL=http://localhost
 # If you want to use Torchlight.dev, enter your API token here to automatically enable it.
 # TORCHLIGHT_TOKEN=torch_
 
-# If you want to change the default port of the realtime compiler server, you can do so here
+# If you want to change the default port or host of the realtime compiler server, you can do so here
 # SERVER_PORT=8080
 # SERVER_HOST=localhost

--- a/.env.example
+++ b/.env.example
@@ -6,3 +6,4 @@ SITE_URL=http://localhost
 
 # If you want to change the default port of the realtime compiler server, you can do so here
 # SERVER_PORT=8080
+# SERVER_HOST=localhost

--- a/config/hyde.php
+++ b/config/hyde.php
@@ -156,6 +156,7 @@ return [
 
     'server' => [
         'port' => env('SERVER_PORT', 8080),
+        'host' => env('SERVER_HOST', 'localhost'),
         'dashboard' => env('SERVER_DASHBOARD', true),
     ],
 

--- a/packages/framework/config/hyde.php
+++ b/packages/framework/config/hyde.php
@@ -156,6 +156,7 @@ return [
 
     'server' => [
         'port' => env('SERVER_PORT', 8080),
+        'host' => env('SERVER_HOST', 'localhost'),
         'dashboard' => env('SERVER_DASHBOARD', true),
     ],
 

--- a/packages/framework/src/Console/Commands/ServeCommand.php
+++ b/packages/framework/src/Console/Commands/ServeCommand.php
@@ -18,7 +18,7 @@ use function sprintf;
 class ServeCommand extends Command
 {
     /** @var string */
-    protected $signature = 'serve {--host=localhost} {--port= : <comment> [default: 8080] </comment>}';
+    protected $signature = 'serve {--host=} {--port= : <comment> [default: 8080] </comment>}';
 
     /** @var string */
     protected $description = 'Start the realtime compiler server.';

--- a/packages/framework/src/Console/Commands/ServeCommand.php
+++ b/packages/framework/src/Console/Commands/ServeCommand.php
@@ -18,7 +18,7 @@ use function sprintf;
 class ServeCommand extends Command
 {
     /** @var string */
-    protected $signature = 'serve {--host= : <comment> [default: "localhost"] </comment>}} {--port= : <comment> [default: 8080] </comment>}';
+    protected $signature = 'serve {--host= : <comment>[default: "localhost"]</comment>}} {--port= : <comment>[default: 8080]</comment>}';
 
     /** @var string */
     protected $description = 'Start the realtime compiler server.';

--- a/packages/framework/src/Console/Commands/ServeCommand.php
+++ b/packages/framework/src/Console/Commands/ServeCommand.php
@@ -41,6 +41,11 @@ class ServeCommand extends Command
         return (int) ($this->option('port') ?: config('hyde.server.port', 8080));
     }
 
+    protected function getHostSelection(): string
+    {
+        return $this->option('host') ?: config('hyde.server.host', 'localhost');
+    }
+
     protected function getExecutablePath(): string
     {
         return Hyde::path('vendor/hyde/realtime-compiler/bin/server.php');

--- a/packages/framework/src/Console/Commands/ServeCommand.php
+++ b/packages/framework/src/Console/Commands/ServeCommand.php
@@ -28,7 +28,7 @@ class ServeCommand extends Command
         $this->line('<info>Starting the HydeRC server...</info> Press Ctrl+C to stop');
 
         $this->runServerProcess(sprintf('php -S %s:%d %s',
-            $this->option('host'),
+            $this->getHostSelection() ?: 'localhost',
             $this->getPortSelection() ?: 8080,
             $this->getExecutablePath()
         ));

--- a/packages/framework/src/Console/Commands/ServeCommand.php
+++ b/packages/framework/src/Console/Commands/ServeCommand.php
@@ -18,7 +18,7 @@ use function sprintf;
 class ServeCommand extends Command
 {
     /** @var string */
-    protected $signature = 'serve {--host=} {--port= : <comment> [default: 8080] </comment>}';
+    protected $signature = 'serve {--host= : <comment> [default: "localhost"] </comment>}} {--port= : <comment> [default: 8080] </comment>}';
 
     /** @var string */
     protected $description = 'Start the realtime compiler server.';

--- a/packages/framework/tests/Feature/Commands/ServeCommandTest.php
+++ b/packages/framework/tests/Feature/Commands/ServeCommandTest.php
@@ -89,6 +89,39 @@ class ServeCommandTest extends TestCase
         Process::assertRan("php -S localhost:8081 {$this->binaryPath()}");
     }
 
+    public function test_hyde_serve_command_with_host_defined_in_config()
+    {
+        config(['hyde.server.host' => 'foo']);
+
+        $this->artisan('serve')
+            ->expectsOutput('Starting the HydeRC server... Press Ctrl+C to stop')
+            ->assertExitCode(0);
+
+        Process::assertRan("php -S foo:8080 {$this->binaryPath()}");
+    }
+
+    public function test_hyde_serve_command_with_host_defined_in_config_and_host_option()
+    {
+        config(['hyde.server.host' => 'foo']);
+
+        $this->artisan('serve --host=bar')
+            ->expectsOutput('Starting the HydeRC server... Press Ctrl+C to stop')
+            ->assertExitCode(0);
+
+        Process::assertRan("php -S bar:8080 {$this->binaryPath()}");
+    }
+
+    public function test_hyde_serve_command_with_host_missing_in_config_and_host_option()
+    {
+        config(['hyde.server.host' => null]);
+
+        $this->artisan('serve --host=foo')
+            ->expectsOutput('Starting the HydeRC server... Press Ctrl+C to stop')
+            ->assertExitCode(0);
+
+        Process::assertRan("php -S foo:8080 {$this->binaryPath()}");
+    }
+
     public function test_hyde_serve_command_with_invalid_config_value()
     {
         config(['hyde.server.port' => 'foo']);


### PR DESCRIPTION
Since we have arguments for both the port and the host, it's weird we only have config options for the port. Well, now we have both.