### PR TITLE
Make HydePage::$title property readonly

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -13,7 +13,7 @@ This serves two purposes:
 - for new features.
 
 ### Changed
-- for changes in existing functionality.
+- Made the `HydePage::$title` property readonly
 
 ### Deprecated
 - for soon-to-be removed features.

--- a/packages/framework/src/Pages/Concerns/HydePage.php
+++ b/packages/framework/src/Pages/Concerns/HydePage.php
@@ -66,7 +66,7 @@ abstract class HydePage implements PageSchema, SerializableContract
     public PageMetadataBag $metadata;
     public NavigationData $navigation;
 
-    public string $title;
+    public readonly string $title;
     public ?string $canonicalUrl;
 
     public static function make(string $identifier = '', FrontMatter|array $matter = []): static

--- a/packages/framework/tests/Feature/HydePageTest.php
+++ b/packages/framework/tests/Feature/HydePageTest.php
@@ -370,9 +370,7 @@ class HydePageTest extends TestCase
             MarkdownPage::all()
         );
         $this->assertEquals(
-            ['_pages/foo.md' => tap(new MarkdownPage('foo'), function ($page) {
-                $page->title = 'Foo';
-            })],
+            ['_pages/foo.md' => (new MarkdownPage('foo'))],
             MarkdownPage::all()->all()
         );
         Filesystem::unlink('_pages/foo.md');


### PR DESCRIPTION
Makes HydePage::$title property readonly as it does not support being persisted