### PR TITLE
Breaking: Rename global properties

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -10,7 +10,7 @@ This serves two purposes:
 2. At release time, you can move the Unreleased section changes into a new release version section.
 
 ### Added
-- for new features.
+- Added a new `HydeKernel::currentPage()` method to return the page being rendered.
 
 ### Changed
 - Renamed global `$currentRoute` and `$currentPage` variables to `$route` and `$routeKey` respectively.

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -19,14 +19,10 @@ This serves two purposes:
 
 ### Deprecated
 - Deprecate `RouteKey::normalize` method as it no longer performs any normalization.
-- Deprecate `RenderData::$currentRoute` pending rename to `$route` as "current" is implied.
-  - This change affects the global $currentRoute variable in Blade templates.
-- Deprecate `RenderData::$currentPage` pending rename to `$routeKey` as "current" is implied, and it's not a page.
-  - This change affects the global $currentPage variable in Blade templates.
-- Deprecate `RenderData::getCurrentRoute()` pending rename to `getRoute()` to match renamed property.
-  - This change affects the `Render::getCurrentRoute()` facade methods.
-- Deprecate `RenderData::getCurrentPage()` pending rename to `getRouteKey()` to match renamed property.
-  - This change affects the `Render::getCurrentPage()` facade methods. 
+- Deprecate `RenderData::getCurrentRoute()` as it is renamed to `getRoute()` to match renamed property.
+  - This change affects the `Render::getCurrentRoute()` and `Hyde::currentRoute()` facade methods.
+- Deprecate `RenderData::getCurrentPage()` as it is renamed to `getRouteKey()` to match renamed property.
+  - This change affects the `Render::getCurrentPage()` and `Hyde::currentPage()` facade methods. 
 
 ### Removed
 - Remove RouteKey normalization for dot notation support by @caendesilva in https://github.com/hydephp/develop/pull/1241

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -19,6 +19,7 @@ This serves two purposes:
 - Deprecate `RouteKey::normalize` method as it no longer performs any normalization.
 - Deprecate `RenderData::$currentRoute` pending rename to `$route` as "current" is implied.
 - Deprecate `RenderData::$currentPage` pending rename to `$routeKey` as "current" is implied, and it's not a page.
+- Deprecate `RenderData::getCurrentPage()` pending rename to `getRouteKey()` to match renamed property.
 
 ### Removed
 - Remove RouteKey normalization for dot notation support by @caendesilva in https://github.com/hydephp/develop/pull/1241

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -18,8 +18,11 @@ This serves two purposes:
 ### Deprecated
 - Deprecate `RouteKey::normalize` method as it no longer performs any normalization.
 - Deprecate `RenderData::$currentRoute` pending rename to `$route` as "current" is implied.
+  - This change affects the global $currentRoute variable in Blade templates.
 - Deprecate `RenderData::$currentPage` pending rename to `$routeKey` as "current" is implied, and it's not a page.
+  - This change affects the global $currentPage variable in Blade templates.
 - Deprecate `RenderData::getCurrentPage()` pending rename to `getRouteKey()` to match renamed property.
+  - This change affects the `Render::getCurrentPage()` facade methods. 
 
 ### Removed
 - Remove RouteKey normalization for dot notation support by @caendesilva in https://github.com/hydephp/develop/pull/1241

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -13,7 +13,9 @@ This serves two purposes:
 - for new features.
 
 ### Changed
-- for changes in existing functionality.
+- Renamed global `$currentRoute` and `$currentPage` variables to `$route` and `$routeKey` respectively.
+- Renamed `Render::getCurrentRoute()` to `Render::getRoute()` to match renamed property.
+- Renamed `Render::getCurrentPage()` to `Render::getRouteKey()` to match renamed property.
 
 ### Deprecated
 - Deprecate `RouteKey::normalize` method as it no longer performs any normalization.

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -18,6 +18,7 @@ This serves two purposes:
 ### Deprecated
 - Deprecate `RouteKey::normalize` method as it no longer performs any normalization.
 - Deprecate `RenderData::$currentRoute` pending rename to `$route` as "current" is implied.
+- Deprecate `RenderData::currentPage` pending rename to `$routeKey` as "current" is implied, and it's not a page.
 
 ### Removed
 - Remove RouteKey normalization for dot notation support by @caendesilva in https://github.com/hydephp/develop/pull/1241

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -18,7 +18,7 @@ This serves two purposes:
 ### Deprecated
 - Deprecate `RouteKey::normalize` method as it no longer performs any normalization.
 - Deprecate `RenderData::$currentRoute` pending rename to `$route` as "current" is implied.
-- Deprecate `RenderData::currentPage` pending rename to `$routeKey` as "current" is implied, and it's not a page.
+- Deprecate `RenderData::$currentPage` pending rename to `$routeKey` as "current" is implied, and it's not a page.
 
 ### Removed
 - Remove RouteKey normalization for dot notation support by @caendesilva in https://github.com/hydephp/develop/pull/1241

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -18,6 +18,9 @@ This serves two purposes:
 - Renamed `Render::getCurrentPage()` to `Render::getRouteKey()` to match renamed property.
 
 ### Deprecated
+
+This release candidate version contains a few deprecations, these will be removed before the final 1.0.0 release.
+
 - Deprecate `RouteKey::normalize` method as it no longer performs any normalization.
 - Deprecate `RenderData::getCurrentRoute()` as it is renamed to `getRoute()` to match renamed property.
   - This change affects the `Render::getCurrentRoute()` and `Hyde::currentRoute()` facade methods.

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -21,6 +21,8 @@ This serves two purposes:
   - This change affects the global $currentRoute variable in Blade templates.
 - Deprecate `RenderData::$currentPage` pending rename to `$routeKey` as "current" is implied, and it's not a page.
   - This change affects the global $currentPage variable in Blade templates.
+- Deprecate `RenderData::getCurrentRoute()` pending rename to `getRoute()` to match renamed property.
+  - This change affects the `Render::getCurrentRoute()` facade methods.
 - Deprecate `RenderData::getCurrentPage()` pending rename to `getRouteKey()` to match renamed property.
   - This change affects the `Render::getCurrentPage()` facade methods. 
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -17,6 +17,7 @@ This serves two purposes:
 
 ### Deprecated
 - Deprecate `RouteKey::normalize` method as it no longer performs any normalization.
+- Deprecate `RenderData::$currentRoute` pending rename to `$route` as "current" is implied.
 
 ### Removed
 - Remove RouteKey normalization for dot notation support by @caendesilva in https://github.com/hydephp/develop/pull/1241

--- a/_ide_helper.php
+++ b/_ide_helper.php
@@ -20,13 +20,13 @@ $page = \Hyde\Support\Facades\Render::getPage();
  * @var \Hyde\Support\Models\Route $currentRoute The route for the page being compiled/previewed
  * @deprecated Rename to $route as "current" is implied
  */
