### PR TITLE
Create new array-based RSS feed config structure

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -15,6 +15,9 @@ This serves two purposes:
 ### Changed
 - Added default RSS feed description value to the config stub.
 - Changed the RSS feed configuration structure to be an array of feed configurations.
+  - Replaced option `hyde.generate_rss_feed` with `hyde.rss.enabled`
+  - Replaced option `hyde.rss_filename` with `hyde.rss.filename`
+  - Replaced option `hyde.rss_description` with `hyde.rss.description`
 
 ### Deprecated
 - for soon-to-be removed features.

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -14,6 +14,7 @@ This serves two purposes:
 
 ### Changed
 - Added default RSS feed description value to the config stub.
+- Changed the RSS feed configuration structure to be an array of feed configurations.
 
 ### Deprecated
 - for soon-to-be removed features.

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -14,7 +14,7 @@ This serves two purposes:
 
 ### Changed
 - Added default RSS feed description value to the config stub.
-- Changed the RSS feed configuration structure to be an array of feed configurations.
+- Changed the RSS feed configuration structure to be an array of feed configurations in [#1258](https://github.com/hydephp/develop/pull/1258)
   - Replaced option `hyde.generate_rss_feed` with `hyde.rss.enabled`
   - Replaced option `hyde.rss_filename` with `hyde.rss.filename`
   - Replaced option `hyde.rss_description` with `hyde.rss.description`

--- a/config/hyde.php
+++ b/config/hyde.php
@@ -117,6 +117,17 @@ return [
     // The channel description.
     'rss_description' =>  env('SITE_NAME', 'HydePHP').' RSS Feed',
 
+    'rss' => [
+        // Should the RSS feed be generated?
+        'enabled' => true,
+
+        // What filename should the RSS file use?
+        'filename' => 'feed.xml',
+
+        // The channel description.
+        'description' => env('SITE_NAME', 'HydePHP').' RSS Feed',
+    ],
+
     /*
     |--------------------------------------------------------------------------
     | Source Root Directory

--- a/config/hyde.php
+++ b/config/hyde.php
@@ -108,15 +108,6 @@ return [
     |
     */
 
-    // Should the RSS feed be generated?
-    'generate_rss_feed' => true,
-
-    // What filename should the RSS file use?
-    'rss_filename' => 'feed.xml',
-
-    // The channel description.
-    'rss_description' =>  env('SITE_NAME', 'HydePHP').' RSS Feed',
-
     'rss' => [
         // Should the RSS feed be generated?
         'enabled' => true,

--- a/docs/digging-deeper/customization.md
+++ b/docs/digging-deeper/customization.md
@@ -65,7 +65,7 @@ When enabled, an RSS feed with your Markdown blog posts will be generated when y
 Note that this requires that a site_url is set!
 
 ```php // config/hyde.php
-'generate_rss_feed' => true, // Default is true
+'rss.enabled' => true, // Default is true
 ```
 
 You can customize the output filename using the following:
@@ -327,7 +327,7 @@ name: HydePHP
 url: http://localhost
 pretty_urls: false
 generate_sitemap: true
-generate_rss_feed: true
+rss.enabled: true
 rss_filename: feed.xml
 # rss_description:
 language: en

--- a/docs/digging-deeper/customization.md
+++ b/docs/digging-deeper/customization.md
@@ -71,7 +71,7 @@ Note that this requires that a site_url is set!
 You can customize the output filename using the following:
 
 ```php // config/hyde.php
-'rss_filename' => 'feed.rss', // Default is feed.xml
+'rss.filename' => 'feed.rss', // Default is feed.xml
 ```
 
 You can set the RSS channel description using the following:
@@ -328,7 +328,7 @@ url: http://localhost
 pretty_urls: false
 generate_sitemap: true
 rss.enabled: true
-rss_filename: feed.xml
+rss.filename: feed.xml
 # rss_description:
 language: en
 output_directory: _site

--- a/docs/digging-deeper/customization.md
+++ b/docs/digging-deeper/customization.md
@@ -77,10 +77,10 @@ You can customize the output filename using the following:
 You can set the RSS channel description using the following:
 
 ```php // config/hyde.php
-'rss_description' => 'A collection of articles and tutorials from my blog', // Example
+'rss.description' => 'A collection of articles and tutorials from my blog', // Example
 ```
 
-If an rss_description is not set one is created by appending "RSS Feed" to your site name.
+If an rss.description is not set one is created by appending "RSS Feed" to your site name.
 
 
 ### Authors
@@ -329,7 +329,7 @@ pretty_urls: false
 generate_sitemap: true
 rss.enabled: true
 rss.filename: feed.xml
-# rss_description:
+# rss.description:
 language: en
 output_directory: _site
 ```

--- a/packages/framework/config/hyde.php
+++ b/packages/framework/config/hyde.php
@@ -117,6 +117,17 @@ return [
     // The channel description.
     'rss_description' =>  env('SITE_NAME', 'HydePHP').' RSS Feed',
 
+    'rss' => [
+        // Should the RSS feed be generated?
+        'enabled' => true,
+
+        // What filename should the RSS file use?
+        'filename' => 'feed.xml',
+
+        // The channel description.
+        'description' => env('SITE_NAME', 'HydePHP').' RSS Feed',
+    ],
+
     /*
     |--------------------------------------------------------------------------
     | Source Root Directory

--- a/packages/framework/config/hyde.php
+++ b/packages/framework/config/hyde.php
@@ -108,15 +108,6 @@ return [
     |
     */
 
-    // Should the RSS feed be generated?
-    'generate_rss_feed' => true,
-
-    // What filename should the RSS file use?
-    'rss_filename' => 'feed.xml',
-
-    // The channel description.
-    'rss_description' =>  env('SITE_NAME', 'HydePHP').' RSS Feed',
-
     'rss' => [
         // Should the RSS feed be generated?
         'enabled' => true,

--- a/packages/framework/src/Facades/Features.php
+++ b/packages/framework/src/Facades/Features.php
@@ -161,7 +161,7 @@ class Features implements SerializableContract
     {
         return static::resolveMockedInstance('rss') ?? Hyde::hasSiteUrl()
             && static::hasMarkdownPosts()
-            && Config::getBool('hyde.generate_rss_feed', true)
+            && Config::getBool('hyde.rss.enabled', true)
             && extension_loaded('simplexml')
             && count(MarkdownPost::files()) > 0;
     }

--- a/packages/framework/src/Framework/Features/XmlGenerators/RssFeedGenerator.php
+++ b/packages/framework/src/Framework/Features/XmlGenerators/RssFeedGenerator.php
@@ -110,7 +110,7 @@ class RssFeedGenerator extends BaseXmlGenerator
 
     public static function getFilename(): string
     {
-        return Config::getString('hyde.rss_filename', 'feed.xml');
+        return Config::getString('hyde.rss.filename', 'feed.xml');
     }
 
     public static function getDescription(): string

--- a/packages/framework/src/Framework/Features/XmlGenerators/RssFeedGenerator.php
+++ b/packages/framework/src/Framework/Features/XmlGenerators/RssFeedGenerator.php
@@ -115,6 +115,6 @@ class RssFeedGenerator extends BaseXmlGenerator
 
     public static function getDescription(): string
     {
-        return Config::getString('hyde.rss_description', Site::name().' RSS Feed');
+        return Config::getString('hyde.rss.description', Site::name().' RSS Feed');
     }
 }

--- a/packages/framework/src/Pages/Concerns/HydePage.php
+++ b/packages/framework/src/Pages/Concerns/HydePage.php
@@ -61,12 +61,11 @@ abstract class HydePage implements PageSchema, SerializableContract
 
     public readonly string $identifier;
     public readonly string $routeKey;
+    public readonly string $title;
 
     public FrontMatter $matter;
     public PageMetadataBag $metadata;
     public NavigationData $navigation;
-
-    public readonly string $title;
 
     public static function make(string $identifier = '', FrontMatter|array $matter = []): static
     {

--- a/packages/framework/tests/Feature/Commands/BuildRssFeedCommandTest.php
+++ b/packages/framework/tests/Feature/Commands/BuildRssFeedCommandTest.php
@@ -31,7 +31,7 @@ class BuildRssFeedCommandTest extends TestCase
     {
         config(['hyde.url' => 'https://example.com']);
         config(['hyde.rss.enabled' => true]);
-        config(['hyde.rss_filename' => 'blog.xml']);
+        config(['hyde.rss.filename' => 'blog.xml']);
         $this->file('_posts/foo.md');
 
         $this->assertFileDoesNotExist(Hyde::path('_site/feed.xml'));

--- a/packages/framework/tests/Feature/Commands/BuildRssFeedCommandTest.php
+++ b/packages/framework/tests/Feature/Commands/BuildRssFeedCommandTest.php
@@ -17,7 +17,7 @@ class BuildRssFeedCommandTest extends TestCase
     public function test_rss_feed_is_generated_when_conditions_are_met()
     {
         config(['hyde.url' => 'https://example.com']);
-        config(['hyde.generate_rss_feed' => true]);
+        config(['hyde.rss.enabled' => true]);
         $this->file('_posts/foo.md');
 
         $this->assertFileDoesNotExist(Hyde::path('_site/feed.xml'));
@@ -30,7 +30,7 @@ class BuildRssFeedCommandTest extends TestCase
     public function test_rss_filename_can_be_changed()
     {
         config(['hyde.url' => 'https://example.com']);
-        config(['hyde.generate_rss_feed' => true]);
+        config(['hyde.rss.enabled' => true]);
         config(['hyde.rss_filename' => 'blog.xml']);
         $this->file('_posts/foo.md');
 

--- a/packages/framework/tests/Feature/GlobalMetadataBagTest.php
+++ b/packages/framework/tests/Feature/GlobalMetadataBagTest.php
@@ -97,7 +97,7 @@ class GlobalMetadataBagTest extends TestCase
         $this->emptyConfig();
 
         config(['hyde.url' => 'foo']);
-        config(['hyde.rss_filename' => 'posts.rss']);
+        config(['hyde.rss.filename' => 'posts.rss']);
         config(['hyde.rss.enabled' => true]);
         $this->file('_posts/foo.md');
 

--- a/packages/framework/tests/Feature/GlobalMetadataBagTest.php
+++ b/packages/framework/tests/Feature/GlobalMetadataBagTest.php
@@ -60,7 +60,7 @@ class GlobalMetadataBagTest extends TestCase
         $this->emptyConfig();
 
         config(['hyde.url' => 'foo']);
-        config(['hyde.generate_rss_feed' => true]);
+        config(['hyde.rss.enabled' => true]);
         $this->file('_posts/foo.md');
 
         $this->assertEquals('<link rel="alternate" href="foo/feed.xml" type="application/rss+xml" title="HydePHP RSS Feed">', GlobalMetadataBag::make()->render());
@@ -71,7 +71,7 @@ class GlobalMetadataBagTest extends TestCase
         $this->emptyConfig();
 
         config(['hyde.url' => 'bar']);
-        config(['hyde.generate_rss_feed' => true]);
+        config(['hyde.rss.enabled' => true]);
         $this->file('_posts/foo.md');
 
         $this->assertEquals('<link rel="alternate" href="bar/feed.xml" type="application/rss+xml" title="HydePHP RSS Feed">', GlobalMetadataBag::make()->render());
@@ -83,7 +83,7 @@ class GlobalMetadataBagTest extends TestCase
 
         config(['hyde.url' => 'foo']);
         config(['hyde.name' => 'Site']);
-        config(['hyde.generate_rss_feed' => true]);
+        config(['hyde.rss.enabled' => true]);
         $config = config('hyde');
         unset($config['rss_description']);
         config(['hyde' => $config]);
@@ -98,7 +98,7 @@ class GlobalMetadataBagTest extends TestCase
 
         config(['hyde.url' => 'foo']);
         config(['hyde.rss_filename' => 'posts.rss']);
-        config(['hyde.generate_rss_feed' => true]);
+        config(['hyde.rss.enabled' => true]);
         $this->file('_posts/foo.md');
 
         $this->assertStringContainsString(
@@ -147,7 +147,7 @@ class GlobalMetadataBagTest extends TestCase
     {
         config(['hyde.url' => null]);
         config(['hyde.meta' => []]);
-        config(['hyde.generate_rss_feed' => false]);
+        config(['hyde.rss.enabled' => false]);
         config(['hyde.generate_sitemap' => false]);
     }
 }

--- a/packages/framework/tests/Feature/GlobalMetadataBagTest.php
+++ b/packages/framework/tests/Feature/GlobalMetadataBagTest.php
@@ -85,7 +85,7 @@ class GlobalMetadataBagTest extends TestCase
         config(['hyde.name' => 'Site']);
         config(['hyde.rss.enabled' => true]);
         $config = config('hyde');
-        unset($config['rss_description']);
+        unset($config['rss']['description']);
         config(['hyde' => $config]);
         $this->file('_posts/foo.md');
 

--- a/packages/framework/tests/Feature/MetadataTest.php
+++ b/packages/framework/tests/Feature/MetadataTest.php
@@ -31,7 +31,7 @@ class MetadataTest extends TestCase
 
         config(['hyde.url' => null]);
         config(['hyde.meta' => []]);
-        config(['hyde.generate_rss_feed' => false]);
+        config(['hyde.rss.enabled' => false]);
         config(['hyde.generate_sitemap' => false]);
     }
 

--- a/packages/framework/tests/Feature/Services/RssFeedServiceTest.php
+++ b/packages/framework/tests/Feature/Services/RssFeedServiceTest.php
@@ -39,7 +39,7 @@ class RssFeedServiceTest extends TestCase
     {
         config(['hyde.name' => 'Test Blog']);
         config(['hyde.url' => 'https://example.com']);
-        config(['hyde.rss_description' => 'Test Blog RSS Feed']);
+        config(['hyde.rss.description' => 'Test Blog RSS Feed']);
 
         $service = new RssFeedGenerator();
         $this->assertTrue(property_exists($service->getXmlElement()->channel, 'title'));
@@ -70,7 +70,7 @@ class RssFeedServiceTest extends TestCase
     {
         config(['hyde.name' => 'Foo']);
         config(['hyde.url' => 'https://blog.foo.com/bar']);
-        config(['hyde.rss_description' => 'Foo is a web log about stuff']);
+        config(['hyde.rss.description' => 'Foo is a web log about stuff']);
 
         $service = new RssFeedGenerator();
         $this->assertEquals('Foo', $service->getXmlElement()->channel->title);

--- a/packages/framework/tests/Feature/Services/RssFeedServiceTest.php
+++ b/packages/framework/tests/Feature/Services/RssFeedServiceTest.php
@@ -149,7 +149,7 @@ class RssFeedServiceTest extends TestCase
     public function test_can_generate_feed_helper_returns_false_if_feeds_are_disabled_in_config()
     {
         config(['hyde.url' => 'foo']);
-        config(['hyde.generate_rss_feed' => false]);
+        config(['hyde.rss.enabled' => false]);
         $this->assertFalse(Features::rss());
     }
 }

--- a/packages/framework/tests/Feature/StaticSiteServiceTest.php
+++ b/packages/framework/tests/Feature/StaticSiteServiceTest.php
@@ -166,7 +166,7 @@ class StaticSiteServiceTest extends TestCase
     public function test_rss_feed_is_not_generated_when_conditions_are_not_met()
     {
         config(['hyde.url' => '']);
-        config(['hyde.generate_rss_feed' => false]);
+        config(['hyde.rss.enabled' => false]);
 
         $this->artisan('build')
             ->doesntExpectOutput('Generating RSS feed...')
@@ -176,7 +176,7 @@ class StaticSiteServiceTest extends TestCase
     public function test_rss_feed_is_generated_when_conditions_are_met()
     {
         config(['hyde.url' => 'https://example.com']);
-        config(['hyde.generate_rss_feed' => true]);
+        config(['hyde.rss.enabled' => true]);
 
         Filesystem::touch('_posts/foo.md');
 


### PR DESCRIPTION
## Updates the RSS configuration array settings

### Development

I believe this to be the (or one of the) last breaking change as HydePHP enters GA in two days.
While **this is a breaking change**, the impact is very low. It's a really easy change, and I don't think that many people have changed this setting, and the BC has not fully kicked in yet, so I think the risk is acceptable.

### Changes the following in `config/hyde.php`:

```php
// Should the RSS feed be generated?
'generate_rss_feed' => true,

// What filename should the RSS file use?
'rss_filename' => 'feed.xml',

// The channel description.
'rss_description' =>  env('SITE_NAME', 'HydePHP').' RSS Feed',
```

### To instead be like this:

```php
'rss' => [
    // Should the RSS feed be generated?
    'enabled' => true,

    // What filename should the RSS file use?
    'filename' => 'feed.xml',

    // The channel description.
    'description' => env('SITE_NAME', 'HydePHP').' RSS Feed',
],
```

## Benefits & Drawbacks

**The benefits of changing the config file structure to use nested arrays as shown in the second code block are:**

1.  **Clarity and organization**: Using nested arrays to group related configuration options makes it easier to understand the purpose and organization of the options, which can improve the overall clarity of the codebase.
    
2.  **Flexibility**: By grouping related options into a nested array, it can make it easier to add additional related options in the future.
    
3.  **Reduced potential for naming conflicts**: Grouping related options into a nested array can help prevent naming conflicts between options that may have similar or identical names.
    

**The drawbacks of changing the config file structure to use nested arrays are:**

1.  **Increased complexity**: The use of nested arrays can add complexity to the codebase, as developers may need to navigate multiple levels of arrays to access the desired configuration option.
    
2.  **Backwards compatibility issues**: If this is a widely used configuration file, changing its structure can create compatibility issues with existing code that expects the original structure.
    
3.  **Increased verbosity**: The use of nested arrays can make the code more verbose, especially when accessing the configuration values. In effect, however, this is not a concern as `rss_description` is not much different than `rss.description`.

_This section was written by ChatGPT_