### PR TITLE
Fix breadcrumbs component markup

### DIFF
--- a/packages/framework/resources/views/components/breadcrumbs.blade.php
+++ b/packages/framework/resources/views/components/breadcrumbs.blade.php
@@ -11,7 +11,7 @@
                 </li>
 
                 @if (! $loop->last)
-                    <li role="presentation">
+                    <li>
                         <span class="px-1" aria-hidden="true">&gt;</span>
                     </li>
                 @endif

--- a/packages/framework/resources/views/components/breadcrumbs.blade.php
+++ b/packages/framework/resources/views/components/breadcrumbs.blade.php
@@ -11,7 +11,7 @@
                 </li>
 
                 @if (! $loop->last)
-                    <li>
+                    <li role="presentation">
                         <span class="px-1" aria-hidden="true">&gt;</span>
                     </li>
                 @endif

--- a/packages/framework/resources/views/components/breadcrumbs.blade.php
+++ b/packages/framework/resources/views/components/breadcrumbs.blade.php
@@ -5,16 +5,11 @@
                 <li>
                     @if (! $loop->last)
                         <a href="{{ $path }}" class="hover:underline">{{ $title }}</a>
+                        <span class="px-1" aria-hidden="true">&gt;</span>
                     @else
                         <a href="{{ $path }}" aria-current="page">{{ $title }}</a>
                     @endif
                 </li>
-
-                @if (! $loop->last)
-                    <li>
-                        <span class="px-1" aria-hidden="true">&gt;</span>
-                    </li>
-                @endif
             @endforeach
         </ol>
     </nav>

--- a/packages/framework/resources/views/components/breadcrumbs.blade.php
+++ b/packages/framework/resources/views/components/breadcrumbs.blade.php
@@ -11,7 +11,9 @@
                 </li>
 
                 @if (! $loop->last)
-                    <span class="px-1" aria-hidden="true">&gt;</span>
+                    <li>
+                        <span class="px-1" aria-hidden="true">&gt;</span>
+                    </li>
                 @endif
             @endforeach
         </ol>

--- a/packages/framework/tests/Unit/BreadcrumbsComponentViewTest.php
+++ b/packages/framework/tests/Unit/BreadcrumbsComponentViewTest.php
@@ -28,8 +28,6 @@ class BreadcrumbsComponentViewTest extends TestCase
                 <ol class="flex">
                     <li>
                         <a href="index.html" class="hover:underline">Home</a>
-                    </li>
-                    <li>
                         <span class="px-1" aria-hidden="true">&gt;</span>
                     </li>
                     <li>
@@ -56,14 +54,10 @@ class BreadcrumbsComponentViewTest extends TestCase
                 <ol class="flex">
                     <li>
                         <a href="../index.html" class="hover:underline">Home</a>
-                    </li>
-                    <li>
                         <span class="px-1" aria-hidden="true">&gt;</span>
                     </li>
                     <li>
                         <a href="../foo/index.html" class="hover:underline">Foo</a>
-                    </li>
-                    <li>
                         <span class="px-1" aria-hidden="true">&gt;</span>
                     </li>
                     <li>
@@ -83,20 +77,14 @@ class BreadcrumbsComponentViewTest extends TestCase
                 <ol class="flex">
                     <li>
                         <a href="../../index.html" class="hover:underline">Home</a>
-                    </li>
-                    <li>
                         <span class="px-1" aria-hidden="true">&gt;</span>
                     </li>
                     <li>
                         <a href="../../foo/index.html" class="hover:underline">Foo</a>
-                    </li>
-                    <li>
                         <span class="px-1" aria-hidden="true">&gt;</span>
                     </li>
                     <li>
                         <a href="../../foo/bar/index.html" class="hover:underline">Bar</a>
-                    </li>
-                    <li>
                         <span class="px-1" aria-hidden="true">&gt;</span>
                     </li>
                     <li>
@@ -116,8 +104,6 @@ class BreadcrumbsComponentViewTest extends TestCase
                 <ol class="flex">
                     <li>
                         <a href="../index.html" class="hover:underline">Home</a>
-                    </li>
-                    <li>
                         <span class="px-1" aria-hidden="true">&gt;</span>
                     </li>
                     <li>
@@ -139,8 +125,6 @@ class BreadcrumbsComponentViewTest extends TestCase
                 <ol class="flex">
                     <li>
                         <a href="index.html" class="hover:underline">Home</a>
