### PR TITLE
Aggressively simplify MediaFile/FileCollection discovery

### DIFF
--- a/packages/framework/src/Foundation/Facades/Files.php
+++ b/packages/framework/src/Foundation/Facades/Files.php
@@ -46,12 +46,6 @@ class Files extends Facade
         return static::getFacadeRoot()->where(fn (ProjectFile $file): bool => $file instanceof SourceFile);
     }
 
-    /** @deprecated */
-    public static function getMediaFiles(): FileCollection
-    {
-        return MediaFile::all();
-    }
-
     /**  @return \Hyde\Foundation\Kernel\FileCollection<string, \Hyde\Support\Filesystem\ProjectFile> */
     public static function getFacadeRoot(): FileCollection
     {

--- a/packages/framework/src/Foundation/Facades/Files.php
+++ b/packages/framework/src/Foundation/Facades/Files.php
@@ -46,7 +46,7 @@ class Files extends Facade
         return static::getFacadeRoot()->where(fn (ProjectFile $file): bool => $file instanceof SourceFile);
     }
 
-    /** @return \Hyde\Foundation\Kernel\FileCollection<\Hyde\Support\Filesystem\MediaFile> */
+    /** @deprecated */
     public static function getMediaFiles(): FileCollection
     {
         return static::getFacadeRoot()->where(fn (ProjectFile $file): bool => $file instanceof MediaFile);

--- a/packages/framework/src/Foundation/Facades/Files.php
+++ b/packages/framework/src/Foundation/Facades/Files.php
@@ -49,7 +49,7 @@ class Files extends Facade
     /** @deprecated */
     public static function getMediaFiles(): FileCollection
     {
-        return static::getFacadeRoot()->where(fn (ProjectFile $file): bool => $file instanceof MediaFile);
+        return MediaFile::all();
     }
 
     /**  @return \Hyde\Foundation\Kernel\FileCollection<string, \Hyde\Support\Filesystem\ProjectFile> */

--- a/packages/framework/src/Foundation/Kernel/FileCollection.php
+++ b/packages/framework/src/Foundation/Kernel/FileCollection.php
@@ -71,6 +71,7 @@ final class FileCollection extends BaseFoundationCollection
         }
     }
 
+    /** @deprecated */
     protected function discoverMediaAssetFiles(): void
     {
         foreach (DiscoveryService::getMediaAssetFiles() as $filepath) {

--- a/packages/framework/src/Foundation/Kernel/FileCollection.php
+++ b/packages/framework/src/Foundation/Kernel/FileCollection.php
@@ -6,17 +6,16 @@ namespace Hyde\Foundation\Kernel;
 
 use Hyde\Foundation\Concerns\BaseFoundationCollection;
 use Hyde\Pages\Concerns\HydePage;
-use Hyde\Support\Filesystem\ProjectFile;
 use Hyde\Support\Filesystem\SourceFile;
 
 /**
  * The FileCollection contains all the discovered source and media files,
  * and thus has an integral role in the Hyde Auto Discovery process.
  *
- * @template T of \Hyde\Support\Filesystem\ProjectFile
+ * @template T of \Hyde\Support\Filesystem\SourceFile
  * @template-extends \Hyde\Foundation\Concerns\BaseFoundationCollection<string, T>
  *
- * @property array<string, ProjectFile> $items The files in the collection.
+ * @property array<string, SourceFile> $items The files in the collection.
  *
  * This class is stored as a singleton in the HydeKernel.
  * You would commonly access it via one of the facades:
@@ -33,7 +32,7 @@ final class FileCollection extends BaseFoundationCollection
      * In order for your file to be further processed you must call this method during the boot process,
      * either using a Kernel bootingCallback, or by using a HydeExtension's discovery handler callback.
      */
-    public function addFile(ProjectFile $file): void
+    public function addFile(SourceFile $file): void
     {
         $this->put($file->getPath(), $file);
     }

--- a/packages/framework/src/Foundation/Kernel/FileCollection.php
+++ b/packages/framework/src/Foundation/Kernel/FileCollection.php
@@ -5,9 +5,7 @@ declare(strict_types=1);
 namespace Hyde\Foundation\Kernel;
 
 use Hyde\Foundation\Concerns\BaseFoundationCollection;
-use Hyde\Framework\Services\DiscoveryService;
 use Hyde\Pages\Concerns\HydePage;
-use Hyde\Support\Filesystem\MediaFile;
 use Hyde\Support\Filesystem\ProjectFile;
 use Hyde\Support\Filesystem\SourceFile;
 
@@ -48,8 +46,6 @@ final class FileCollection extends BaseFoundationCollection
                 $this->discoverFilesFor($pageClass);
             }
         }
-
-        $this->discoverMediaAssetFiles();
     }
 
     protected function runExtensionCallbacks(): void
@@ -68,14 +64,6 @@ final class FileCollection extends BaseFoundationCollection
             if (! str_starts_with(basename((string) $filepath), '_')) {
                 $this->addFile(SourceFile::make($filepath, $pageClass));
             }
-        }
-    }
-
-    /** @deprecated */
-    protected function discoverMediaAssetFiles(): void
-    {
-        foreach (DiscoveryService::getMediaAssetFiles() as $filepath) {
-            $this->addFile(MediaFile::make($filepath));
         }
     }
 }

--- a/packages/framework/src/Framework/Services/BuildService.php
+++ b/packages/framework/src/Framework/Services/BuildService.php
@@ -55,7 +55,7 @@ class BuildService
         $this->withProgressBar(array_keys(MediaFile::all()), function (string $identifier): void {
             $sitePath = Hyde::siteMediaPath($identifier);
             $this->needsParentDirectory($sitePath);
-            copy($identifier, $sitePath);
+            copy(Hyde::mediaPath($identifier), $sitePath);
         });
 
         $this->newLine(2);

