### PR TITLE
Refactor RelatedPublicationsComponent

### DIFF
--- a/packages/framework/src/Foundation/Providers/ViewServiceProvider.php
+++ b/packages/framework/src/Foundation/Providers/ViewServiceProvider.php
@@ -7,6 +7,7 @@ namespace Hyde\Foundation\Providers;
 use Hyde\Framework\Views\Components\LinkComponent;
 use Hyde\Framework\Views\Components\BreadcrumbsComponent;
 use Hyde\Hyde;
+use Hyde\Publications\Views\Components\RelatedPublicationsComponent;
 use Illuminate\Support\Facades\Blade;
 use Illuminate\Support\ServiceProvider;
 
@@ -50,5 +51,6 @@ class ViewServiceProvider extends ServiceProvider
 
         Blade::component('link', LinkComponent::class);
         Blade::component('hyde::breadcrumbs', BreadcrumbsComponent::class);
+        Blade::component('hyde::relatedPublications', RelatedPublicationsComponent::class);
     }
 }

--- a/packages/framework/src/Foundation/Providers/ViewServiceProvider.php
+++ b/packages/framework/src/Foundation/Providers/ViewServiceProvider.php
@@ -7,7 +7,6 @@ namespace Hyde\Foundation\Providers;
 use Hyde\Framework\Views\Components\LinkComponent;
 use Hyde\Framework\Views\Components\BreadcrumbsComponent;
 use Hyde\Hyde;
-use Hyde\Publications\Views\Components\RelatedPublicationsComponent;
 use Illuminate\Support\Facades\Blade;
 use Illuminate\Support\ServiceProvider;
 
@@ -51,6 +50,5 @@ class ViewServiceProvider extends ServiceProvider
 
         Blade::component('link', LinkComponent::class);
         Blade::component('hyde::breadcrumbs', BreadcrumbsComponent::class);
-        Blade::component('hyde::relatedPublications', RelatedPublicationsComponent::class);
     }
 }

--- a/packages/framework/src/Publications/Views/Components/RelatedPublicationsComponent.php
+++ b/packages/framework/src/Publications/Views/Components/RelatedPublicationsComponent.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Hyde\Publications\Views\Components;
 
 use Hyde\Hyde;
-use Hyde\Pages\Concerns\HydePage;
 use Hyde\Publications\Models\PublicationPage;
 use Hyde\Publications\Models\PublicationType;
 use Hyde\Publications\PublicationService;
@@ -34,7 +33,7 @@ class RelatedPublicationsComponent extends Component
         // Get current publicationType
         $currentHydePage = Hyde::currentRoute()->getPage();
         $publicationType = $currentHydePage->getType();
-        if (!$publicationType) {
+        if (! $publicationType) {
             return collect();
         }
 
@@ -71,7 +70,6 @@ class RelatedPublicationsComponent extends Component
         return $this->sortRelatedPagesByRelevance($allRelatedPages, $max);
     }
 
-
     protected function getTagsForPage(PublicationPage $publicationPage, Collection $tagFields): Collection
     {
         $thisPageTags = collect();
@@ -84,14 +82,13 @@ class RelatedPublicationsComponent extends Component
         return $thisPageTags;
     }
 
