### PR TITLE
HydePHP v1.0.0 - Release Candidate Six

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,16 @@ HydePHP consists of two primary components, Hyde/Hyde and Hyde/Framework. Develo
 
 <!-- CHANGELOG_START -->
 
+## [v1.0.0-RC.6](https://github.com/hydephp/develop/releases/tag/v1.0.0-RC.6) - 2023-03-14
+
+### Removed
+- Removed IDE helpers for removed global variables from the IDE helper file. https://github.com/hydephp/develop/pull/1274
+- Removed default values from Hyde facade method annotations. https://github.com/hydephp/develop/pull/1275
+
+### Fixed
+- Added missing version prefix to default generator meta tag value. https://github.com/hydephp/develop/pull/1272
+
+
 ## [v1.0.0-RC.5](https://github.com/hydephp/develop/releases/tag/v1.0.0-RC.5) - 2023-03-13
 
 ### Added

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -19,11 +19,10 @@ This serves two purposes:
 - for soon-to-be removed features.
 
 ### Removed
-- Removed IDE helpers for removed global variables from the IDE helper file. https://github.com/hydephp/develop/pull/1274
-- Removed default values from Hyde facade method annotations
+- for now removed features.
 
 ### Fixed
-- Added missing version prefix to default generator meta tag value. https://github.com/hydephp/develop/pull/1272
+- for any bug fixes.
 
 ### Security
 - in case of vulnerabilities.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "hyde",
-    "version": "1.0.0-RC.5",
+    "version": "1.0.0-RC.6",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "hyde",
-            "version": "1.0.0-RC.5",
+            "version": "1.0.0-RC.6",
             "license": "MIT",
             "devDependencies": {
                 "@tailwindcss/typography": "^0.5.2",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     },
     "name": "hyde",
     "description": "Elegant and Powerful Static App Builder",
-    "version": "1.0.0-RC.5",
+    "version": "1.0.0-RC.6",
     "main": "hyde",
     "directories": {
         "test": "tests"

--- a/packages/framework/src/Foundation/HydeKernel.php
+++ b/packages/framework/src/Foundation/HydeKernel.php
@@ -49,7 +49,7 @@ class HydeKernel implements SerializableContract
     use Serializable;
     use Macroable;
 
-    final public const VERSION = '1.0.0-RC.5';
+    final public const VERSION = '1.0.0-RC.6';
 
     protected static self $instance;
 


### PR DESCRIPTION
## [v1.0.0-RC.6](https://github.com/hydephp/develop/releases/tag/v1.0.0-RC.6) - 2023-03-14

### Removed
- Removed IDE helpers for removed global variables from the IDE helper file. https://github.com/hydephp/develop/pull/1274
- Removed default values from Hyde facade method annotations. https://github.com/hydephp/develop/pull/1275

### Fixed
- Added missing version prefix to default generator meta tag value. https://github.com/hydephp/develop/pull/1272