-                    </li>
-                    <li>
                         <span class="px-1" aria-hidden="true">&gt;</span>
                     </li>
                     <li>

--- a/packages/framework/tests/Unit/BreadcrumbsComponentViewTest.php
+++ b/packages/framework/tests/Unit/BreadcrumbsComponentViewTest.php
@@ -29,7 +29,7 @@ class BreadcrumbsComponentViewTest extends TestCase
                     <li>
                         <a href="index.html" class="hover:underline">Home</a>
                     </li>
-                    <li role="presentation">
+                    <li>
                         <span class="px-1" aria-hidden="true">&gt;</span>
                     </li>
                     <li>
@@ -57,13 +57,13 @@ class BreadcrumbsComponentViewTest extends TestCase
                     <li>
                         <a href="../index.html" class="hover:underline">Home</a>
                     </li>
-                    <li role="presentation">
+                    <li>
                         <span class="px-1" aria-hidden="true">&gt;</span>
                     </li>
                     <li>
                         <a href="../foo/index.html" class="hover:underline">Foo</a>
                     </li>
-                    <li role="presentation">
+                    <li>
                         <span class="px-1" aria-hidden="true">&gt;</span>
                     </li>
                     <li>
@@ -84,19 +84,19 @@ class BreadcrumbsComponentViewTest extends TestCase
                     <li>
                         <a href="../../index.html" class="hover:underline">Home</a>
                     </li>
-                    <li role="presentation">
+                    <li>
                         <span class="px-1" aria-hidden="true">&gt;</span>
                     </li>
                     <li>
                         <a href="../../foo/index.html" class="hover:underline">Foo</a>
                     </li>
-                    <li role="presentation">
+                    <li>
                         <span class="px-1" aria-hidden="true">&gt;</span>
                     </li>
                     <li>
                         <a href="../../foo/bar/index.html" class="hover:underline">Bar</a>
                     </li>
-                    <li role="presentation">
+                    <li>
                         <span class="px-1" aria-hidden="true">&gt;</span>
                     </li>
                     <li>
@@ -117,7 +117,7 @@ class BreadcrumbsComponentViewTest extends TestCase
                     <li>
                         <a href="../index.html" class="hover:underline">Home</a>
                     </li>
-                    <li role="presentation">
+                    <li>
                         <span class="px-1" aria-hidden="true">&gt;</span>
                     </li>
                     <li>
@@ -140,7 +140,7 @@ class BreadcrumbsComponentViewTest extends TestCase
                     <li>
                         <a href="index.html" class="hover:underline">Home</a>
                     </li>
-                    <li role="presentation">
+                    <li>
                         <span class="px-1" aria-hidden="true">&gt;</span>
                     </li>
                     <li>

--- a/packages/framework/tests/Unit/BreadcrumbsComponentViewTest.php
+++ b/packages/framework/tests/Unit/BreadcrumbsComponentViewTest.php
@@ -29,7 +29,9 @@ class BreadcrumbsComponentViewTest extends TestCase
                     <li>
                         <a href="index.html" class="hover:underline">Home</a>
                     </li>
-                    <span class="px-1" aria-hidden="true">&gt;</span>
+                    <li>
+                        <span class="px-1" aria-hidden="true">&gt;</span>
+                    </li>
                     <li>
                         <a href="foo.html" aria-current="page">Foo</a>
                     </li>
@@ -55,11 +57,15 @@ class BreadcrumbsComponentViewTest extends TestCase
                     <li>
                         <a href="../index.html" class="hover:underline">Home</a>
                     </li>
-                    <span class="px-1" aria-hidden="true">&gt;</span>
+                    <li>
+                        <span class="px-1" aria-hidden="true">&gt;</span>
+                    </li>
                     <li>
                         <a href="../foo/index.html" class="hover:underline">Foo</a>
                     </li>
-                    <span class="px-1" aria-hidden="true">&gt;</span>
+                    <li>
+                        <span class="px-1" aria-hidden="true">&gt;</span>
+                    </li>
                     <li>
                         <a href="../foo/bar.html" aria-current="page">Bar</a>
                     </li>
@@ -78,15 +84,21 @@ class BreadcrumbsComponentViewTest extends TestCase
                     <li>
                         <a href="../../index.html" class="hover:underline">Home</a>
                     </li>
