### PR TITLE
Update pretty relative index links to rewrite to `./` instead of `/`

### DIFF
--- a/_pages/404.blade.php
+++ b/_pages/404.blade.php
@@ -31,7 +31,7 @@
                 Sorry, the page you are looking for could not be found.
             </p>
 
-            <a href="{{ config('hyde.url') ?? '/' }}">
+            <a href="{{ config('hyde.url') ?? './' }}">
                 <button
                     class="bg-transparent text-grey-darkest font-bold uppercase tracking-wide py-3 px-6 border-2 border-grey-light hover:border-grey rounded-lg">
                     Go Home

--- a/packages/framework/resources/views/pages/404.blade.php
+++ b/packages/framework/resources/views/pages/404.blade.php
@@ -31,7 +31,7 @@
                 Sorry, the page you are looking for could not be found.
             </p>
 
-            <a href="{{ config('hyde.url') ?? '/' }}">
+            <a href="{{ config('hyde.url') ?? './' }}">
                 <button
                     class="bg-transparent text-grey-darkest font-bold uppercase tracking-wide py-3 px-6 border-2 border-grey-light hover:border-grey rounded-lg">
                     Go Home

--- a/packages/framework/src/Foundation/Kernel/Hyperlinks.php
+++ b/packages/framework/src/Foundation/Kernel/Hyperlinks.php
@@ -78,6 +78,10 @@ class Hyperlinks
         }
         $route .= $this->formatLink($destination);
 
+        if (Config::getBool('hyde.pretty_urls', false) === true && $route === '/') {
+            return './';
+        }
+
         return str_replace('//', '/', $route);
     }
 

--- a/packages/framework/tests/Unit/BreadcrumbsComponentTest.php
+++ b/packages/framework/tests/Unit/BreadcrumbsComponentTest.php
@@ -105,7 +105,7 @@ class BreadcrumbsComponentTest extends UnitTestCase
         self::mockConfig(['hyde.pretty_urls' => true]);
         $this->mockPage(new MarkdownPage('index'));
 
-        $this->assertSame(['/' => 'Home'], (new BreadcrumbsComponent())->breadcrumbs);
+        $this->assertSame(['./' => 'Home'], (new BreadcrumbsComponent())->breadcrumbs);
     }
 
     public function testCanGenerateBreadcrumbsForNestedPageWithPrettyUrls()

--- a/packages/framework/tests/Unit/Foundation/HyperlinkFileHelperRelativeLinkTest.php
+++ b/packages/framework/tests/Unit/Foundation/HyperlinkFileHelperRelativeLinkTest.php
@@ -29,42 +29,42 @@ class HyperlinkFileHelperRelativeLinkTest extends UnitTestCase
         View::swap(Mockery::mock(Factory::class)->makePartial());
     }
 
-    public function test_helper_returns_string_as_is_if_current_is_not_set()
+    public function testHelperReturnsStringAsIsIfCurrentIsNotSet()
     {
         $this->assertEquals('foo/bar.html', Hyde::relativeLink('foo/bar.html'));
     }
 
-    public function test_helper_injects_proper_number_of_doubles_slash()
+    public function testHelperInjectsProperNumberOfDoublesSlash()
     {
         $this->mockCurrentPage('foo/bar.html');
         $this->assertEquals('../foo.html', Hyde::relativeLink('foo.html'));
     }
 
-    public function test_helper_injects_proper_number_of_doubles_slash_for_deeply_nested_paths()
+    public function testHelperInjectsProperNumberOfDoublesSlashForDeeplyNestedPaths()
     {
         $this->mockCurrentPage('foo/bar/baz/qux.html');
         $this->assertEquals('../../../foo.html', Hyde::relativeLink('foo.html'));
     }
 
-    public function test_helper_handles_destination_without_file_extension()
+    public function testHelperHandlesDestinationWithoutFileExtension()
     {
         $this->mockCurrentPage('foo/bar.html');
         $this->assertEquals('../foo', Hyde::relativeLink('foo'));
     }
 
-    public function test_helper_handles_current_without_file_extension()
+    public function testHelperHandlesCurrentWithoutFileExtension()
     {
         $this->mockCurrentPage('foo/bar');
         $this->assertEquals('../foo.html', Hyde::relativeLink('foo.html'));
     }
 
-    public function test_helper_handles_case_without_any_file_extensions()
+    public function testHelperHandlesCaseWithoutAnyFileExtensions()
     {
         $this->mockCurrentPage('foo/bar');
         $this->assertEquals('../foo', Hyde::relativeLink('foo'));
     }
 
-    public function test_helper_handles_case_with_mixed_file_extensions()
+    public function testHelperHandlesCaseWithMixedFileExtensions()
     {
         $this->mockCurrentPage('foo/bar.md');
         $this->assertEquals('../foo.md', Hyde::relativeLink('foo.md'));
@@ -72,7 +72,7 @@ class HyperlinkFileHelperRelativeLinkTest extends UnitTestCase
         $this->assertEquals('../foo.txt', Hyde::relativeLink('foo.txt'));
     }
 
