### PR TITLE
Inline and simplify publication parsing method

### DIFF
--- a/packages/publications/src/PublicationService.php
+++ b/packages/publications/src/PublicationService.php
@@ -73,7 +73,7 @@ class PublicationService
     /**
      * Parse a publication Markdown source file and return a PublicationPage object.
      *
-     * @param  string  $identifier  Example: my-publication/hello.md or my-publication/hello
+     * @param  string  $identifier  Example: my-publication/hello
      *
      * @deprecated Will be merged into called method
      */

--- a/packages/publications/src/PublicationService.php
+++ b/packages/publications/src/PublicationService.php
@@ -71,18 +71,6 @@ class PublicationService
     }
 
     /**
-     * Parse a publication Markdown source file and return a PublicationPage object.
-     *
-     * @param  string  $identifier  Example: my-publication/hello
-     *
-     * @deprecated Will be merged into called method
-     */
-    public static function parsePublicationFile(string $identifier): PublicationPage
-    {
-        return PublicationPage::parse($identifier);
-    }
-
-    /**
      * Check whether a given publication type exists.
      */
     public static function publicationTypeExists(string $publicationTypeName): bool

--- a/packages/publications/src/PublicationService.php
+++ b/packages/publications/src/PublicationService.php
@@ -79,7 +79,7 @@ class PublicationService
      */
     public static function parsePublicationFile(string $identifier): PublicationPage
     {
-        return PublicationPage::parse(Str::replaceLast('.md', '', $identifier));
+        return PublicationPage::parse($identifier);
     }
 
     /**

--- a/packages/publications/src/PublicationsExtension.php
+++ b/packages/publications/src/PublicationsExtension.php
@@ -131,7 +131,7 @@ class PublicationsExtension extends HydeExtension
     protected static function findPublicationsForType(PublicationType $publicationType): Collection
     {
         return Collection::make(static::getPublicationFiles($publicationType->getDirectory()))->map(function (string $file): PublicationPage {
-            return PublicationService::parsePublicationFile(Str::before(Hyde::pathToRelative($file), PublicationPage::fileExtension()));
+            return PublicationPage::parse(Str::before(Hyde::pathToRelative($file), PublicationPage::fileExtension()));
         });
     }
 

--- a/packages/publications/src/PublicationsExtension.php
+++ b/packages/publications/src/PublicationsExtension.php
@@ -15,6 +15,7 @@ use Hyde\Publications\Models\PublicationListPage;
 use Hyde\Publications\Models\PublicationPage;
 use Hyde\Publications\Models\PublicationType;
 use Illuminate\Support\Collection;
+use Illuminate\Support\Str;
 use function range;
 use function str_ends_with;
 
@@ -130,7 +131,7 @@ class PublicationsExtension extends HydeExtension
     protected static function findPublicationsForType(PublicationType $publicationType): Collection
     {
         return Collection::make(static::getPublicationFiles($publicationType->getDirectory()))->map(function (string $file): PublicationPage {
-            return PublicationService::parsePublicationFile(Hyde::pathToRelative($file));
+            return PublicationService::parsePublicationFile(Str::before(Hyde::pathToRelative($file), PublicationPage::fileExtension()));
         });
     }
 

--- a/packages/publications/tests/Feature/PublicationServiceTest.php
+++ b/packages/publications/tests/Feature/PublicationServiceTest.php
@@ -74,7 +74,7 @@ class PublicationServiceTest extends TestCase
 
         $this->assertEquals(
             new Collection([
-                PublicationService::parsePublicationFile('test-publication/foo.md'),
+                PublicationService::parsePublicationFile('test-publication/foo'),
             ]),
             PublicationService::getPublicationsForType(PublicationType::get('test-publication'))
         );
@@ -101,9 +101,9 @@ class PublicationServiceTest extends TestCase
 
         $this->assertEquals(
             new Collection([
-                PublicationService::parsePublicationFile('test-publication/one.md'),
-                PublicationService::parsePublicationFile('test-publication/two.md'),
-                PublicationService::parsePublicationFile('test-publication/three.md'),
+                PublicationService::parsePublicationFile('test-publication/one'),
+                PublicationService::parsePublicationFile('test-publication/two'),
+                PublicationService::parsePublicationFile('test-publication/three'),
             ]),
             PublicationService::getPublicationsForType(PublicationType::get('test-publication'))
         );
@@ -119,9 +119,9 @@ class PublicationServiceTest extends TestCase
 
         $this->assertEquals(
             new Collection([
-                PublicationService::parsePublicationFile('test-publication/three.md'),
-                PublicationService::parsePublicationFile('test-publication/two.md'),
-                PublicationService::parsePublicationFile('test-publication/one.md'),
+                PublicationService::parsePublicationFile('test-publication/three'),
+                PublicationService::parsePublicationFile('test-publication/two'),
+                PublicationService::parsePublicationFile('test-publication/one'),
             ]),
             PublicationService::getPublicationsForType(PublicationType::get('test-publication'))
         );
@@ -137,9 +137,9 @@ class PublicationServiceTest extends TestCase
 
         $this->assertEquals(
             new Collection([
-                PublicationService::parsePublicationFile('test-publication/one.md'),
-                PublicationService::parsePublicationFile('test-publication/two.md'),
-                PublicationService::parsePublicationFile('test-publication/three.md'),
+                PublicationService::parsePublicationFile('test-publication/one'),
+                PublicationService::parsePublicationFile('test-publication/two'),
+                PublicationService::parsePublicationFile('test-publication/three'),
             ]),
             PublicationService::getPublicationsForType(PublicationType::get('test-publication'), 'readCount')
         );
@@ -155,9 +155,9 @@ class PublicationServiceTest extends TestCase
 
         $this->assertEquals(
             new Collection([
-                PublicationService::parsePublicationFile('test-publication/three.md'),
-                PublicationService::parsePublicationFile('test-publication/two.md'),
-                PublicationService::parsePublicationFile('test-publication/one.md'),
+                PublicationService::parsePublicationFile('test-publication/three'),
+                PublicationService::parsePublicationFile('test-publication/two'),
+                PublicationService::parsePublicationFile('test-publication/one'),
             ]),
             PublicationService::getPublicationsForType(PublicationType::get('test-publication'), 'readCount', false)
         );
@@ -173,9 +173,9 @@ class PublicationServiceTest extends TestCase
 
         $this->assertEquals(
             new Collection([
-                PublicationService::parsePublicationFile('test-publication/one.md'),
-                PublicationService::parsePublicationFile('test-publication/three.md'),
-                PublicationService::parsePublicationFile('test-publication/two.md'),
+                PublicationService::parsePublicationFile('test-publication/one'),
+                PublicationService::parsePublicationFile('test-publication/three'),
+                PublicationService::parsePublicationFile('test-publication/two'),
             ]),
             PublicationService::getPublicationsForType(PublicationType::get('test-publication'), 'invalid')
         );
@@ -232,17 +232,6 @@ class PublicationServiceTest extends TestCase
         $file = PublicationService::parsePublicationFile('test-publication/foo');
         $this->assertInstanceOf(PublicationPage::class, $file);
         $this->assertEquals('test-publication/foo', $file->getIdentifier());
-    }
-
-    public function testParsePublicationFileWithFileExtension()
-    {
-        $this->createPublicationType();
-        $this->createPublication();
-
-        $this->assertEquals(
-            PublicationService::parsePublicationFile('test-publication/foo'),
-            PublicationService::parsePublicationFile('test-publication/foo.md')
-        );
     }
 
     public function testParsePublicationFileWithNonExistentFile()

--- a/packages/publications/tests/Feature/PublicationServiceTest.php
+++ b/packages/publications/tests/Feature/PublicationServiceTest.php
@@ -74,7 +74,7 @@ class PublicationServiceTest extends TestCase
 
         $this->assertEquals(
             new Collection([
-                PublicationService::parsePublicationFile('test-publication/foo'),
+                PublicationPage::parse('test-publication/foo'),
             ]),
             PublicationService::getPublicationsForType(PublicationType::get('test-publication'))
         );
@@ -101,9 +101,9 @@ class PublicationServiceTest extends TestCase
 
         $this->assertEquals(
             new Collection([
-                PublicationService::parsePublicationFile('test-publication/one'),
-                PublicationService::parsePublicationFile('test-publication/two'),
-                PublicationService::parsePublicationFile('test-publication/three'),
+                PublicationPage::parse('test-publication/one'),
+                PublicationPage::parse('test-publication/two'),
+                PublicationPage::parse('test-publication/three'),
             ]),
             PublicationService::getPublicationsForType(PublicationType::get('test-publication'))
         );
@@ -119,9 +119,9 @@ class PublicationServiceTest extends TestCase
 
         $this->assertEquals(
             new Collection([
-                PublicationService::parsePublicationFile('test-publication/three'),
-                PublicationService::parsePublicationFile('test-publication/two'),
-                PublicationService::parsePublicationFile('test-publication/one'),
+                PublicationPage::parse('test-publication/three'),
+                PublicationPage::parse('test-publication/two'),
+                PublicationPage::parse('test-publication/one'),
             ]),
             PublicationService::getPublicationsForType(PublicationType::get('test-publication'))
         );
@@ -137,9 +137,9 @@ class PublicationServiceTest extends TestCase
 
         $this->assertEquals(
             new Collection([
-                PublicationService::parsePublicationFile('test-publication/one'),
-                PublicationService::parsePublicationFile('test-publication/two'),
-                PublicationService::parsePublicationFile('test-publication/three'),
+                PublicationPage::parse('test-publication/one'),
+                PublicationPage::parse('test-publication/two'),
+                PublicationPage::parse('test-publication/three'),
             ]),
             PublicationService::getPublicationsForType(PublicationType::get('test-publication'), 'readCount')
         );
@@ -155,9 +155,9 @@ class PublicationServiceTest extends TestCase
 
         $this->assertEquals(
             new Collection([
-                PublicationService::parsePublicationFile('test-publication/three'),
-                PublicationService::parsePublicationFile('test-publication/two'),
-                PublicationService::parsePublicationFile('test-publication/one'),
+                PublicationPage::parse('test-publication/three'),
+                PublicationPage::parse('test-publication/two'),
+                PublicationPage::parse('test-publication/one'),
             ]),
             PublicationService::getPublicationsForType(PublicationType::get('test-publication'), 'readCount', false)
         );
@@ -173,9 +173,9 @@ class PublicationServiceTest extends TestCase
 
         $this->assertEquals(
             new Collection([
-                PublicationService::parsePublicationFile('test-publication/one'),
-                PublicationService::parsePublicationFile('test-publication/three'),
-                PublicationService::parsePublicationFile('test-publication/two'),
+                PublicationPage::parse('test-publication/one'),
+                PublicationPage::parse('test-publication/three'),
+                PublicationPage::parse('test-publication/two'),
             ]),
             PublicationService::getPublicationsForType(PublicationType::get('test-publication'), 'invalid')
         );
@@ -229,7 +229,7 @@ class PublicationServiceTest extends TestCase
         $this->createPublicationType();
         $this->createPublication();
 
-        $file = PublicationService::parsePublicationFile('test-publication/foo');
+        $file = PublicationPage::parse('test-publication/foo');
         $this->assertInstanceOf(PublicationPage::class, $file);
         $this->assertEquals('test-publication/foo', $file->getIdentifier());
     }
@@ -241,7 +241,7 @@ class PublicationServiceTest extends TestCase
         $this->expectException(FileNotFoundException::class);
         $this->expectExceptionMessage('File [test-publication/foo.md] not found.');
 
-        PublicationService::parsePublicationFile('test-publication/foo');
+        PublicationPage::parse('test-publication/foo');
     }
 
     public function testPublicationTypeExists()


### PR DESCRIPTION
## Changes Made

Removes the deprecated `PublicationService::parsePublicationFile` method, so you would call `PublicationPage::parse($identifier)` instead. 

## Potential Impact

May break things on the `publications-feature` branch.

## Reasoning

This is breaking because the called method does not accept identifiers ending with file extensions. This is intentionally not "fixed" as identifiers by definition cannot have file extensions, and this inconsistent leniency is unexpected since the core extension classes and the framework itself does not do this.

## Upgrade

```php
- PublicationService::parsePublicationFile('test-publication/foo.md')
- PublicationService::parsePublicationFile('test-publication/foo')
+ PublicationPage::parse('test-publication/foo')
```