### PR TITLE
Set the serve command process to run forever

### DIFF
--- a/packages/framework/src/Console/Commands/ServeCommand.php
+++ b/packages/framework/src/Console/Commands/ServeCommand.php
@@ -54,7 +54,7 @@ class ServeCommand extends Command
     /** @codeCoverageIgnore Until output is testable */
     protected function runServerProcess(string $command): void
     {
-        Process::run($command, function (string $type, string $line): void {
+        Process::forever()->run($command, function (string $type, string $line): void {
             $this->output->write($line);
         });
     }


### PR DESCRIPTION
Fixes critical bug in https://github.com/hydephp/develop/pull/1132 where the command times out after 60 seconds, which is of course not desired at all.