### PR TITLE
Update supported versions in package security policies

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -7,7 +7,7 @@ These are the version ranges of HydePHP, and their support status. We follow [Se
 | Version | Supported          | Classification       |
 |---------|--------------------|----------------------|
 | 1.x     | :white_check_mark: | General Availability |
-| > 0.64  | :warning:          | Beta (legacy)        |
+| > 0.64  | :x:                | Beta (legacy)        |
 | < 0.64  | :x:                | Beta (legacy)        |
 | < 0.8   | :x:                | Alpha stage          |
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -4,12 +4,12 @@
 
 These are the version ranges of HydePHP, and their support status. We follow [Semantic Versioning](https://semver.org), and you can read about our [Backwards Compatability](https://github.com/hydephp/policies/blob/master/backwards-compatability.md) promise here.
 
-| Version | Supported | Classification            |
-|---------|-----------|---------------------------|
+| Version | Supported          | Classification       |
+|---------|--------------------|----------------------|
 | 1.x     | :white_check_mark: | General Availability |
-| > 0.64  | :warning: | Beta (legacy)             |
-| < 0.64  | :x:       | Beta (legacy)             |
-| < 0.8   | :x:       | Alpha stage               |
+| > 0.64  | :warning:          | Beta (legacy)        |
+| < 0.64  | :x:                | Beta (legacy)        |
+| < 0.8   | :x:                | Alpha stage          |
 
 
 ## Reporting a Vulnerability

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -7,7 +7,6 @@ These are the version ranges of HydePHP, and their support status. We follow [Se
 | Version | Supported          | Classification       |
 |---------|--------------------|----------------------|
 | 1.x     | :white_check_mark: | General Availability |
-| > 0.64  | :x:                | Beta (legacy)        |
 | < 0.64  | :x:                | Beta (legacy)        |
 | < 0.8   | :x:                | Alpha stage          |
 

--- a/packages/framework/SECURITY.md
+++ b/packages/framework/SECURITY.md
@@ -7,11 +7,11 @@
 Versions in the 0.x series are not stable and may change at any time.
 No backwards compatibility guarantees are made and there will be breaking changes without notice.
 
-| Version | Supported | Classification            |
-|---------|-----------|---------------------------|
-| > 0.50  | :warning: | Beta (active development) |
-| < 0.50  | :x:       | Beta (legacy)             |
-| < 0.8   | :x:       | Alpha stage               |
+| Version | Supported | Classification  |
+|---------|-----------|-----------------|
+| < 0.64  | :x:       | Beta (legacy)   |
+| < 0.50  | :x:       | Beta (legacy)   |
+| < 0.8   | :x:       | Alpha stage     |
 
 
 <!-- 

--- a/packages/framework/SECURITY.md
+++ b/packages/framework/SECURITY.md
@@ -7,11 +7,12 @@
 Versions in the 0.x series are not stable and may change at any time.
 No backwards compatibility guarantees are made and there will be breaking changes without notice.
 
-| Version | Supported | Classification  |
-|---------|-----------|-----------------|
-| < 0.64  | :x:       | Beta (legacy)   |
-| < 0.50  | :x:       | Beta (legacy)   |
-| < 0.8   | :x:       | Alpha stage     |
+| Version | Supported          | Classification       |
+|---------|--------------------|----------------------|
+| 1.x     | :white_check_mark: | General Availability |
+| < 0.64  | :x:                | Beta (legacy)        |
+| < 0.50  | :x:                | Beta (legacy)        |
+| < 0.8   | :x:                | Alpha stage          |
 
 
 <!-- 

--- a/packages/framework/SECURITY.md
+++ b/packages/framework/SECURITY.md
@@ -22,5 +22,6 @@ These are the version ranges of HydePHP, and their support status. We follow [Se
 ## Reporting a Vulnerability
 
 If you discover a security vulnerability within this package, please send an e-mail to the creator, Caen De Silva, via caen@desilva.se.
+You can also report a vulnerability through GitHub on the [Security Advisory](https://github.com/hydephp/develop/security/advisories) page.
 
 All security vulnerabilities will be promptly addressed.

--- a/packages/framework/SECURITY.md
+++ b/packages/framework/SECURITY.md
@@ -2,10 +2,7 @@
 
 ## Supported Versions
 
-### Hyde is currently in Beta and has no supported versions.
-
-Versions in the 0.x series are not stable and may change at any time.
-No backwards compatibility guarantees are made and there will be breaking changes without notice.
+These are the version ranges of HydePHP, and their support status. We follow [Semantic Versioning](https://semver.org), and you can read about our [Backwards Compatability](https://github.com/hydephp/policies/blob/master/backwards-compatability.md) promise here.
 
 | Version | Supported          | Classification       |
 |---------|--------------------|----------------------|


### PR DESCRIPTION
Updates the security documents to include v1.0 General Availability, and to keep a consistent presentation.