### PR TITLE
Deprecate HydePage canonical url property

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -16,7 +16,7 @@ This serves two purposes:
 - for changes in existing functionality.
 
 ### Deprecated
-- for soon-to-be removed features.
+- HydePage::$canonicalUrl
 
 ### Removed
 - for now removed features.

--- a/packages/framework/src/Markdown/Contracts/FrontMatter/PageSchema.php
+++ b/packages/framework/src/Markdown/Contracts/FrontMatter/PageSchema.php
@@ -13,7 +13,7 @@ interface PageSchema extends FrontMatterSchema
 {
     public const PAGE_SCHEMA = [
         'title'         => 'string',
-        'canonicalUrl'  => 'string',
+        'canonicalUrl'  => 'string', // DEPRECATED
         'navigation'    => NavigationSchema::NAVIGATION_SCHEMA,
     ];
 }

--- a/packages/framework/src/Pages/Concerns/HydePage.php
+++ b/packages/framework/src/Pages/Concerns/HydePage.php
@@ -67,6 +67,8 @@ abstract class HydePage implements PageSchema, SerializableContract
     public NavigationData $navigation;
 
     public string $title;
+
+    /** @deprecated This property requires information that is setup-dependent, and will work better through a runtime accessor. Since it is mainly related to blog posts, it will be moved there. */
     public ?string $canonicalUrl;
 
     public static function make(string $identifier = '', FrontMatter|array $matter = []): static

--- a/packages/framework/src/Pages/Concerns/HydePage.php
+++ b/packages/framework/src/Pages/Concerns/HydePage.php
@@ -68,7 +68,7 @@ abstract class HydePage implements PageSchema, SerializableContract
 
     public string $title;
 
-    /** @deprecated This property requires information that is setup-dependent, and will work better through a runtime accessor. Since it is mainly related to blog posts, it will be moved there. */
+    /** @deprecated v1.0.0-RC.3 - This property requires information that is setup-dependent, and will work better through a runtime accessor. Since it is mainly related to blog posts, it will be moved there. */
     public ?string $canonicalUrl;
 
     public static function make(string $identifier = '', FrontMatter|array $matter = []): static


### PR DESCRIPTION
This property requires information that is setup-dependent, and will work better through a runtime accessor. Since it is mainly related to blog posts, the schema option will be moved there.
