### PR TITLE
Remove support for customizing the messages in custom exceptions

### DIFF
--- a/packages/framework/src/Foundation/Kernel/FileCollection.php
+++ b/packages/framework/src/Foundation/Kernel/FileCollection.php
@@ -61,7 +61,7 @@ final class FileCollection extends BaseFoundationCollection
 
     public function getFile(string $filePath): SourceFile
     {
-        return $this->get($filePath) ?? throw new FileNotFoundException(message: "File [$filePath] not found in file collection");
+        return $this->get($filePath) ?? throw new FileNotFoundException($filePath);
     }
 
     /**

--- a/packages/framework/src/Foundation/Kernel/PageCollection.php
+++ b/packages/framework/src/Foundation/Kernel/PageCollection.php
@@ -50,7 +50,7 @@ final class PageCollection extends BaseFoundationCollection
 
     public function getPage(string $sourcePath): HydePage
     {
-        return $this->get($sourcePath) ?? throw new FileNotFoundException(message: "Page [$sourcePath] not found in page collection");
+        return $this->get($sourcePath) ?? throw new FileNotFoundException($sourcePath);
     }
 
     /**

--- a/packages/framework/src/Foundation/Kernel/RouteCollection.php
+++ b/packages/framework/src/Foundation/Kernel/RouteCollection.php
@@ -46,7 +46,7 @@ final class RouteCollection extends BaseFoundationCollection
 
     public function getRoute(string $routeKey): Route
     {
-        return $this->get($routeKey) ?? throw new RouteNotFoundException(message: "Route [$routeKey] not found in route collection");
+        return $this->get($routeKey) ?? throw new RouteNotFoundException($routeKey);
     }
 
     /**

--- a/packages/framework/src/Framework/Exceptions/FileConflictException.php
+++ b/packages/framework/src/Framework/Exceptions/FileConflictException.php
@@ -17,7 +17,8 @@ class FileConflictException extends Exception
 
     public function __construct(?string $path = null)
     {
-        $this->message = $path ? sprintf('File [%s] already exists.', Hyde::pathToRelative($path)) : $this->message;
+        $message = $path ? sprintf('File [%s] already exists.', Hyde::pathToRelative($path)) : $this->message;
+        $this->message = $message;
 
         parent::__construct($this->message);
     }

--- a/packages/framework/src/Framework/Exceptions/FileConflictException.php
+++ b/packages/framework/src/Framework/Exceptions/FileConflictException.php
@@ -19,6 +19,6 @@ class FileConflictException extends Exception
     {
         $this->message = $path ? sprintf('File [%s] already exists.', Hyde::pathToRelative($path)) : $this->message;
 
-        parent::__construct($this->message, $this->code);
+        parent::__construct($this->message);
     }
 }

--- a/packages/framework/src/Framework/Exceptions/FileConflictException.php
+++ b/packages/framework/src/Framework/Exceptions/FileConflictException.php
@@ -18,7 +18,6 @@ class FileConflictException extends Exception
     public function __construct(?string $path = null)
     {
         $message = $path ? sprintf('File [%s] already exists.', Hyde::pathToRelative($path)) : $this->message;
-        $this->message = $message;
 
         parent::__construct($message);
     }

--- a/packages/framework/src/Framework/Exceptions/FileConflictException.php
+++ b/packages/framework/src/Framework/Exceptions/FileConflictException.php
@@ -17,7 +17,7 @@ class FileConflictException extends Exception
 
     public function __construct(?string $path = null)
     {
-        $this->message = ($path ? sprintf('File [%s] already exists.', Hyde::pathToRelative($path)) : $this->message);
+        $this->message = $path ? sprintf('File [%s] already exists.', Hyde::pathToRelative($path)) : $this->message;
 
         parent::__construct($this->message, $this->code);
     }

--- a/packages/framework/src/Framework/Exceptions/FileConflictException.php
+++ b/packages/framework/src/Framework/Exceptions/FileConflictException.php
@@ -17,7 +17,7 @@ class FileConflictException extends Exception
 
     public function __construct(?string $path = null)
     {
-        $this->message = null ?? ($path ? sprintf('File [%s] already exists.', Hyde::pathToRelative($path)) : $this->message);
+        $this->message = ($path ? sprintf('File [%s] already exists.', Hyde::pathToRelative($path)) : $this->message);
 
         parent::__construct($this->message, $this->code);
     }

--- a/packages/framework/src/Framework/Exceptions/FileConflictException.php
+++ b/packages/framework/src/Framework/Exceptions/FileConflictException.php
@@ -17,7 +17,7 @@ class FileConflictException extends Exception
 
     public function __construct(?string $path = null, ?string $message = null)
     {
-        $this->message = $message ?? ($path ? sprintf('File [%s] already exists.', Hyde::pathToRelative($path)) : $this->message);
+        $this->message = null ?? ($path ? sprintf('File [%s] already exists.', Hyde::pathToRelative($path)) : $this->message);
 
         parent::__construct($this->message, $this->code);
     }

--- a/packages/framework/src/Framework/Exceptions/FileConflictException.php
+++ b/packages/framework/src/Framework/Exceptions/FileConflictException.php
@@ -15,7 +15,7 @@ class FileConflictException extends Exception
     /** @var int */
     protected $code = 409;
 
