### PR TITLE
HydePHP v1.0.0 - Release Candidate Two

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,37 @@ HydePHP consists of two primary components, Hyde/Hyde and Hyde/Framework. Develo
 
 <!-- CHANGELOG_START -->
 
+## [v1.0.0-RC.2](https://github.com/hydephp/develop/releases/tag/v1.0.0-RC.2) - 2023-03-10
+
+### Added
+- Added a new `HydeKernel::currentPage()` method to return the page being rendered.
+
+### Changed
+- Renamed global `$currentRoute` and `$currentPage` variables to `$route` and `$routeKey` respectively.
+- Renamed `Render::getCurrentRoute()` to `Render::getRoute()` to match renamed property.
+- Renamed `Render::getCurrentPage()` to `Render::getRouteKey()` to match renamed property.
+
+### Deprecated
+
+This release candidate version contains a few deprecations, these will be removed before the final 1.0.0 release.
+
+- Deprecate `RouteKey::normalize` method as it no longer performs any normalization.
+- Deprecate `RenderData::getCurrentRoute()` as it is renamed to `getRoute()` to match renamed property.
+  - This change affects the `Render::getCurrentRoute()` and `Hyde::currentRoute()` facade methods.
+- Deprecate `RenderData::getCurrentPage()` as it is renamed to `getRouteKey()` to match renamed property.
+  - This change affects the `Render::getCurrentPage()` and `Hyde::currentPage()` facade methods. 
+
+### Removed
+- Remove RouteKey normalization for dot notation support by @caendesilva in https://github.com/hydephp/develop/pull/1241
+
+### Fixed
+- Update MarkdownPost::getLatestPosts helper to sort using the DateTime object timestamp by @caendesilva in https://github.com/hydephp/develop/pull/1235
+- Update PostAuthor::all() to map entries into array keyed by username by @caendesilva in https://github.com/hydephp/develop/pull/1236
+- Normalize internal author array keys to lowercase to make author usernames case-insensitive by @caendesilva in https://github.com/hydephp/develop/pull/1237
+- Update pretty relative index links to rewrite to `./` instead of `/` by @caendesilva in https://github.com/hydephp/develop/pull/1238
+- Fixed https://github.com/hydephp/develop/issues/1240
+
+
 ## [v1.0.0-RC.1](https://github.com/hydephp/develop/releases/tag/v1.0.0-RC.1) - 2023-03-07
 
 ### About

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -10,32 +10,19 @@ This serves two purposes:
 2. At release time, you can move the Unreleased section changes into a new release version section.
 
 ### Added
-- Added a new `HydeKernel::currentPage()` method to return the page being rendered.
+- for new features.
 
 ### Changed
-- Renamed global `$currentRoute` and `$currentPage` variables to `$route` and `$routeKey` respectively.
-- Renamed `Render::getCurrentRoute()` to `Render::getRoute()` to match renamed property.
-- Renamed `Render::getCurrentPage()` to `Render::getRouteKey()` to match renamed property.
+- for changes in existing functionality.
 
 ### Deprecated
-
-This release candidate version contains a few deprecations, these will be removed before the final 1.0.0 release.
-
-- Deprecate `RouteKey::normalize` method as it no longer performs any normalization.
-- Deprecate `RenderData::getCurrentRoute()` as it is renamed to `getRoute()` to match renamed property.
-  - This change affects the `Render::getCurrentRoute()` and `Hyde::currentRoute()` facade methods.
-- Deprecate `RenderData::getCurrentPage()` as it is renamed to `getRouteKey()` to match renamed property.
-  - This change affects the `Render::getCurrentPage()` and `Hyde::currentPage()` facade methods. 
+- for soon-to-be removed features.
 
 ### Removed
-- Remove RouteKey normalization for dot notation support by @caendesilva in https://github.com/hydephp/develop/pull/1241
+- for now removed features.
 
 ### Fixed
-- Update MarkdownPost::getLatestPosts helper to sort using the DateTime object timestamp by @caendesilva in https://github.com/hydephp/develop/pull/1235
-- Update PostAuthor::all() to map entries into array keyed by username by @caendesilva in https://github.com/hydephp/develop/pull/1236
-- Normalize internal author array keys to lowercase to make author usernames case-insensitive by @caendesilva in https://github.com/hydephp/develop/pull/1237
-- Update pretty relative index links to rewrite to `./` instead of `/` by @caendesilva in https://github.com/hydephp/develop/pull/1238
-- Fixed https://github.com/hydephp/develop/issues/1240
+- for any bug fixes.
 
 ### Security
 - in case of vulnerabilities.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "hyde",
-    "version": "1.0.0-RC.1",
+    "version": "1.0.0-RC.2",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "hyde",
-            "version": "1.0.0-RC.1",
+            "version": "1.0.0-RC.2",
             "license": "MIT",
             "devDependencies": {
                 "@tailwindcss/typography": "^0.5.2",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     },
     "name": "hyde",
     "description": "Elegant and Powerful Static App Builder",
-    "version": "1.0.0-RC.1",
+    "version": "1.0.0-RC.2",
     "main": "hyde",
     "directories": {
         "test": "tests"

--- a/packages/framework/src/Foundation/HydeKernel.php
+++ b/packages/framework/src/Foundation/HydeKernel.php
@@ -49,7 +49,7 @@ class HydeKernel implements SerializableContract
     use Serializable;
     use Macroable;
 
-    final public const VERSION = '1.0.0-RC.1';
+    final public const VERSION = '1.0.0-RC.2';
 
     protected static self $instance;
 


### PR DESCRIPTION
## [v1.0.0-RC.2](https://github.com/hydephp/develop/releases/tag/v1.0.0-RC.2) - 2023-03-10

### Added
- Added a new `HydeKernel::currentPage()` method to return the page being rendered.

### Changed
- Renamed global `$currentRoute` and `$currentPage` variables to `$route` and `$routeKey` respectively.
- Renamed `Render::getCurrentRoute()` to `Render::getRoute()` to match renamed property.
- Renamed `Render::getCurrentPage()` to `Render::getRouteKey()` to match renamed property.

### Deprecated

This release candidate version contains a few deprecations, these will be removed before the final 1.0.0 release.

- Deprecate `RouteKey::normalize` method as it no longer performs any normalization.
- Deprecate `RenderData::getCurrentRoute()` as it is renamed to `getRoute()` to match renamed property.
  - This change affects the `Render::getCurrentRoute()` and `Hyde::currentRoute()` facade methods.
- Deprecate `RenderData::getCurrentPage()` as it is renamed to `getRouteKey()` to match renamed property.
  - This change affects the `Render::getCurrentPage()` and `Hyde::currentPage()` facade methods. 

### Removed
- Remove RouteKey normalization for dot notation support by @caendesilva in https://github.com/hydephp/develop/pull/1241

### Fixed
- Update MarkdownPost::getLatestPosts helper to sort using the DateTime object timestamp by @caendesilva in https://github.com/hydephp/develop/pull/1235
- Update PostAuthor::all() to map entries into array keyed by username by @caendesilva in https://github.com/hydephp/develop/pull/1236
- Normalize internal author array keys to lowercase to make author usernames case-insensitive by @caendesilva in https://github.com/hydephp/develop/pull/1237
- Update pretty relative index links to rewrite to `./` instead of `/` by @caendesilva in https://github.com/hydephp/develop/pull/1238
- Fixed https://github.com/hydephp/develop/issues/1240