-    public function test_helper_handles_different_file_extensions()
+    public function testHelperHandlesDifferentFileExtensions()
     {
         $this->mockCurrentPage('foo/bar');
         $this->assertEquals('../foo.png', Hyde::relativeLink('foo.png'));
@@ -80,28 +80,28 @@ class HyperlinkFileHelperRelativeLinkTest extends UnitTestCase
         $this->assertEquals('../foo.js', Hyde::relativeLink('foo.js'));
     }
 
-    public function test_helper_returns_pretty_url_if_enabled_and_destination_is_a_html_file()
+    public function testHelperReturnsPrettyUrlIfEnabledAndDestinationIsAHtmlFile()
     {
         self::mockConfig(['hyde.pretty_urls' => true]);
         $this->mockCurrentPage('foo/bar.html');
         $this->assertEquals('../foo', Hyde::relativeLink('foo.html'));
     }
 
-    public function test_helper_method_does_not_require_current_path_to_be_html_to_use_pretty_urls()
+    public function testHelperMethodDoesNotRequireCurrentPathToBeHtmlToUsePrettyUrls()
     {
         self::mockConfig(['hyde.pretty_urls' => true]);
         $this->mockCurrentPage('foo/bar');
         $this->assertEquals('../foo', Hyde::relativeLink('foo.html'));
     }
 
-    public function test_helper_returns_does_not_return_pretty_url_if_when_enabled_but_and_destination_is_not_a_html_file()
+    public function testHelperReturnsDoesNotReturnPrettyUrlIfWhenEnabledButAndDestinationIsNotAHtmlFile()
     {
         self::mockConfig(['hyde.pretty_urls' => true]);
         $this->mockCurrentPage('foo/bar.html');
         $this->assertEquals('../foo.png', Hyde::relativeLink('foo.png'));
     }
 
-    public function test_helper_rewrites_index_when_using_pretty_urls()
+    public function testHelperRewritesIndexWhenUsingPrettyUrls()
     {
         self::mockConfig(['hyde.pretty_urls' => true]);
         $this->mockCurrentPage('foo.html');
@@ -112,7 +112,7 @@ class HyperlinkFileHelperRelativeLinkTest extends UnitTestCase
         $this->assertEquals('../../', Hyde::relativeLink('index.html'));
     }
 
-    public function test_helper_does_not_rewrite_index_when_not_using_pretty_urls()
+    public function testHelperDoesNotRewriteIndexWhenNotUsingPrettyUrls()
     {
         self::mockConfig(['hyde.pretty_urls' => false]);
         $this->mockCurrentPage('foo.html');
@@ -123,7 +123,7 @@ class HyperlinkFileHelperRelativeLinkTest extends UnitTestCase
         $this->assertEquals('../../index.html', Hyde::relativeLink('index.html'));
     }
 
-    public function test_helper_rewrites_documentation_page_index_when_using_pretty_urls()
+    public function testHelperRewritesDocumentationPageIndexWhenUsingPrettyUrls()
     {
         self::mockConfig(['hyde.pretty_urls' => true]);
         $this->mockCurrentPage('foo.html');
@@ -136,7 +136,7 @@ class HyperlinkFileHelperRelativeLinkTest extends UnitTestCase
         $this->assertEquals('../docs/', Hyde::relativeLink('docs/index.html'));
     }
 
-    public function test_helper_does_not_rewrite_documentation_page_index_when_not_using_pretty_urls()
+    public function testHelperDoesNotRewriteDocumentationPageIndexWhenNotUsingPrettyUrls()
     {
         self::mockConfig(['hyde.pretty_urls' => false]);
         $this->mockCurrentPage('foo.html');
@@ -149,7 +149,7 @@ class HyperlinkFileHelperRelativeLinkTest extends UnitTestCase
         $this->assertEquals('../docs/index.html', Hyde::relativeLink('docs/index.html'));
     }
 
-    public function test_helper_does_not_rewrite_already_processed_links()
+    public function testHelperDoesNotRewriteAlreadyProcessedLinks()
     {
         $this->assertEquals('../foo', Hyde::relativeLink('../foo'));
     }