-    public function __construct(?string $path = null, ?string $message = null)
+    public function __construct(?string $path = null)
     {
         $this->message = null ?? ($path ? sprintf('File [%s] already exists.', Hyde::pathToRelative($path)) : $this->message);
 

--- a/packages/framework/src/Framework/Exceptions/FileConflictException.php
+++ b/packages/framework/src/Framework/Exceptions/FileConflictException.php
@@ -20,6 +20,6 @@ class FileConflictException extends Exception
         $message = $path ? sprintf('File [%s] already exists.', Hyde::pathToRelative($path)) : $this->message;
         $this->message = $message;
 
-        parent::__construct($this->message);
+        parent::__construct($message);
     }
 }

--- a/packages/framework/src/Framework/Exceptions/FileConflictException.php
+++ b/packages/framework/src/Framework/Exceptions/FileConflictException.php
@@ -17,8 +17,6 @@ class FileConflictException extends Exception
 
     public function __construct(?string $path = null)
     {
-        $message = $path ? sprintf('File [%s] already exists.', Hyde::pathToRelative($path)) : $this->message;
-
-        parent::__construct($message);
+        parent::__construct($path ? sprintf('File [%s] already exists.', Hyde::pathToRelative($path)) : $this->message);
     }
 }

--- a/packages/framework/src/Framework/Exceptions/FileNotFoundException.php
+++ b/packages/framework/src/Framework/Exceptions/FileNotFoundException.php
@@ -15,7 +15,7 @@ class FileNotFoundException extends Exception
     /** @var int */
     protected $code = 404;
 
-    public function __construct(?string $path = null, ?string $message = null)
+    public function __construct(?string $path = null)
     {
         $this->message = null ?? ($path ? sprintf('File [%s] not found.', Hyde::pathToRelative($path)) : $this->message);
 

--- a/packages/framework/src/Framework/Exceptions/FileNotFoundException.php
+++ b/packages/framework/src/Framework/Exceptions/FileNotFoundException.php
@@ -19,6 +19,6 @@ class FileNotFoundException extends Exception
     {
         $this->message = $path ? sprintf('File [%s] not found.', Hyde::pathToRelative($path)) : $this->message;
 
-        parent::__construct($this->message, $this->code);
+        parent::__construct($this->message);
     }
 }

--- a/packages/framework/src/Framework/Exceptions/FileNotFoundException.php
+++ b/packages/framework/src/Framework/Exceptions/FileNotFoundException.php
@@ -17,8 +17,6 @@ class FileNotFoundException extends Exception
 
     public function __construct(?string $path = null)
     {
-        $message = $path ? sprintf('File [%s] not found.', Hyde::pathToRelative($path)) : $this->message;
-
-        parent::__construct($message);
+        parent::__construct($path ? sprintf('File [%s] not found.', Hyde::pathToRelative($path)) : $this->message);
     }
 }