-$currentRoute = \Hyde\Support\Facades\Render::getCurrentRoute();
+$currentRoute = \Hyde\Support\Facades\Render::getRoute();
 
 /**
  * @var string $currentPage The route key for the page being compiled/previewed
  * @deprecated Rename to $routeKey as "current" is implied, and it's not a page
  */
-$currentPage = \Hyde\Support\Facades\Render::getCurrentPage();
+$currentPage = \Hyde\Support\Facades\Render::getRouteKey();
 
 // Facades (aliased in app/config.php)
 

--- a/_ide_helper.php
+++ b/_ide_helper.php
@@ -16,10 +16,16 @@ declare(strict_types=1);
 /** @var \Hyde\Pages\Concerns\HydePage $page The page being compiled/previewed */
 $page = \Hyde\Support\Facades\Render::getPage();
 
-/** @var \Hyde\Support\Models\Route $currentRoute The route for the page being compiled/previewed */
+/**
+ * @var \Hyde\Support\Models\Route $currentRoute The route for the page being compiled/previewed
+ * @deprecated Rename to $route as "current" is implied
+ */
 $currentRoute = \Hyde\Support\Facades\Render::getCurrentRoute();
 
-/** @var string $currentPage The route key for the page being compiled/previewed */
+/**
+ * @var string $currentPage The route key for the page being compiled/previewed
+ * @deprecated Rename to $routeKey as "current" is implied, and it's not a page
+ */
 $currentPage = \Hyde\Support\Facades\Render::getCurrentPage();
 
 // Facades (aliased in app/config.php)

--- a/_ide_helper.php
+++ b/_ide_helper.php
@@ -18,15 +18,21 @@ $page = \Hyde\Support\Facades\Render::getPage();
 
 /**
  * @var \Hyde\Support\Models\Route $currentRoute The route for the page being compiled/previewed
- * @deprecated Rename to $route as "current" is implied
+ * @deprecated Renamed to $route as "current" is implied
  */
 $currentRoute = \Hyde\Support\Facades\Render::getRoute();
 
 /**
  * @var string $currentPage The route key for the page being compiled/previewed
- * @deprecated Rename to $routeKey as "current" is implied, and it's not a page
+ * @deprecated Renamed to $routeKey as "current" is implied, and it's not a page
  */
 $currentPage = \Hyde\Support\Facades\Render::getRouteKey();
+
+/*** @var \Hyde\Support\Models\Route $currentRoute The route for the page being compiled/previewed */
+$route = \Hyde\Support\Facades\Render::getRoute();
+
+/** @var string $currentPage The route key for the page being compiled/previewed */
+$routeKey = \Hyde\Support\Facades\Render::getRouteKey();
 
 // Facades (aliased in app/config.php)
 

--- a/packages/framework/src/Foundation/Concerns/ManagesViewData.php
+++ b/packages/framework/src/Foundation/Concerns/ManagesViewData.php
@@ -38,4 +38,12 @@ trait ManagesViewData
     {
         return Render::getRoute();
     }
+
+    /**
+     * Get the page being rendered.
+     */
+    public function currentPage(): ?HydePage
+    {
+        return Render::getPage();
+    }
 }

--- a/packages/framework/src/Foundation/Concerns/ManagesViewData.php
+++ b/packages/framework/src/Foundation/Concerns/ManagesViewData.php
@@ -26,7 +26,7 @@ trait ManagesViewData
     /**
      * Get the route key for the page being rendered.
      */
-    public function currentPage(): ?string
+    public function currentRouteKey(): ?string
     {
         return Render::getRouteKey();
     }

--- a/packages/framework/src/Foundation/Concerns/ManagesViewData.php
+++ b/packages/framework/src/Foundation/Concerns/ManagesViewData.php
@@ -28,7 +28,7 @@ trait ManagesViewData
      */
     public function currentPage(): ?string
     {
-        return Render::getCurrentPage();
+        return Render::getRouteKey();
     }
 
     /**
@@ -36,6 +36,6 @@ trait ManagesViewData
      */
     public function currentRoute(): ?Route
     {
-        return Render::getCurrentRoute();
+        return Render::getRoute();
     }
 }

--- a/packages/framework/src/Foundation/Kernel/Hyperlinks.php
+++ b/packages/framework/src/Foundation/Kernel/Hyperlinks.php
@@ -71,7 +71,7 @@ class Hyperlinks
             return $destination;
         }
 
