### PR TITLE
Refactor the Extensions API to use Kernel Singletons instead of static classes

### DIFF
--- a/packages/framework/src/Foundation/Concerns/HydeExtension.php
+++ b/packages/framework/src/Foundation/Concerns/HydeExtension.php
@@ -50,7 +50,7 @@ abstract class HydeExtension
      * at the end of the file discovery process. The collection instance
      * will be injected, so that you can interact with it directly.
      */
-    public static function discoverFiles(FileCollection $collection): void
+    public function discoverFiles(FileCollection $collection): void
     {
         //
     }
@@ -61,7 +61,7 @@ abstract class HydeExtension
      * at the end of the page discovery process. The collection instance
      * will be injected, so that you can interact with it directly.
      */
-    public static function discoverPages(PageCollection $collection): void
+    public function discoverPages(PageCollection $collection): void
     {
         //
     }
@@ -72,7 +72,7 @@ abstract class HydeExtension
      * at the end of the route discovery process. The collection instance
      * will be injected, so that you can interact with it directly.
      */
-    public static function discoverRoutes(RouteCollection $collection): void
+    public function discoverRoutes(RouteCollection $collection): void
     {
         //
     }

--- a/packages/framework/src/Foundation/Concerns/ManagesExtensions.php
+++ b/packages/framework/src/Foundation/Concerns/ManagesExtensions.php
@@ -47,7 +47,7 @@ trait ManagesExtensions
 
         if (! in_array($extension, $this->extensions, true)) {
             $this->extensions[$extension] = new $extension();
-        }
+        } // Else throw?
     }
 
     /**

--- a/packages/framework/src/Foundation/Concerns/ManagesExtensions.php
+++ b/packages/framework/src/Foundation/Concerns/ManagesExtensions.php
@@ -50,6 +50,16 @@ trait ManagesExtensions
         }
     }
 
+    /**
+     * Get the singleton instance of the specified extension.
+     *
+     * @param  class-string<\Hyde\Foundation\Concerns\HydeExtension>  $extension
+     */
+    public function getExtension(string $extension): HydeExtension
+    {
+        return $this->extensions[$extension];
+    }
+
     /** @return array<class-string<\Hyde\Foundation\Concerns\HydeExtension>> */
     public function getRegisteredExtensions(): array
     {

--- a/packages/framework/src/Foundation/Concerns/ManagesExtensions.php
+++ b/packages/framework/src/Foundation/Concerns/ManagesExtensions.php
@@ -6,6 +6,7 @@ namespace Hyde\Foundation\Concerns;
 
 use BadMethodCallException;
 use InvalidArgumentException;
+use function array_keys;
 use function array_map;
 use function array_merge;
 use function array_unique;
@@ -69,7 +70,7 @@ trait ManagesExtensions
     /** @return array<class-string<\Hyde\Foundation\Concerns\HydeExtension>> */
     public function getRegisteredExtensions(): array
     {
-        return $this->extensions;
+        return array_keys($this->extensions);
     }
 
     /** @return array<class-string<\Hyde\Pages\Concerns\HydePage>> */

--- a/packages/framework/src/Foundation/Concerns/ManagesExtensions.php
+++ b/packages/framework/src/Foundation/Concerns/ManagesExtensions.php
@@ -58,7 +58,7 @@ trait ManagesExtensions
     public function getExtension(string $extension): HydeExtension
     {
         if (! isset($this->extensions[$extension])) {
-            throw new InvalidArgumentException("The specified extension [{$extension}] is not registered.");
+            throw new InvalidArgumentException("The specified extension [$extension] is not registered.");
         }
 
         return $this->extensions[$extension];

--- a/packages/framework/src/Foundation/Concerns/ManagesExtensions.php
+++ b/packages/framework/src/Foundation/Concerns/ManagesExtensions.php
@@ -48,6 +48,8 @@ trait ManagesExtensions
 
         if (! in_array($extension, $this->getRegisteredExtensions(), true)) {
             $this->extensions[$extension] = new $extension();
+        } else {
+            throw new InvalidArgumentException("Extension [$extension] is already registered.");
         }
     }
 

--- a/packages/framework/src/Foundation/Concerns/ManagesExtensions.php
+++ b/packages/framework/src/Foundation/Concerns/ManagesExtensions.php
@@ -46,7 +46,7 @@ trait ManagesExtensions
         }
 
         if (! in_array($extension, $this->extensions, true)) {
-            $this->extensions[] = $extension;
+            $this->extensions[] = new $extension();
         }
     }
 

--- a/packages/framework/src/Foundation/Concerns/ManagesExtensions.php
+++ b/packages/framework/src/Foundation/Concerns/ManagesExtensions.php
@@ -64,6 +64,8 @@ trait ManagesExtensions
         return $this->extensions[$extension];
     }
 
+    // Todo: Add is loaded method?
+
     /** @return array<class-string<\Hyde\Foundation\Concerns\HydeExtension>> */
     public function getRegisteredExtensions(): array
     {

--- a/packages/framework/src/Foundation/Concerns/ManagesExtensions.php
+++ b/packages/framework/src/Foundation/Concerns/ManagesExtensions.php
@@ -10,6 +10,7 @@ use function array_keys;
 use function array_map;
 use function array_merge;
 use function array_unique;
+use function array_values;
 use function in_array;
 use function is_subclass_of;
 
@@ -66,6 +67,12 @@ trait ManagesExtensions
     }
 
     // Todo: Add is loaded method?
+
+    /** @return array<\Hyde\Foundation\Concerns\HydeExtension> */
+    public function getExtensions(): array
+    {
+        return array_values($this->extensions);
+    }
 
     /** @return array<class-string<\Hyde\Foundation\Concerns\HydeExtension>> */
     public function getRegisteredExtensions(): array

--- a/packages/framework/src/Foundation/Concerns/ManagesExtensions.php
+++ b/packages/framework/src/Foundation/Concerns/ManagesExtensions.php
@@ -65,7 +65,15 @@ trait ManagesExtensions
         return $this->extensions[$extension];
     }
 
-    // Todo: Add is loaded method?
+    /**
+     * Determine if the specified extension is registered.
+     * 
+     * @param  class-string<\Hyde\Foundation\Concerns\HydeExtension>  $extension
+     */
+    public function hasExtension(string $extension): bool
+    {
+        return isset($this->extensions[$extension]);
+    }
 
     /** @return array<\Hyde\Foundation\Concerns\HydeExtension> */
     public function getExtensions(): array

