### PR TITLE
Breaking: Remove flattened output documentation paths

### DIFF
--- a/packages/framework/src/Pages/Concerns/UsesFlattenedOutputPaths.php
+++ b/packages/framework/src/Pages/Concerns/UsesFlattenedOutputPaths.php
@@ -8,6 +8,8 @@ use function basename;
 use function unslash;
 
 /**
+ * @deprecated This trait and feature will be removed as it breaks pages with the same name in different directories.
+ *
  * This trait is used to flatten the output path of a page. This is only used for the documentation pages,
  * where all pages are output to the same directory, but where putting the page in a subdirectory will
  * create a nested navigation structure in the sidebar.

--- a/packages/framework/src/Pages/Concerns/UsesFlattenedOutputPaths.php
+++ b/packages/framework/src/Pages/Concerns/UsesFlattenedOutputPaths.php
@@ -13,7 +13,6 @@ use function unslash;
  * This trait is used to flatten the output path of a page. This is only used for the documentation pages,
  * where all pages are output to the same directory, but where putting the page in a subdirectory will
  * create a nested navigation structure in the sidebar.
- *
  * @see https://hydephp.com/docs/master/documentation-pages#using-subdirectories
  */
 trait UsesFlattenedOutputPaths

--- a/packages/framework/src/Pages/Concerns/UsesFlattenedOutputPaths.php
+++ b/packages/framework/src/Pages/Concerns/UsesFlattenedOutputPaths.php
@@ -1,8 +1,0 @@
-<?php
-
-declare(strict_types=1);
-
-namespace Hyde\Pages\Concerns;
-
-use function basename;
-use function unslash;

--- a/packages/framework/src/Pages/Concerns/UsesFlattenedOutputPaths.php
+++ b/packages/framework/src/Pages/Concerns/UsesFlattenedOutputPaths.php
@@ -6,34 +6,3 @@ namespace Hyde\Pages\Concerns;
 
 use function basename;
 use function unslash;
-
-/**
- * @deprecated This trait and feature will be removed as it breaks pages with the same name in different directories.
- *
- * This trait is used to flatten the output path of a page. This is only used for the documentation pages,
- * where all pages are output to the same directory, but where putting the page in a subdirectory will
- * create a nested navigation structure in the sidebar.
- * @see https://hydephp.com/docs/master/documentation-pages#using-subdirectories
- */
-trait UsesFlattenedOutputPaths
-{
-    /**
-     * Get the route key for the page.
-     *
-     * Uses the identifier basename so nested pages are flattened.
-     */
-    public function getRouteKey(): string
-    {
-        return unslash(static::outputDirectory().'/'.basename($this->identifier));
-    }
-
-    /**
-     * Get the path where the compiled page will be saved.
-     *
-     * Uses the identifier basename so nested pages are flattened.
-     */
-    public function getOutputPath(): string
-    {
-        return static::outputPath(basename($this->identifier));
-    }
-}

--- a/packages/framework/src/Pages/DocumentationPage.php
+++ b/packages/framework/src/Pages/DocumentationPage.php
@@ -18,8 +18,6 @@ use Hyde\Support\Models\Route;
  */
 class DocumentationPage extends BaseMarkdownPage
 {
-    use Concerns\UsesFlattenedOutputPaths;
-
     public static string $sourceDirectory = '_docs';
     public static string $outputDirectory = 'docs';
     public static string $template = 'hyde::layouts/docs';

--- a/packages/framework/tests/Unit/DocumentationPageTest.php
+++ b/packages/framework/tests/Unit/DocumentationPageTest.php
@@ -34,6 +34,8 @@ class DocumentationPageTest extends TestCase
 
         config(['hyde.output_directories.documentation-page' => 'documentation/latest/']);
         (new HydeServiceProvider($this->app))->register();
+
+        $page = DocumentationPage::make('foo');
         $this->assertEquals('documentation/latest/foo', $page->getRouteKey());
     }
 

--- a/packages/framework/tests/Unit/DocumentationPageTest.php
+++ b/packages/framework/tests/Unit/DocumentationPageTest.php
@@ -168,10 +168,10 @@ class DocumentationPageTest extends TestCase
         $this->assertFalse(DocumentationPage::hasTableOfContents());
     }
 
-    public function test_compiled_pages_originating_in_subdirectories_get_output_to_root_docs_path()
+    public function test_compiled_pages_originating_in_subdirectories_retain_subdirectory_structure()
     {
         $page = DocumentationPage::make('foo/bar');
-        $this->assertEquals('docs/bar.html', $page->getOutputPath());
+        $this->assertEquals('docs/foo/bar.html', $page->getOutputPath());
     }
 
     public function test_page_has_front_matter()

--- a/packages/framework/tests/Unit/DocumentationPageTest.php
+++ b/packages/framework/tests/Unit/DocumentationPageTest.php
@@ -31,7 +31,10 @@ class DocumentationPageTest extends TestCase
     {
         $page = DocumentationPage::make('foo');
         $this->assertEquals('docs/foo', $page->getRouteKey());
+    }
 
+    public function test_can_get_current_custom_page_path()
+    {
         config(['hyde.output_directories.documentation-page' => 'documentation/latest/']);
         (new HydeServiceProvider($this->app))->register();
 

--- a/packages/framework/tests/Unit/DocumentationPageTest.php
+++ b/packages/framework/tests/Unit/DocumentationPageTest.php
@@ -18,7 +18,6 @@ use Illuminate\Support\Facades\File;
  * @covers \Hyde\Pages\DocumentationPage
  * @covers \Hyde\Framework\Factories\Concerns\HasFactory
  * @covers \Hyde\Framework\Factories\NavigationDataFactory
- * @covers \Hyde\Pages\Concerns\UsesFlattenedOutputPaths
  */
 class DocumentationPageTest extends TestCase
 {


### PR DESCRIPTION
Removes the UsesFlattenedOutputPaths trait, and the overall feature, as it breaks pages with the same name in different directories. Fixes https://github.com/hydephp/develop/issues/1164

This is unfortunately likely lead to URL breaks in built sites.