-        $nestCount = substr_count($this->kernel->currentPage() ?? '', '/');
+        $nestCount = substr_count($this->kernel->currentRouteKey() ?? '', '/');
         $route = '';
         if ($nestCount > 0) {
             $route .= str_repeat('../', $nestCount);

--- a/packages/framework/src/Support/Facades/Render.php
+++ b/packages/framework/src/Support/Facades/Render.php
@@ -16,8 +16,8 @@ use Illuminate\Support\Facades\Facade;
  *
  * @method static void setPage(HydePage $page)
  * @method static HydePage|null getPage()
- * @method static Route|null getCurrentRoute()
- * @method static string|null getCurrentPage()
+ * @method static Route|null getRoute()
+ * @method static string|null getRouteKey()
  * @method static void share(string $key, mixed $value)
  * @method static void shareToView()
  * @method static void clearData()

--- a/packages/framework/src/Support/Models/RenderData.php
+++ b/packages/framework/src/Support/Models/RenderData.php
@@ -22,8 +22,7 @@ class RenderData implements Arrayable
 {
     protected HydePage $page;
 
-    /** @deprecated v1.0.0-RC.2 - Rename to $route as "current" is implied */
-    protected Route $currentRoute;
+    protected Route $route;
 
     /** @deprecated v1.0.0-RC.2 - Rename to $routeKey as "current" is implied, and it's not a page */
     protected string $currentPage;
@@ -31,7 +30,7 @@ class RenderData implements Arrayable
     public function setPage(HydePage $page): void
     {
         $this->page = $page;
-        $this->currentRoute = $page->getRoute();
+        $this->route = $page->getRoute();
         $this->currentPage = $page->getRouteKey();
 
         $this->shareToView();
@@ -54,7 +53,7 @@ class RenderData implements Arrayable
 
     public function getRoute(): ?Route
     {
-        return $this->currentRoute ?? null;
+        return $this->route ?? null;
     }
 
     /**
@@ -89,8 +88,8 @@ class RenderData implements Arrayable
 
     public function clearData(): void
     {
-        unset($this->page, $this->currentRoute, $this->currentPage);
-        View::share(['page' => null, 'currentRoute' => null, 'currentPage' => null]);
+        unset($this->page, $this->route, $this->currentPage);
+        View::share(['page' => null, 'route' => null, 'currentPage' => null]);
     }
 
     /**
@@ -101,7 +100,7 @@ class RenderData implements Arrayable
         return [
             'render' => $this,
             'page' => $this->getPage(),
-            'currentRoute' => $this->getRoute(),
+            'route' => $this->getRoute(),
             'currentPage' => $this->getRouteKey(),
         ];
     }

--- a/packages/framework/src/Support/Models/RenderData.php
+++ b/packages/framework/src/Support/Models/RenderData.php
@@ -41,6 +41,9 @@ class RenderData implements Arrayable
         return $this->page ?? null;
     }
 
+    /**
+     * @deprecated Rename to getRoute() to match renamed property.
+     */
     public function getCurrentRoute(): ?Route
     {
         return $this->currentRoute ?? null;

--- a/packages/framework/src/Support/Models/RenderData.php
+++ b/packages/framework/src/Support/Models/RenderData.php
@@ -46,7 +46,7 @@ class RenderData implements Arrayable
      */
     public function getCurrentRoute(): ?Route
     {
-        return $this->currentRoute ?? null;
+        return $this->getRoute();
     }
 
     public function getRoute(): ?Route
@@ -59,7 +59,7 @@ class RenderData implements Arrayable
      */
     public function getCurrentPage(): ?string
     {
-        return $this->currentPage ?? null;
+        return $this->getRouteKey();
     }
 
     public function getRouteKey(): ?string

--- a/packages/framework/src/Support/Models/RenderData.php
+++ b/packages/framework/src/Support/Models/RenderData.php
@@ -23,6 +23,8 @@ class RenderData implements Arrayable
 
     /** @deprecated Rename to $route as "current" is implied */
     protected Route $currentRoute;
+
+    /** @deprecated Rename to $routeKey as "current" is implied, and it's not a page */
     protected string $currentPage;
 
     public function setPage(HydePage $page): void

--- a/packages/framework/src/Support/Models/RenderData.php
+++ b/packages/framework/src/Support/Models/RenderData.php
@@ -22,7 +22,7 @@ class RenderData implements Arrayable
     protected HydePage $page;
 
     /** @deprecated Rename to $route as "current" is implied */
-    protected Route $route;
+    protected Route $currentRoute;
 
     /** @deprecated Rename to $routeKey as "current" is implied, and it's not a page */
     protected string $currentPage;
@@ -30,7 +30,7 @@ class RenderData implements Arrayable
     public function setPage(HydePage $page): void
     {
         $this->page = $page;
-        $this->route = $page->getRoute();
+        $this->currentRoute = $page->getRoute();
         $this->currentPage = $page->getRouteKey();
 
         $this->shareToView();
@@ -43,7 +43,7 @@ class RenderData implements Arrayable
 
     public function getCurrentRoute(): ?Route
     {
-        return $this->route ?? null;
+        return $this->currentRoute ?? null;
     }
 
     /**
@@ -71,7 +71,7 @@ class RenderData implements Arrayable
 
     public function clearData(): void
     {
-        unset($this->page, $this->route, $this->currentPage);
+        unset($this->page, $this->currentRoute, $this->currentPage);
         View::share(['page' => null, 'currentRoute' => null, 'currentPage' => null]);
     }
 

--- a/packages/framework/src/Support/Models/RenderData.php
+++ b/packages/framework/src/Support/Models/RenderData.php
@@ -22,10 +22,10 @@ class RenderData implements Arrayable
 {
     protected HydePage $page;
 
-    /** @deprecated Rename to $route as "current" is implied */
+    /** @deprecated v1.0.0-RC.2 - Rename to $route as "current" is implied */
     protected Route $currentRoute;
 
-    /** @deprecated Rename to $routeKey as "current" is implied, and it's not a page */
+    /** @deprecated v1.0.0-RC.2 - Rename to $routeKey as "current" is implied, and it's not a page */
     protected string $currentPage;
 
     public function setPage(HydePage $page): void
@@ -43,7 +43,7 @@ class RenderData implements Arrayable
     }
 
     /**
-     * @deprecated Renamed to getRoute() to match renamed property.
+     * @deprecated v1.0.0-RC.2 - Renamed to getRoute() to match renamed property.
      */
     #[Deprecated(reason: 'Renamed to getRoute() to match renamed property.', replacement: '%class%->getRoute()')]
     public function getCurrentRoute(): ?Route
@@ -57,7 +57,7 @@ class RenderData implements Arrayable
     }
 
     /**
-     * @deprecated Renamed to getRouteKey() to match renamed property.
+     * @deprecated v1.0.0-RC.2 - Renamed to getRouteKey() to match renamed property.
      */
     #[Deprecated(reason: 'Renamed to getRoute() to match renamed property.', replacement: '%class%->getRouteKey()')]
     public function getCurrentPage(): ?string

--- a/packages/framework/src/Support/Models/RenderData.php
+++ b/packages/framework/src/Support/Models/RenderData.php
@@ -8,6 +8,7 @@ use Hyde\Pages\Concerns\HydePage;
 use Illuminate\Contracts\Support\Arrayable;
 use Illuminate\Support\Facades\View;
 use InvalidArgumentException;
+use JetBrains\PhpStorm\Deprecated;
 
 /**
  * Contains data for the current page being rendered/compiled.
@@ -44,6 +45,7 @@ class RenderData implements Arrayable
     /**
      * @deprecated Renamed to getRoute() to match renamed property.
      */
+    #[Deprecated(reason: 'Renamed to getRoute() to match renamed property.')]
     public function getCurrentRoute(): ?Route
     {
         return $this->getRoute();
@@ -57,6 +59,7 @@ class RenderData implements Arrayable
     /**
      * @deprecated Renamed to getRouteKey() to match renamed property.
      */
+    #[Deprecated(reason: 'Renamed to getRoute() to match renamed property.')]
     public function getCurrentPage(): ?string
     {
         return $this->getRouteKey();

--- a/packages/framework/src/Support/Models/RenderData.php
+++ b/packages/framework/src/Support/Models/RenderData.php
@@ -20,6 +20,8 @@ use InvalidArgumentException;
 class RenderData implements Arrayable
 {
     protected HydePage $page;
+
+    /** @deprecated Rename to $route as "current" is implied */
     protected Route $currentRoute;
     protected string $currentPage;
 

--- a/packages/framework/src/Support/Models/RenderData.php
+++ b/packages/framework/src/Support/Models/RenderData.php
@@ -44,6 +44,7 @@ class RenderData implements Arrayable
 
     /**
      * @deprecated v1.0.0-RC.2 - Renamed to getRoute() to match renamed property.
+     * @codeCoverageIgnore
      */
     #[Deprecated(reason: 'Renamed to getRoute() to match renamed property.', replacement: '%class%->getRoute()')]
     public function getCurrentRoute(): ?Route
@@ -58,6 +59,7 @@ class RenderData implements Arrayable
 
     /**
      * @deprecated v1.0.0-RC.2 - Renamed to getRouteKey() to match renamed property.
+     * @codeCoverageIgnore
      */
     #[Deprecated(reason: 'Renamed to getRoute() to match renamed property.', replacement: '%class%->getRouteKey()')]
     public function getCurrentPage(): ?string

--- a/packages/framework/src/Support/Models/RenderData.php
+++ b/packages/framework/src/Support/Models/RenderData.php
@@ -22,7 +22,7 @@ class RenderData implements Arrayable
     protected HydePage $page;
 
     /** @deprecated Rename to $route as "current" is implied */
-    protected Route $currentRoute;
+    protected Route $route;
 
     /** @deprecated Rename to $routeKey as "current" is implied, and it's not a page */
     protected string $currentPage;
@@ -30,7 +30,7 @@ class RenderData implements Arrayable
     public function setPage(HydePage $page): void
     {
         $this->page = $page;
-        $this->currentRoute = $page->getRoute();
+        $this->route = $page->getRoute();
         $this->currentPage = $page->getRouteKey();
 
         $this->shareToView();
@@ -43,7 +43,7 @@ class RenderData implements Arrayable
 
     public function getCurrentRoute(): ?Route
     {
-        return $this->currentRoute ?? null;
+        return $this->route ?? null;
     }
 
     /**
@@ -71,7 +71,7 @@ class RenderData implements Arrayable
 
     public function clearData(): void
     {
-        unset($this->page, $this->currentRoute, $this->currentPage);
+        unset($this->page, $this->route, $this->currentPage);
         View::share(['page' => null, 'currentRoute' => null, 'currentPage' => null]);
     }
 

--- a/packages/framework/src/Support/Models/RenderData.php
+++ b/packages/framework/src/Support/Models/RenderData.php
@@ -39,10 +39,10 @@ class RenderData implements Arrayable
     }
 
     /**
-     * @deprecated v1.0.0-RC.2 - Renamed to getRoute() to match renamed property.
+     * @deprecated v1.0.0-RC.2 - Renamed to getRoute() to match renamed property. This method will be removed before version 1.0.
      * @codeCoverageIgnore
      */
-    #[Deprecated(reason: 'Renamed to getRoute() to match renamed property.', replacement: '%class%->getRoute()')]
+    #[Deprecated(reason: 'Renamed to getRoute() to match renamed property. This method will be removed before version 1.0.', replacement: '%class%->getRoute()')]
     public function getCurrentRoute(): ?Route
     {
         return $this->getRoute();
@@ -54,10 +54,10 @@ class RenderData implements Arrayable
     }
 
     /**
-     * @deprecated v1.0.0-RC.2 - Renamed to getRouteKey() to match renamed property.
+     * @deprecated v1.0.0-RC.2 - Renamed to getRouteKey() to match renamed property. This method will be removed before version 1.0.
      * @codeCoverageIgnore
      */
-    #[Deprecated(reason: 'Renamed to getRoute() to match renamed property.', replacement: '%class%->getRouteKey()')]
+    #[Deprecated(reason: 'Renamed to getRoute() to match renamed property. This method will be removed before version 1.0.', replacement: '%class%->getRouteKey()')]
     public function getCurrentPage(): ?string
     {
         return $this->getRouteKey();

--- a/packages/framework/src/Support/Models/RenderData.php
+++ b/packages/framework/src/Support/Models/RenderData.php
@@ -42,7 +42,7 @@ class RenderData implements Arrayable
     }
 
     /**
-     * @deprecated Rename to getRoute() to match renamed property.
+     * @deprecated Renamed to getRoute() to match renamed property.
      */
     public function getCurrentRoute(): ?Route
     {
@@ -55,7 +55,7 @@ class RenderData implements Arrayable
     }
 
     /**
-     * @deprecated Rename to getRouteKey() to match renamed property.
+     * @deprecated Renamed to getRouteKey() to match renamed property.
      */
     public function getCurrentPage(): ?string
     {

--- a/packages/framework/src/Support/Models/RenderData.php
+++ b/packages/framework/src/Support/Models/RenderData.php
@@ -24,14 +24,13 @@ class RenderData implements Arrayable
 
     protected Route $route;
 
-    /** @deprecated v1.0.0-RC.2 - Rename to $routeKey as "current" is implied, and it's not a page */
-    protected string $currentPage;
+    protected string $routeKey;
 
     public function setPage(HydePage $page): void
     {
         $this->page = $page;
         $this->route = $page->getRoute();
-        $this->currentPage = $page->getRouteKey();
+        $this->routeKey = $page->getRouteKey();
 
         $this->shareToView();
     }
@@ -68,7 +67,7 @@ class RenderData implements Arrayable
 
     public function getRouteKey(): ?string
     {
-        return $this->currentPage ?? null;
+        return $this->routeKey ?? null;
     }
 
     public function shareToView(): void
@@ -88,8 +87,8 @@ class RenderData implements Arrayable
 
     public function clearData(): void
     {
-        unset($this->page, $this->route, $this->currentPage);
-        View::share(['page' => null, 'route' => null, 'currentPage' => null]);
+        unset($this->page, $this->route, $this->routeKey);
+        View::share(['page' => null, 'route' => null, 'routeKey' => null]);
     }
 
     /**
@@ -101,7 +100,7 @@ class RenderData implements Arrayable
             'render' => $this,
             'page' => $this->getPage(),
             'route' => $this->getRoute(),
-            'currentPage' => $this->getRouteKey(),
+            'routeKey' => $this->getRouteKey(),
         ];
     }
 }

--- a/packages/framework/src/Support/Models/RenderData.php
+++ b/packages/framework/src/Support/Models/RenderData.php
@@ -45,7 +45,7 @@ class RenderData implements Arrayable
     /**
      * @deprecated Renamed to getRoute() to match renamed property.
      */
-    #[Deprecated(reason: 'Renamed to getRoute() to match renamed property.')]
+    #[Deprecated(reason: 'Renamed to getRoute() to match renamed property.', replacement: '%class%->getRoute()')]
     public function getCurrentRoute(): ?Route
     {
         return $this->getRoute();
@@ -59,7 +59,7 @@ class RenderData implements Arrayable
     /**
      * @deprecated Renamed to getRouteKey() to match renamed property.
      */
-    #[Deprecated(reason: 'Renamed to getRoute() to match renamed property.')]
+    #[Deprecated(reason: 'Renamed to getRoute() to match renamed property.', replacement: '%class%->getRouteKey()')]
     public function getCurrentPage(): ?string
     {
         return $this->getRouteKey();

--- a/packages/framework/src/Support/Models/RenderData.php
+++ b/packages/framework/src/Support/Models/RenderData.php
@@ -21,9 +21,7 @@ use JetBrains\PhpStorm\Deprecated;
 class RenderData implements Arrayable
 {
     protected HydePage $page;
-
     protected Route $route;
-
     protected string $routeKey;
 
     public function setPage(HydePage $page): void

--- a/packages/framework/src/Support/Models/RenderData.php
+++ b/packages/framework/src/Support/Models/RenderData.php
@@ -62,6 +62,11 @@ class RenderData implements Arrayable
         return $this->currentPage ?? null;
     }
 
+    public function getRouteKey(): ?string
+    {
+        return $this->currentPage ?? null;
+    }
+
     public function shareToView(): void
     {
         View::share($this->toArray());

--- a/packages/framework/src/Support/Models/RenderData.php
+++ b/packages/framework/src/Support/Models/RenderData.php
@@ -49,6 +49,11 @@ class RenderData implements Arrayable
         return $this->currentRoute ?? null;
     }
 
+    public function getRoute(): ?Route
+    {
+        return $this->currentRoute ?? null;
+    }
+
     /**
      * @deprecated Rename to getRouteKey() to match renamed property.
      */

--- a/packages/framework/src/Support/Models/RenderData.php
+++ b/packages/framework/src/Support/Models/RenderData.php
@@ -99,8 +99,8 @@ class RenderData implements Arrayable
         return [
             'render' => $this,
             'page' => $this->getPage(),
-            'currentRoute' => $this->getCurrentRoute(),
-            'currentPage' => $this->getCurrentPage(),
+            'currentRoute' => $this->getRoute(),
+            'currentPage' => $this->getRouteKey(),
         ];
     }
 }

--- a/packages/framework/src/Support/Models/RenderData.php
+++ b/packages/framework/src/Support/Models/RenderData.php
@@ -46,6 +46,9 @@ class RenderData implements Arrayable
         return $this->currentRoute ?? null;
     }
 
+    /**
+     * @deprecated Rename to getRouteKey() to match renamed property.
+     */
     public function getCurrentPage(): ?string
     {
         return $this->currentPage ?? null;

--- a/packages/framework/tests/Feature/DarkmodeFeatureTest.php
+++ b/packages/framework/tests/Feature/DarkmodeFeatureTest.php
@@ -47,7 +47,7 @@ class DarkmodeFeatureTest extends TestCase
         $view = view('hyde::layouts/page')->with([
             'title' => 'foo',
             'content' => 'foo',
-            'currentPage' => 'foo',
+            'routeKey' => 'foo',
         ])->render();
 
         $this->assertStringContainsString('title="Toggle theme"', $view);
@@ -66,7 +66,7 @@ class DarkmodeFeatureTest extends TestCase
         $view = view('hyde::layouts/docs')->with([
             'title' => 'foo',
             'content' => 'foo',
-            'currentPage' => 'foo',
+            'routeKey' => 'foo',
         ])->render();
 
         $this->assertStringContainsString('title="Toggle theme"', $view);
@@ -83,7 +83,7 @@ class DarkmodeFeatureTest extends TestCase
         $view = view('hyde::layouts/page')->with([
             'title' => 'foo',
             'content' => 'foo',
-            'currentPage' => 'foo',
+            'routeKey' => 'foo',
         ])->render();
 
         $this->assertStringNotContainsString('title="Toggle theme"', $view);
@@ -101,7 +101,7 @@ class DarkmodeFeatureTest extends TestCase
         $view = view('hyde::layouts/docs')->with([
             'title' => 'foo',
             'content' => 'foo',
-            'currentPage' => 'foo',
+            'routeKey' => 'foo',
         ])->render();
 
         $this->assertStringNotContainsString('title="Toggle theme"', $view);

--- a/packages/framework/tests/Feature/GlobalMetadataBagTest.php
+++ b/packages/framework/tests/Feature/GlobalMetadataBagTest.php
@@ -119,7 +119,7 @@ class GlobalMetadataBagTest extends TestCase
         $page = new MarkdownPage('foo');
         $page->metadata->add($duplicate);
 
-        Render::share('currentPage', 'foo');
+        Render::share('routeKey', 'foo');
         Render::share('page', $page);
 
         $this->assertEquals(['metadata:keep' => $keep], GlobalMetadataBag::make()->get());
@@ -134,7 +134,7 @@ class GlobalMetadataBagTest extends TestCase
         $page = new MarkdownPage('foo');
         $page->metadata->add(Meta::name('foo', 'baz'));
 
-        Render::share('currentPage', 'foo');
+        Render::share('routeKey', 'foo');
         Render::share('page', $page);
 
         $this->assertEquals([], GlobalMetadataBag::make()->get());

--- a/packages/framework/tests/Feature/HydeKernelTest.php
+++ b/packages/framework/tests/Feature/HydeKernelTest.php
@@ -79,7 +79,7 @@ class HydeKernelTest extends TestCase
 
     public function test_current_page_helper_returns_current_page_name()
     {
-        Render::share('currentPage', 'foo');
+        Render::share('routeKey', 'foo');
         $this->assertSame('foo', Hyde::currentPage());
     }
 
@@ -151,29 +151,29 @@ class HydeKernelTest extends TestCase
 
     public function test_relative_link_helper_returns_relative_link_to_destination()
     {
-        Render::share('currentPage', 'bar');
+        Render::share('routeKey', 'bar');
         $this->assertSame('foo', Hyde::relativeLink('foo'));
 
-        Render::share('currentPage', 'foo/bar');
+        Render::share('routeKey', 'foo/bar');
         $this->assertSame('../foo', Hyde::relativeLink('foo'));
     }
 
     public function test_media_link_helper_returns_relative_link_to_destination()
     {
-        Render::share('currentPage', 'bar');
+        Render::share('routeKey', 'bar');
         $this->assertSame('media/foo', Hyde::mediaLink('foo'));
 
-        Render::share('currentPage', 'foo/bar');
+        Render::share('routeKey', 'foo/bar');
         $this->assertSame('../media/foo', Hyde::mediaLink('foo'));
     }
 
     public function test_image_helper_returns_image_path_for_given_name()
     {
-        Render::share('currentPage', 'foo');
+        Render::share('routeKey', 'foo');
         $this->assertSame('media/foo.jpg', Hyde::asset('foo.jpg'));
         $this->assertSame('https://example.com/foo.jpg', Hyde::asset('https://example.com/foo.jpg'));
 
-        Render::share('currentPage', 'foo/bar');
+        Render::share('routeKey', 'foo/bar');
         $this->assertSame('../media/foo.jpg', Hyde::asset('foo.jpg'));
         $this->assertSame('https://example.com/foo.jpg', Hyde::asset('https://example.com/foo.jpg'));
     }

--- a/packages/framework/tests/Feature/HydeKernelTest.php
+++ b/packages/framework/tests/Feature/HydeKernelTest.php
@@ -90,7 +90,6 @@ class HydeKernelTest extends TestCase
         Render::share('route', $expected);
         $this->assertInstanceOf(Route::class, Hyde::currentRoute());
         $this->assertSame($expected, Hyde::currentRoute());
-        $this->assertSame($expected, Hyde::currentRoute());
     }
 
     public function test_current_page_helper_returns_current_page_object()
@@ -98,7 +97,6 @@ class HydeKernelTest extends TestCase
         $expected = new MarkdownPage();
         Render::share('page', $expected);
         $this->assertInstanceOf(HydePage::class, Hyde::currentPage());
-        $this->assertSame($expected, Hyde::currentPage());
         $this->assertSame($expected, Hyde::currentPage());
     }
 

--- a/packages/framework/tests/Feature/HydeKernelTest.php
+++ b/packages/framework/tests/Feature/HydeKernelTest.php
@@ -13,6 +13,7 @@ use Hyde\Foundation\Kernel\Filesystem;
 use Hyde\Framework\HydeServiceProvider;
 use Hyde\Hyde;
 use Hyde\Pages\BladePage;
+use Hyde\Pages\Concerns\HydePage;
 use Hyde\Pages\DocumentationPage;
 use Hyde\Pages\InMemoryPage;
 use Hyde\Pages\MarkdownPage;
@@ -90,6 +91,15 @@ class HydeKernelTest extends TestCase
         $this->assertInstanceOf(Route::class, Hyde::currentRoute());
         $this->assertSame($expected, Hyde::currentRoute());
         $this->assertSame($expected, Hyde::currentRoute());
+    }
+
+    public function test_current_page_helper_returns_current_page_object()
+    {
+        $expected = new MarkdownPage();
+        Render::share('page', $expected);
+        $this->assertInstanceOf(HydePage::class, Hyde::currentPage());
+        $this->assertSame($expected, Hyde::currentPage());
+        $this->assertSame($expected, Hyde::currentPage());
     }
 
     public function test_make_title_helper_returns_title_from_page_slug()

--- a/packages/framework/tests/Feature/HydeKernelTest.php
+++ b/packages/framework/tests/Feature/HydeKernelTest.php
@@ -86,7 +86,7 @@ class HydeKernelTest extends TestCase
     public function test_current_route_helper_returns_current_route_object()
     {
         $expected = new Route(new MarkdownPage());
-        Render::share('currentRoute', $expected);
+        Render::share('route', $expected);
         $this->assertInstanceOf(Route::class, Hyde::currentRoute());
         $this->assertSame($expected, Hyde::currentRoute());
         $this->assertSame($expected, Hyde::currentRoute());

--- a/packages/framework/tests/Feature/HydeKernelTest.php
+++ b/packages/framework/tests/Feature/HydeKernelTest.php
@@ -80,7 +80,7 @@ class HydeKernelTest extends TestCase
     public function test_current_page_helper_returns_current_page_name()
     {
         Render::share('routeKey', 'foo');
-        $this->assertSame('foo', Hyde::currentPage());
+        $this->assertSame('foo', Hyde::currentRouteKey());
     }
 
     public function test_current_route_helper_returns_current_route_object()

--- a/packages/framework/tests/Feature/RenderHelperTest.php
+++ b/packages/framework/tests/Feature/RenderHelperTest.php
@@ -33,20 +33,20 @@ class RenderHelperTest extends TestCase
         $this->assertSame($page, View::shared('page'));
     }
 
-    public function testGetCurrentRoute()
+    public function testGetRoute()
     {
-        $this->assertNull(Render::getCurrentRoute());
+        $this->assertNull(Render::getRoute());
 
         Render::setPage($page = new MarkdownPage());
-        $this->assertEquals($page->getRoute(), Render::getCurrentRoute());
+        $this->assertEquals($page->getRoute(), Render::getRoute());
     }
 
-    public function testGetCurrentPage()
+    public function testGetRouteKey()
     {
-        $this->assertNull(Render::getCurrentPage());
+        $this->assertNull(Render::getRouteKey());
 
         Render::setPage($page = new MarkdownPage());
-        $this->assertSame($page->getRouteKey(), Render::getCurrentPage());
+        $this->assertSame($page->getRouteKey(), Render::getRouteKey());
     }
 
     public function testShareToView()
@@ -64,10 +64,10 @@ class RenderHelperTest extends TestCase
 
     public function testShare()
     {
-        $this->assertNull(Render::getCurrentPage());
+        $this->assertNull(Render::getRouteKey());
 
         Render::share('currentPage', 'bar');
-        $this->assertSame('bar', Render::getCurrentPage());
+        $this->assertSame('bar', Render::getRouteKey());
     }
 
     public function testShareInvalidProperty()

--- a/packages/framework/tests/Feature/RenderHelperTest.php
+++ b/packages/framework/tests/Feature/RenderHelperTest.php
@@ -52,13 +52,13 @@ class RenderHelperTest extends TestCase
     public function testShareToView()
     {
         $this->assertNull(View::shared('page'));
-        $this->assertNull(View::shared('currentRoute'));
+        $this->assertNull(View::shared('route'));
         $this->assertNull(View::shared('currentPage'));
 
         Render::setPage($page = new MarkdownPage());
 
         $this->assertSame($page, View::shared('page'));
-        $this->assertEquals($page->getRoute(), View::shared('currentRoute'));
+        $this->assertEquals($page->getRoute(), View::shared('route'));
         $this->assertSame($page->getRouteKey(), View::shared('currentPage'));
     }
 
@@ -110,12 +110,12 @@ class RenderHelperTest extends TestCase
         Render::setPage(new MarkdownPage());
 
         $this->assertNotNull(View::shared('page'));
-        $this->assertNotNull(View::shared('currentRoute'));
+        $this->assertNotNull(View::shared('route'));
         $this->assertNotNull(View::shared('currentPage'));
 
         Render::clearData();
         $this->assertNull(View::shared('page'));
-        $this->assertNull(View::shared('currentRoute'));
+        $this->assertNull(View::shared('route'));
         $this->assertNull(View::shared('currentPage'));
     }
 
@@ -143,7 +143,7 @@ class RenderHelperTest extends TestCase
         $this->assertSame([
             'render' => $render,
             'page' => null,
-            'currentRoute' => null,
+            'route' => null,
             'currentPage' => null,
         ], $render->toArray());
 
@@ -151,7 +151,7 @@ class RenderHelperTest extends TestCase
         $this->assertEquals([
             'render' => $render,
             'page' => $page,
-            'currentRoute' => $page->getRoute(),
+            'route' => $page->getRoute(),
             'currentPage' => $page->getRouteKey(),
         ], $render->toArray());
     }

--- a/packages/framework/tests/Feature/RenderHelperTest.php
+++ b/packages/framework/tests/Feature/RenderHelperTest.php
@@ -53,20 +53,20 @@ class RenderHelperTest extends TestCase
     {
         $this->assertNull(View::shared('page'));
         $this->assertNull(View::shared('route'));
-        $this->assertNull(View::shared('currentPage'));
+        $this->assertNull(View::shared('routeKey'));
 
         Render::setPage($page = new MarkdownPage());
 
         $this->assertSame($page, View::shared('page'));
         $this->assertEquals($page->getRoute(), View::shared('route'));
-        $this->assertSame($page->getRouteKey(), View::shared('currentPage'));
+        $this->assertSame($page->getRouteKey(), View::shared('routeKey'));
     }
 
     public function testShare()
     {
         $this->assertNull(Render::getRouteKey());
 
-        Render::share('currentPage', 'bar');
+        Render::share('routeKey', 'bar');
         $this->assertSame('bar', Render::getRouteKey());
     }
 
@@ -80,10 +80,10 @@ class RenderHelperTest extends TestCase
 
     public function testShareCascadesDataToView()
     {
-        $this->assertNull(View::shared('currentPage'));
+        $this->assertNull(View::shared('routeKey'));
 
-        Render::share('currentPage', 'bar');
-        $this->assertSame('bar', View::shared('currentPage'));
+        Render::share('routeKey', 'bar');
+        $this->assertSame('bar', View::shared('routeKey'));
     }
 
     public function testClearData()
@@ -111,12 +111,12 @@ class RenderHelperTest extends TestCase
 
         $this->assertNotNull(View::shared('page'));
         $this->assertNotNull(View::shared('route'));
-        $this->assertNotNull(View::shared('currentPage'));
+        $this->assertNotNull(View::shared('routeKey'));
 
         Render::clearData();
         $this->assertNull(View::shared('page'));
         $this->assertNull(View::shared('route'));
-        $this->assertNull(View::shared('currentPage'));
+        $this->assertNull(View::shared('routeKey'));
     }
 
     public function testClearDataDoesNotClearOtherViewData()
@@ -144,7 +144,7 @@ class RenderHelperTest extends TestCase
             'render' => $render,
             'page' => null,
             'route' => null,
-            'currentPage' => null,
+            'routeKey' => null,
         ], $render->toArray());
 
         Render::setPage($page = new MarkdownPage());
