### PR TITLE
Bugfix: Fix missing `justify-between` class on the documentation article header

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -22,7 +22,7 @@ This serves two purposes:
 - for now removed features.
 
 ### Fixed
-- for any bug fixes.
+- Bugfix: Fix missing `justify-between` class on the documentation article header [#1265](https://github.com/hydephp/develop/pull/1265)
 
 ### Security
 - in case of vulnerabilities.

--- a/packages/framework/resources/views/components/docs/documentation-article.blade.php
+++ b/packages/framework/resources/views/components/docs/documentation-article.blade.php
@@ -7,7 +7,7 @@
         'torchlight-enabled' => $document->hasTorchlight()])>
     @yield('content')
 
-    <header id="document-header" class="flex items-center flex-wrap prose-h1:mb-3">
+    <header id="document-header" class="flex items-center flex-wrap justify-between prose-h1:mb-3">
         {{ $document->renderHeader() }}
     </header>
     <section id="document-main-content" itemprop="articleBody">


### PR DESCRIPTION
This is needed when using the edit page link in the footer