--- a/packages/framework/src/Framework/Services/BuildService.php
+++ b/packages/framework/src/Framework/Services/BuildService.php
@@ -52,10 +52,10 @@ class BuildService
         $this->needsDirectory(Hyde::siteMediaPath());
 
         $this->comment('Transferring Media Assets...');
-        $this->withProgressBar(array_keys(MediaFile::all()), function (string $filepath): void {
-            $sitePath = Hyde::siteMediaPath($filepath);
+        $this->withProgressBar(array_keys(MediaFile::all()), function (string $identifier): void {
+            $sitePath = Hyde::siteMediaPath($identifier);
             $this->needsParentDirectory($sitePath);
-            copy($filepath, $sitePath);
+            copy($identifier, $sitePath);
         });
 
         $this->newLine(2);

--- a/packages/framework/src/Framework/Services/BuildService.php
+++ b/packages/framework/src/Framework/Services/BuildService.php
@@ -15,7 +15,6 @@ use Hyde\Support\Filesystem\MediaFile;
 use Hyde\Support\Models\Route;
 use Illuminate\Console\Concerns\InteractsWithIO;
 use Illuminate\Console\OutputStyle;
-use function array_keys;
 use function collect;
 
 /**
@@ -52,7 +51,7 @@ class BuildService
         $this->needsDirectory(Hyde::siteMediaPath());
 
         $this->comment('Transferring Media Assets...');
-        $this->withProgressBar(array_keys(MediaFile::all()), function (string $identifier): void {
+        $this->withProgressBar(MediaFile::files(), function (string $identifier): void {
             $sitePath = Hyde::siteMediaPath($identifier);
             $this->needsParentDirectory($sitePath);
             copy(Hyde::mediaPath($identifier), $sitePath);

--- a/packages/framework/src/Framework/Services/BuildService.php
+++ b/packages/framework/src/Framework/Services/BuildService.php
@@ -11,10 +11,12 @@ use Hyde\Framework\Actions\StaticPageBuilder;
 use Hyde\Framework\Concerns\InteractsWithDirectories;
 use Hyde\Hyde;
 use Hyde\Pages\Concerns\HydePage;
+use Hyde\Support\Filesystem\MediaFile;
 use Hyde\Support\Models\Route;
 use Illuminate\Console\Concerns\InteractsWithIO;
 use Illuminate\Console\OutputStyle;
 use Illuminate\Support\Str;
+use function array_keys;
 use function collect;
 
 /**
@@ -51,8 +53,8 @@ class BuildService
         $this->needsDirectory(Hyde::siteMediaPath());
 
         $this->comment('Transferring Media Assets...');
-        $this->withProgressBar(DiscoveryService::getMediaAssetFiles(), function (string $filepath): void {
-            $sitePath = Hyde::siteMediaPath(Str::after($filepath, Hyde::mediaPath()));
+        $this->withProgressBar(array_keys(MediaFile::all()), function (string $filepath): void {
+            $sitePath = Hyde::siteMediaPath(Str::after($filepath, Hyde::getMediaDirectory()));
             $this->needsParentDirectory($sitePath);
             copy($filepath, $sitePath);
         });

--- a/packages/framework/src/Framework/Services/BuildService.php
+++ b/packages/framework/src/Framework/Services/BuildService.php
@@ -15,7 +15,6 @@ use Hyde\Support\Filesystem\MediaFile;
 use Hyde\Support\Models\Route;
 use Illuminate\Console\Concerns\InteractsWithIO;
 use Illuminate\Console\OutputStyle;
-use Illuminate\Support\Str;
 use function array_keys;
 use function collect;
 
@@ -54,7 +53,7 @@ class BuildService
 
         $this->comment('Transferring Media Assets...');
         $this->withProgressBar(array_keys(MediaFile::all()), function (string $filepath): void {
-            $sitePath = Hyde::siteMediaPath(Str::after($filepath, Hyde::getMediaDirectory()));
+            $sitePath = Hyde::siteMediaPath($filepath);
             $this->needsParentDirectory($sitePath);
             copy($filepath, $sitePath);
         });

--- a/packages/framework/src/Framework/Services/DiscoveryService.php
+++ b/packages/framework/src/Framework/Services/DiscoveryService.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Hyde\Framework\Services;
 
 use Hyde\Hyde;
-use Hyde\Support\Filesystem\MediaFile;
 use Illuminate\Support\Str;
 use function unslash;
 
@@ -34,15 +33,5 @@ class DiscoveryService
             $pageClass::sourceDirectory().'/',
             $pageClass::fileExtension())
         );
-    }
-
-    /**
-     * Get all the Media asset filenames.
-     *
-     * @return array<string> An array of filenames relative to the media source directory.
-     */
-    public static function getMediaAssetFiles(): array
-    {
-        return MediaFile::files();
     }
 }

--- a/packages/framework/src/Framework/Services/DiscoveryService.php
+++ b/packages/framework/src/Framework/Services/DiscoveryService.php
@@ -43,6 +43,6 @@ class DiscoveryService
      */
     public static function getMediaAssetFiles(): array
     {
-        return array_keys(MediaFile::all());
+        return MediaFile::files();
     }
 }

--- a/packages/framework/src/Framework/Services/DiscoveryService.php
+++ b/packages/framework/src/Framework/Services/DiscoveryService.php
@@ -5,11 +5,8 @@ declare(strict_types=1);
 namespace Hyde\Framework\Services;
 
 use Hyde\Hyde;
