### PR TITLE
Rename RebuildStaticPageCommand class to RebuildPageCommand as all pages are static

### DIFF
--- a/packages/framework/src/Console/Commands/RebuildPageCommand.php
+++ b/packages/framework/src/Console/Commands/RebuildPageCommand.php
@@ -21,9 +21,9 @@ use function unslash;
 /**
  * Hyde Command to build a single static site file.
  *
- * @see \Hyde\Framework\Testing\Feature\Commands\RebuildStaticSiteCommandTest
+ * @see \Hyde\Framework\Testing\Feature\Commands\RebuildPageCommand
  */
-class RebuildStaticPageCommand extends Command
+class RebuildPageCommand extends Command
 {
     /** @var string */
     protected $signature = 'rebuild {path : The relative file path (example: _posts/hello-world.md)}';

--- a/packages/framework/src/Console/ConsoleServiceProvider.php
+++ b/packages/framework/src/Console/ConsoleServiceProvider.php
@@ -19,7 +19,7 @@ class ConsoleServiceProvider extends ServiceProvider
             Commands\BuildSearchCommand::class,
             Commands\BuildSiteCommand::class,
             Commands\BuildSitemapCommand::class,
-            Commands\RebuildStaticPageCommand::class,
+            Commands\RebuildPageCommand::class,
 
             Commands\MakePageCommand::class,
             Commands\MakePostCommand::class,

--- a/packages/framework/tests/Feature/Commands/RebuildPageCommand.php
+++ b/packages/framework/tests/Feature/Commands/RebuildPageCommand.php
@@ -8,9 +8,9 @@ use Hyde\Hyde;
 use Hyde\Testing\TestCase;
 
 /**
- * @covers \Hyde\Console\Commands\RebuildStaticPageCommand
+ * @covers \Hyde\Console\Commands\RebuildPageCommand
  */
-class RebuildStaticPageCommandTest extends TestCase
+class RebuildPageCommand extends TestCase
 {
     public function test_handle_is_successful_with_valid_path()
     {


### PR DESCRIPTION
Only renames the command class, not the signature.