### PR TITLE
Update FrontMatter::get method to return data array instead of $this

### DIFF
--- a/packages/framework/src/Framework/Concerns/InteractsWithFrontMatter.php
+++ b/packages/framework/src/Framework/Concerns/InteractsWithFrontMatter.php
@@ -34,7 +34,11 @@ trait InteractsWithFrontMatter
      */
     public function matter(string $key = null, mixed $default = null): mixed
     {
-        return $this->matter->get($key, $default);
+        if ($key) {
+            return $this->matter->get($key, $default);
+        }
+
+        return $this->matter;
     }
 
     /**

--- a/packages/framework/src/Framework/Concerns/InteractsWithFrontMatter.php
+++ b/packages/framework/src/Framework/Concerns/InteractsWithFrontMatter.php
@@ -34,7 +34,7 @@ trait InteractsWithFrontMatter
      */
     public function matter(string $key = null, mixed $default = null): mixed
     {
-        return $this->matter->get($key, $default);
+        return $this->matter->get($key, $default ?? $this->matter);
     }
 
     /**

--- a/packages/framework/src/Framework/Concerns/InteractsWithFrontMatter.php
+++ b/packages/framework/src/Framework/Concerns/InteractsWithFrontMatter.php
@@ -34,7 +34,7 @@ trait InteractsWithFrontMatter
      */
     public function matter(string $key = null, mixed $default = null): mixed
     {
-        return $this->matter->get($key, $default ?? $this->matter);
+        return $this->matter->get($key, $default);
     }
 
     /**

--- a/packages/framework/src/Markdown/Models/FrontMatter.php
+++ b/packages/framework/src/Markdown/Models/FrontMatter.php
@@ -54,7 +54,7 @@ class FrontMatter implements Stringable, SerializableContract
             return Arr::get($this->data, $key, $default);
         }
 
-        return $this;
+        return $this->data;
     }
 
     public function set(string $key, mixed $value): static

--- a/packages/framework/tests/Unit/FrontMatterModelTest.php
+++ b/packages/framework/tests/Unit/FrontMatterModelTest.php
@@ -55,16 +55,16 @@ class FrontMatterModelTest extends TestCase
         $this->assertNull($matter->foo);
     }
 
-    public function test_get_method_returns_self_when_no_argument_is_specified()
+    public function test_get_method_returns_data_when_no_argument_is_specified()
     {
         $matter = new FrontMatter();
-        $this->assertSame($matter, $matter->get());
+        $this->assertSame([], $matter->get());
     }
 
-    public function test_get_method_returns_self_when_no_argument_is_specified_with_data()
+    public function test_get_method_returns_data_when_no_argument_is_specified_with_data()
     {
         $matter = new FrontMatter(['foo' => 'bar']);
-        $this->assertSame($matter, $matter->get());
+        $this->assertSame(['foo' => 'bar'], $matter->get());
     }
 
     public function test_get_method_returns_null_if_specified_front_matter_key_does_not_exist()


### PR DESCRIPTION
### Issue Description
The get function was returning the entire object $this when it was called without a $key argument, instead of returning the entire data array. This caused confusion for users of the code, as the semantics were not consistent with what was expected.

### Solution
To fix this issue, the function was modified to return the entire data array when it is called without a $key argument. Additionally, this change modifies the way that the `InteractsWithFrontMatter` trait interacts with the `FrontMatter` method, ensuring that the trait method complies with the contracted description in the implemented interface. This auxiliary change also ensures backwards compatibility for the $page->matter() methods.

This pull request fixes issue #1157.