--- a/packages/framework/src/Foundation/Concerns/ManagesExtensions.php
+++ b/packages/framework/src/Foundation/Concerns/ManagesExtensions.php
@@ -57,6 +57,10 @@ trait ManagesExtensions
      */
     public function getExtension(string $extension): HydeExtension
     {
+        if (! isset($this->extensions[$extension])) {
+            throw new InvalidArgumentException("The specified extension [{$extension}] is not registered.");
+        }
+
         return $this->extensions[$extension];
     }
 

--- a/packages/framework/src/Foundation/Concerns/ManagesExtensions.php
+++ b/packages/framework/src/Foundation/Concerns/ManagesExtensions.php
@@ -48,7 +48,7 @@ trait ManagesExtensions
 
         if (! in_array($extension, $this->extensions, true)) {
             $this->extensions[$extension] = new $extension();
-        } // Todo: Else throw?
+        }
     }
 
     /**
@@ -67,7 +67,7 @@ trait ManagesExtensions
 
     /**
      * Determine if the specified extension is registered.
-     * 
+     *
      * @param  class-string<\Hyde\Foundation\Concerns\HydeExtension>  $extension
      */
     public function hasExtension(string $extension): bool

--- a/packages/framework/src/Foundation/Concerns/ManagesExtensions.php
+++ b/packages/framework/src/Foundation/Concerns/ManagesExtensions.php
@@ -46,7 +46,7 @@ trait ManagesExtensions
         }
 
         if (! in_array($extension, $this->extensions, true)) {
-            $this->extensions[] = new $extension();
+            $this->extensions[$extension] = new $extension();
         }
     }
 

--- a/packages/framework/src/Foundation/Concerns/ManagesExtensions.php
+++ b/packages/framework/src/Foundation/Concerns/ManagesExtensions.php
@@ -46,10 +46,10 @@ trait ManagesExtensions
             throw new InvalidArgumentException('The specified class must extend the HydeExtension class.');
         }
 
-        if (! in_array($extension, $this->getRegisteredExtensions(), true)) {
-            $this->extensions[$extension] = new $extension();
-        } else {
+        if (in_array($extension, $this->getRegisteredExtensions(), true)) {
             throw new InvalidArgumentException("Extension [$extension] is already registered.");
+        } else {
+            $this->extensions[$extension] = new $extension();
         }
     }
 

--- a/packages/framework/src/Foundation/Concerns/ManagesExtensions.php
+++ b/packages/framework/src/Foundation/Concerns/ManagesExtensions.php
@@ -48,9 +48,9 @@ trait ManagesExtensions
 
         if (in_array($extension, $this->getRegisteredExtensions(), true)) {
             throw new InvalidArgumentException("Extension [$extension] is already registered.");
-        } else {
-            $this->extensions[$extension] = new $extension();
         }
+
+        $this->extensions[$extension] = new $extension();
     }
 
     /**

--- a/packages/framework/src/Foundation/Concerns/ManagesExtensions.php
+++ b/packages/framework/src/Foundation/Concerns/ManagesExtensions.php
@@ -46,7 +46,7 @@ trait ManagesExtensions
             throw new InvalidArgumentException('The specified class must extend the HydeExtension class.');
         }
 
-        if (! in_array($extension, $this->extensions, true)) {
+        if (! in_array($extension, $this->getRegisteredExtensions(), true)) {
             $this->extensions[$extension] = new $extension();
         }
     }

--- a/packages/framework/src/Foundation/Concerns/ManagesExtensions.php
+++ b/packages/framework/src/Foundation/Concerns/ManagesExtensions.php
@@ -10,7 +10,6 @@ use function array_keys;
 use function array_map;
 use function array_merge;
 use function array_unique;
-use function array_values;
 use function in_array;
 use function is_subclass_of;
 
@@ -71,7 +70,7 @@ trait ManagesExtensions
     /** @return array<\Hyde\Foundation\Concerns\HydeExtension> */
     public function getExtensions(): array
     {
-        return array_values($this->extensions);
+        return $this->extensions;
     }
 
     /** @return array<class-string<\Hyde\Foundation\Concerns\HydeExtension>> */

--- a/packages/framework/src/Foundation/Concerns/ManagesExtensions.php
+++ b/packages/framework/src/Foundation/Concerns/ManagesExtensions.php
@@ -47,7 +47,7 @@ trait ManagesExtensions
 
         if (! in_array($extension, $this->extensions, true)) {
             $this->extensions[$extension] = new $extension();
-        } // Else throw?
+        } // Todo: Else throw?
     }
 
     /**

--- a/packages/framework/src/Foundation/Concerns/ManagesExtensions.php
+++ b/packages/framework/src/Foundation/Concerns/ManagesExtensions.php
@@ -47,6 +47,9 @@ trait ManagesExtensions
         }
 
         if (in_array($extension, $this->getRegisteredExtensions(), true)) {
+            // While throwing an exception here is not required since we are using an associative array,
+            // it may be helpful for the developer to know that their registration logic may be flawed.
+
             throw new InvalidArgumentException("Extension [$extension] is already registered.");
         }
 

--- a/packages/framework/src/Foundation/Concerns/ManagesExtensions.php
+++ b/packages/framework/src/Foundation/Concerns/ManagesExtensions.php
@@ -59,7 +59,7 @@ trait ManagesExtensions
     public function getExtension(string $extension): HydeExtension
     {
         if (! isset($this->extensions[$extension])) {
-            throw new InvalidArgumentException("The specified extension [$extension] is not registered.");
+            throw new InvalidArgumentException("Extension [$extension] is not registered.");
         }
 
         return $this->extensions[$extension];

--- a/packages/framework/src/Foundation/HydeKernel.php
+++ b/packages/framework/src/Foundation/HydeKernel.php
@@ -102,7 +102,7 @@ class HydeKernel implements SerializableContract
             'sourceRoot' => $this->sourceRoot,
             'outputDirectory' => $this->outputDirectory,
             'mediaDirectory' => $this->mediaDirectory,
-            'extensions' => array_keys($this->extensions),
+            'extensions' => $this->getRegisteredExtensions(),
             'features' => $this->features(),
             'files' => $this->files(),
             'pages' => $this->pages(),

--- a/packages/framework/src/Foundation/HydeKernel.php
+++ b/packages/framework/src/Foundation/HydeKernel.php
@@ -102,7 +102,7 @@ class HydeKernel implements SerializableContract
             'sourceRoot' => $this->sourceRoot,
             'outputDirectory' => $this->outputDirectory,
             'mediaDirectory' => $this->mediaDirectory,
-            'extensions' => $this->extensions,
+            'extensions' => array_keys($this->extensions),
             'features' => $this->features(),
             'files' => $this->files(),
             'pages' => $this->pages(),

--- a/packages/framework/src/Foundation/HydeKernel.php
+++ b/packages/framework/src/Foundation/HydeKernel.php
@@ -68,15 +68,15 @@ class HydeKernel implements SerializableContract
     protected bool $booted = false;
 
     /** @var array<class-string<\Hyde\Foundation\Concerns\HydeExtension>> */