+use Hyde\Support\Filesystem\MediaFile;
 use Illuminate\Support\Str;
-use Hyde\Facades\Config;
-use function glob;
-use function implode;
-use function sprintf;
 use function unslash;
 
 /**
@@ -47,13 +44,6 @@ class DiscoveryService
      */
     public static function getMediaAssetFiles(): array
     {
-        return glob(Hyde::path(static::getMediaGlobPattern()), GLOB_BRACE) ?: [];
-    }
-
-    protected static function getMediaGlobPattern(): string
-    {
-        return sprintf(Hyde::getMediaDirectory().'/{*,**/*,**/*/*}.{%s}', implode(',',
-            Config::getArray('hyde.media_extensions', self::DEFAULT_MEDIA_EXTENSIONS)
-        ));
+        return collect(MediaFile::all())->map(fn (MediaFile $file): string => $file->getAbsolutePath())->values()->toArray();
     }
 }

--- a/packages/framework/src/Framework/Services/DiscoveryService.php
+++ b/packages/framework/src/Framework/Services/DiscoveryService.php
@@ -37,13 +37,12 @@ class DiscoveryService
     }
 
     /**
-     * Get all the Media asset file paths.
-     * Returns a full file path, unlike the other get*List methods.
+     * Get all the Media asset filenames.
      *
-     * @return array<string> An array of absolute file paths.
+     * @return array<string> An array of filenames relative to the media source directory.
      */
     public static function getMediaAssetFiles(): array
     {
-        return collect(MediaFile::all())->map(fn (MediaFile $file): string => $file->getAbsolutePath())->values()->toArray();
+        return array_keys(MediaFile::all());
     }
 }

--- a/packages/framework/src/Framework/Services/DiscoveryService.php
+++ b/packages/framework/src/Framework/Services/DiscoveryService.php
@@ -17,8 +17,6 @@ use function unslash;
  */
 class DiscoveryService
 {
-    final public const DEFAULT_MEDIA_EXTENSIONS = ['png', 'svg', 'jpg', 'jpeg', 'gif', 'ico', 'css', 'js'];
-
     /**
      * Format a filename to an identifier for a given model. Unlike the basename function, any nested paths
      * within the source directory are retained in order to satisfy the page identifier definition.

--- a/packages/framework/src/Support/Filesystem/MediaFile.php
+++ b/packages/framework/src/Support/Filesystem/MediaFile.php
@@ -21,7 +21,7 @@ class MediaFile extends ProjectFile
     /** @return array<string, \Hyde\Support\Filesystem\MediaFile> */
     public static function all(): array
     {
-        return Files::getMediaFiles()->all();
+        return Files::where(fn (ProjectFile $file): bool => $file instanceof MediaFile)->all();
     }
 
     public function toArray(): array

--- a/packages/framework/src/Support/Filesystem/MediaFile.php
+++ b/packages/framework/src/Support/Filesystem/MediaFile.php
@@ -90,7 +90,7 @@ class MediaFile extends ProjectFile
         return collect(static::getMediaAssetFiles())->mapWithKeys(function (string $filepath): array {
             $file = static::make($filepath);
 
-            return [$file->getPath() => $file];
+            return [$file->getIdentifier() => $file];
         })->all();
     }
 

--- a/packages/framework/src/Support/Filesystem/MediaFile.php
+++ b/packages/framework/src/Support/Filesystem/MediaFile.php
@@ -5,7 +5,9 @@ declare(strict_types=1);
 namespace Hyde\Support\Filesystem;
 
 use Hyde\Foundation\Facades\Files;
+use Hyde\Foundation\Kernel\FileCollection;
 use Hyde\Framework\Exceptions\FileNotFoundException;
+use Hyde\Framework\Services\DiscoveryService;
 use function array_merge;
 use function extension_loaded;
 use function file_exists;
@@ -71,5 +73,14 @@ class MediaFile extends ProjectFile
         }
 
         return 'text/plain';
+    }
+
+    protected static function discoverMediaAssetFiles(): FileCollection
+    {
+        $collection = new FileCollection();
+        foreach (DiscoveryService::getMediaAssetFiles() as $filepath) {
+            $collection->addFile(MediaFile::make($filepath));
+        }
+        return $collection;
     }
 }

--- a/packages/framework/src/Support/Filesystem/MediaFile.php
+++ b/packages/framework/src/Support/Filesystem/MediaFile.php
@@ -22,7 +22,7 @@ class MediaFile extends ProjectFile
     /** @return array<string, \Hyde\Support\Filesystem\MediaFile> */
     public static function all(): array
     {
-        return static::discoverMediaAssetFiles()->all();
+        return static::discoverMediaAssetFiles();
     }
 
     public function toArray(): array
@@ -74,7 +74,7 @@ class MediaFile extends ProjectFile
         return 'text/plain';
     }
 
-    protected static function discoverMediaAssetFiles(): Collection
+    protected static function discoverMediaAssetFiles(): array
     {
         $collection = new Collection();
         foreach (DiscoveryService::getMediaAssetFiles() as $filepath) {
@@ -82,6 +82,6 @@ class MediaFile extends ProjectFile
             $collection->put($file->getPath(), $file);
         }
 
-        return $collection;
+        return $collection->all();
     }
 }

--- a/packages/framework/src/Support/Filesystem/MediaFile.php
+++ b/packages/framework/src/Support/Filesystem/MediaFile.php
@@ -32,6 +32,7 @@ class MediaFile extends ProjectFile
         return static::discoverMediaAssetFiles();
     }
 
