### PR TITLE
Remove deprecated `CreatesNewPageSourceFile::getOutputPath` method

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -28,6 +28,7 @@ This serves two purposes:
 - Removed `RenderData:.getCurrentRoute` method deprecated in v1.0.0-RC.2
 - Removed deprecated `HydePage::$canonicalUrl` property (replaced with `HydePage::getCanonicalUrl()`).
 - Removed deprecated `SourceFile::withoutDirectoryPrefix` method only used in one test.
+- Removed deprecated `CreatesNewPageSourceFile::getOutputPath` method as the save method now returns the path.
 
 ### Fixed
 - Fixed the blog post article view where metadata assembly used legacy hard-coded paths instead of dynamic path information.

--- a/packages/framework/src/Framework/Actions/CreatesNewPageSourceFile.php
+++ b/packages/framework/src/Framework/Actions/CreatesNewPageSourceFile.php
@@ -62,12 +62,6 @@ class CreatesNewPageSourceFile
         return $this->outputPath;
     }
 
-    /** @deprecated This method may be removed as the save method now returns the path. */
-    public function getOutputPath(): string
-    {
-        return $this->outputPath;
-    }
-
     protected function parseTitle(string $title): string
     {
         return Str::afterLast($title, '/');

--- a/packages/framework/tests/Feature/Actions/CreatesNewPageSourceFileTest.php
+++ b/packages/framework/tests/Feature/Actions/CreatesNewPageSourceFileTest.php
@@ -137,16 +137,16 @@ class CreatesNewPageSourceFileTest extends TestCase
     {
         $this->assertSame(
             Hyde::path('_pages/test-page.md'),
-            (new CreatesNewPageSourceFile('Test Page'))->getOutputPath()
+            (new CreatesNewPageSourceFile('Test Page'))->save()
         );
 
         $this->assertSame(
             Hyde::path('_pages/test-page.blade.php'),
-            (new CreatesNewPageSourceFile('Test Page', BladePage::class))->getOutputPath()
+            (new CreatesNewPageSourceFile('Test Page', BladePage::class))->save()
         );
 
-        // Filesystem::unlink('_pages/test-page.md');
-        // Filesystem::unlink('_pages/test-page.blade.php');
+        Filesystem::unlink('_pages/test-page.md');
+        Filesystem::unlink('_pages/test-page.blade.php');
     }
 
     public function test_file_is_created_using_slug_generated_from_title()


### PR DESCRIPTION
This method is removed as the save method now returns the path