### PR TITLE
Prefix version for default meta generator value

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -22,7 +22,7 @@ This serves two purposes:
 - for now removed features.
 
 ### Fixed
-- for any bug fixes.
+- Added missing version prefix to default generator meta tag value. https://github.com/hydephp/develop/pull/1272
 
 ### Security
 - in case of vulnerabilities.

--- a/config/hyde.php
+++ b/config/hyde.php
@@ -220,7 +220,7 @@ return [
         // Meta::name('twitter:creator', '@HydeFramework'),
         // Meta::name('description', 'My Hyde Blog'),
         // Meta::name('keywords', 'Static Sites, Blogs, Documentation'),
-        Meta::name('generator', 'HydePHP '.Hyde\Hyde::version()),
+        Meta::name('generator', 'HydePHP v'.Hyde\Hyde::version()),
         Meta::property('site_name', env('SITE_NAME', 'HydePHP')),
     ],
 

--- a/packages/framework/config/hyde.php
+++ b/packages/framework/config/hyde.php
@@ -220,7 +220,7 @@ return [
         // Meta::name('twitter:creator', '@HydeFramework'),
         // Meta::name('description', 'My Hyde Blog'),
         // Meta::name('keywords', 'Static Sites, Blogs, Documentation'),
-        Meta::name('generator', 'HydePHP '.Hyde\Hyde::version()),
+        Meta::name('generator', 'HydePHP v'.Hyde\Hyde::version()),
         Meta::property('site_name', env('SITE_NAME', 'HydePHP')),
     ],
 

--- a/packages/framework/tests/Feature/MetadataViewTest.php
+++ b/packages/framework/tests/Feature/MetadataViewTest.php
@@ -80,7 +80,7 @@ class MetadataViewTest extends TestCase
             '<meta name="viewport" content="width=device-width, initial-scale=1">',
             '<meta id="meta-color-scheme" name="color-scheme" content="light">',
             '<link rel="sitemap" href="http://localhost/sitemap.xml" type="application/xml" title="Sitemap">',
-            '<meta name="generator" content="HydePHP '.HydeKernel::VERSION.'">',
+            '<meta name="generator" content="HydePHP v'.HydeKernel::VERSION.'">',
             '<meta property="og:site_name" content="HydePHP">',
         ];
     }


### PR DESCRIPTION
This was lost when moving to a version constant instead of Composer value. Thus I consider this to be a bugfix.