### PR TITLE
Invert the run/handle methods of build tasks 

### DIFF
--- a/packages/framework/src/Console/Commands/BuildRssFeedCommand.php
+++ b/packages/framework/src/Console/Commands/BuildRssFeedCommand.php
@@ -22,6 +22,6 @@ class BuildRssFeedCommand extends Command
 
     public function handle(): int
     {
-        return (new GenerateRssFeed($this->output))->handle();
+        return (new GenerateRssFeed($this->output))->run();
     }
 }

--- a/packages/framework/src/Console/Commands/BuildSearchCommand.php
+++ b/packages/framework/src/Console/Commands/BuildSearchCommand.php
@@ -22,6 +22,6 @@ class BuildSearchCommand extends Command
 
     public function handle(): int
     {
-        return (new GenerateSearch($this->output))->handle();
+        return (new GenerateSearch($this->output))->run();
     }
 }

--- a/packages/framework/src/Console/Commands/BuildSitemapCommand.php
+++ b/packages/framework/src/Console/Commands/BuildSitemapCommand.php
@@ -22,6 +22,6 @@ class BuildSitemapCommand extends Command
 
     public function handle(): int
     {
-        return (new GenerateSitemap($this->output))->handle();
+        return (new GenerateSitemap($this->output))->run();
     }
 }

--- a/packages/framework/src/Console/Commands/RebuildStaticPageCommand.php
+++ b/packages/framework/src/Console/Commands/RebuildStaticPageCommand.php
@@ -41,7 +41,7 @@ class RebuildStaticPageCommand extends Command
             return Command::SUCCESS;
         }
 
-        return $this->makeBuildTask($this->output, $this->getNormalizedPathString())->handle();
+        return $this->makeBuildTask($this->output, $this->getNormalizedPathString())->run();
     }
 
     protected function getNormalizedPathString(): string
@@ -63,7 +63,7 @@ class RebuildStaticPageCommand extends Command
                 $this->path = $path;
             }
 
-            public function run(): void
+            public function handle(): void
             {
                 $this->validate();
 

--- a/packages/framework/src/Framework/Features/BuildTasks/BuildTask.php
+++ b/packages/framework/src/Framework/Features/BuildTasks/BuildTask.php
@@ -27,7 +27,7 @@ abstract class BuildTask
     /** @var \Illuminate\Console\OutputStyle|null */
     protected $output;
 
-    abstract public function run(): void;
+    abstract public function handle(): void;
 
     /** @phpstan-consistent-constructor */
     public function __construct(?OutputStyle $output = null)
@@ -35,14 +35,14 @@ abstract class BuildTask
         $this->output = $output;
     }
 
