### PR TITLE
Update MarkdownPost::getLatestPosts helper to sort using the DateTime object timestamp

### DIFF
--- a/packages/framework/src/Pages/MarkdownPost.php
+++ b/packages/framework/src/Pages/MarkdownPost.php
@@ -35,7 +35,7 @@ class MarkdownPost extends BaseMarkdownPage implements BlogPostSchema
     /** @return \Hyde\Foundation\Kernel\PageCollection<\Hyde\Pages\MarkdownPost> */
     public static function getLatestPosts(): PageCollection
     {
-        return static::all()->sortByDesc(function (MarkdownPost $post): int {
+        return static::all()->sortByDesc(function (self $post): int {
             return $post->date->dateTimeObject->getTimestamp();
         });
     }

--- a/packages/framework/src/Pages/MarkdownPost.php
+++ b/packages/framework/src/Pages/MarkdownPost.php
@@ -36,7 +36,7 @@ class MarkdownPost extends BaseMarkdownPage implements BlogPostSchema
     public static function getLatestPosts(): PageCollection
     {
         return static::all()->sortByDesc(function (self $post): int {
-            return $post->date->dateTimeObject->getTimestamp();
+            return $post->date?->dateTimeObject->getTimestamp();
         });
     }
 

--- a/packages/framework/src/Pages/MarkdownPost.php
+++ b/packages/framework/src/Pages/MarkdownPost.php
@@ -36,7 +36,7 @@ class MarkdownPost extends BaseMarkdownPage implements BlogPostSchema
     public static function getLatestPosts(): PageCollection
     {
         return static::all()->sortByDesc(function (self $post): int {
-            return $post->date?->dateTimeObject->getTimestamp();
+            return $post->date?->dateTimeObject->getTimestamp() ?? 0;
         });
     }
 

--- a/packages/framework/src/Pages/MarkdownPost.php
+++ b/packages/framework/src/Pages/MarkdownPost.php
@@ -35,7 +35,9 @@ class MarkdownPost extends BaseMarkdownPage implements BlogPostSchema
     /** @return \Hyde\Foundation\Kernel\PageCollection<\Hyde\Pages\MarkdownPost> */
     public static function getLatestPosts(): PageCollection
     {
-        return static::all()->sortByDesc('matter.date');
+        return static::all()->sortByDesc(function (MarkdownPost $post): int {
+            return $post->date->dateTimeObject->getTimestamp();
+        });
     }
 
     public function toArray(): array


### PR DESCRIPTION
Since the front matter data can differ in format, we should sort using the normalized DateTime object. By using the Unix timestamp we will always be able to sort using the proper order in time.