--- a/packages/framework/src/Framework/Exceptions/FileNotFoundException.php
+++ b/packages/framework/src/Framework/Exceptions/FileNotFoundException.php
@@ -20,6 +20,6 @@ class FileNotFoundException extends Exception
         $message = $path ? sprintf('File [%s] not found.', Hyde::pathToRelative($path)) : $this->message;
         $this->message = $message;
 
-        parent::__construct($this->message);
+        parent::__construct($message);
     }
 }

--- a/packages/framework/src/Framework/Exceptions/FileNotFoundException.php
+++ b/packages/framework/src/Framework/Exceptions/FileNotFoundException.php
@@ -17,7 +17,7 @@ class FileNotFoundException extends Exception
 
     public function __construct(?string $path = null, ?string $message = null)
     {
-        $this->message = $message ?? ($path ? sprintf('File [%s] not found.', Hyde::pathToRelative($path)) : $this->message);
+        $this->message = null ?? ($path ? sprintf('File [%s] not found.', Hyde::pathToRelative($path)) : $this->message);
 
         parent::__construct($this->message, $this->code);
     }

--- a/packages/framework/src/Framework/Exceptions/FileNotFoundException.php
+++ b/packages/framework/src/Framework/Exceptions/FileNotFoundException.php
@@ -18,7 +18,6 @@ class FileNotFoundException extends Exception
     public function __construct(?string $path = null)
     {
         $message = $path ? sprintf('File [%s] not found.', Hyde::pathToRelative($path)) : $this->message;
-        $this->message = $message;
 
         parent::__construct($message);
     }

--- a/packages/framework/src/Framework/Exceptions/FileNotFoundException.php
+++ b/packages/framework/src/Framework/Exceptions/FileNotFoundException.php
@@ -17,7 +17,7 @@ class FileNotFoundException extends Exception
 
     public function __construct(?string $path = null)
     {
-        $this->message = null ?? ($path ? sprintf('File [%s] not found.', Hyde::pathToRelative($path)) : $this->message);
+        $this->message = ($path ? sprintf('File [%s] not found.', Hyde::pathToRelative($path)) : $this->message);
 
         parent::__construct($this->message, $this->code);
     }

--- a/packages/framework/src/Framework/Exceptions/FileNotFoundException.php
+++ b/packages/framework/src/Framework/Exceptions/FileNotFoundException.php
@@ -17,7 +17,8 @@ class FileNotFoundException extends Exception
 
     public function __construct(?string $path = null)
     {
-        $this->message = $path ? sprintf('File [%s] not found.', Hyde::pathToRelative($path)) : $this->message;
+        $message = $path ? sprintf('File [%s] not found.', Hyde::pathToRelative($path)) : $this->message;
+        $this->message = $message;
 
         parent::__construct($this->message);
     }

--- a/packages/framework/src/Framework/Exceptions/FileNotFoundException.php
+++ b/packages/framework/src/Framework/Exceptions/FileNotFoundException.php
@@ -17,7 +17,7 @@ class FileNotFoundException extends Exception
 
     public function __construct(?string $path = null)
     {
-        $this->message = ($path ? sprintf('File [%s] not found.', Hyde::pathToRelative($path)) : $this->message);
+        $this->message = $path ? sprintf('File [%s] not found.', Hyde::pathToRelative($path)) : $this->message;
 
         parent::__construct($this->message, $this->code);
     }

--- a/packages/framework/src/Framework/Exceptions/RouteNotFoundException.php
+++ b/packages/framework/src/Framework/Exceptions/RouteNotFoundException.php
@@ -19,6 +19,6 @@ class RouteNotFoundException extends Exception
         $message = $routeKey ? sprintf('Route [%s] not found.', $routeKey) : $this->message;
         $this->message = $message;
 
-        parent::__construct($this->message);
+        parent::__construct($message);
     }
 }

