### PR TITLE
HydePHP v1.0.0 - Release Candidate Seven

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,17 @@ HydePHP consists of two primary components, Hyde/Hyde and Hyde/Framework. Develo
 
 <!-- CHANGELOG_START -->
 
+## [v1.0.0-RC.7](https://github.com/hydephp/develop/releases/tag/v1.0.0-RC.7) - 2023-03-14
+
+### Added
+- Added generics to the Hyde facade method annotations https://github.com/hydephp/develop/pull/1280
+
+### Changed
+- Updated 404 page home link to use the index route instead of the site URL https://github.com/hydephp/develop/pull/1278
+- Improved generic type usage in the RegisterFileLocations trait https://github.com/hydephp/develop/pull/1279
+- Bumped HydeFront to v3.1 https://github.com/hydephp/develop/pull/1281
+
+
 ## [v1.0.0-RC.6](https://github.com/hydephp/develop/releases/tag/v1.0.0-RC.6) - 2023-03-14
 
 ### Removed

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -10,12 +10,10 @@ This serves two purposes:
 2. At release time, you can move the Unreleased section changes into a new release version section.
 
 ### Added
-- Added generics to the Hyde facade method annotations https://github.com/hydephp/develop/pull/1280
+- for new features.
 
 ### Changed
-- Updated 404 page home link to use the index route instead of the site URL https://github.com/hydephp/develop/pull/1278
-- Improved generic type usage in the RegisterFileLocations trait https://github.com/hydephp/develop/pull/1279
-- Bumped HydeFront to v3.1 https://github.com/hydephp/develop/pull/1281
+- for changes in existing functionality.
 
 ### Deprecated
 - for soon-to-be removed features.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "hyde",
-    "version": "1.0.0-RC.6",
+    "version": "1.0.0-RC.7",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "hyde",
-            "version": "1.0.0-RC.6",
+            "version": "1.0.0-RC.7",
             "license": "MIT",
             "devDependencies": {
                 "@tailwindcss/typography": "^0.5.2",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     },
     "name": "hyde",
     "description": "Elegant and Powerful Static App Builder",
-    "version": "1.0.0-RC.6",
+    "version": "1.0.0-RC.7",
     "main": "hyde",
     "directories": {
         "test": "tests"

--- a/packages/framework/src/Foundation/HydeKernel.php
+++ b/packages/framework/src/Foundation/HydeKernel.php
@@ -49,7 +49,7 @@ class HydeKernel implements SerializableContract
     use Serializable;
     use Macroable;
 
-    final public const VERSION = '1.0.0-RC.6';
+    final public const VERSION = '1.0.0-RC.7';
 
     protected static self $instance;
 


### PR DESCRIPTION
## [v1.0.0-RC.7](https://github.com/hydephp/develop/releases/tag/v1.0.0-RC.7) - 2023-03-14

### Added
- Added generics to the Hyde facade method annotations https://github.com/hydephp/develop/pull/1280

### Changed
- Updated 404 page home link to use the index route instead of the site URL https://github.com/hydephp/develop/pull/1278
- Improved generic type usage in the RegisterFileLocations trait https://github.com/hydephp/develop/pull/1279
- Bumped HydeFront to v3.1 https://github.com/hydephp/develop/pull/1281