--- a/packages/framework/tests/Unit/Foundation/HyperlinkFileHelperRelativeLinkTest.php
+++ b/packages/framework/tests/Unit/Foundation/HyperlinkFileHelperRelativeLinkTest.php
@@ -105,7 +105,7 @@ class HyperlinkFileHelperRelativeLinkTest extends UnitTestCase
     {
         self::mockConfig(['hyde.pretty_urls' => true]);
         $this->mockCurrentPage('foo.html');
-        $this->assertEquals('/', Hyde::relativeLink('index.html'));
+        $this->assertEquals('./', Hyde::relativeLink('index.html'));
         $this->mockCurrentPage('foo/bar.html');
         $this->assertEquals('../', Hyde::relativeLink('index.html'));
         $this->mockCurrentPage('foo/bar/baz.html');

--- a/packages/framework/tests/Unit/Foundation/HyperlinkFileHelperRelativeLinkTest.php
+++ b/packages/framework/tests/Unit/Foundation/HyperlinkFileHelperRelativeLinkTest.php
@@ -5,13 +5,30 @@ declare(strict_types=1);
 namespace Hyde\Framework\Testing\Unit\Foundation;
 
 use Hyde\Hyde;
-use Hyde\Testing\TestCase;
+use Hyde\Support\Facades\Render;
+use Hyde\Support\Models\RenderData;
+use Hyde\Testing\InteractsWithPages;
+use Hyde\Testing\UnitTestCase;
+use Illuminate\Support\Facades\View;
+use Illuminate\View\Factory;
+use Mockery;
 
 /**
  * @covers \Hyde\Foundation\Kernel\Hyperlinks::relativeLink
  */
-class HyperlinkFileHelperRelativeLinkTest extends TestCase
+class HyperlinkFileHelperRelativeLinkTest extends UnitTestCase
 {
+    use InteractsWithPages;
+
+    protected static bool $needsKernel = true;
+    protected static bool $needsConfig = true;
+
+    protected function setUp(): void
+    {
+        Render::swap(new RenderData());
+        View::swap(Mockery::mock(Factory::class)->makePartial());
+    }
+
     public function test_helper_returns_string_as_is_if_current_is_not_set()
     {
         $this->assertEquals('foo/bar.html', Hyde::relativeLink('foo/bar.html'));
@@ -65,28 +82,28 @@ class HyperlinkFileHelperRelativeLinkTest extends TestCase
 
     public function test_helper_returns_pretty_url_if_enabled_and_destination_is_a_html_file()
     {
-        config(['hyde.pretty_urls' => true]);
+        self::mockConfig(['hyde.pretty_urls' => true]);
         $this->mockCurrentPage('foo/bar.html');
         $this->assertEquals('../foo', Hyde::relativeLink('foo.html'));
     }
 
     public function test_helper_method_does_not_require_current_path_to_be_html_to_use_pretty_urls()
     {
-        config(['hyde.pretty_urls' => true]);
+        self::mockConfig(['hyde.pretty_urls' => true]);
         $this->mockCurrentPage('foo/bar');
         $this->assertEquals('../foo', Hyde::relativeLink('foo.html'));
     }
 
     public function test_helper_returns_does_not_return_pretty_url_if_when_enabled_but_and_destination_is_not_a_html_file()
     {
-        config(['hyde.pretty_urls' => true]);
+        self::mockConfig(['hyde.pretty_urls' => true]);
         $this->mockCurrentPage('foo/bar.html');
         $this->assertEquals('../foo.png', Hyde::relativeLink('foo.png'));
     }
 
     public function test_helper_rewrites_index_when_using_pretty_urls()
     {
-        config(['hyde.pretty_urls' => true]);
+        self::mockConfig(['hyde.pretty_urls' => true]);
         $this->mockCurrentPage('foo.html');
         $this->assertEquals('/', Hyde::relativeLink('index.html'));
         $this->mockCurrentPage('foo/bar.html');
@@ -97,7 +114,7 @@ class HyperlinkFileHelperRelativeLinkTest extends TestCase
 
     public function test_helper_does_not_rewrite_index_when_not_using_pretty_urls()
     {
-        config(['hyde.pretty_urls' => false]);
+        self::mockConfig(['hyde.pretty_urls' => false]);
         $this->mockCurrentPage('foo.html');
         $this->assertEquals('index.html', Hyde::relativeLink('index.html'));
         $this->mockCurrentPage('foo/bar.html');
@@ -108,7 +125,7 @@ class HyperlinkFileHelperRelativeLinkTest extends TestCase
 
     public function test_helper_rewrites_documentation_page_index_when_using_pretty_urls()
     {
-        config(['hyde.pretty_urls' => true]);
+        self::mockConfig(['hyde.pretty_urls' => true]);
         $this->mockCurrentPage('foo.html');
         $this->assertEquals('docs/', Hyde::relativeLink('docs/index.html'));
         $this->mockCurrentPage('docs.html');
@@ -121,7 +138,7 @@ class HyperlinkFileHelperRelativeLinkTest extends TestCase
 
     public function test_helper_does_not_rewrite_documentation_page_index_when_not_using_pretty_urls()
     {
-        config(['hyde.pretty_urls' => false]);
+        self::mockConfig(['hyde.pretty_urls' => false]);
         $this->mockCurrentPage('foo.html');
         $this->assertEquals('docs/index.html', Hyde::relativeLink('docs/index.html'));
         $this->mockCurrentPage('docs.html');


### PR DESCRIPTION
This fixes an edge case bug when using pretty URLs in a subdirectory where the index page was not properly resolved relatively.

So a link to 'index.html' when using pretty URLs is now actually relative, instead of linking to the webroot which breaks subdirectories and local browsing. Both `.` and `./` work, so I choose the latter as I think it looks better.