--- a/packages/framework/src/Framework/Exceptions/RouteNotFoundException.php
+++ b/packages/framework/src/Framework/Exceptions/RouteNotFoundException.php
@@ -16,7 +16,7 @@ class RouteNotFoundException extends Exception
 
     public function __construct(?string $routeKey = null)
     {
-        $this->message = ($routeKey ? "Route [$routeKey] not found." : $this->message);
+        $this->message = $routeKey ? "Route [$routeKey] not found." : $this->message;
 
         parent::__construct($this->message, $this->code);
     }

--- a/packages/framework/src/Framework/Exceptions/RouteNotFoundException.php
+++ b/packages/framework/src/Framework/Exceptions/RouteNotFoundException.php
@@ -16,7 +16,7 @@ class RouteNotFoundException extends Exception
 
     public function __construct(?string $routeKey = null)
     {
-        $this->message = null ?? ($routeKey ? "Route [$routeKey] not found." : $this->message);
+        $this->message = ($routeKey ? "Route [$routeKey] not found." : $this->message);
 
         parent::__construct($this->message, $this->code);
     }

--- a/packages/framework/src/Framework/Exceptions/RouteNotFoundException.php
+++ b/packages/framework/src/Framework/Exceptions/RouteNotFoundException.php
@@ -16,8 +16,6 @@ class RouteNotFoundException extends Exception
 
     public function __construct(?string $routeKey = null)
     {
-        $message = $routeKey ? sprintf('Route [%s] not found.', $routeKey) : $this->message;
-
-        parent::__construct($message);
+        parent::__construct($routeKey ? sprintf('Route [%s] not found.', $routeKey) : $this->message);
     }
 }

--- a/packages/framework/src/Framework/Exceptions/RouteNotFoundException.php
+++ b/packages/framework/src/Framework/Exceptions/RouteNotFoundException.php
@@ -16,7 +16,7 @@ class RouteNotFoundException extends Exception
 
     public function __construct(?string $routeKey = null, ?string $message = null)
     {
-        $this->message = $message ?? ($routeKey ? "Route [$routeKey] not found." : $this->message);
+        $this->message = null ?? ($routeKey ? "Route [$routeKey] not found." : $this->message);
 
         parent::__construct($this->message, $this->code);
     }

--- a/packages/framework/src/Framework/Exceptions/RouteNotFoundException.php
+++ b/packages/framework/src/Framework/Exceptions/RouteNotFoundException.php
@@ -14,7 +14,7 @@ class RouteNotFoundException extends Exception
     /** @var int */
     protected $code = 404;
 
-    public function __construct(?string $routeKey = null, ?string $message = null)
+    public function __construct(?string $routeKey = null)
     {
         $this->message = null ?? ($routeKey ? "Route [$routeKey] not found." : $this->message);
 

--- a/packages/framework/src/Framework/Exceptions/RouteNotFoundException.php
+++ b/packages/framework/src/Framework/Exceptions/RouteNotFoundException.php
@@ -18,6 +18,6 @@ class RouteNotFoundException extends Exception
     {
         $this->message = $routeKey ? sprintf('Route [%s] not found.', $routeKey) : $this->message;
 
-        parent::__construct($this->message, $this->code);
+        parent::__construct($this->message);
     }
 }

--- a/packages/framework/src/Framework/Exceptions/RouteNotFoundException.php
+++ b/packages/framework/src/Framework/Exceptions/RouteNotFoundException.php
@@ -17,7 +17,6 @@ class RouteNotFoundException extends Exception
     public function __construct(?string $routeKey = null)
     {
         $message = $routeKey ? sprintf('Route [%s] not found.', $routeKey) : $this->message;
-        $this->message = $message;
 
         parent::__construct($message);
     }

--- a/packages/framework/src/Framework/Exceptions/RouteNotFoundException.php
+++ b/packages/framework/src/Framework/Exceptions/RouteNotFoundException.php
@@ -16,7 +16,8 @@ class RouteNotFoundException extends Exception
 
     public function __construct(?string $routeKey = null)
     {
-        $this->message = $routeKey ? sprintf('Route [%s] not found.', $routeKey) : $this->message;
+        $message = $routeKey ? sprintf('Route [%s] not found.', $routeKey) : $this->message;
+        $this->message = $message;
 
         parent::__construct($this->message);
     }