+    /** @return array<string> */
     public static function files(): array
     {
         return array_keys(static::all());

--- a/packages/framework/src/Support/Filesystem/MediaFile.php
+++ b/packages/framework/src/Support/Filesystem/MediaFile.php
@@ -6,6 +6,7 @@ namespace Hyde\Support\Filesystem;
 
 use Hyde\Foundation\Facades\Files;
 use Hyde\Framework\Exceptions\FileNotFoundException;
+use function array_merge;
 use function extension_loaded;
 use function file_exists;
 use function filesize;

--- a/packages/framework/src/Support/Filesystem/MediaFile.php
+++ b/packages/framework/src/Support/Filesystem/MediaFile.php
@@ -6,13 +6,13 @@ namespace Hyde\Support\Filesystem;
 
 use Hyde\Framework\Exceptions\FileNotFoundException;
 use Hyde\Framework\Services\DiscoveryService;
-use function array_merge;
 use function extension_loaded;
+use function array_merge;
 use function file_exists;
 use function filesize;
+use function pathinfo;
 use function collect;
 use function is_file;
-use function pathinfo;
 
 /**
  * File abstraction for a project media file.

--- a/packages/framework/src/Support/Filesystem/MediaFile.php
+++ b/packages/framework/src/Support/Filesystem/MediaFile.php
@@ -4,8 +4,10 @@ declare(strict_types=1);
 
 namespace Hyde\Support\Filesystem;
 
+use Hyde\Hyde;
 use Hyde\Framework\Exceptions\FileNotFoundException;
 use Hyde\Framework\Services\DiscoveryService;
+use Illuminate\Support\Str;
 use function extension_loaded;
 use function array_merge;
 use function file_exists;
@@ -23,6 +25,11 @@ class MediaFile extends ProjectFile
     public static function all(): array
     {
         return static::discoverMediaAssetFiles();
+    }
+
+    public function getIdentifier(): string
+    {
+        return Str::after($this->getPath(), Hyde::getMediaDirectory().'/');
     }
 
     public function toArray(): array

--- a/packages/framework/src/Support/Filesystem/MediaFile.php
+++ b/packages/framework/src/Support/Filesystem/MediaFile.php
@@ -7,7 +7,6 @@ namespace Hyde\Support\Filesystem;
 use Hyde\Hyde;
 use Hyde\Facades\Config;
 use Hyde\Framework\Exceptions\FileNotFoundException;
-use Hyde\Framework\Services\DiscoveryService;
 use Illuminate\Support\Str;
 use function extension_loaded;
 use function file_exists;
@@ -26,6 +25,8 @@ use function glob;
  */
 class MediaFile extends ProjectFile
 {
+    final public const DEFAULT_MEDIA_EXTENSIONS = ['png', 'svg', 'jpg', 'jpeg', 'gif', 'ico', 'css', 'js'];
+
     /** @return array<string, \Hyde\Support\Filesystem\MediaFile> The array keys are the filenames relative to the _media/ directory */
     public static function all(): array
     {
@@ -109,7 +110,7 @@ class MediaFile extends ProjectFile
     protected static function getMediaGlobPattern(): string
     {
         return sprintf(Hyde::getMediaDirectory().'/{*,**/*,**/*/*}.{%s}', implode(',',
-            Config::getArray('hyde.media_extensions', DiscoveryService::DEFAULT_MEDIA_EXTENSIONS)
+            Config::getArray('hyde.media_extensions', self::DEFAULT_MEDIA_EXTENSIONS)
         ));
     }
 }

--- a/packages/framework/src/Support/Filesystem/MediaFile.php
+++ b/packages/framework/src/Support/Filesystem/MediaFile.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Hyde\Support\Filesystem;
 
+use Hyde\Foundation\Facades\Files;
 use function extension_loaded;
 use function file_exists;
 use function filesize;
@@ -63,5 +64,10 @@ class MediaFile extends ProjectFile
         }
 
         return 'text/plain';
+    }
+
+    public static function all(): array
+    {
+        return Files::getMediaFiles()->all();
     }
 }

--- a/packages/framework/src/Support/Filesystem/MediaFile.php
+++ b/packages/framework/src/Support/Filesystem/MediaFile.php
@@ -10,16 +10,16 @@ use Hyde\Framework\Exceptions\FileNotFoundException;
 use Hyde\Framework\Services\DiscoveryService;
 use Illuminate\Support\Str;
 use function extension_loaded;
-use function array_keys;
-use function array_merge;
 use function file_exists;
+use function array_merge;
+use function array_keys;
 use function filesize;
-use function glob;
 use function implode;
 use function pathinfo;
 use function collect;
 use function is_file;
 use function sprintf;