-    protected array $extensions = [
-        HydeCoreExtension::class,
-    ];
+    protected array $extensions = [];
 
     public function __construct(?string $basePath = null)
     {
         $this->setBasePath($basePath ?? getcwd());
         $this->filesystem = new Filesystem($this);
         $this->hyperlinks = new Hyperlinks($this);
+
+        $this->registerExtension(HydeCoreExtension::class);
     }
 
     public static function version(): string

--- a/packages/framework/src/Foundation/HydeKernel.php
+++ b/packages/framework/src/Foundation/HydeKernel.php
@@ -67,7 +67,7 @@ class HydeKernel implements SerializableContract
 
     protected bool $booted = false;
 
-    /** @var array<\Hyde\Foundation\Concerns\HydeExtension> */
+    /** @var array<class-string<\Hyde\Foundation\Concerns\HydeExtension>, \Hyde\Foundation\Concerns\HydeExtension> */
     protected array $extensions = [];
 
     public function __construct(?string $basePath = null)

--- a/packages/framework/src/Foundation/HydeKernel.php
+++ b/packages/framework/src/Foundation/HydeKernel.php
@@ -67,7 +67,7 @@ class HydeKernel implements SerializableContract
 
     protected bool $booted = false;
 
-    /** @var array<class-string<\Hyde\Foundation\Concerns\HydeExtension>> */
+    /** @var array<\Hyde\Foundation\Concerns\HydeExtension> */
     protected array $extensions = [];
 
     public function __construct(?string $basePath = null)