--- a/packages/framework/src/Framework/Exceptions/RouteNotFoundException.php
+++ b/packages/framework/src/Framework/Exceptions/RouteNotFoundException.php
@@ -16,7 +16,7 @@ class RouteNotFoundException extends Exception
 
     public function __construct(?string $routeKey = null)
     {
-        $this->message = $routeKey ? "Route [$routeKey] not found." : $this->message;
+        $this->message = $routeKey ? sprintf('Route [%s] not found.', $routeKey) : $this->message;
 
         parent::__construct($this->message, $this->code);
     }

--- a/packages/framework/src/Framework/Exceptions/UnsupportedPageTypeException.php
+++ b/packages/framework/src/Framework/Exceptions/UnsupportedPageTypeException.php
@@ -16,6 +16,6 @@ class UnsupportedPageTypeException extends Exception
 
     public function __construct(?string $page = null)
     {
-        parent::__construct($page ? sprintf("The page type [%s] is not supported.", $page) : $this->message);
+        parent::__construct($page ? sprintf('The page type [%s] is not supported.', $page) : $this->message);
     }
 }

--- a/packages/framework/src/Framework/Exceptions/UnsupportedPageTypeException.php
+++ b/packages/framework/src/Framework/Exceptions/UnsupportedPageTypeException.php
@@ -16,7 +16,8 @@ class UnsupportedPageTypeException extends Exception
 
     public function __construct(?string $page = null)
     {
-        $this->message = $page ? "The page type [$page] is not supported." : $this->message;
+        $message = $page ? "The page type [$page] is not supported." : $this->message;
+        $this->message = $message;
 
         parent::__construct($this->message);
     }

--- a/packages/framework/src/Framework/Exceptions/UnsupportedPageTypeException.php
+++ b/packages/framework/src/Framework/Exceptions/UnsupportedPageTypeException.php
@@ -17,7 +17,6 @@ class UnsupportedPageTypeException extends Exception
     public function __construct(?string $page = null)
     {
         $message = $page ? "The page type [$page] is not supported." : $this->message;
-        $this->message = $message;
 
         parent::__construct($message);
     }

--- a/packages/framework/src/Framework/Exceptions/UnsupportedPageTypeException.php
+++ b/packages/framework/src/Framework/Exceptions/UnsupportedPageTypeException.php
@@ -18,6 +18,6 @@ class UnsupportedPageTypeException extends Exception
     {
         $this->message = $page ? "The page type [$page] is not supported." : $this->message;
 
-        parent::__construct($this->message, $this->code);
+        parent::__construct($this->message);
     }
 }

--- a/packages/framework/src/Framework/Exceptions/UnsupportedPageTypeException.php
+++ b/packages/framework/src/Framework/Exceptions/UnsupportedPageTypeException.php
@@ -16,8 +16,6 @@ class UnsupportedPageTypeException extends Exception
 
     public function __construct(?string $page = null)
     {
-        $message = $page ? "The page type [$page] is not supported." : $this->message;
-
-        parent::__construct($message);
+        parent::__construct($page ? "The page type [$page] is not supported." : $this->message);
     }
 }

--- a/packages/framework/src/Framework/Exceptions/UnsupportedPageTypeException.php
+++ b/packages/framework/src/Framework/Exceptions/UnsupportedPageTypeException.php
@@ -16,6 +16,6 @@ class UnsupportedPageTypeException extends Exception
 
     public function __construct(?string $page = null)
     {
-        parent::__construct($page ? "The page type [$page] is not supported." : $this->message);
+        parent::__construct($page ? sprintf("The page type [%s] is not supported.", $page) : $this->message);
     }
 }

--- a/packages/framework/src/Framework/Exceptions/UnsupportedPageTypeException.php
+++ b/packages/framework/src/Framework/Exceptions/UnsupportedPageTypeException.php
@@ -19,6 +19,6 @@ class UnsupportedPageTypeException extends Exception
         $message = $page ? "The page type [$page] is not supported." : $this->message;
         $this->message = $message;
 
