### PR TITLE
Update RealtimeCompiler to support URLs with periods

### DIFF
--- a/packages/realtime-compiler/src/Routing/PageRouter.php
+++ b/packages/realtime-compiler/src/Routing/PageRouter.php
@@ -79,6 +79,6 @@ class PageRouter
             return new DocumentationSearchPage();
         }
 
-        return Routes::getOrFail($this->normalizePath($this->request->path))->getPage();
+        return Routes::getRoute($this->normalizePath($this->request->path))->getPage();
     }
 }


### PR DESCRIPTION
Update RealtimeCompiler PageRouter to get route directly from page as route key normalization breaks when there is a period in the URL.

This is because things like `http://localhost:8080/docs/1.x/index.html` would be parsed as `http://localhost:8080/docs/1/x/index.html` which results in `Route [docs/1/x/index] not found.`

This then begs the question if we should support normalizing route keys to support dot notation at all.