+use function glob;
 
 /**
  * File abstraction for a project media file.

--- a/packages/framework/src/Support/Filesystem/MediaFile.php
+++ b/packages/framework/src/Support/Filesystem/MediaFile.php
@@ -34,7 +34,7 @@ class MediaFile extends ProjectFile
 
     public function getContentLength(): int
     {
-        if (! is_file($this->path)) {
+        if (! is_file($this->getAbsolutePath())) {
             throw new FileNotFoundException(message: "Could not get the content length of file '$this->path'");
         }
 

--- a/packages/framework/src/Support/Filesystem/MediaFile.php
+++ b/packages/framework/src/Support/Filesystem/MediaFile.php
@@ -25,7 +25,7 @@ use function glob;
  */
 class MediaFile extends ProjectFile
 {
-    final public const DEFAULT_MEDIA_EXTENSIONS = ['png', 'svg', 'jpg', 'jpeg', 'gif', 'ico', 'css', 'js'];
+    final public const EXTENSIONS = ['png', 'svg', 'jpg', 'jpeg', 'gif', 'ico', 'css', 'js'];
 
     /** @return array<string, \Hyde\Support\Filesystem\MediaFile> The array keys are the filenames relative to the _media/ directory */
     public static function all(): array
@@ -110,7 +110,7 @@ class MediaFile extends ProjectFile
     protected static function getMediaGlobPattern(): string
     {
         return sprintf(Hyde::getMediaDirectory().'/{*,**/*,**/*/*}.{%s}', implode(',',
-            Config::getArray('hyde.media_extensions', self::DEFAULT_MEDIA_EXTENSIONS)
+            Config::getArray('hyde.media_extensions', self::EXTENSIONS)
         ));
     }
 }

--- a/packages/framework/src/Support/Filesystem/MediaFile.php
+++ b/packages/framework/src/Support/Filesystem/MediaFile.php
@@ -25,6 +25,7 @@ use function glob;
  */
 class MediaFile extends ProjectFile
 {
+    /** @var array<string> The default extensions for media types */
     final public const EXTENSIONS = ['png', 'svg', 'jpg', 'jpeg', 'gif', 'ico', 'css', 'js'];
 
     /** @return array<string, \Hyde\Support\Filesystem\MediaFile> The array keys are the filenames relative to the _media/ directory */

--- a/packages/framework/src/Support/Filesystem/MediaFile.php
+++ b/packages/framework/src/Support/Filesystem/MediaFile.php
@@ -26,13 +26,13 @@ use function glob;
  */
 class MediaFile extends ProjectFile
 {
-    /** @return array<string, \Hyde\Support\Filesystem\MediaFile> */
+    /** @return array<string, \Hyde\Support\Filesystem\MediaFile> The array keys are the filenames relative to the _media/ directory */
     public static function all(): array
     {
         return static::discoverMediaAssetFiles();
     }
 
-    /** @return array<string> */
+    /** @return array<string> Array of filenames relative to the _media/ directory */
     public static function files(): array
     {
         return array_keys(static::all());

--- a/packages/framework/src/Support/Filesystem/MediaFile.php
+++ b/packages/framework/src/Support/Filesystem/MediaFile.php
@@ -35,7 +35,7 @@ class MediaFile extends ProjectFile
     public function getContentLength(): int
     {
         if (! is_file($this->getAbsolutePath())) {
-            throw new FileNotFoundException(message: "Could not get the content length of file '$this->path'");
+            throw new FileNotFoundException(message: "Could not get the content length of file [$this->path]");
         }
 
         return filesize($this->getAbsolutePath());

--- a/packages/framework/src/Support/Filesystem/MediaFile.php
+++ b/packages/framework/src/Support/Filesystem/MediaFile.php
@@ -10,6 +10,7 @@ use function array_merge;
 use function extension_loaded;
 use function file_exists;
 use function filesize;
+use function collect;
 use function is_file;
 use function pathinfo;
 
@@ -75,12 +76,9 @@ class MediaFile extends ProjectFile
 
     protected static function discoverMediaAssetFiles(): array
     {
-        $files = [];
-        foreach (DiscoveryService::getMediaAssetFiles() as $filepath) {
+        return collect(DiscoveryService::getMediaAssetFiles())->mapWithKeys(function (string $filepath): array {
             $file = static::make($filepath);
-            $files[$file->getPath()] = $file;
-        }
-
-        return $files;
+            return [$file->getPath() => $file];
+        })->all();
     }
 }

--- a/packages/framework/src/Support/Filesystem/MediaFile.php
+++ b/packages/framework/src/Support/Filesystem/MediaFile.php
@@ -17,6 +17,12 @@ use function pathinfo;
  */
 class MediaFile extends ProjectFile
 {
+    /** @return array<string, \Hyde\Support\Filesystem\MediaFile> */
+    public static function all(): array
+    {
+        return Files::getMediaFiles()->all();
+    }
+
     public function toArray(): array
     {
         return array_merge(parent::toArray(), [
@@ -64,11 +70,5 @@ class MediaFile extends ProjectFile
         }
 
         return 'text/plain';
-    }
-
-    /** @return array<string, \Hyde\Support\Filesystem\MediaFile> */
-    public static function all(): array
-    {
-        return Files::getMediaFiles()->all();
     }
 }

--- a/packages/framework/src/Support/Filesystem/MediaFile.php
+++ b/packages/framework/src/Support/Filesystem/MediaFile.php
@@ -10,6 +10,7 @@ use Hyde\Framework\Exceptions\FileNotFoundException;
 use Hyde\Framework\Services\DiscoveryService;
 use Illuminate\Support\Str;
 use function extension_loaded;
+use function array_keys;
 use function array_merge;
 use function file_exists;
 use function filesize;
@@ -29,6 +30,11 @@ class MediaFile extends ProjectFile
     public static function all(): array
     {
         return static::discoverMediaAssetFiles();
+    }
+
+    public static function files(): array
+    {
+        return array_keys(static::all());
     }
 
     public function getIdentifier(): string

--- a/packages/framework/src/Support/Filesystem/MediaFile.php
+++ b/packages/framework/src/Support/Filesystem/MediaFile.php
@@ -5,10 +5,10 @@ declare(strict_types=1);
 namespace Hyde\Support\Filesystem;
 
 use Hyde\Foundation\Facades\Files;
+use Hyde\Framework\Exceptions\FileNotFoundException;
 use function extension_loaded;
 use function file_exists;
 use function filesize;
-use Hyde\Framework\Exceptions\FileNotFoundException;
 use function is_file;
 use function pathinfo;
 

--- a/packages/framework/src/Support/Filesystem/MediaFile.php
+++ b/packages/framework/src/Support/Filesystem/MediaFile.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace Hyde\Support\Filesystem;
 
 use Hyde\Foundation\Facades\Files;
-use Hyde\Foundation\Kernel\FileCollection;
+use Illuminate\Support\Collection;
 use Hyde\Framework\Exceptions\FileNotFoundException;
 use Hyde\Framework\Services\DiscoveryService;
 use function array_merge;
@@ -75,11 +75,12 @@ class MediaFile extends ProjectFile
         return 'text/plain';
     }
 
-    protected static function discoverMediaAssetFiles(): FileCollection
+    protected static function discoverMediaAssetFiles(): Collection
     {
-        $collection = new FileCollection();
+        $collection = new Collection();
         foreach (DiscoveryService::getMediaAssetFiles() as $filepath) {
-            $collection->addFile(MediaFile::make($filepath));
+            $file = static::make($filepath);
+            $collection->put($file->getPath(), $file);
         }
         return $collection;
     }

--- a/packages/framework/src/Support/Filesystem/MediaFile.php
+++ b/packages/framework/src/Support/Filesystem/MediaFile.php
@@ -66,6 +66,7 @@ class MediaFile extends ProjectFile
         return 'text/plain';
     }
 
+    /** @return array<string, \Hyde\Support\Filesystem\MediaFile> */
     public static function all(): array
     {
         return Files::getMediaFiles()->all();

--- a/packages/framework/src/Support/Filesystem/MediaFile.php
+++ b/packages/framework/src/Support/Filesystem/MediaFile.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Hyde\Support\Filesystem;
 
-use Illuminate\Support\Collection;
 use Hyde\Framework\Exceptions\FileNotFoundException;
 use Hyde\Framework\Services\DiscoveryService;
 use function array_merge;
@@ -76,12 +75,12 @@ class MediaFile extends ProjectFile
 
     protected static function discoverMediaAssetFiles(): array
     {
-        $collection = new Collection();
+        $files = [];
         foreach (DiscoveryService::getMediaAssetFiles() as $filepath) {
             $file = static::make($filepath);
-            $collection->put($file->getPath(), $file);
+            $files[$file->getPath()] = $file;
         }
 
-        return $collection->all();
+        return $files;
     }
 }

--- a/packages/framework/src/Support/Filesystem/MediaFile.php
+++ b/packages/framework/src/Support/Filesystem/MediaFile.php
@@ -23,7 +23,7 @@ class MediaFile extends ProjectFile
     /** @return array<string, \Hyde\Support\Filesystem\MediaFile> */
     public static function all(): array
     {
-        return Files::where(fn (ProjectFile $file): bool => $file instanceof MediaFile)->all();
+        return static::discoverMediaAssetFiles()->all();
     }
 
     public function toArray(): array

--- a/packages/framework/src/Support/Filesystem/MediaFile.php
+++ b/packages/framework/src/Support/Filesystem/MediaFile.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Hyde\Support\Filesystem;
 
-use Hyde\Foundation\Facades\Files;
 use Illuminate\Support\Collection;
 use Hyde\Framework\Exceptions\FileNotFoundException;
 use Hyde\Framework\Services\DiscoveryService;
@@ -82,6 +81,7 @@ class MediaFile extends ProjectFile
             $file = static::make($filepath);
             $collection->put($file->getPath(), $file);
         }
+
         return $collection;
     }
 }