-        parent::__construct($this->message);
+        parent::__construct($message);
     }
 }

--- a/packages/framework/src/Support/Filesystem/MediaFile.php
+++ b/packages/framework/src/Support/Filesystem/MediaFile.php
@@ -56,7 +56,7 @@ class MediaFile extends ProjectFile
     public function getContentLength(): int
     {
         if (! is_file($this->getAbsolutePath())) {
-            throw new FileNotFoundException(message: "Could not get the content length of file [$this->path]");
+            throw new FileNotFoundException($this->path);
         }
 
         return filesize($this->getAbsolutePath());

--- a/packages/framework/tests/Feature/FileCollectionTest.php
+++ b/packages/framework/tests/Feature/FileCollectionTest.php
@@ -45,7 +45,7 @@ class FileCollectionTest extends TestCase
     public function test_get_file_throws_exception_when_file_is_not_found()
     {
         $this->expectException(FileNotFoundException::class);
-        $this->expectExceptionMessage('File [_pages/foo.blade.php] not found in file collection');
+        $this->expectExceptionMessage('File [_pages/foo.blade.php] not found');
 
         Files::getFile('_pages/foo.blade.php');
     }

--- a/packages/framework/tests/Feature/PageCollectionTest.php
+++ b/packages/framework/tests/Feature/PageCollectionTest.php
@@ -182,7 +182,7 @@ class PageCollectionTest extends TestCase
     public function test_get_file_throws_exception_when_file_is_not_found()
     {
         $this->expectException(FileNotFoundException::class);
-        $this->expectExceptionMessage('Page [_pages/foo.blade.php] not found in page collection');
+        $this->expectExceptionMessage('File [_pages/foo.blade.php] not found');
 
         Pages::getPage('_pages/foo.blade.php');
     }

--- a/packages/framework/tests/Feature/RouteCollectionTest.php
+++ b/packages/framework/tests/Feature/RouteCollectionTest.php
@@ -113,7 +113,7 @@ class RouteCollectionTest extends TestCase
     public function test_get_route_with_non_existing_route()
     {
         $this->expectException(RouteNotFoundException::class);
-        $this->expectExceptionMessage('Route [non-existing] not found in route collection');
+        $this->expectExceptionMessage('Route [non-existing] not found');
         Routes::getRoute('non-existing');
     }
 }

--- a/packages/framework/tests/Feature/Support/MediaFileTest.php
+++ b/packages/framework/tests/Feature/Support/MediaFileTest.php
@@ -124,14 +124,14 @@ class MediaFileTest extends TestCase
         $this->directory('foo');
 
         $this->expectException(FileNotFoundException::class);
-        $this->expectExceptionMessage('Could not get the content length of file [foo]');
+        $this->expectExceptionMessage('File [foo] not found.');
         MediaFile::make('foo')->getContentLength();
     }
 
     public function test_getContentLength_with_non_existent_file()
     {
         $this->expectException(FileNotFoundException::class);
-        $this->expectExceptionMessage('Could not get the content length of file [foo]');
+        $this->expectExceptionMessage('File [foo] not found.');
         MediaFile::make('foo')->getContentLength();
     }
 

--- a/packages/framework/tests/Unit/CustomExceptionsTest.php
+++ b/packages/framework/tests/Unit/CustomExceptionsTest.php
@@ -36,16 +36,6 @@ class CustomExceptionsTest extends UnitTestCase
         $this->assertSame('File [foo] already exists.', (new FileConflictException('foo'))->getMessage());
     }
 
-    public function testFileConflictExceptionWithCustomMessage()
-    {
-        $this->assertSame('Custom message', (new FileConflictException(message: 'Custom message'))->getMessage());
-    }
-
-    public function testFileConflictExceptionWithPathAndCustomMessage()
-    {
-        $this->assertSame('Custom message', (new FileConflictException('foo', 'Custom message'))->getMessage());
-    }
-
     public function testFileConflictExceptionWithAbsolutePath()
     {
         $this->assertSame('File [foo] already exists.', (new FileConflictException(Hyde::path('foo')))->getMessage());
@@ -61,16 +51,6 @@ class CustomExceptionsTest extends UnitTestCase
         $this->assertSame('File [foo] not found.', (new FileNotFoundException('foo'))->getMessage());
     }
 
