### PR TITLE
HydePHP v1.0.0 - Release Candidate Four

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,30 @@ HydePHP consists of two primary components, Hyde/Hyde and Hyde/Framework. Develo
 
 <!-- CHANGELOG_START -->
 
+## [v1.0.0-RC.4](https://github.com/hydephp/develop/releases/tag/v1.0.0-RC.4) - 2023-03-12
+
+### Added
+- Added new method `HydePage::getCanonicalUrl()` to replace deprecated `HydePage::$canonicalUrl` property.
+
+### Changed
+- Added default RSS feed description value to the config stub in [#1253](https://github.com/hydephp/develop/pull/1253)
+- Changed the RSS feed configuration structure to be an array of feed configurations in [#1258](https://github.com/hydephp/develop/pull/1258)
+  - Replaced option `hyde.generate_rss_feed` with `hyde.rss.enabled`
+  - Replaced option `hyde.rss_filename` with `hyde.rss.filename`
+  - Replaced option `hyde.rss_description` with `hyde.rss.description`
+
+### Removed
+- Removed `RouteKey::normalize` method deprecated in v1.0.0-RC.2
+- Removed `RenderData:.getCurrentPage` method deprecated in v1.0.0-RC.2
+- Removed `RenderData:.getCurrentRoute` method deprecated in v1.0.0-RC.2
+- Removed deprecated `HydePage::$canonicalUrl` property (replaced with `HydePage::getCanonicalUrl()`).
+- Removed deprecated `SourceFile::withoutDirectoryPrefix` method only used in one test.
+- Removed deprecated `CreatesNewPageSourceFile::getOutputPath` method as the save method now returns the path.
+
+### Fixed
+- Fixed the blog post article view where metadata assembly used legacy hard-coded paths instead of dynamic path information.
+
+
 ## [v1.0.0-RC.3](https://github.com/hydephp/develop/releases/tag/v1.0.0-RC.3) - 2023-03-11
 
 ### Changed

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -10,28 +10,19 @@ This serves two purposes:
 2. At release time, you can move the Unreleased section changes into a new release version section.
 
 ### Added
-- Added new method `HydePage::getCanonicalUrl()` to replace deprecated `HydePage::$canonicalUrl` property.
+- for new features.
 
 ### Changed
-- Added default RSS feed description value to the config stub in [#1253](https://github.com/hydephp/develop/pull/1253)
-- Changed the RSS feed configuration structure to be an array of feed configurations in [#1258](https://github.com/hydephp/develop/pull/1258)
-  - Replaced option `hyde.generate_rss_feed` with `hyde.rss.enabled`
-  - Replaced option `hyde.rss_filename` with `hyde.rss.filename`
-  - Replaced option `hyde.rss_description` with `hyde.rss.description`
+- for changes in existing functionality.
 
 ### Deprecated
 - for soon-to-be removed features.
 
 ### Removed
-- Removed `RouteKey::normalize` method deprecated in v1.0.0-RC.2
-- Removed `RenderData:.getCurrentPage` method deprecated in v1.0.0-RC.2
-- Removed `RenderData:.getCurrentRoute` method deprecated in v1.0.0-RC.2
-- Removed deprecated `HydePage::$canonicalUrl` property (replaced with `HydePage::getCanonicalUrl()`).
-- Removed deprecated `SourceFile::withoutDirectoryPrefix` method only used in one test.
-- Removed deprecated `CreatesNewPageSourceFile::getOutputPath` method as the save method now returns the path.
+- for now removed features.
 
 ### Fixed
-- Fixed the blog post article view where metadata assembly used legacy hard-coded paths instead of dynamic path information.
+- for any bug fixes.
 
 ### Security
 - in case of vulnerabilities.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "hyde",
-    "version": "1.0.0-RC.3",
+    "version": "1.0.0-RC.4",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "hyde",
-            "version": "1.0.0-RC.3",
+            "version": "1.0.0-RC.4",
             "license": "MIT",
             "devDependencies": {
                 "@tailwindcss/typography": "^0.5.2",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     },
     "name": "hyde",
     "description": "Elegant and Powerful Static App Builder",
-    "version": "1.0.0-RC.3",
+    "version": "1.0.0-RC.4",
     "main": "hyde",
     "directories": {
         "test": "tests"

--- a/packages/framework/src/Foundation/HydeKernel.php
+++ b/packages/framework/src/Foundation/HydeKernel.php
@@ -49,7 +49,7 @@ class HydeKernel implements SerializableContract
     use Serializable;
     use Macroable;
 
-    final public const VERSION = '1.0.0-RC.3';
+    final public const VERSION = '1.0.0-RC.4';
 
     protected static self $instance;
 


### PR DESCRIPTION

## [v1.0.0-RC.4](https://github.com/hydephp/develop/releases/tag/v1.0.0-RC.4) - 2023-03-12

### Added
- Added new method `HydePage::getCanonicalUrl()` to replace deprecated `HydePage::$canonicalUrl` property.

### Changed
- Added default RSS feed description value to the config stub in [#1253](https://github.com/hydephp/develop/pull/1253)
- Changed the RSS feed configuration structure to be an array of feed configurations in [#1258](https://github.com/hydephp/develop/pull/1258)
  - Replaced option `hyde.generate_rss_feed` with `hyde.rss.enabled`
  - Replaced option `hyde.rss_filename` with `hyde.rss.filename`
  - Replaced option `hyde.rss_description` with `hyde.rss.description`

### Removed
- Removed `RouteKey::normalize` method deprecated in v1.0.0-RC.2
- Removed `RenderData:.getCurrentPage` method deprecated in v1.0.0-RC.2
- Removed `RenderData:.getCurrentRoute` method deprecated in v1.0.0-RC.2
- Removed deprecated `HydePage::$canonicalUrl` property (replaced with `HydePage::getCanonicalUrl()`).
- Removed deprecated `SourceFile::withoutDirectoryPrefix` method only used in one test.
- Removed deprecated `CreatesNewPageSourceFile::getOutputPath` method as the save method now returns the path.

### Fixed
- Fixed the blog post article view where metadata assembly used legacy hard-coded paths instead of dynamic path information.