-                    <span class="px-1" aria-hidden="true">&gt;</span>
+                    <li>
+                        <span class="px-1" aria-hidden="true">&gt;</span>
+                    </li>
                     <li>
                         <a href="../../foo/index.html" class="hover:underline">Foo</a>
                     </li>
-                    <span class="px-1" aria-hidden="true">&gt;</span>
+                    <li>
+                        <span class="px-1" aria-hidden="true">&gt;</span>
+                    </li>
                     <li>
                         <a href="../../foo/bar/index.html" class="hover:underline">Bar</a>
                     </li>
-                    <span class="px-1" aria-hidden="true">&gt;</span>
+                    <li>
+                        <span class="px-1" aria-hidden="true">&gt;</span>
+                    </li>
                     <li>
                         <a href="../../foo/bar/baz.html" aria-current="page">Baz</a>
                     </li>
@@ -105,7 +117,9 @@ class BreadcrumbsComponentViewTest extends TestCase
                     <li>
                         <a href="../index.html" class="hover:underline">Home</a>
                     </li>
-                    <span class="px-1" aria-hidden="true">&gt;</span>
+                    <li>
+                        <span class="px-1" aria-hidden="true">&gt;</span>
+                    </li>
                     <li>
                         <a href="../foo/index.html" aria-current="page">Foo</a>
                     </li>
@@ -126,7 +140,9 @@ class BreadcrumbsComponentViewTest extends TestCase
                     <li>
                         <a href="index.html" class="hover:underline">Home</a>
                     </li>
-                    <span class="px-1" aria-hidden="true">&gt;</span>
+                    <li>
+                        <span class="px-1" aria-hidden="true">&gt;</span>
+                    </li>
                     <li>
                         <a href=".html" aria-current="page"></a>
                     </li>

--- a/packages/framework/tests/Unit/BreadcrumbsComponentViewTest.php
+++ b/packages/framework/tests/Unit/BreadcrumbsComponentViewTest.php
@@ -29,7 +29,7 @@ class BreadcrumbsComponentViewTest extends TestCase
                     <li>
                         <a href="index.html" class="hover:underline">Home</a>
                     </li>
-                    <li>
+                    <li role="presentation">
                         <span class="px-1" aria-hidden="true">&gt;</span>
                     </li>
                     <li>
@@ -57,13 +57,13 @@ class BreadcrumbsComponentViewTest extends TestCase
                     <li>
                         <a href="../index.html" class="hover:underline">Home</a>
                     </li>
-                    <li>
+                    <li role="presentation">
                         <span class="px-1" aria-hidden="true">&gt;</span>
                     </li>
                     <li>
                         <a href="../foo/index.html" class="hover:underline">Foo</a>
                     </li>
-                    <li>
+                    <li role="presentation">
                         <span class="px-1" aria-hidden="true">&gt;</span>
                     </li>
                     <li>
@@ -84,19 +84,19 @@ class BreadcrumbsComponentViewTest extends TestCase
                     <li>
                         <a href="../../index.html" class="hover:underline">Home</a>
                     </li>
-                    <li>
+                    <li role="presentation">
                         <span class="px-1" aria-hidden="true">&gt;</span>
                     </li>
                     <li>
                         <a href="../../foo/index.html" class="hover:underline">Foo</a>
                     </li>
-                    <li>
+                    <li role="presentation">
                         <span class="px-1" aria-hidden="true">&gt;</span>
                     </li>
                     <li>
                         <a href="../../foo/bar/index.html" class="hover:underline">Bar</a>
                     </li>
-                    <li>
+                    <li role="presentation">
                         <span class="px-1" aria-hidden="true">&gt;</span>
                     </li>
                     <li>
@@ -117,7 +117,7 @@ class BreadcrumbsComponentViewTest extends TestCase
                     <li>
                         <a href="../index.html" class="hover:underline">Home</a>
                     </li>
-                    <li>
+                    <li role="presentation">
                         <span class="px-1" aria-hidden="true">&gt;</span>
                     </li>
                     <li>
@@ -140,7 +140,7 @@ class BreadcrumbsComponentViewTest extends TestCase
                     <li>
                         <a href="index.html" class="hover:underline">Home</a>
                     </li>
-                    <li>
+                    <li role="presentation">
                         <span class="px-1" aria-hidden="true">&gt;</span>
                     </li>
                     <li>


### PR DESCRIPTION
Merges the span divider element into the list item. Now validates under https://validator.w3.org/nu/#textarea