@@ -152,7 +152,7 @@ class RenderHelperTest extends TestCase
             'render' => $render,
             'page' => $page,
             'route' => $page->getRoute(),
-            'currentPage' => $page->getRouteKey(),
+            'routeKey' => $page->getRouteKey(),
         ], $render->toArray());
     }
 }

--- a/packages/framework/tests/Unit/BreadcrumbsComponentTest.php
+++ b/packages/framework/tests/Unit/BreadcrumbsComponentTest.php
@@ -140,7 +140,7 @@ class BreadcrumbsComponentTest extends UnitTestCase
 
     protected function mockPage(MarkdownPage $page): void
     {
-        Render::shouldReceive('getCurrentRoute')->once()->andReturn(new Route($page));
-        Render::shouldReceive('getCurrentPage')->andReturn($page->getOutputPath());
+        Render::shouldReceive('getRoute')->once()->andReturn(new Route($page));
+        Render::shouldReceive('getRouteKey')->andReturn($page->getOutputPath());
     }
 }

--- a/packages/framework/tests/Unit/Facades/RouteFacadeTest.php
+++ b/packages/framework/tests/Unit/Facades/RouteFacadeTest.php
@@ -61,14 +61,14 @@ class RouteFacadeTest extends UnitTestCase
     public function testCurrentReturnsCurrentRoute()
     {
         $route = new Route(new MarkdownPage('foo'));
-        Render::shouldReceive('getCurrentRoute')->andReturn($route);
+        Render::shouldReceive('getRoute')->andReturn($route);
         $this->assertSame($route, Routes::current());
         Render::swap(new RenderData());
     }
 
     public function testCurrentReturnsNullIfRouteIsNotFound()
     {
-        Render::shouldReceive('getCurrentRoute')->andReturn(null);
+        Render::shouldReceive('getRoute')->andReturn(null);
         $this->assertNull(Routes::current());
         Render::swap(new RenderData());
     }