-    public function testFileNotFoundExceptionWithCustomMessage()
-    {
-        $this->assertSame('Custom message', (new FileNotFoundException(message: 'Custom message'))->getMessage());
-    }
-
-    public function testFileNotFoundExceptionWithPathAndCustomMessage()
-    {
-        $this->assertSame('Custom message', (new FileNotFoundException('foo', 'Custom message'))->getMessage());
-    }
-
     public function testFileNotFoundExceptionWithAbsolutePath()
     {
         $this->assertSame('File [foo] not found.', (new FileNotFoundException(Hyde::path('foo')))->getMessage());
@@ -84,16 +64,6 @@ class CustomExceptionsTest extends UnitTestCase
     public function testRouteNotFoundExceptionWithRouteKey()
     {
         $this->assertSame('Route [foo] not found.', (new RouteNotFoundException('foo'))->getMessage());
-    }
-
-    public function testRouteNotFoundExceptionWithCustomMessage()
-    {
-        $this->assertSame('Custom message', (new RouteNotFoundException(message: 'Custom message'))->getMessage());
-    }
-
-    public function testRouteNotFoundExceptionWithCustomMessageAndRouteKey()
-    {
-        $this->assertSame('Custom message', (new RouteNotFoundException('foo', 'Custom message'))->getMessage());
     }
 
     public function testUnsupportedPageTypeExceptionWithDefaultMessage()

--- a/packages/framework/tests/Unit/FileConflictExceptionTest.php
+++ b/packages/framework/tests/Unit/FileConflictExceptionTest.php
@@ -46,14 +46,4 @@ class FileConflictExceptionTest extends UnitTestCase
         HydeKernel::setInstance(new HydeKernel('my-base-path'));
         $this->assertSame('File [path/to/file] already exists.', (new FileConflictException('my-base-path/path/to/file'))->getMessage());
     }
-
-    public function test_exception_message_with_custom_message()
-    {
-        $this->assertSame('Custom message', (new FileConflictException(null, 'Custom message'))->getMessage());
-    }
-
-    public function test_exception_message_with_custom_message_and_path()
-    {
-        $this->assertSame('Custom message', (new FileConflictException('foo', 'Custom message'))->getMessage());
-    }
 }

--- a/packages/framework/tests/Unit/RouteNotFoundExceptionTest.php
+++ b/packages/framework/tests/Unit/RouteNotFoundExceptionTest.php
@@ -27,13 +27,4 @@ class RouteNotFoundExceptionTest extends UnitTestCase
 
         throw new RouteNotFoundException('not-found');
     }
-
-    public function test_it_throws_an_exception_with_custom_message()
-    {
-        $this->expectException(RouteNotFoundException::class);
-        $this->expectExceptionMessage('Custom message');
-        $this->expectExceptionCode(404);
-
-        throw new RouteNotFoundException(null, 'Custom message');
-    }
 }

--- a/packages/realtime-compiler/tests/RealtimeCompilerTest.php
+++ b/packages/realtime-compiler/tests/RealtimeCompilerTest.php
@@ -90,7 +90,7 @@ test('handle throws route not found exception for missing route', function () {
 
     $kernel = new HttpKernel();
     $kernel->handle(new Request());
-})->throws(RouteNotFoundException::class, 'Route [missing] not found in route collection');
+})->throws(RouteNotFoundException::class, 'Route [missing] not found');
 
 test('handle sends 404 error response for missing asset', function () {
     mockRoute('missing.css');


### PR DESCRIPTION
The whole reason we created these exceptions was to provide a normalized and consistent output. That disappears the moment we introduce complexity like this.

I also don't think messages like `"Could not get the content length of file [$this->path]"` is required when the stacktrace shows the message was thrown in a `getContentLength()` method. Since all exceptions are targeted at developers, we can count on the stacktraces to be visible.