### PR TITLE
Reimplement flattened output documentation paths feature

### DIFF
--- a/config/docs.php
+++ b/config/docs.php
@@ -113,4 +113,22 @@ return [
         'changelog',
     ],
 
+    /*
+    |--------------------------------------------------------------------------
+    | Flattened Output Paths
+    |--------------------------------------------------------------------------
+    |
+    | If this setting is set to true, Hyde will output all documentation pages
+    | into the same configured documentation output directory. This means
+    | that you can use the automatic directory based grouping feature,
+    | but still have a "flat" output structure. Note that this means
+    | that you can't have two documentation pages with the same
+    | filename or navigation menu label as they will overwrite each other.
+    |
+    | If you set this to false, Hyde will match the directory structure
+    | of the source files (just like all other pages).
+    |
+    */
+
+    'flattened_output_paths' => true,
 ];

--- a/docs/creating-content/documentation-pages.md
+++ b/docs/creating-content/documentation-pages.md
@@ -156,7 +156,7 @@ Since [v0.52.0-beta](https://github.com/hydephp/develop/releases/tag/v0.52.0-bet
 
 For example, putting a Markdown file in `_docs/getting-started/`, is equivalent to adding the same front matter in the step above.
 
-> Note that the file will still be compiled to the `_site/docs/` directory like it would be if you didn't use the sub-directories.
+> Note that when the [flattened output paths](#using-flattened-output-paths) setting is enabled, the file will still be compiled to the `_site/docs/` directory like it would be if you didn't use the sub-directories.
 
 
 ### Hiding items
@@ -329,3 +329,16 @@ Just target the `.edit-page-link` class.
 #### Changing the Blade view
 
 You can also publish the `edit-source-button.blade.php` view and change it to your liking.
+
+#### Using flattened output paths
+
+If this setting is set to true, Hyde will output all documentation pages into the same configured documentation output directory.
+This means that you can use the automatic directory based grouping feature, but still have a "flat" output structure.
+Note that this means that you can't have two documentation pages with the same filename or navigation menu label as they will overwrite each other.
+
+If you set this to false, Hyde will match the directory structure of the source files (just like all other pages).
+
+```php
+// Filepath: config/docs.php
+'flattened_output_paths' => true,
+```

--- a/packages/framework/config/docs.php
+++ b/packages/framework/config/docs.php
@@ -113,4 +113,22 @@ return [
         'changelog',
     ],
 
+    /*
+    |--------------------------------------------------------------------------
+    | Flattened Output Paths
+    |--------------------------------------------------------------------------
+    |
+    | If this setting is set to true, Hyde will output all documentation pages
+    | into the same configured documentation output directory. This means
+    | that you can use the automatic directory based grouping feature,
+    | but still have a "flat" output structure. Note that this means
+    | that you can't have two documentation pages with the same
+    | filename or navigation menu label as they will overwrite each other.
+    |
+    | If you set this to false, Hyde will match the directory structure
+    | of the source files (just like all other pages).
+    |
+    */
+
+    'flattened_output_paths' => true,
 ];

--- a/packages/framework/src/Pages/DocumentationPage.php
+++ b/packages/framework/src/Pages/DocumentationPage.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Hyde\Pages;
 
+use Hyde\Facades\Config;
 use Hyde\Framework\Actions\GeneratesSidebarTableOfContents;
 use Hyde\Pages\Concerns\BaseMarkdownPage;
 use Hyde\Support\Models\Route;
@@ -53,5 +54,29 @@ class DocumentationPage extends BaseMarkdownPage
     public function getTableOfContents(): string
     {
         return (new GeneratesSidebarTableOfContents($this->markdown))->execute();
+    }
+
+    /**
+     * Get the route key for the page.
+     *
+     * If flattened outputs are enabled, this will use the identifier basename so nested pages are flattened.
+     */
+    public function getRouteKey(): string
+    {
+        return Config::getBool('docs.flattened_output_paths', true)
+            ? unslash(static::outputDirectory().'/'.basename($this->identifier))
+            : parent::getRouteKey();
+    }
+
+    /**
+     * Get the path where the compiled page will be saved.
+     *
+     * If flattened outputs are enabled, this will use the identifier basename so nested pages are flattened.
+     */
+    public function getOutputPath(): string
+    {
+        return Config::getBool('docs.flattened_output_paths', true)
+            ? static::outputPath(basename($this->identifier))
+            : parent::getOutputPath();
     }
 }

--- a/packages/framework/tests/Unit/DocumentationPageTest.php
+++ b/packages/framework/tests/Unit/DocumentationPageTest.php
@@ -42,6 +42,34 @@ class DocumentationPageTest extends TestCase
         $this->assertEquals('documentation/latest/foo', $page->getRouteKey());
     }
 
+    public function test_can_get_current_page_path_when_using_flattened_output_paths()
+    {
+        Config::set('docs.flattened_output_paths', true);
+
+        $page = DocumentationPage::make('foo/bar');
+        $this->assertEquals('docs/bar', $page->getRouteKey());
+
+        config(['hyde.output_directories.documentation-page' => 'documentation/latest/']);
+        (new HydeServiceProvider($this->app))->register();
+
+        $page = DocumentationPage::make('foo/bar');
+        $this->assertEquals('documentation/latest/bar', $page->getRouteKey());
+    }
+
+    public function test_can_get_current_page_path_when_not_using_flattened_output_paths()
+    {
+        Config::set('docs.flattened_output_paths', false);
+
+        $page = DocumentationPage::make('foo/bar');
+        $this->assertEquals('docs/foo/bar', $page->getRouteKey());
+
+        config(['hyde.output_directories.documentation-page' => 'documentation/latest/']);
+        (new HydeServiceProvider($this->app))->register();
+
+        $page = DocumentationPage::make('foo/bar');
+        $this->assertEquals('documentation/latest/foo/bar', $page->getRouteKey());
+    }
+
     public function test_can_get_online_source_path()
     {
         $page = DocumentationPage::make('foo');
@@ -173,8 +201,22 @@ class DocumentationPageTest extends TestCase
         $this->assertFalse(DocumentationPage::hasTableOfContents());
     }
 
-    public function test_compiled_pages_originating_in_subdirectories_retain_subdirectory_structure()
+    public function test_compiled_pages_originating_in_subdirectories_get_output_to_root_docs_path()
     {
+        $page = DocumentationPage::make('foo/bar');
+        $this->assertEquals('docs/bar.html', $page->getOutputPath());
+    }
+
+    public function test_compiled_pages_originating_in_subdirectories_get_output_to_root_docs_path_when_using_flattened_output_paths()
+    {
+        Config::set('docs.flattened_output_paths', true);
+        $page = DocumentationPage::make('foo/bar');
+        $this->assertEquals('docs/bar.html', $page->getOutputPath());
+    }
+
+    public function test_compiled_pages_originating_in_subdirectories_retain_subdirectory_structure_when_not_using_flattened_output_paths()
+    {
+        Config::set('docs.flattened_output_paths', false);
         $page = DocumentationPage::make('foo/bar');
         $this->assertEquals('docs/foo/bar.html', $page->getOutputPath());
     }


### PR DESCRIPTION
Reverts hydephp/develop#1166 but reimplements it as a configurable feature