### PR TITLE
Remove deprecated `HydePage::$canonicalUrl` property

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -10,7 +10,7 @@ This serves two purposes:
 2. At release time, you can move the Unreleased section changes into a new release version section.
 
 ### Added
-- for new features.
+- Added new method `HydePage::getCanonicalUrl()` to replace deprecated `HydePage::$canonicalUrl` property.
 
 ### Changed
 - Added default RSS feed description value to config stub.
@@ -22,6 +22,7 @@ This serves two purposes:
 - Removed `RouteKey::normalize` method deprecated in v1.0.0-RC.2
 - Removed `RenderData:.getCurrentPage` method deprecated in v1.0.0-RC.2
 - Removed `RenderData:.getCurrentRoute` method deprecated in v1.0.0-RC.2
+- Removed deprecated `HydePage::$canonicalUrl` property (replaced with `HydePage::getCanonicalUrl()`).
 
 ### Fixed
 - Fixed the blog post article view where metadata assembly used legacy hard-coded paths instead of dynamic path information.

--- a/packages/framework/resources/views/components/post/article.blade.php
+++ b/packages/framework/resources/views/components/post/article.blade.php
@@ -2,8 +2,8 @@
          itemtype="https://schema.org/Article"
     @class(['post-article mx-auto prose dark:prose-invert', 'torchlight-enabled' => Hyde\Facades\Features::hasTorchlight()])>
     <meta itemprop="identifier" content="{{ $page->identifier }}">
-    @if($page->canonicalUrl !== null)
-        <meta itemprop="url" content="{{ $page->canonicalUrl }}">
+    @if($page->getCanonicalUrl() !== null)
+        <meta itemprop="url" content="{{ $page->getCanonicalUrl() }}">
     @endif
 
     <header aria-label="Header section" role="doc-pageheader">

--- a/packages/framework/resources/views/components/post/article.blade.php
+++ b/packages/framework/resources/views/components/post/article.blade.php
@@ -2,7 +2,7 @@
          itemtype="https://schema.org/Article"
     @class(['post-article mx-auto prose dark:prose-invert', 'torchlight-enabled' => Hyde\Facades\Features::hasTorchlight()])>
     <meta itemprop="identifier" content="{{ $page->identifier }}">
-    @isset($page->canonicalUrl)
+    @if($page->canonicalUrl !== null)
         <meta itemprop="url" content="{{ $page->canonicalUrl }}">
     @endif
 

--- a/packages/framework/src/Framework/Factories/HydePageDataFactory.php
+++ b/packages/framework/src/Framework/Factories/HydePageDataFactory.php
@@ -26,7 +26,6 @@ class HydePageDataFactory extends Concerns\PageDataFactory implements PageSchema
     final public const SCHEMA = PageSchema::PAGE_SCHEMA;
 
     protected readonly string $title;
-    protected readonly ?string $canonicalUrl;
     protected readonly ?NavigationData $navigation;
     private readonly string $routeKey;
     private readonly string $outputPath;
@@ -45,18 +44,16 @@ class HydePageDataFactory extends Concerns\PageDataFactory implements PageSchema
         $this->routeKey = $this->pageData->routeKey;
 
         $this->title = $this->makeTitle();
-        $this->canonicalUrl = $this->makeCanonicalUrl();
         $this->navigation = $this->makeNavigation();
     }
 
     /**
-     * @return array{title: string, canonicalUrl: string|null, navigation: \Hyde\Framework\Features\Navigation\NavigationData|null}
+     * @return array{title: string, navigation: \Hyde\Framework\Features\Navigation\NavigationData|null}
      */
     public function toArray(): array
     {
         return [
             'title' => $this->title,
-            'canonicalUrl' => $this->canonicalUrl,
             'navigation' => $this->navigation,
         ];
     }
@@ -64,11 +61,6 @@ class HydePageDataFactory extends Concerns\PageDataFactory implements PageSchema
     protected function makeTitle(): string
     {
         return trim($this->findTitleForPage());
-    }
-
-    protected function makeCanonicalUrl(): ?string
-    {
-        return $this->getCanonicalUrl();
     }
 
     protected function makeNavigation(): NavigationData
