### PR TITLE
Add default RSS feed description value to config stub

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -13,7 +13,7 @@ This serves two purposes:
 - for new features.
 
 ### Changed
-- for changes in existing functionality.
+- Added default RSS feed description value to config stub.
 
 ### Deprecated
 - for soon-to-be removed features.

--- a/config/hyde.php
+++ b/config/hyde.php
@@ -114,8 +114,8 @@ return [
     // What filename should the RSS file use?
     'rss_filename' => 'feed.xml',
 
-    // The channel description. By default this is "Site Name + RSS Feed".
-    // 'rss_description' => '',
+    // The channel description.
+    'rss_description' =>  env('SITE_NAME', 'HydePHP').' RSS Feed',
 
     /*
     |--------------------------------------------------------------------------

--- a/packages/framework/config/hyde.php
+++ b/packages/framework/config/hyde.php
@@ -114,8 +114,8 @@ return [
     // What filename should the RSS file use?
     'rss_filename' => 'feed.xml',
 
-    // The channel description. By default this is "Site Name + RSS Feed".
-    // 'rss_description' => '',
+    // The channel description.
+    'rss_description' =>  env('SITE_NAME', 'HydePHP').' RSS Feed',
 
     /*
     |--------------------------------------------------------------------------

--- a/packages/framework/tests/Feature/GlobalMetadataBagTest.php
+++ b/packages/framework/tests/Feature/GlobalMetadataBagTest.php
@@ -84,6 +84,9 @@ class GlobalMetadataBagTest extends TestCase
         config(['hyde.url' => 'foo']);
         config(['hyde.name' => 'Site']);
         config(['hyde.generate_rss_feed' => true]);
+        $config = config('hyde');
+        unset($config['rss_description']);
+        config(['hyde' => $config]);
         $this->file('_posts/foo.md');
 
         $this->assertEquals('<link rel="alternate" href="foo/feed.xml" type="application/rss+xml" title="Site RSS Feed">', GlobalMetadataBag::make()->render());

--- a/packages/framework/tests/Feature/Services/RssFeedServiceTest.php
+++ b/packages/framework/tests/Feature/Services/RssFeedServiceTest.php
@@ -39,6 +39,7 @@ class RssFeedServiceTest extends TestCase
     {
         config(['hyde.name' => 'Test Blog']);
         config(['hyde.url' => 'https://example.com']);
+        config(['hyde.rss_description' => 'Test Blog RSS Feed']);
 
         $service = new RssFeedGenerator();
         $this->assertTrue(property_exists($service->getXmlElement()->channel, 'title'));


### PR DESCRIPTION
This adds better IDE support, but changes no behaviour. It uses the same concatenation as in the docs header option.