-    public function handle(): int
+    public function run(): int
     {
         $this->startClock();
 
         $this->write("<comment>{$this->getMessage()}...</comment> ");
 
         try {
-            $this->run();
+            $this->handle();
             $this->then();
         } catch (Throwable $exception) {
             $this->writeln('<error>Failed</error>');

--- a/packages/framework/src/Framework/Features/BuildTasks/PostBuildTasks/GenerateBuildManifest.php
+++ b/packages/framework/src/Framework/Features/BuildTasks/PostBuildTasks/GenerateBuildManifest.php
@@ -25,7 +25,7 @@ class GenerateBuildManifest extends BuildTask
         $this->output = null;
     }
 
-    public function run(): void
+    public function handle(): void
     {
         $pages = new Collection();
 

--- a/packages/framework/src/Framework/Features/BuildTasks/PostBuildTasks/GenerateRssFeed.php
+++ b/packages/framework/src/Framework/Features/BuildTasks/PostBuildTasks/GenerateRssFeed.php
@@ -12,7 +12,7 @@ class GenerateRssFeed extends BuildTask
 {
     public static string $message = 'Generating RSS feed';
 
-    public function run(): void
+    public function handle(): void
     {
         file_put_contents(
             Hyde::sitePath(RssFeedGenerator::getFilename()),

--- a/packages/framework/src/Framework/Features/BuildTasks/PostBuildTasks/GenerateSearch.php
+++ b/packages/framework/src/Framework/Features/BuildTasks/PostBuildTasks/GenerateSearch.php
@@ -15,7 +15,7 @@ class GenerateSearch extends BuildTask
 
     public static string $message = 'Generating search index';
 
-    public function run(): void
+    public function handle(): void
     {
         DocumentationSearchService::generate();
 

--- a/packages/framework/src/Framework/Features/BuildTasks/PostBuildTasks/GenerateSitemap.php
+++ b/packages/framework/src/Framework/Features/BuildTasks/PostBuildTasks/GenerateSitemap.php
@@ -12,7 +12,7 @@ class GenerateSitemap extends BuildTask
 {
     public static string $message = 'Generating sitemap';
 
-    public function run(): void
+    public function handle(): void
     {
         file_put_contents(
             Hyde::sitePath('sitemap.xml'),

--- a/packages/framework/src/Framework/Services/BuildTaskService.php
+++ b/packages/framework/src/Framework/Services/BuildTaskService.php
@@ -89,7 +89,7 @@ class BuildTaskService
 
     protected function runTask(BuildTask $task): void
     {
-        $task->handle();
+        $task->run();
     }
 
     protected function registerTasks(array $tasks): void

--- a/packages/framework/tests/Feature/Services/BuildTaskServiceTest.php
+++ b/packages/framework/tests/Feature/Services/BuildTaskServiceTest.php
@@ -147,11 +147,11 @@ class BuildTaskServiceTest extends TestCase
     {
         $return = (new class extends BuildTask
         {
-            public function run(): void
+            public function handle(): void
             {
                 throw new Exception('foo', 1);
             }
-        })->handle();
+        })->run();
 
         $this->assertEquals(1, $return);
     }
@@ -174,7 +174,7 @@ namespace App\Actions;
 use Hyde\Framework\Features\BuildTasks\BuildTask;
 
 class FooBuildTask extends BuildTask {
-    public function run(): void {
+    public function handle(): void {
         echo "FooBuildTask";
     }
 }');
@@ -198,7 +198,7 @@ class FooBuildTask extends BuildTask {
 
 class TestBuildTask extends BuildTask
 {
-    public function run(): void
+    public function handle(): void
     {
         echo 'BuildTask';
     }

--- a/packages/framework/tests/Unit/BuildTaskServiceUnitTest.php
+++ b/packages/framework/tests/Unit/BuildTaskServiceUnitTest.php
@@ -113,7 +113,7 @@ class BuildTaskServiceUnitTest extends UnitTestCase
 
 class PostBuildTaskTestClass extends BuildTask
 {
-    public function run(): void
+    public function handle(): void
     {
         //
     }
@@ -121,7 +121,7 @@ class PostBuildTaskTestClass extends BuildTask
 
 class GenerateSitemap extends FrameworkGenerateSitemap
 {
-    public function run(): void
+    public function handle(): void
     {
         //
     }

--- a/packages/framework/tests/Unit/GenerateBuildManifestTest.php
+++ b/packages/framework/tests/Unit/GenerateBuildManifestTest.php
@@ -16,7 +16,7 @@ class GenerateBuildManifestTest extends TestCase
 {
     public function test_action_generates_build_manifest()
     {
-        (new GenerateBuildManifest())->run();
+        (new GenerateBuildManifest())->handle();
 
         $this->assertFileExists(Hyde::path('app/storage/framework/cache/build-manifest.json'));
 


### PR DESCRIPTION
Since build tasks are in a sense "micro commands," it is more semantic to have the handle method be the abstract method used to provide the task logic, and the run method be the one called by the service.

This requires an inversion of how the exit code is handled too, but I think it's more intuitive as it changes the child method to return a value instead of needing a class property for the exit code.

Targets https://github.com/hydephp/develop/pull/1152 and fixes https://github.com/hydephp/develop/issues/1158