@@ -101,19 +93,6 @@ class HydePageDataFactory extends Concerns\PageDataFactory implements PageSchema
     {
         if (str_contains($this->identifier, '/') && str_ends_with($this->identifier, '/index')) {
             return Hyde::makeTitle(basename(dirname($this->identifier)));
-        }
-
-        return null;
-    }
-
-    private function getCanonicalUrl(): ?string
-    {
-        if (! empty($this->matter('canonicalUrl'))) {
-            return $this->matter('canonicalUrl');
-        }
-
-        if (Hyde::hasSiteUrl() && ! empty($this->identifier)) {
-            return Hyde::url($this->outputPath);
         }
 
         return null;

--- a/packages/framework/src/Framework/Features/Metadata/PageMetadataBag.php
+++ b/packages/framework/src/Framework/Features/Metadata/PageMetadataBag.php
@@ -47,9 +47,9 @@ class PageMetadataBag extends MetadataBag
         $this->addPostMetadataIfExists($page, 'description');
         $this->addPostMetadataIfExists($page, 'author');
         $this->addPostMetadataIfExists($page, 'category', 'keywords');
-        $this->addPostMetadataIfExists($page, 'canonicalUrl', 'url');
 
         if ($page->getCanonicalUrl()) {
+            $this->add(Meta::name('url', $page->getCanonicalUrl()));
             $this->add(Meta::property('url', $page->getCanonicalUrl()));
         }
 

--- a/packages/framework/src/Framework/Features/Metadata/PageMetadataBag.php
+++ b/packages/framework/src/Framework/Features/Metadata/PageMetadataBag.php
@@ -28,8 +28,8 @@ class PageMetadataBag extends MetadataBag
 
     protected function addDynamicPageMetadata(HydePage $page): void
     {
-        if ($page->has('canonicalUrl')) {
-            $this->add(Meta::link('canonical', $page->data('canonicalUrl')));
+        if ($page->getCanonicalUrl()) {
+            $this->add(Meta::link('canonical', $page->getCanonicalUrl()));
         }
 
         if ($page->has('title')) {
@@ -49,8 +49,8 @@ class PageMetadataBag extends MetadataBag
         $this->addPostMetadataIfExists($page, 'category', 'keywords');
         $this->addPostMetadataIfExists($page, 'canonicalUrl', 'url');
 
-        if ($page->has('canonicalUrl')) {
-            $this->add(Meta::property('url', $page->data('canonicalUrl')));
+        if ($page->getCanonicalUrl()) {
+            $this->add(Meta::property('url', $page->getCanonicalUrl()));
         }
 
         if ($page->has('date')) {

--- a/packages/framework/src/Framework/Features/XmlGenerators/RssFeedGenerator.php
+++ b/packages/framework/src/Framework/Features/XmlGenerators/RssFeedGenerator.php
@@ -52,9 +52,9 @@ class RssFeedGenerator extends BaseXmlGenerator
 
     protected function addDynamicItemData(SimpleXMLElement $item, MarkdownPost $post): void
     {
-        if ($post->canonicalUrl !== null) {
-            $this->addChild($item, 'link', $post->canonicalUrl);
-            $this->addChild($item, 'guid', $post->canonicalUrl);
+        if ($post->getCanonicalUrl() !== null) {
+            $this->addChild($item, 'link', $post->getCanonicalUrl());
+            $this->addChild($item, 'guid', $post->getCanonicalUrl());
         }
 
         if (isset($post->date)) {

--- a/packages/framework/src/Framework/Features/XmlGenerators/RssFeedGenerator.php
+++ b/packages/framework/src/Framework/Features/XmlGenerators/RssFeedGenerator.php
@@ -52,7 +52,7 @@ class RssFeedGenerator extends BaseXmlGenerator
 
     protected function addDynamicItemData(SimpleXMLElement $item, MarkdownPost $post): void
     {
-        if (isset($post->canonicalUrl)) {
+        if ($post->canonicalUrl !== null) {
             $this->addChild($item, 'link', $post->canonicalUrl);
             $this->addChild($item, 'guid', $post->canonicalUrl);
         }

--- a/packages/framework/src/Markdown/Contracts/FrontMatter/PageSchema.php
+++ b/packages/framework/src/Markdown/Contracts/FrontMatter/PageSchema.php
@@ -13,7 +13,7 @@ interface PageSchema extends FrontMatterSchema
 {
     public const PAGE_SCHEMA = [
         'title'         => 'string',
-        'canonicalUrl'  => 'string', // DEPRECATED
+        'canonicalUrl'  => 'string', // While not present in the page data, it is supported as a front matter key
         'navigation'    => NavigationSchema::NAVIGATION_SCHEMA,
     ];
 }

--- a/packages/framework/src/Markdown/Contracts/FrontMatter/PageSchema.php
+++ b/packages/framework/src/Markdown/Contracts/FrontMatter/PageSchema.php
@@ -13,7 +13,7 @@ interface PageSchema extends FrontMatterSchema
 {
     public const PAGE_SCHEMA = [
         'title'         => 'string',
-        'canonicalUrl'  => 'string', // While not present in the page data, it is supported as a front matter key
+        'canonicalUrl'  => 'string', // While not present in the page data, it is supported as a front matter key for the accessor data source.
         'navigation'    => NavigationSchema::NAVIGATION_SCHEMA,
     ];
 }

--- a/packages/framework/src/Pages/Concerns/HydePage.php
+++ b/packages/framework/src/Pages/Concerns/HydePage.php
@@ -383,6 +383,19 @@ abstract class HydePage implements PageSchema, SerializableContract
         return $this->navigation->group;
     }
 
+    public function getCanonicalUrl(): ?string
+    {
+        if (! empty($this->matter('canonicalUrl'))) {
+            return $this->matter('canonicalUrl');
+        }
+
+        if (Hyde::hasSiteUrl() && ! empty($this->identifier)) {
+            return Hyde::url($this->getOutputPath());
+        }
+
+        return null;
+    }
+
     protected function constructMetadata(): void
     {
         $this->metadata = new PageMetadataBag($this);

--- a/packages/framework/src/Pages/Concerns/HydePage.php
+++ b/packages/framework/src/Pages/Concerns/HydePage.php
@@ -260,7 +260,6 @@ abstract class HydePage implements PageSchema, SerializableContract
             'metadata' => $this->metadata,
             'navigation' => $this->navigation,
             'title' => $this->title,
-            'canonicalUrl' => $this->canonicalUrl,
         ];
     }
 

--- a/packages/framework/src/Pages/Concerns/HydePage.php
+++ b/packages/framework/src/Pages/Concerns/HydePage.php
@@ -68,9 +68,6 @@ abstract class HydePage implements PageSchema, SerializableContract
 
     public readonly string $title;
 
-    /** @deprecated v1.0.0-RC.3 - This property requires information that is setup-dependent, and will work better through a runtime accessor. Since it is mainly related to blog posts, it will be moved there. */
-    public ?string $canonicalUrl;
-
     public static function make(string $identifier = '', FrontMatter|array $matter = []): static
     {
         return new static($identifier, $matter);

--- a/packages/framework/tests/Feature/HydePageTest.php
+++ b/packages/framework/tests/Feature/HydePageTest.php
@@ -253,7 +253,6 @@ class HydePageTest extends TestCase
             'metadata',
             'navigation',
             'title',
-            'canonicalUrl',
         ],
             array_keys((new TestPage('hello-world'))->toArray())
         );

--- a/packages/framework/tests/Feature/HydePageTest.php
+++ b/packages/framework/tests/Feature/HydePageTest.php
@@ -841,7 +841,7 @@ class HydePageTest extends TestCase
         config(['hyde.url' => 'https://example.com']);
         $page = new MarkdownPage('foo');
 
-        $this->assertEquals('https://example.com/foo.html', $page->canonicalUrl);
+        $this->assertEquals('https://example.com/foo.html', $page->getCanonicalUrl());
     }
 
     public function test_get_canonical_url_returns_pretty_url_for_top_level_page()
@@ -850,7 +850,7 @@ class HydePageTest extends TestCase
         config(['hyde.pretty_urls' => true]);
         $page = new MarkdownPage('foo');
 
-        $this->assertEquals('https://example.com/foo', $page->canonicalUrl);
+        $this->assertEquals('https://example.com/foo', $page->getCanonicalUrl());
     }
 
     public function test_get_canonical_url_returns_url_for_nested_page()
@@ -858,7 +858,7 @@ class HydePageTest extends TestCase
         config(['hyde.url' => 'https://example.com']);
         $page = new MarkdownPage('foo/bar');
 
-        $this->assertEquals('https://example.com/foo/bar.html', $page->canonicalUrl);
+        $this->assertEquals('https://example.com/foo/bar.html', $page->getCanonicalUrl());
     }
 
     public function test_get_canonical_url_returns_url_for_deeply_nested_page()
@@ -866,14 +866,14 @@ class HydePageTest extends TestCase
         config(['hyde.url' => 'https://example.com']);
         $page = new MarkdownPage('foo/bar/baz');
 
-        $this->assertEquals('https://example.com/foo/bar/baz.html', $page->canonicalUrl);
+        $this->assertEquals('https://example.com/foo/bar/baz.html', $page->getCanonicalUrl());
     }
 
     public function test_canonical_url_is_not_set_when_identifier_is_null()
     {
         config(['hyde.url' => 'https://example.com']);
         $page = new MarkdownPage();
-        $this->assertNull($page->canonicalUrl);
+        $this->assertNull($page->getCanonicalUrl());
         $this->assertStringNotContainsString(
             '<link rel="canonical"',
             $page->metadata()->render()
@@ -884,7 +884,7 @@ class HydePageTest extends TestCase
     {
         config(['hyde.url' => null]);
         $page = new MarkdownPage('foo');
-        $this->assertNull($page->canonicalUrl);
+        $this->assertNull($page->getCanonicalUrl());
         $this->assertStringNotContainsString(
             '<link rel="canonical"',
             $page->metadata()->render()
@@ -895,7 +895,7 @@ class HydePageTest extends TestCase
     {
         config(['hyde.url' => 'https://example.com']);
         $page = MarkdownPage::make(matter: ['canonicalUrl' => 'foo/bar']);
-        $this->assertEquals('foo/bar', $page->canonicalUrl);
+        $this->assertEquals('foo/bar', $page->getCanonicalUrl());
         $this->assertStringContainsString(
             '<link rel="canonical" href="foo/bar">',
             $page->metadata()->render()

--- a/packages/framework/tests/Feature/HydePageTest.php
+++ b/packages/framework/tests/Feature/HydePageTest.php
@@ -901,6 +901,31 @@ class HydePageTest extends TestCase
         );
     }
 
+    public function test_can_create_canonical_url_using_base_url_from_config()
+    {
+        config(['hyde' => [
+            'url' => 'https://example.com',
+        ]]);
+
+        $this->assertSame('https://example.com/foo.html', (new MarkdownPage('foo'))->getCanonicalUrl());
+    }
+
+    public function test_can_create_canonical_url_using_base_url_from_config_using_pretty_urls()
+    {
+        config(['hyde' => [
+            'url' => 'https://example.com',
+            'pretty_urls' => true,
+        ]]);
+
+        $this->assertSame('https://example.com/foo', (new MarkdownPage('foo'))->getCanonicalUrl());
+    }
+
+    public function test_canonical_url_is_null_when_no_base_url_is_set()
+    {
+        config(['hyde' => []]);
+        $this->assertNull((new MarkdownPage('foo'))->getCanonicalUrl());
+    }
+
     public function test_render_page_metadata_returns_string()
     {
         $page = new MarkdownPage('foo');

--- a/packages/framework/tests/Unit/HydePageDataFactoryTest.php
+++ b/packages/framework/tests/Unit/HydePageDataFactoryTest.php
@@ -74,30 +74,6 @@ class HydePageDataFactoryTest extends UnitTestCase
         $this->assertSame('Bar', $this->factoryFromPage(new MarkdownPage('foo/bar/index'))->toArray()['title']);
     }
 
-    public function testCanCreateCanonicalUrlUsingBaseUrlFromConfig()
-    {
-        self::mockConfig(['hyde' => [
-            'url' => 'https://example.com',
-        ]]);
-
-        $this->assertSame('https://example.com/foo.html', $this->factoryFromPage(new MarkdownPage('foo'))->toArray()['canonicalUrl']);
-    }
-
-    public function testCanCreateCanonicalUrlUsingBaseUrlFromConfigUsingPrettyUrls()
-    {
-        self::mockConfig(['hyde' => [
-            'url' => 'https://example.com',
-            'pretty_urls' => true,
-        ]]);
-
-        $this->assertSame('https://example.com/foo', $this->factoryFromPage(new MarkdownPage('foo'))->toArray()['canonicalUrl']);
-    }
-
-    public function testCanonicalUrlIsNullWhenNoBaseUrlIsSet()
-    {
-        $this->assertNull($this->factoryFromPage(new MarkdownPage('foo'))->toArray()['canonicalUrl']);
-    }
-
     public function testNavigationDataIsGeneratedByNavigationDataFactory()
     {
         $this->assertInstanceOf(NavigationData::class, $this->factory()->toArray()['navigation']);

--- a/packages/framework/tests/Unit/HydePageDataFactoryTest.php
+++ b/packages/framework/tests/Unit/HydePageDataFactoryTest.php
@@ -36,7 +36,7 @@ class HydePageDataFactoryTest extends UnitTestCase
 
     public function testToArrayContainsExpectedKeys()
     {
-        $this->assertSame(['title', 'canonicalUrl', 'navigation'], array_keys($this->factory()->toArray()));
+        $this->assertSame(['title', 'navigation'], array_keys($this->factory()->toArray()));
     }
 
     public function testCanCreateTitleFromMatter()

--- a/packages/framework/tests/Unit/HydePageSerializableUnitTest.php
+++ b/packages/framework/tests/Unit/HydePageSerializableUnitTest.php
@@ -51,7 +51,7 @@ class HydePageSerializableUnitTest extends UnitTestCase
     public function testHydePageToArrayKeys()
     {
         $this->assertSame(
-            ['class', 'identifier', 'routeKey', 'matter', 'metadata', 'navigation', 'title', 'canonicalUrl'],
+            ['class', 'identifier', 'routeKey', 'matter', 'metadata', 'navigation', 'title'],
             array_keys((new InstantiableHydePage())->toArray())
         );
     }
@@ -59,7 +59,7 @@ class HydePageSerializableUnitTest extends UnitTestCase
     public function testHtmlPageToArrayKeys()
     {
         $this->assertSame(
-            ['class', 'identifier', 'routeKey', 'matter', 'metadata', 'navigation', 'title', 'canonicalUrl'],
+            ['class', 'identifier', 'routeKey', 'matter', 'metadata', 'navigation', 'title'],
             array_keys((new HtmlPage())->toArray())
         );
     }
@@ -67,7 +67,7 @@ class HydePageSerializableUnitTest extends UnitTestCase
     public function testBladePageToArrayKeys()
     {
         $this->assertSame(
-            ['class', 'identifier', 'routeKey', 'matter', 'metadata', 'navigation', 'title', 'canonicalUrl'],
+            ['class', 'identifier', 'routeKey', 'matter', 'metadata', 'navigation', 'title'],
             array_keys((new BladePage())->toArray())
         );
     }
@@ -75,7 +75,7 @@ class HydePageSerializableUnitTest extends UnitTestCase
     public function testMarkdownPageToArrayKeys()
     {
         $this->assertSame(
-            ['class', 'identifier', 'routeKey', 'matter', 'metadata', 'navigation', 'title', 'canonicalUrl'],
+            ['class', 'identifier', 'routeKey', 'matter', 'metadata', 'navigation', 'title'],
             array_keys((new MarkdownPage())->toArray())
         );
     }
@@ -83,7 +83,7 @@ class HydePageSerializableUnitTest extends UnitTestCase
     public function testMarkdownPostToArrayKeys()
     {
         $this->assertSame(
-            ['class', 'identifier', 'routeKey', 'matter', 'metadata', 'navigation', 'title', 'canonicalUrl', 'description', 'category', 'date', 'author', 'image'],
+            ['class', 'identifier', 'routeKey', 'matter', 'metadata', 'navigation', 'title', 'description', 'category', 'date', 'author', 'image'],
             array_keys((new MarkdownPost())->toArray())
         );
     }
@@ -91,7 +91,7 @@ class HydePageSerializableUnitTest extends UnitTestCase
     public function testDocumentationPageToArrayKeys()
     {
         $this->assertSame(
-            ['class', 'identifier', 'routeKey', 'matter', 'metadata', 'navigation', 'title', 'canonicalUrl'],
+            ['class', 'identifier', 'routeKey', 'matter', 'metadata', 'navigation', 'title'],
             array_keys((new DocumentationPage())->toArray())
         );
     }
@@ -107,7 +107,6 @@ class HydePageSerializableUnitTest extends UnitTestCase
             'metadata' => $page->metadata,
             'navigation' => $page->navigation,
             'title' => $page->title,
-            'canonicalUrl' => $page->canonicalUrl,
         ],
             $page->toArray()
         );
@@ -124,7 +123,6 @@ class HydePageSerializableUnitTest extends UnitTestCase
             'metadata' => $page->metadata,
             'navigation' => $page->navigation,
             'title' => $page->title,
-            'canonicalUrl' => $page->canonicalUrl,
         ],
             $page->toArray()
         );
@@ -141,7 +139,6 @@ class HydePageSerializableUnitTest extends UnitTestCase
             'metadata' => $page->metadata,
             'navigation' => $page->navigation,
             'title' => $page->title,
-            'canonicalUrl' => $page->canonicalUrl,
         ],
             $page->toArray()
         );
@@ -158,7 +155,6 @@ class HydePageSerializableUnitTest extends UnitTestCase
             'metadata' => $page->metadata,
             'navigation' => $page->navigation,
             'title' => $page->title,
-            'canonicalUrl' => $page->canonicalUrl,
         ],
             $page->toArray()
         );
@@ -175,7 +171,6 @@ class HydePageSerializableUnitTest extends UnitTestCase
             'metadata' => $page->metadata,
             'navigation' => $page->navigation,
             'title' => $page->title,
-            'canonicalUrl' => $page->canonicalUrl,
             'description' => $page->description,
             'category' => $page->category,
             'date' => $page->date,
@@ -197,7 +192,6 @@ class HydePageSerializableUnitTest extends UnitTestCase
             'metadata' => $page->metadata,
             'navigation' => $page->navigation,
             'title' => $page->title,
-            'canonicalUrl' => $page->canonicalUrl,
         ],
             $page->toArray()
         );