--- a/packages/framework/tests/Unit/HydeFileHelpersTest.php
+++ b/packages/framework/tests/Unit/HydeFileHelpersTest.php
@@ -27,7 +27,7 @@ class HydeFileHelpersTest extends TestCase
 
     public function test_current_route_returns_current_route_view_property()
     {
-        Render::share('currentRoute', Routes::get('index'));
+        Render::share('route', Routes::get('index'));
         $this->assertEquals(Routes::get('index'), Hyde::currentRoute());
     }
 

--- a/packages/framework/tests/Unit/HydeFileHelpersTest.php
+++ b/packages/framework/tests/Unit/HydeFileHelpersTest.php
@@ -16,7 +16,7 @@ class HydeFileHelpersTest extends TestCase
 {
     public function test_current_page_returns_current_page_view_property()
     {
-        Render::share('currentPage', 'foo');
+        Render::share('routeKey', 'foo');
         $this->assertEquals('foo', Hyde::currentPage());
     }
 

--- a/packages/framework/tests/Unit/HydeFileHelpersTest.php
+++ b/packages/framework/tests/Unit/HydeFileHelpersTest.php
@@ -17,12 +17,12 @@ class HydeFileHelpersTest extends TestCase
     public function test_current_page_returns_current_page_view_property()
     {
         Render::share('routeKey', 'foo');
-        $this->assertEquals('foo', Hyde::currentPage());
+        $this->assertEquals('foo', Hyde::currentRouteKey());
     }
 
     public function test_current_page_falls_back_to_empty_string_if_current_page_view_property_is_not_set()
     {
-        $this->assertEquals('', Hyde::currentPage());
+        $this->assertEquals('', Hyde::currentRouteKey());
     }
 
     public function test_current_route_returns_current_route_view_property()

--- a/packages/framework/tests/Unit/NavItemIsCurrentHelperTest.php
+++ b/packages/framework/tests/Unit/NavItemIsCurrentHelperTest.php
@@ -238,8 +238,8 @@ class NavItemIsCurrentHelperTest extends UnitTestCase
     protected function mockRenderData(Route $route): void
     {
         Render::swap(Mockery::mock(RenderData::class, [
-            'getCurrentRoute' => $route,
-            'getCurrentPage' => $route->getRouteKey(),
+            'getRoute' => $route,
+            'getRouteKey' => $route->getRouteKey(),
         ]));
     }
 

--- a/packages/framework/tests/Unit/NavItemTest.php
+++ b/packages/framework/tests/Unit/NavItemTest.php
@@ -80,7 +80,7 @@ class NavItemTest extends UnitTestCase
 
     public function test__toString()
     {
-        Render::shouldReceive('getCurrentPage')->once()->andReturn('index');
+        Render::shouldReceive('getRouteKey')->once()->andReturn('index');
 
         $this->assertSame('index.html', (string) NavItem::fromRoute(Routes::get('index')));
     }
@@ -141,24 +141,24 @@ class NavItemTest extends UnitTestCase
     public function testRouteBasedNavItemDestinationsAreResolvedRelatively()
     {
         Render::swap(Mockery::mock(RenderData::class, [
-            'getCurrentRoute' => (new Route(new InMemoryPage('foo'))),
-            'getCurrentPage' => 'foo',
+            'getRoute' => (new Route(new InMemoryPage('foo'))),
+            'getRouteKey' => 'foo',
         ]));
 
         $this->assertSame('foo.html', (string) NavItem::fromRoute(new Route(new InMemoryPage('foo'))));
         $this->assertSame('foo/bar.html', (string) NavItem::fromRoute(new Route(new InMemoryPage('foo/bar'))));
 
         Render::swap(Mockery::mock(RenderData::class, [
-            'getCurrentRoute' => (new Route(new InMemoryPage('foo/bar'))),
-            'getCurrentPage' => 'foo/bar',
+            'getRoute' => (new Route(new InMemoryPage('foo/bar'))),
+            'getRouteKey' => 'foo/bar',
         ]));
 
         $this->assertSame('../foo.html', (string) NavItem::fromRoute(new Route(new InMemoryPage('foo'))));
         $this->assertSame('../foo/bar.html', (string) NavItem::fromRoute(new Route(new InMemoryPage('foo/bar'))));
 
         Render::swap(Mockery::mock(RenderData::class, [
-            'getCurrentRoute' => (new Route(new InMemoryPage('foo/bar/baz'))),
-            'getCurrentPage' => 'foo/bar/baz',
+            'getRoute' => (new Route(new InMemoryPage('foo/bar/baz'))),
+            'getRouteKey' => 'foo/bar/baz',
         ]));
 
         $this->assertSame('../../foo.html', (string) NavItem::fromRoute(new Route(new InMemoryPage('foo'))));
@@ -168,8 +168,8 @@ class NavItemTest extends UnitTestCase
     public function testIsCurrent()
     {
         Render::swap(Mockery::mock(RenderData::class, [
-            'getCurrentRoute' => (new Route(new InMemoryPage('foo'))),
-            'getCurrentPage' => 'foo',
+            'getRoute' => (new Route(new InMemoryPage('foo'))),
+            'getRouteKey' => 'foo',
         ]));
         $this->assertTrue(NavItem::fromRoute(new Route(new InMemoryPage('foo')))->isCurrent());
         $this->assertFalse(NavItem::fromRoute(new Route(new InMemoryPage('bar')))->isCurrent());

--- a/packages/framework/tests/Unit/RouteTest.php
+++ b/packages/framework/tests/Unit/RouteTest.php
@@ -80,7 +80,7 @@ class RouteTest extends UnitTestCase
     public function testGetLinkReturnsCorrectPathForNestedCurrentPage()
     {
         $route = new Route(new MarkdownPage('foo'));
-        Render::shouldReceive('getCurrentPage')->andReturn('foo/bar');
+        Render::shouldReceive('getRouteKey')->andReturn('foo/bar');
 
         $this->assertSame(Hyde::relativeLink($route->getOutputPath()), $route->getLink());
         $this->assertSame('../foo.html', $route->getLink());

--- a/packages/framework/tests/Unit/Views/Components/LinkComponentTest.php
+++ b/packages/framework/tests/Unit/Views/Components/LinkComponentTest.php
@@ -28,7 +28,7 @@ class LinkComponentTest extends TestCase
 
     public function test_link_component_can_be_rendered_with_route_for_nested_pages()
     {
-        Render::share('currentPage', 'foo/bar');
+        Render::share('routeKey', 'foo/bar');
         $route = Routes::get('index');
         $this->assertEquals('<a href="../index.html">bar</a>', rtrim(
             Blade::render('<x-link href="'.$route.'">bar</x-link>')));

--- a/packages/framework/tests/Unit/Views/ScriptsComponentViewTest.php
+++ b/packages/framework/tests/Unit/Views/ScriptsComponentViewTest.php
@@ -58,7 +58,7 @@ class ScriptsComponentViewTest extends TestCase
 
     public function test_scripts_can_be_pushed_to_the_component_scripts_stack()
     {
-        view()->share('currentPage', '');
+        view()->share('routeKey', '');
 
         $this->assertStringContainsString('foo bar',
              Blade::render('

--- a/packages/framework/tests/Unit/Views/StylesComponentViewTest.php
+++ b/packages/framework/tests/Unit/Views/StylesComponentViewTest.php
@@ -59,7 +59,7 @@ class StylesComponentViewTest extends TestCase
 
     public function test_styles_can_be_pushed_to_the_component_styles_stack()
     {
-        Render::share('currentPage', '');
+        Render::share('routeKey', '');
 
         $this->assertStringContainsString('foo bar',
              Blade::render('

--- a/packages/testing/src/InteractsWithPages.php
+++ b/packages/testing/src/InteractsWithPages.php
@@ -19,11 +19,11 @@ trait InteractsWithPages
     protected function mockPage(?HydePage $page = null, ?string $currentPage = null): void
     {
         Render::share('page', $page ?? new MarkdownPage());
-        Render::share('currentPage', $currentPage ?? 'PHPUnit');
+        Render::share('routeKey', $currentPage ?? 'PHPUnit');
     }
 
     protected function mockCurrentPage(string $currentPage): void
     {
-        Render::share('currentPage', $currentPage);
+        Render::share('routeKey', $currentPage);
     }
 }

--- a/packages/testing/src/InteractsWithPages.php
+++ b/packages/testing/src/InteractsWithPages.php
@@ -13,7 +13,7 @@ trait InteractsWithPages
 {
     protected function mockRoute(?Route $route = null): void
     {
-        Render::share('currentRoute', $route ?? (new Route(new MarkdownPage())));
+        Render::share('route', $route ?? (new Route(new MarkdownPage())));
     }
 
     protected function mockPage(?HydePage $page = null, ?string $currentPage = null): void


### PR DESCRIPTION
This will hopefully be the last breaking change. The old accessors are present but deprecated and will be removed before v1.0-proper. I think the RC break is justified here as since the properties are not documented I don't think many people use it so the impact is low, and the naming issue is quite severe. These are legacy properties introduced before route keys were a thing.

- The global `$currentRoute` variable will be renamed to `$route` as "current" is implied
- The global `$currentRoute` variable will be renamed to `$routeKey` as "current" is implied, and it's not a page.

For this, the location of the actual shared variables (in the ViewData) class are also deprecated, and updated for the renames. Most of these changes should be easy to upgrade with search+replace in project files.