--- a/packages/framework/src/Foundation/Kernel/FileCollection.php
+++ b/packages/framework/src/Foundation/Kernel/FileCollection.php
@@ -74,7 +74,7 @@ final class FileCollection extends BaseFoundationCollection
     protected function runExtensionCallbacks(): self
     {
         /** @var class-string<\Hyde\Foundation\Concerns\HydeExtension> $extension */
-        foreach ($this->kernel->getRegisteredExtensions() as $extension) {
+        foreach ($this->kernel->getExtensions() as $extension) {
             $extension::discoverFiles($this);
         }
 

--- a/packages/framework/src/Foundation/Kernel/FileCollection.php
+++ b/packages/framework/src/Foundation/Kernel/FileCollection.php
@@ -75,7 +75,7 @@ final class FileCollection extends BaseFoundationCollection
     {
         /** @var class-string<\Hyde\Foundation\Concerns\HydeExtension> $extension */
         foreach ($this->kernel->getExtensions() as $extension) {
-            $extension::discoverFiles($this);
+            $extension->discoverFiles($this);
         }
 
         return $this;

--- a/packages/framework/src/Foundation/Kernel/PageCollection.php
+++ b/packages/framework/src/Foundation/Kernel/PageCollection.php
@@ -72,7 +72,7 @@ final class PageCollection extends BaseFoundationCollection
     protected function runExtensionCallbacks(): self
     {
         /** @var class-string<\Hyde\Foundation\Concerns\HydeExtension> $extension */
-        foreach ($this->kernel->getRegisteredExtensions() as $extension) {
+        foreach ($this->kernel->getExtensions() as $extension) {
             $extension::discoverPages($this);
         }
 

--- a/packages/framework/src/Foundation/Kernel/PageCollection.php
+++ b/packages/framework/src/Foundation/Kernel/PageCollection.php
@@ -73,7 +73,7 @@ final class PageCollection extends BaseFoundationCollection
     {
         /** @var class-string<\Hyde\Foundation\Concerns\HydeExtension> $extension */
         foreach ($this->kernel->getExtensions() as $extension) {
-            $extension::discoverPages($this);
+            $extension->discoverPages($this);
         }
 
         return $this;

--- a/packages/framework/src/Foundation/Kernel/RouteCollection.php
+++ b/packages/framework/src/Foundation/Kernel/RouteCollection.php
@@ -94,7 +94,7 @@ final class RouteCollection extends BaseFoundationCollection
     protected function runExtensionCallbacks(): self
     {
         /** @var class-string<\Hyde\Foundation\Concerns\HydeExtension> $extension */
-        foreach ($this->kernel->getRegisteredExtensions() as $extension) {
+        foreach ($this->kernel->getExtensions() as $extension) {
             $extension::discoverRoutes($this);
         }
 

--- a/packages/framework/src/Foundation/Kernel/RouteCollection.php
+++ b/packages/framework/src/Foundation/Kernel/RouteCollection.php
@@ -95,7 +95,7 @@ final class RouteCollection extends BaseFoundationCollection
     {
         /** @var class-string<\Hyde\Foundation\Concerns\HydeExtension> $extension */
         foreach ($this->kernel->getExtensions() as $extension) {
-            $extension::discoverRoutes($this);
+            $extension->discoverRoutes($this);
         }
 
         return $this;

--- a/packages/framework/tests/Feature/HydeExtensionFeatureTest.php
+++ b/packages/framework/tests/Feature/HydeExtensionFeatureTest.php
@@ -55,9 +55,11 @@ class HydeExtensionFeatureTest extends TestCase
 
     public function testBaseClassDiscoveryHandlers()
     {
-        HydeExtension::discoverFiles(Hyde::files());
-        HydeExtension::discoverPages(Hyde::pages());
-        HydeExtension::discoverRoutes(Hyde::routes());
+        $extension = new InstantiableHydeExtension();
+
+        $extension->discoverFiles(Hyde::files());
+        $extension->discoverPages(Hyde::pages());
+        $extension->discoverRoutes(Hyde::routes());
 
         $this->markTestSuccessful();
     }

--- a/packages/framework/tests/Feature/HydeExtensionFeatureTest.php
+++ b/packages/framework/tests/Feature/HydeExtensionFeatureTest.php
@@ -57,6 +57,30 @@ class HydeExtensionFeatureTest extends TestCase
         HydeTestExtension::$callCache = [];
     }
 
+    public function testFileHandlerDependencyInjection()
+    {
+        $this->kernel->registerExtension(InspectableTestExtension::class);
+        $this->kernel->boot();
+
+        $this->assertInstanceOf(FileCollection::class, ...InspectableTestExtension::getCalled('files'));
+    }
+
+    public function testPageHandlerDependencyInjection()
+    {
+        $this->kernel->registerExtension(InspectableTestExtension::class);
+        $this->kernel->boot();
+
+        $this->assertInstanceOf(PageCollection::class, ...InspectableTestExtension::getCalled('pages'));
+    }
+
+    public function testRouteHandlerDependencyInjection()
+    {
+        $this->kernel->registerExtension(InspectableTestExtension::class);
+        $this->kernel->boot();
+
+        $this->assertInstanceOf(RouteCollection::class, ...InspectableTestExtension::getCalled('routes'));
+    }
+
     public function test_register_extension_method_throws_exception_when_kernel_is_already_booted()
     {
         $this->expectException(BadMethodCallException::class);
@@ -175,5 +199,30 @@ class TestPageExtension extends HydeExtension
         return [
             TestPageClass::class,
         ];
+    }
+}
+
+class InspectableTestExtension extends HydeExtension
+{
+    private static array $callCache = [];
+
+    public function discoverFiles(FileCollection $collection): void
+    {
+        self::$callCache['files'] = func_get_args();
+    }
+
+    public function discoverPages(PageCollection $collection): void
+    {
+        self::$callCache['pages'] = func_get_args();
+    }
+
+    public function discoverRoutes(RouteCollection $collection): void
+    {
+        self::$callCache['routes'] = func_get_args();
+    }
+
+    public static function getCalled(string $method): array
+    {
+        return self::$callCache[$method];
     }
 }

--- a/packages/framework/tests/Feature/HydeExtensionFeatureTest.php
+++ b/packages/framework/tests/Feature/HydeExtensionFeatureTest.php
@@ -225,17 +225,17 @@ class HydeTestExtension extends HydeExtension
         ];
     }
 
-    public static function discoverFiles(FileCollection $collection): void
+    public function discoverFiles(FileCollection $collection): void
     {
         static::$callCache[] = 'files';
     }
 
-    public static function discoverPages(PageCollection $collection): void
+    public function discoverPages(PageCollection $collection): void
     {
         static::$callCache[] = 'pages';
     }
 
-    public static function discoverRoutes(RouteCollection $collection): void
+    public function discoverRoutes(RouteCollection $collection): void
     {
         static::$callCache[] = 'routes';
     }
@@ -245,17 +245,17 @@ class InspectableTestExtension extends HydeExtension
 {
     private static array $callCache = [];
 
-    public static function discoverFiles(FileCollection $collection): void
+    public function discoverFiles(FileCollection $collection): void
     {
         self::$callCache['files'] = func_get_args();
     }
 
-    public static function discoverPages(PageCollection $collection): void
+    public function discoverPages(PageCollection $collection): void
     {
         self::$callCache['pages'] = func_get_args();
     }
 
-    public static function discoverRoutes(RouteCollection $collection): void
+    public function discoverRoutes(RouteCollection $collection): void
     {
         self::$callCache['routes'] = func_get_args();
     }

--- a/packages/framework/tests/Feature/HydeExtensionFeatureTest.php
+++ b/packages/framework/tests/Feature/HydeExtensionFeatureTest.php
@@ -266,6 +266,11 @@ class InspectableTestExtension extends HydeExtension
     }
 }
 
+class InstantiableHydeExtension extends HydeExtension
+{
+    //
+}
+
 class HydeExtensionTestPage extends HydePage
 {
     public static string $sourceDirectory = 'foo';

--- a/packages/framework/tests/Unit/ExtensionsUnitTest.php
+++ b/packages/framework/tests/Unit/ExtensionsUnitTest.php
@@ -94,7 +94,8 @@ class ExtensionsUnitTest extends UnitTestCase
         $this->kernel->registerExtension(HydeTestExtension::class);
         try {
             $this->kernel->registerExtension(HydeTestExtension::class);
-        } catch (InvalidArgumentException) {}
+        } catch (InvalidArgumentException) {
+        }
 
         $this->assertSame([HydeCoreExtension::class, HydeTestExtension::class], $this->kernel->getRegisteredExtensions());
     }

--- a/packages/framework/tests/Unit/ExtensionsUnitTest.php
+++ b/packages/framework/tests/Unit/ExtensionsUnitTest.php
@@ -80,6 +80,17 @@ class ExtensionsUnitTest extends UnitTestCase
         $this->kernel->registerExtension('foo');
     }
 
+    public function test_register_extension_method_does_not_register_already_registered_classes()
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Extension ['.HydeTestExtension::class.'] is already registered.');
+
+        $this->kernel->registerExtension(HydeTestExtension::class);
+        $this->kernel->registerExtension(HydeTestExtension::class);
+
+        $this->assertSame([HydeCoreExtension::class, HydeTestExtension::class], $this->kernel->getRegisteredExtensions());
+    }
+
     public function testGetExtensionWithValidExtension()
     {
         $this->assertInstanceOf(HydeCoreExtension::class, $this->kernel->getExtension(HydeCoreExtension::class));
@@ -179,17 +190,6 @@ class ExtensionsUnitTest extends UnitTestCase
             DocumentationPage::class,
             HydeExtensionTestPage::class,
         ], $this->kernel->getRegisteredPageClasses());