@@ -218,8 +212,7 @@ class HydePageSerializableUnitTest extends UnitTestCase
                     "hidden": false,
                     "group": null
                 },
-                "title": "",
-                "canonicalUrl": null
+                "title": ""
             }
             JSON, (new InstantiableHydePage())->toJson(128)
         );

--- a/packages/framework/tests/Unit/Pages/MarkdownPostHelpersTest.php
+++ b/packages/framework/tests/Unit/Pages/MarkdownPostHelpersTest.php
@@ -22,14 +22,14 @@ class MarkdownPostHelpersTest extends TestCase
     {
         config(['hyde.url' => 'https://example.com']);
         $post = new MarkdownPost('foo-bar');
-        $this->assertEquals('https://example.com/posts/foo-bar.html', $post->canonicalUrl);
+        $this->assertEquals('https://example.com/posts/foo-bar.html', $post->getCanonicalUrl());
     }
 
     public function test_get_canonical_link_returns_pretty_url_when_enabled()
     {
         config(['hyde.url' => 'https://example.com', 'hyde.pretty_urls' => true]);
         $post = new MarkdownPost('foo-bar');
-        $this->assertEquals('https://example.com/posts/foo-bar', $post->canonicalUrl);
+        $this->assertEquals('https://example.com/posts/foo-bar', $post->getCanonicalUrl());
     }
 
     public function test_get_post_description_returns_post_description_when_set_in_front_matter()


### PR DESCRIPTION
The idea is that the internal data state should be as portable as possible. Having a canonicalUrl as part of the internal data structure breaks this portability as it is in many cases entirely dependent on the environment the data is used in. This means that it should not be part of the internal data structure, nor its serialized form. It's much better suited as a runtime accessor method. Thus, this PR removes the deprecated property, and replaces it with a new public method that uses the same logic ported from the page factory creator so the end result is still the same.