### PR TITLE
HydePHP v1.0.0 - Release Candidate Three

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,15 @@ HydePHP consists of two primary components, Hyde/Hyde and Hyde/Framework. Develo
 
 <!-- CHANGELOG_START -->
 
+## [v1.0.0-RC.3](https://github.com/hydephp/develop/releases/tag/v1.0.0-RC.3) - 2023-03-11
+
+### Changed
+- Made the `HydePage::$title` property readonly
+
+### Deprecated
+- `HydePage::$canonicalUrl`
+
+
 ## [v1.0.0-RC.2](https://github.com/hydephp/develop/releases/tag/v1.0.0-RC.2) - 2023-03-10
 
 ### Added

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -13,10 +13,10 @@ This serves two purposes:
 - for new features.
 
 ### Changed
-- Made the `HydePage::$title` property readonly
+- for changes in existing functionality.
 
 ### Deprecated
-- HydePage::$canonicalUrl
+- for soon-to-be removed features.
 
 ### Removed
 - for now removed features.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "hyde",
-    "version": "1.0.0-RC.2",
+    "version": "1.0.0-RC.3",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "hyde",
-            "version": "1.0.0-RC.2",
+            "version": "1.0.0-RC.3",
             "license": "MIT",
             "devDependencies": {
                 "@tailwindcss/typography": "^0.5.2",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     },
     "name": "hyde",
     "description": "Elegant and Powerful Static App Builder",
-    "version": "1.0.0-RC.2",
+    "version": "1.0.0-RC.3",
     "main": "hyde",
     "directories": {
         "test": "tests"

--- a/packages/framework/src/Foundation/HydeKernel.php
+++ b/packages/framework/src/Foundation/HydeKernel.php
@@ -49,7 +49,7 @@ class HydeKernel implements SerializableContract
     use Serializable;
     use Macroable;
 
-    final public const VERSION = '1.0.0-RC.2';
+    final public const VERSION = '1.0.0-RC.3';
 
     protected static self $instance;
 


### PR DESCRIPTION
## [v1.0.0-RC.3](https://github.com/hydephp/develop/releases/tag/v1.0.0-RC.3) - 2023-03-11

### Changed
- Made the `HydePage::$title` property readonly

### Deprecated
- `HydePage::$canonicalUrl`
