### PR TITLE
Update duplicate navigation item filtering to include group prefix

### DIFF
--- a/packages/framework/src/Framework/Features/Navigation/BaseNavigationMenu.php
+++ b/packages/framework/src/Framework/Features/Navigation/BaseNavigationMenu.php
@@ -68,7 +68,7 @@ abstract class BaseNavigationMenu
     protected function filterDuplicateItems(): Collection
     {
         return $this->items->unique(function (NavItem $item): string {
-            return $item->label;
+            return $item->getGroup().$item->label;
         });
     }
 

--- a/packages/framework/src/Framework/Features/Navigation/NavItem.php
+++ b/packages/framework/src/Framework/Features/Navigation/NavItem.php
@@ -122,7 +122,7 @@ class NavItem implements Stringable
 
     public function getGroup(): ?string
     {
-        return $this->normalizeGroupKey($this->route->getPage()->data('navigation.group'));
+        return $this->normalizeGroupKey($this->getRoute()?->getPage()->data('navigation.group'));
     }
 
     public function getRoute(): ?Route

--- a/packages/framework/tests/Feature/Services/DocumentationSidebarTest.php
+++ b/packages/framework/tests/Feature/Services/DocumentationSidebarTest.php
@@ -337,6 +337,39 @@ class DocumentationSidebarTest extends TestCase
         $this->assertTrue(DocumentationSidebar::create()->isGroupActive('baz'));
     }
 
+    public function test_can_have_multiple_grouped_pages_with_the_same_name_labels()
+    {
+        $this->makePage('foo', ['navigation.group' => 'foo', 'navigation.label' => 'Foo']);
+        $this->makePage('bar', ['navigation.group' => 'bar', 'navigation.label' => 'Foo']);
+
+        $sidebar = DocumentationSidebar::create();
+        $this->assertCount(2, $sidebar->items);
+
+        $this->assertEquals(
+            collect([
+                NavItem::fromRoute(Route::get('docs/bar'))->setPriority(999),
+                NavItem::fromRoute(Route::get('docs/foo'))->setPriority(999),
+            ]),
+            $sidebar->items
+        );
+    }
+
+    public function test_duplicate_labels_within_the_same_group_is_removed()
+    {
+        $this->makePage('foo', ['navigation.group' => 'foo', 'navigation.label' => 'Foo']);
+        $this->makePage('bar', ['navigation.group' => 'foo', 'navigation.label' => 'Foo']);
+
+        $sidebar = DocumentationSidebar::create();
+        $this->assertCount(1, $sidebar->items);
+
+        $this->assertEquals(
+            collect([
+                NavItem::fromRoute(Route::get('docs/bar'))->setPriority(999),
+            ]),
+            $sidebar->items
+        );
+    }
+
     public function test_is_group_active_for_index_page_with_no_groups()
     {
         $this->makePage('index');


### PR DESCRIPTION
This means that items in groups with the same name are not considered duplicate. Fixes https://github.com/hydephp/develop/issues/1169