--- a/packages/framework/tests/Feature/DiscoveryServiceTest.php
+++ b/packages/framework/tests/Feature/DiscoveryServiceTest.php
@@ -11,6 +11,7 @@ use Hyde\Pages\BladePage;
 use Hyde\Pages\DocumentationPage;
 use Hyde\Pages\MarkdownPage;
 use Hyde\Pages\MarkdownPost;
+use Hyde\Support\Filesystem\MediaFile;
 use Hyde\Testing\UnitTestCase;
 
 /**
@@ -79,7 +80,7 @@ class DiscoveryServiceTest extends UnitTestCase
 
     public function test_get_media_asset_files()
     {
-        $this->assertTrue(is_array(DiscoveryService::getMediaAssetFiles()));
+        $this->assertTrue(is_array(MediaFile::files()));
     }
 
     public function test_get_media_asset_files_discovers_files()
@@ -89,7 +90,7 @@ class DiscoveryServiceTest extends UnitTestCase
         foreach ($testFiles as $fileType) {
             $path = 'test.'.$fileType;
             $this->file('_media/'.$path);
-            $this->assertContains($path, DiscoveryService::getMediaAssetFiles());
+            $this->assertContains($path, MediaFile::files());
         }
     }
 
@@ -97,9 +98,9 @@ class DiscoveryServiceTest extends UnitTestCase
     {
         $path = 'test.custom';
         $this->file("_media/$path");
-        $this->assertNotContains($path, DiscoveryService::getMediaAssetFiles());
+        $this->assertNotContains($path, MediaFile::files());
         self::mockConfig(['hyde.media_extensions' => ['custom']]);
-        $this->assertContains($path, DiscoveryService::getMediaAssetFiles());
+        $this->assertContains($path, MediaFile::files());
     }
 
     public function test_get_media_asset_files_discovers_files_recursively()
@@ -107,7 +108,7 @@ class DiscoveryServiceTest extends UnitTestCase
         $path = 'foo/bar.png';
         $this->directory('_media/foo');
         $this->file("_media/$path");
-        $this->assertContains($path, DiscoveryService::getMediaAssetFiles());
+        $this->assertContains($path, MediaFile::files());
     }
 
     public function test_get_media_asset_files_discovers_files_very_recursively()
@@ -115,7 +116,7 @@ class DiscoveryServiceTest extends UnitTestCase
         $path = 'foo/bar/img.png';
         $this->directory(dirname("_media/$path"), recursive: true);
         $this->file("_media/$path");
-        $this->assertContains($path, DiscoveryService::getMediaAssetFiles());
+        $this->assertContains($path, MediaFile::files());
         Filesystem::deleteDirectory('_media/foo');
     }
 
@@ -126,14 +127,14 @@ class DiscoveryServiceTest extends UnitTestCase
         $this->file('_media/test.2');
         $this->file('_media/test.3');
 
-        $this->assertEquals([], DiscoveryService::getMediaAssetFiles());
+        $this->assertEquals([], MediaFile::files());
 
         self::mockConfig(['hyde.media_extensions' => ['1,2,3']]);
         $this->assertEquals([
             'test.1',
             'test.2',
             'test.3',
-        ], DiscoveryService::getMediaAssetFiles());
+        ], MediaFile::files());
     }
 
     public function test_media_asset_extensions_can_be_added_by_array()
@@ -143,13 +144,13 @@ class DiscoveryServiceTest extends UnitTestCase
         $this->file('_media/test.2');
         $this->file('_media/test.3');
 
-        $this->assertEquals([], DiscoveryService::getMediaAssetFiles());
+        $this->assertEquals([], MediaFile::files());
         self::mockConfig(['hyde.media_extensions' => ['1', '2', '3']]);
         $this->assertEquals([
             'test.1',
             'test.2',
             'test.3',
-        ], DiscoveryService::getMediaAssetFiles());
+        ], MediaFile::files());
     }
 
     public function test_blade_page_files_starting_with_underscore_are_ignored()

--- a/packages/framework/tests/Feature/DiscoveryServiceTest.php
+++ b/packages/framework/tests/Feature/DiscoveryServiceTest.php
@@ -87,16 +87,16 @@ class DiscoveryServiceTest extends UnitTestCase
         $testFiles = ['png', 'svg', 'jpg', 'jpeg', 'gif', 'ico', 'css', 'js'];
 
         foreach ($testFiles as $fileType) {
-            $path = Hyde::path('_media/test.'.$fileType);
-            $this->file($path);
+            $path = 'test.'.$fileType;
+            $this->file('_media/'.$path);
             $this->assertContains($path, DiscoveryService::getMediaAssetFiles());
         }
     }
 
     public function test_get_media_asset_files_discovers_custom_file_types()
     {
-        $path = Hyde::path('_media/test.custom');
-        $this->file($path);
+        $path = 'test.custom';
+        $this->file("_media/$path");
         $this->assertNotContains($path, DiscoveryService::getMediaAssetFiles());
         self::mockConfig(['hyde.media_extensions' => ['custom']]);
         $this->assertContains($path, DiscoveryService::getMediaAssetFiles());
@@ -104,19 +104,19 @@ class DiscoveryServiceTest extends UnitTestCase
 
     public function test_get_media_asset_files_discovers_files_recursively()
     {
-        $path = Hyde::path('_media/foo/bar.png');
+        $path = 'foo/bar.png';
         $this->directory('_media/foo');
-        $this->file($path);
+        $this->file("_media/$path");
         $this->assertContains($path, DiscoveryService::getMediaAssetFiles());
     }
 
     public function test_get_media_asset_files_discovers_files_very_recursively()
     {
-        $path = Hyde::path('_media/foo/bar/img.png');
-        $this->directory(dirname($path), recursive: true);
-        $this->file($path);
+        $path = 'foo/bar/img.png';
+        $this->directory(dirname("_media/$path"), recursive: true);
+        $this->file("_media/$path");
         $this->assertContains($path, DiscoveryService::getMediaAssetFiles());
-        Filesystem::deleteDirectory(Hyde::path('_media/foo'));
+        Filesystem::deleteDirectory('_media/foo');
     }
 
     public function test_media_asset_extensions_can_be_added_by_comma_separated_values()
@@ -130,9 +130,9 @@ class DiscoveryServiceTest extends UnitTestCase
 
         self::mockConfig(['hyde.media_extensions' => ['1,2,3']]);
         $this->assertEquals([
-            Hyde::path('_media/test.1'),
-            Hyde::path('_media/test.2'),
-            Hyde::path('_media/test.3'),
+            'test.1',
+            'test.2',
+            'test.3',
         ], DiscoveryService::getMediaAssetFiles());
     }
 
@@ -146,9 +146,9 @@ class DiscoveryServiceTest extends UnitTestCase
         $this->assertEquals([], DiscoveryService::getMediaAssetFiles());
         self::mockConfig(['hyde.media_extensions' => ['1', '2', '3']]);
         $this->assertEquals([
-            Hyde::path('_media/test.1'),
-            Hyde::path('_media/test.2'),
-            Hyde::path('_media/test.3'),
+            'test.1',
+            'test.2',
+            'test.3',
         ], DiscoveryService::getMediaAssetFiles());
     }
 

--- a/packages/framework/tests/Feature/FileCollectionTest.php
+++ b/packages/framework/tests/Feature/FileCollectionTest.php
@@ -70,21 +70,6 @@ class FileCollectionTest extends TestCase
         $this->restoreDefaultPages();
     }
 
-    public function test_get_media_files_returns_all_discovered_media_files()
-    {
-        $this->assertEquals([
-            '_media/app.css' => new MediaFile('_media/app.css'),
-        ], Files::getMediaFiles()->all());
-    }
-
-    public function test_get_media_files_does_not_include_non_media_files()
-    {
-        $this->file('_media/foo.blade.php');
-        $this->assertEquals([
-            '_media/app.css' => new MediaFile('_media/app.css'),
-        ], Files::getMediaFiles()->all());
-    }
-
     public function test_blade_pages_are_discovered()
     {
         $this->file('_pages/foo.blade.php');

--- a/packages/framework/tests/Feature/FileCollectionTest.php
+++ b/packages/framework/tests/Feature/FileCollectionTest.php
@@ -12,7 +12,6 @@ use Hyde\Pages\BladePage;
 use Hyde\Pages\DocumentationPage;
 use Hyde\Pages\MarkdownPage;
 use Hyde\Pages\MarkdownPost;
-use Hyde\Support\Filesystem\MediaFile;
 use Hyde\Support\Filesystem\SourceFile;
 use Hyde\Testing\TestCase;
 use Illuminate\Support\Collection;
@@ -33,7 +32,6 @@ class FileCollectionTest extends TestCase
         $this->assertEquals([
             '_pages/404.blade.php' => new SourceFile('_pages/404.blade.php', BladePage::class),
             '_pages/index.blade.php' => new SourceFile('_pages/index.blade.php', BladePage::class),
-            '_media/app.css' => new MediaFile('_media/app.css'),
         ], $collection->all());
     }
 

--- a/packages/framework/tests/Feature/Support/MediaFileTest.php
+++ b/packages/framework/tests/Feature/Support/MediaFileTest.php
@@ -167,7 +167,7 @@ class MediaFileTest extends TestCase
     public function test_all_helper_returns_all_media_files()
     {
         $this->assertEquals([
-            '_media/app.css' => new MediaFile('_media/app.css'),
+            'app.css' => new MediaFile('_media/app.css'),
         ], MediaFile::all());
     }
 
@@ -175,7 +175,7 @@ class MediaFileTest extends TestCase
     {
         $this->file('_media/foo.blade.php');
         $this->assertEquals([
-            '_media/app.css' => new MediaFile('_media/app.css'),
+            'app.css' => new MediaFile('_media/app.css'),
         ], MediaFile::all());
     }
 

--- a/packages/framework/tests/Feature/Support/MediaFileTest.php
+++ b/packages/framework/tests/Feature/Support/MediaFileTest.php
@@ -178,4 +178,14 @@ class MediaFileTest extends TestCase
             '_media/app.css' => new MediaFile('_media/app.css'),
         ], MediaFile::all());
     }
+
+    public function testGetIdentifier()
+    {
+        $this->assertSame('foo', MediaFile::make('foo')->getIdentifier());
+    }
+
+    public function testGetIdentifierWithSubdirectory()
+    {
+        $this->assertSame('foo/bar', MediaFile::make('foo/bar')->getIdentifier());
+    }
 }

--- a/packages/framework/tests/Feature/Support/MediaFileTest.php
+++ b/packages/framework/tests/Feature/Support/MediaFileTest.php
@@ -179,6 +179,11 @@ class MediaFileTest extends TestCase
         ], MediaFile::all());
     }
 
+    public function test_files_helper()
+    {
+        $this->assertSame(['app.css'], MediaFile::files());
+    }
+
     public function testGetIdentifier()
     {
         $this->assertSame('foo', MediaFile::make('foo')->getIdentifier());

--- a/packages/framework/tests/Feature/Support/MediaFileTest.php
+++ b/packages/framework/tests/Feature/Support/MediaFileTest.php
@@ -163,4 +163,19 @@ class MediaFileTest extends TestCase
     {
         $this->assertSame('text/plain', MediaFile::make('foo')->getMimeType());
     }
+
+    public function test_all_helper_returns_all_media_files()
+    {
+        $this->assertEquals([
+            '_media/app.css' => new MediaFile('_media/app.css'),
+        ], MediaFile::all());
+    }
+
+    public function test_all_helper_does_not_include_non_media_files()
+    {
+        $this->file('_media/foo.blade.php');
+        $this->assertEquals([
+            '_media/app.css' => new MediaFile('_media/app.css'),
+        ], MediaFile::all());
+    }
 }

--- a/packages/framework/tests/Feature/Support/MediaFileTest.php
+++ b/packages/framework/tests/Feature/Support/MediaFileTest.php
@@ -124,14 +124,14 @@ class MediaFileTest extends TestCase
         $this->directory('foo');
 
         $this->expectException(FileNotFoundException::class);
-        $this->expectExceptionMessage("Could not get the content length of file 'foo'");
+        $this->expectExceptionMessage('Could not get the content length of file [foo]');
         MediaFile::make('foo')->getContentLength();
     }
 
     public function test_getContentLength_with_non_existent_file()
     {
         $this->expectException(FileNotFoundException::class);
-        $this->expectExceptionMessage("Could not get the content length of file 'foo'");
+        $this->expectExceptionMessage('Could not get the content length of file [foo]');
         MediaFile::make('foo')->getContentLength();
     }
 


### PR DESCRIPTION
In all honesty, MediaFile objects do not need to be auto-discovered at all, considering they are only ever used in the build loop. Since they are never further processed, that complexity is not warranted. Nor do they have any need to be cached. Fixes https://github.com/hydephp/develop/issues/1204