-
-    protected function getAllRelatedPages (Collection $publicationPages, Collection $tagFields, Collection $currPageTags): Collection
+    protected function getAllRelatedPages(Collection $publicationPages, Collection $tagFields, Collection $currPageTags): Collection
     {
         $allRelatedPages = collect();
 
         foreach ($publicationPages as $publicationPage) {
             $publicationPageTags = $this->getTagsForPage($publicationPage, $tagFields);
-            $matchedTagCount     = $publicationPageTags->intersect($currPageTags)->count();
+            $matchedTagCount = $publicationPageTags->intersect($currPageTags)->count();
 
             // We have shared/matching tags, add this page info to $allRelatedPages
             if ($matchedTagCount) {
@@ -107,7 +104,6 @@ class RelatedPublicationsComponent extends Component
 
         return $allRelatedPages;
     }
-
 
     protected function sortRelatedPagesByRelevance(Collection $allRelatedPages, int $max): Collection
     {

--- a/packages/framework/src/Publications/Views/Components/RelatedPublicationsComponent.php
+++ b/packages/framework/src/Publications/Views/Components/RelatedPublicationsComponent.php
@@ -5,14 +5,18 @@ declare(strict_types=1);
 namespace Hyde\Publications\Views\Components;
 
 use Hyde\Hyde;
+use Hyde\Pages\Concerns\HydePage;
+use Hyde\Publications\Models\PublicationPage;
+use Hyde\Publications\Models\PublicationType;
 use Hyde\Publications\PublicationService;
 use Illuminate\Contracts\View\Factory;
 use Illuminate\Contracts\View\View;
+use Illuminate\Support\Collection;
 use Illuminate\View\Component;
 
 class RelatedPublicationsComponent extends Component
 {
-    public array $relatedPublications;
+    public Collection $relatedPublications;
 
     public function __construct()
     {
@@ -25,13 +29,13 @@ class RelatedPublicationsComponent extends Component
         return view('hyde-publications::components.related-publications');
     }
 
-    protected function makeRelatedPublications(int $max = 5): array
+    protected function makeRelatedPublications(int $max = 5): Collection
     {
         // Get current publicationType
-        $currPage = Hyde::currentRoute()->getPage();
-        $publicationType = $currPage->getType();
+        $currHydePage = Hyde::currentRoute()->getPage();
+        $publicationType = $currHydePage->getType();
         if (! $publicationType) {
-            return [];
+            return collect();
         }
 
         // Get the tag fields for the current publicationType -> exit if there aren't any
@@ -39,39 +43,61 @@ class RelatedPublicationsComponent extends Component
             return $field->tagGroup !== null;
         });
         if ($tagFields->isEmpty()) {
-            return [];
+            return collect();
         }
 
-        // Get a list of all tags for the current page
+        // Get a list of all pages for this page's publicationType: 1 means we only have current page & no related pages exist
         $publicationPages = PublicationService::getPublicationsForType($publicationType)->keyBy('identifier');
-        $thisPage = $publicationPages->get($currPage->getIdentifier());
-        $publicationPages->forget($currPage->getIdentifier());
-        $thisPageTags = [];
-        foreach ($tagFields as $tagField) {
-            $thisPageTags = array_merge($thisPageTags, $thisPage->matter->get($tagField->name, []));
+        if ($publicationPages->count() <= 1) {
+            return collect();
         }
 
+        // Get all tags for the current page
+        $currPageTags = $this->getTagsForPage($publicationPages->get($currHydePage->getIdentifier()), $tagFields);
+        if ($currPageTags->isEmpty()) {
+            return collect();
+        }
+
+        // Forget the current page pages since we don't want to show it as a related page against itself
+        $publicationPages->forget($currHydePage->getIdentifier());
+
+        // Get all related pages
+        $allRelatedPages = $this->getAllRelatedPages($publicationPages, $tagFields, $currPageTags);
+        if ($allRelatedPages->isEmpty()) {
+            return collect();
+        }
+
+        // Sort them by relevance (count of shared tags & newest dates)
+        return $this->sortRelatedPagesByRelevance($allRelatedPages, $max);
+    }
+
+
+    protected function getTagsForPage(PublicationPage $publicationPage, Collection $tagFields): Collection
+    {
+        $currPageTags = collect();
+
+        // There could be multiple tag fields, most pubTypes will only have one
+        foreach ($tagFields as $tagField) {
+            $currPageTags = $currPageTags->merge($publicationPage->matter->get($tagField->name, []));
+        }
+
+        return $currPageTags;
+    }
+
+
+    protected function getAllRelatedPages (Collection $publicationPages, Collection $tagFields, Collection $currPageTags): Collection
+    {
         $allRelatedPages = collect();
+
         foreach ($publicationPages as $publicationPage) {
-            // Get a list of all tags for $publicationPage
-            $pubPageTags = [];
-            foreach ($tagFields as $tagField) {
-                $pubPageTags = array_merge($pubPageTags, $publicationPage->matter->get($tagField->name, []));
-            }
+            $pubPageTags     = $this->getTagsForPage($publicationPage, $tagFields);
+            $matchedTagCount = $pubPageTags->intersect($currPageTags)->count();
 
-            // Now count how many of $thisPageTags are also in $pubPageTags
-            $count = 0;
-            foreach ($thisPageTags as $thisPageTag) {
-                if (in_array($thisPageTag, $pubPageTags)) {
-                    $count++;
-                }
-            }
-
-            // We have shared/matching tags, add this page and it's count to $allRelatedPages
-            if ($count) {
+            // We have shared/matching tags, add this page info to $allRelatedPages
+            if ($matchedTagCount) {
                 $allRelatedPages->add(
                     collect([
-                        'count'      => $count,
+                        'count'      => $matchedTagCount,
                         'identifier' => $publicationPage->identifier,
                         'page'       => $publicationPage,
                     ])
@@ -79,18 +105,25 @@ class RelatedPublicationsComponent extends Component
             }
         }
 
-        // We found nothing -> exit
-        if (! count($allRelatedPages)) {
-            return [];
-        }
+        return $allRelatedPages;
+    }
 
-        // Sort everything by count and then by most recent date -> seems the most logical & relevant
+
+    protected function sortRelatedPagesByRelevance(Collection $allRelatedPages, int $max): Collection
+    {
+        $relatedPages = collect();
+
+        // Group related pages by the number of shared tags and then sort by keys (# of shared tags) descending
         $allRelatedPagesGrouped = $allRelatedPages->groupBy('count')->sortKeysDesc(SORT_NUMERIC);
-        $relatedPages = [];
-        foreach ($allRelatedPagesGrouped as $k=>$v) {
-            $sorted = $v->sortByDesc('page.matter.__createdAt');
-            foreach ($sorted as $kk=>$vv) {
-                $relatedPages[$vv['identifier']] = $vv['page'];
+
+        // Iterate over groups
+        foreach ($allRelatedPagesGrouped as $v) {
+            // Sort group by recency, newest pages first
+            $sortedGroup = $v->sortByDesc('page.matter.__createdAt');
+
+            // Now add to $relatedPages, quit at $max
+            foreach ($sortedGroup as $vv) {
+                $relatedPages->put($vv['identifier'], $vv['page']);
                 if (count($relatedPages) >= $max) {
                     break 2;
                 }


### PR DESCRIPTION
This is the promised refactoring of the RelatedPublicationsComponent; it should be more readable and easily understandable than the original version. j

Sorry for the superfluous registration of the component in the wrong file. It tried to reset/undo the commit for this (which seems to have worked locally) but github refuses to honor it. So please undo this 1 line change after merging this PR.