-    }
-
-    public function test_register_extension_method_does_not_register_already_registered_classes()
-    {
-        $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('Extension ['.HydeTestExtension::class.'] is already registered.');
-
-        $this->kernel->registerExtension(HydeTestExtension::class);
-        $this->kernel->registerExtension(HydeTestExtension::class);
-
-        $this->assertSame([HydeCoreExtension::class, HydeTestExtension::class], $this->kernel->getRegisteredExtensions());
     }
 
     protected function markTestSuccessful(): void

--- a/packages/framework/tests/Unit/ExtensionsUnitTest.php
+++ b/packages/framework/tests/Unit/ExtensionsUnitTest.php
@@ -19,6 +19,7 @@ use Hyde\Foundation\Kernel\PageCollection;
 use Hyde\Foundation\Kernel\RouteCollection;
 use Hyde\Testing\UnitTestCase;
 use InvalidArgumentException;
+use BadMethodCallException;
 use stdClass;
 
 /**
@@ -62,6 +63,16 @@ class ExtensionsUnitTest extends UnitTestCase
         $this->kernel->registerExtension(HydeTestExtension::class);
 
         $this->assertSame([HydeCoreExtension::class, HydeTestExtension::class], $this->kernel->getRegisteredExtensions());
+    }
+
+    public function testRegisterExtensionAfterKernelIsBooted()
+    {
+        $this->kernel->boot();
+
+        $this->expectException(BadMethodCallException::class);
+        $this->expectExceptionMessage('Cannot register an extension after the Kernel has been booted.');
+
+        $this->kernel->registerExtension(HydeTestExtension::class);
     }
 
     public function testRegisterExtensionWithInvalidExtensionClass()

--- a/packages/framework/tests/Unit/ExtensionsUnitTest.php
+++ b/packages/framework/tests/Unit/ExtensionsUnitTest.php
@@ -71,39 +71,27 @@ class ExtensionsUnitTest extends UnitTestCase
     {
         $this->kernel->registerExtension(InspectableTestExtension::class);
 
-        $collection = FileCollection::init($this->kernel);
-        $collection->boot();
+        InspectableTestExtension::setTest($this);
 
-        InspectableTestExtension::verifyExpectations(function (array $called) use ($collection) {
-            $this->assertInstanceOf(FileCollection::class, ...$called['files']);
-            $this->assertSame($collection, ...$called['files']);
-        });
+        FileCollection::init($this->kernel)->boot();
     }
 
     public function testPageHandlerDependencyInjection()
     {
         $this->kernel->registerExtension(InspectableTestExtension::class);
 
-        $collection = PageCollection::init($this->kernel);
-        $collection->boot();
+        InspectableTestExtension::setTest($this);
 
-        InspectableTestExtension::verifyExpectations(function (array $called) use ($collection) {
-            $this->assertInstanceOf(PageCollection::class, ...$called['pages']);
-            $this->assertSame($collection, ...$called['pages']);
-        });
+        PageCollection::init($this->kernel)->boot();
     }
 
     public function testRouteHandlerDependencyInjection()
     {
         $this->kernel->registerExtension(InspectableTestExtension::class);
 
-        $collection = RouteCollection::init($this->kernel);
-        $collection->boot();
+        InspectableTestExtension::setTest($this);
 
-        InspectableTestExtension::verifyExpectations(function (array $called) use ($collection) {
-            $this->assertInstanceOf(RouteCollection::class, ...$called['routes']);
-            $this->assertSame($collection, ...$called['routes']);
-        });
+        RouteCollection::init($this->kernel)->boot();
     }
 
     public function test_get_registered_page_classes_returns_core_extension_classes()
@@ -194,28 +182,26 @@ class HydeTestExtension extends HydeExtension
 
 class InspectableTestExtension extends HydeExtension
 {
-    private static array $callCache = [];
+    private static UnitTestCase $test;
 
-    public function discoverFiles(FileCollection $collection): void
+    public static function setTest(UnitTestCase $test): void
     {
-        self::$callCache['files'] = func_get_args();
+        self::$test = $test;
     }
 
-    public function discoverPages(PageCollection $collection): void
+    public function discoverFiles($collection): void
     {
-        self::$callCache['pages'] = func_get_args();
+        self::$test->assertInstanceOf(FileCollection::class, $collection);
     }
 
-    public function discoverRoutes(RouteCollection $collection): void
+    public function discoverPages($collection): void
     {
-        self::$callCache['routes'] = func_get_args();
+        self::$test->assertInstanceOf(PageCollection::class, $collection);
     }
 
-    public static function verifyExpectations(Closure $closure): void
+    public function discoverRoutes($collection): void
     {
-        $closure(self::$callCache);
-
-        self::$callCache = [];
+        self::$test->assertInstanceOf(RouteCollection::class, $collection);
     }
 }
 

--- a/packages/framework/tests/Unit/ExtensionsUnitTest.php
+++ b/packages/framework/tests/Unit/ExtensionsUnitTest.php
@@ -87,6 +87,14 @@ class ExtensionsUnitTest extends UnitTestCase
 
         $this->kernel->registerExtension(HydeTestExtension::class);
         $this->kernel->registerExtension(HydeTestExtension::class);
+    }
+
+    public function testRegisterExtensionMethodDoesNotRegisterAlreadyRegisteredClasses()
+    {
+        $this->kernel->registerExtension(HydeTestExtension::class);
+        try {
+            $this->kernel->registerExtension(HydeTestExtension::class);
+        } catch (InvalidArgumentException) {}
 
         $this->assertSame([HydeCoreExtension::class, HydeTestExtension::class], $this->kernel->getRegisteredExtensions());
     }

--- a/packages/framework/tests/Unit/ExtensionsUnitTest.php
+++ b/packages/framework/tests/Unit/ExtensionsUnitTest.php
@@ -184,29 +184,11 @@ class InstantiableHydeExtension extends HydeExtension
 
 class HydeTestExtension extends HydeExtension
 {
-    // An easy way to assert the handlers are called.
-    public static array $callCache = [];
-
     public static function getPageClasses(): array
     {
         return [
             HydeExtensionTestPage::class,
         ];
-    }
-
-    public function discoverFiles(FileCollection $collection): void
-    {
-        static::$callCache[] = 'files';
-    }
-
-    public function discoverPages(PageCollection $collection): void
-    {
-        static::$callCache[] = 'pages';
-    }
-
-    public function discoverRoutes(RouteCollection $collection): void
-    {
-        static::$callCache[] = 'routes';
     }
 }
 

--- a/packages/framework/tests/Unit/ExtensionsUnitTest.php
+++ b/packages/framework/tests/Unit/ExtensionsUnitTest.php
@@ -87,8 +87,6 @@ class ExtensionsUnitTest extends UnitTestCase
 
         $this->kernel->registerExtension(HydeTestExtension::class);
         $this->kernel->registerExtension(HydeTestExtension::class);
-
-        $this->assertSame([HydeCoreExtension::class, HydeTestExtension::class], $this->kernel->getRegisteredExtensions());
     }
 
     public function testGetExtensionWithValidExtension()

--- a/packages/framework/tests/Unit/ExtensionsUnitTest.php
+++ b/packages/framework/tests/Unit/ExtensionsUnitTest.php
@@ -18,6 +18,7 @@ use Hyde\Foundation\Kernel\FileCollection;
 use Hyde\Foundation\Kernel\PageCollection;
 use Hyde\Foundation\Kernel\RouteCollection;
 use Hyde\Testing\UnitTestCase;
+use InvalidArgumentException;
 
 /**
  * @covers \Hyde\Foundation\HydeKernel
@@ -132,6 +133,26 @@ class ExtensionsUnitTest extends UnitTestCase
         $this->kernel->registerExtension(HydeTestExtension::class);
 
         $this->assertSame([HydeCoreExtension::class, HydeTestExtension::class], $this->kernel->getRegisteredExtensions());
+    }
+
+    public function testGetExtensionWithValidExtension()
+    {
+        $this->assertInstanceOf(HydeCoreExtension::class, $this->kernel->getExtension(HydeCoreExtension::class));
+    }
+
+    public function testGetExtensionWithCustomExtension()
+    {
+        $this->kernel->registerExtension(HydeTestExtension::class);
+
+        $this->assertInstanceOf(HydeTestExtension::class, $this->kernel->getExtension(HydeTestExtension::class));
+    }
+
+    public function testGetExtensionWithInvalidExtension()
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Extension [foo] is not registered.');
+
+        $this->kernel->getExtension('foo');
     }
 
     protected function markTestSuccessful(): void

--- a/packages/framework/tests/Unit/ExtensionsUnitTest.php
+++ b/packages/framework/tests/Unit/ExtensionsUnitTest.php
@@ -132,6 +132,9 @@ class ExtensionsUnitTest extends UnitTestCase
 
     public function test_register_extension_method_does_not_register_already_registered_classes()
     {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Extension ['.HydeTestExtension::class.'] is already registered.');
+
         $this->kernel->registerExtension(HydeTestExtension::class);
         $this->kernel->registerExtension(HydeTestExtension::class);
 

--- a/packages/framework/tests/Unit/ExtensionsUnitTest.php
+++ b/packages/framework/tests/Unit/ExtensionsUnitTest.php
@@ -58,9 +58,6 @@ class ExtensionsUnitTest extends UnitTestCase
 
     public function testCanRegisterNewExtension()
     {
-        HydeKernel::setInstance(new HydeKernel());
-
-        $this->kernel = HydeKernel::getInstance();
         $this->kernel->registerExtension(HydeTestExtension::class);
 
         $this->assertSame([HydeCoreExtension::class, HydeTestExtension::class], $this->kernel->getRegisteredExtensions());

--- a/packages/framework/tests/Unit/ExtensionsUnitTest.php
+++ b/packages/framework/tests/Unit/ExtensionsUnitTest.php
@@ -72,13 +72,12 @@ class ExtensionsUnitTest extends UnitTestCase
         $this->kernel->registerExtension(InspectableTestExtension::class);
 
         $collection = FileCollection::init($this->kernel);
-
-        InspectableTestExtension::spy('files', function ($argument) use ($collection) {
-            $this->assertInstanceOf(FileCollection::class, $argument);
-            $this->assertSame($collection, $argument);
-        });
-
         $collection->boot();
+
+        InspectableTestExtension::verifyExpectations(function (array $called) use ($collection) {
+            $this->assertInstanceOf(FileCollection::class, ...$called['files']);
+            $this->assertSame($collection, ...$called['files']);
+        });
     }
 
     public function testPageHandlerDependencyInjection()
@@ -86,13 +85,12 @@ class ExtensionsUnitTest extends UnitTestCase
         $this->kernel->registerExtension(InspectableTestExtension::class);
 
         $collection = PageCollection::init($this->kernel);
-
-        InspectableTestExtension::spy('pages', function ($argument) use ($collection) {
-            $this->assertInstanceOf(PageCollection::class, $argument);
-            $this->assertSame($collection, $argument);
-        });
-
         $collection->boot();
+
+        InspectableTestExtension::verifyExpectations(function (array $called) use ($collection) {
+            $this->assertInstanceOf(PageCollection::class, ...$called['pages']);
+            $this->assertSame($collection, ...$called['pages']);
+        });
     }
 
     public function testRouteHandlerDependencyInjection()
@@ -100,13 +98,12 @@ class ExtensionsUnitTest extends UnitTestCase
         $this->kernel->registerExtension(InspectableTestExtension::class);
 
         $collection = RouteCollection::init($this->kernel);
-
-        InspectableTestExtension::spy('routes', function ($argument) use ($collection) {
-            $this->assertInstanceOf(RouteCollection::class, $argument);
-            $this->assertSame($collection, $argument);
-        });
-
         $collection->boot();
+
+        InspectableTestExtension::verifyExpectations(function (array $called) use ($collection) {
+            $this->assertInstanceOf(RouteCollection::class, ...$called['routes']);
+            $this->assertSame($collection, ...$called['routes']);
+        });
     }
 
     public function test_get_registered_page_classes_returns_core_extension_classes()
@@ -197,26 +194,28 @@ class HydeTestExtension extends HydeExtension
 
 class InspectableTestExtension extends HydeExtension
 {
-    private static array $mocks = [];
-
-    public static function spy(string $method, Closure $closure): void
-    {
-        self::$mocks[$method] = $closure;
-    }
+    private static array $callCache = [];
 
     public function discoverFiles(FileCollection $collection): void
     {
-        (self::$mocks['files'] ?? fn () => null)(...func_get_args());
+        self::$callCache['files'] = func_get_args();
     }
 
     public function discoverPages(PageCollection $collection): void
     {
-        (self::$mocks['pages'] ?? fn () => null)(...func_get_args());
+        self::$callCache['pages'] = func_get_args();
     }
 
     public function discoverRoutes(RouteCollection $collection): void
     {
-        (self::$mocks['routes'] ?? fn () => null)(...func_get_args());
+        self::$callCache['routes'] = func_get_args();
+    }
+
+    public static function verifyExpectations(Closure $closure): void
+    {
+        $closure(self::$callCache);
+
+        self::$callCache = [];
     }
 }
 

--- a/packages/framework/tests/Unit/ExtensionsUnitTest.php
+++ b/packages/framework/tests/Unit/ExtensionsUnitTest.php
@@ -159,6 +159,23 @@ class ExtensionsUnitTest extends UnitTestCase
         $this->kernel->getExtension('foo');
     }
 
+    public function testHasExtensionWithValidExtension()
+    {
+        $this->assertTrue($this->kernel->hasExtension(HydeCoreExtension::class));
+    }
+
+    public function testHasExtensionWithCustomExtension()
+    {
+        $this->kernel->registerExtension(HydeTestExtension::class);
+
+        $this->assertTrue($this->kernel->hasExtension(HydeTestExtension::class));
+    }
+
+    public function testHasExtensionWithInvalidExtension()
+    {
+        $this->assertFalse($this->kernel->hasExtension('foo'));
+    }
+
     protected function markTestSuccessful(): void
     {
         $this->assertTrue(true);

--- a/packages/framework/tests/Unit/ExtensionsUnitTest.php
+++ b/packages/framework/tests/Unit/ExtensionsUnitTest.php
@@ -80,7 +80,7 @@ class ExtensionsUnitTest extends UnitTestCase
         $this->kernel->registerExtension('foo');
     }
 
-    public function test_register_extension_method_does_not_register_already_registered_classes()
+    public function testRegisterExtensionWithAlreadyRegisteredExtension()
     {
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('Extension ['.HydeTestExtension::class.'] is already registered.');

--- a/packages/framework/tests/Unit/ExtensionsUnitTest.php
+++ b/packages/framework/tests/Unit/ExtensionsUnitTest.php
@@ -19,6 +19,7 @@ use Hyde\Foundation\Kernel\PageCollection;
 use Hyde\Foundation\Kernel\RouteCollection;
 use Hyde\Testing\UnitTestCase;
 use InvalidArgumentException;
+use stdClass;
 
 /**
  * @covers \Hyde\Foundation\HydeKernel
@@ -61,6 +62,22 @@ class ExtensionsUnitTest extends UnitTestCase
         $this->kernel->registerExtension(HydeTestExtension::class);
 
         $this->assertSame([HydeCoreExtension::class, HydeTestExtension::class], $this->kernel->getRegisteredExtensions());
+    }
+
+    public function testRegisterExtensionWithInvalidExtensionClass()
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('The specified class must extend the HydeExtension class.');
+
+        $this->kernel->registerExtension(stdClass::class);
+    }
+
+    public function testRegisterExtensionWithNonClassString()
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('The specified class must extend the HydeExtension class.');
+
+        $this->kernel->registerExtension('foo');
     }
 
     public function testGetExtensionWithValidExtension()

--- a/packages/framework/tests/Unit/ExtensionsUnitTest.php
+++ b/packages/framework/tests/Unit/ExtensionsUnitTest.php
@@ -92,9 +92,11 @@ class ExtensionsUnitTest extends UnitTestCase
     public function testRegisterExtensionMethodDoesNotRegisterAlreadyRegisteredClasses()
     {
         $this->kernel->registerExtension(HydeTestExtension::class);
+
         try {
             $this->kernel->registerExtension(HydeTestExtension::class);
         } catch (InvalidArgumentException) {
+            //
         }
 
         $this->assertSame([HydeCoreExtension::class, HydeTestExtension::class], $this->kernel->getRegisteredExtensions());

--- a/packages/framework/tests/Unit/ExtensionsUnitTest.php
+++ b/packages/framework/tests/Unit/ExtensionsUnitTest.php
@@ -62,9 +62,9 @@ class ExtensionsUnitTest extends UnitTestCase
         HydeKernel::setInstance(new HydeKernel());
 
         $this->kernel = HydeKernel::getInstance();
-        $this->kernel->registerExtension(HydeTestExtension::class);
+        $this->kernel->registerExtension(InspectableTestExtension::class);
 
-        $this->assertSame([HydeCoreExtension::class, HydeTestExtension::class], $this->kernel->getRegisteredExtensions());
+        $this->assertSame([HydeCoreExtension::class, InspectableTestExtension::class], $this->kernel->getRegisteredExtensions());
     }
 
     public function testFileHandlerDependencyInjection()

--- a/packages/framework/tests/Unit/ExtensionsUnitTest.php
+++ b/packages/framework/tests/Unit/ExtensionsUnitTest.php
@@ -66,6 +66,43 @@ class ExtensionsUnitTest extends UnitTestCase
         $this->assertSame([HydeCoreExtension::class, HydeTestExtension::class], $this->kernel->getRegisteredExtensions());
     }
 
+    public function testGetExtensionWithValidExtension()
+    {
+        $this->assertInstanceOf(HydeCoreExtension::class, $this->kernel->getExtension(HydeCoreExtension::class));
+    }
+
+    public function testGetExtensionWithCustomExtension()
+    {
+        $this->kernel->registerExtension(HydeTestExtension::class);
+
+        $this->assertInstanceOf(HydeTestExtension::class, $this->kernel->getExtension(HydeTestExtension::class));
+    }
+
+    public function testGetExtensionWithInvalidExtension()
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Extension [foo] is not registered.');
+
+        $this->kernel->getExtension('foo');
+    }
+
+    public function testHasExtensionWithValidExtension()
+    {
+        $this->assertTrue($this->kernel->hasExtension(HydeCoreExtension::class));
+    }
+
+    public function testHasExtensionWithCustomExtension()
+    {
+        $this->kernel->registerExtension(HydeTestExtension::class);
+
+        $this->assertTrue($this->kernel->hasExtension(HydeTestExtension::class));
+    }
+
+    public function testHasExtensionWithInvalidExtension()
+    {
+        $this->assertFalse($this->kernel->hasExtension('foo'));
+    }
+
     public function testFileHandlerDependencyInjection()
     {
         $this->kernel->registerExtension(InspectableTestExtension::class);
@@ -139,43 +176,6 @@ class ExtensionsUnitTest extends UnitTestCase
         $this->kernel->registerExtension(HydeTestExtension::class);
 
         $this->assertSame([HydeCoreExtension::class, HydeTestExtension::class], $this->kernel->getRegisteredExtensions());
-    }
-
-    public function testGetExtensionWithValidExtension()
-    {
-        $this->assertInstanceOf(HydeCoreExtension::class, $this->kernel->getExtension(HydeCoreExtension::class));
-    }
-
-    public function testGetExtensionWithCustomExtension()
-    {
-        $this->kernel->registerExtension(HydeTestExtension::class);
-
-        $this->assertInstanceOf(HydeTestExtension::class, $this->kernel->getExtension(HydeTestExtension::class));
-    }
-
-    public function testGetExtensionWithInvalidExtension()
-    {
-        $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('Extension [foo] is not registered.');
-
-        $this->kernel->getExtension('foo');
-    }
-
-    public function testHasExtensionWithValidExtension()
-    {
-        $this->assertTrue($this->kernel->hasExtension(HydeCoreExtension::class));
-    }
-
-    public function testHasExtensionWithCustomExtension()
-    {
-        $this->kernel->registerExtension(HydeTestExtension::class);
-
-        $this->assertTrue($this->kernel->hasExtension(HydeTestExtension::class));
-    }
-
-    public function testHasExtensionWithInvalidExtension()
-    {
-        $this->assertFalse($this->kernel->hasExtension('foo'));
     }
 
     protected function markTestSuccessful(): void

--- a/packages/framework/tests/Unit/ExtensionsUnitTest.php
+++ b/packages/framework/tests/Unit/ExtensionsUnitTest.php
@@ -62,9 +62,9 @@ class ExtensionsUnitTest extends UnitTestCase
         HydeKernel::setInstance(new HydeKernel());
 
         $this->kernel = HydeKernel::getInstance();
-        $this->kernel->registerExtension(InspectableTestExtension::class);
+        $this->kernel->registerExtension(HydeTestExtension::class);
 
-        $this->assertSame([HydeCoreExtension::class, InspectableTestExtension::class], $this->kernel->getRegisteredExtensions());
+        $this->assertSame([HydeCoreExtension::class, HydeTestExtension::class], $this->kernel->getRegisteredExtensions());
     }
 
     public function testFileHandlerDependencyInjection()

--- a/packages/framework/tests/Unit/ExtensionsUnitTest.php
+++ b/packages/framework/tests/Unit/ExtensionsUnitTest.php
@@ -87,6 +87,8 @@ class ExtensionsUnitTest extends UnitTestCase
 
         $this->kernel->registerExtension(HydeTestExtension::class);
         $this->kernel->registerExtension(HydeTestExtension::class);
+
+        $this->assertSame([HydeCoreExtension::class, HydeTestExtension::class], $this->kernel->getRegisteredExtensions());
     }
 
     public function testGetExtensionWithValidExtension()

--- a/packages/framework/tests/Unit/ExtensionsUnitTest.php
+++ b/packages/framework/tests/Unit/ExtensionsUnitTest.php
@@ -69,7 +69,7 @@ class ExtensionsUnitTest extends UnitTestCase
     public function testFileHandlerDependencyInjection()
     {
         $this->kernel->registerExtension(InspectableTestExtension::class);
-        $this->kernel->boot();
+        FileCollection::init($this->kernel)->boot();
 
         $this->assertInstanceOf(FileCollection::class, ...InspectableTestExtension::getCalled('files'));
     }
@@ -77,7 +77,7 @@ class ExtensionsUnitTest extends UnitTestCase
     public function testPageHandlerDependencyInjection()
     {
         $this->kernel->registerExtension(InspectableTestExtension::class);
-        $this->kernel->boot();
+        PageCollection::init($this->kernel)->boot();
 
         $this->assertInstanceOf(PageCollection::class, ...InspectableTestExtension::getCalled('pages'));
     }
@@ -85,7 +85,7 @@ class ExtensionsUnitTest extends UnitTestCase
     public function testRouteHandlerDependencyInjection()
     {
         $this->kernel->registerExtension(InspectableTestExtension::class);
-        $this->kernel->boot();
+        RouteCollection::init($this->kernel)->boot();
 
         $this->assertInstanceOf(RouteCollection::class, ...InspectableTestExtension::getCalled('routes'));
     }


### PR DESCRIPTION
## Refactor the Extensions API to be Singletons instead of static classes

### Abstract

This PR refactors the Extensions API so that its discovery handler methods are no longer static, and loaded extensions are now stored as singletons within the kernel container. This makes extensions much easier to test as state is cleared and methods are mockable. Resolves https://github.com/hydephp/develop/issues/1139.

### API Breaks

This will break all existing extensions. It should be easy enough however, just remove the static keyword. As it currently stands, the getPageClasses method is still static. Also improves the extensions feature/unit tests.

### Upgrading

Remove the `static` keyword from the discovery handler methods in your extension.

```php
class MyExtension extends HydeExtension()
{
  - public static function discoverFiles(FileCollection $collection): void;
  - public static function discoverPages(PageCollection $collection): void;
  - public static function discoverRoutes(RouteCollection $collection): void;
  
  + public function discoverFiles(FileCollection $collection): void;
  + public function discoverPages(PageCollection $collection): void;
  + public function discoverRoutes(RouteCollection $collection): void;
}
```

### Related changes in the PR

#### Minor changes

Refactors the surrounding tests. Adds new helpers needed to interact with the new singleton container. 

#### Exceptions will be thrown when attempting to register an already registered extension

In terms of developer experience, it's generally better to provide clear and helpful error messages rather than ignoring errors or providing no feedback at all.

> If attempting to reregister an extension is not expected behavior and could lead to issues, throwing an exception with a clear error message would be the best option. This way, developers can quickly identify the issue and fix it.
> 
> If reregistering an extension is not considered an issue and can be safely ignored, it's still good practice to provide some feedback to the developer, such as a log message indicating that the extension has already been registered. This can help with debugging and troubleshooting in case issues arise in the future.
>
> ~ ChatGPT