### PR TITLE
Update ReadingTime to round up to one minute

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -22,7 +22,7 @@ This serves two purposes:
 - for now removed features.
 
 ### Fixed
-- for any bug fixes.
+- Fixed "ReadingTime calculation should never be under one minute" [#1286](https://github.com/hydephp/develop/issues/1286) in [#1285](https://github.com/hydephp/develop/pull/1285)
 
 ### Security
 - in case of vulnerabilities.

--- a/packages/framework/src/Support/ReadingTime.php
+++ b/packages/framework/src/Support/ReadingTime.php
@@ -31,6 +31,7 @@ class ReadingTime implements Stringable
 
     /** @var int The number of seconds it takes to read the text. */
     protected int $seconds;
+    protected bool $roundUp;
 
     public static function fromString(string $text): static
     {
@@ -42,9 +43,10 @@ class ReadingTime implements Stringable
         return static::fromString(Filesystem::getContents($path));
     }
 
-    public function __construct(string $text)
+    public function __construct(string $text, bool $roundUp = false)
     {
         $this->text = $text;
+        $this->roundUp = $roundUp;
 
         $this->generate();
     }
@@ -96,6 +98,10 @@ class ReadingTime implements Stringable
 
         $minutes = $wordCount / static::$wordsPerMinute;
         $seconds = (int) floor($minutes * 60);
+
+        if ($seconds < 60 && $this->roundUp) {
+            $seconds = 60;
+        }
 
         $this->wordCount = $wordCount;
         $this->seconds = $seconds;

--- a/packages/framework/src/Support/ReadingTime.php
+++ b/packages/framework/src/Support/ReadingTime.php
@@ -76,16 +76,12 @@ class ReadingTime implements Stringable
 
     public function getSecondsOver(): int
     {
-        if ($this->getMinutes() < 1) {
-            return 0;
-        }
-
         return (int) round(($this->getMinutesAsFloat() - $this->getMinutes()) * 60);
     }
 
     public function getFormatted(string $format = '%dmin, %dsec'): string
     {
-        return sprintf($format, $this->getMinutes() ?: 1, $this->getSecondsOver());
+        return sprintf($format, $this->getMinutes() ?: 1, $this->getMinutes() < 1 ? 0 : $this->getSecondsOver());
     }
 
     /** @param  \Closure(int, int): string $closure The closure will receive the minutes and seconds as integers and should return a string. */

--- a/packages/framework/src/Support/ReadingTime.php
+++ b/packages/framework/src/Support/ReadingTime.php
@@ -42,11 +42,11 @@ class ReadingTime implements Stringable
         return static::fromString(Filesystem::getContents($path));
     }
 
-    public function __construct(string $text, bool $roundUp = false)
+    public function __construct(string $text)
     {
         $this->text = $text;
 
-        $this->generate($roundUp);
+        $this->generate();
     }
 
     public function __toString()
@@ -90,16 +90,12 @@ class ReadingTime implements Stringable
         return $closure($this->getMinutes(), $this->getSecondsOver());
     }
 
-    protected function generate(bool $roundUp = false): void
+    protected function generate(): void
     {
         $wordCount = str_word_count($this->text);
 
         $minutes = $wordCount / static::$wordsPerMinute;
         $seconds = (int) floor($minutes * 60);
-
-        if ($roundUp && $seconds < 60) {
-            $seconds = 60;
-        }
 
         $this->wordCount = $wordCount;
         $this->seconds = $seconds;

--- a/packages/framework/src/Support/ReadingTime.php
+++ b/packages/framework/src/Support/ReadingTime.php
@@ -76,12 +76,16 @@ class ReadingTime implements Stringable
 
     public function getSecondsOver(): int
     {
+        if ($this->getMinutes() < 1) {
+            return 0;
+        }
+
         return (int) round(($this->getMinutesAsFloat() - $this->getMinutes()) * 60);
     }
 
     public function getFormatted(string $format = '%dmin, %dsec'): string
     {
-        return sprintf($format, $this->getMinutes() ?: 1, $this->getMinutes() < 1 ? 0 : $this->getSecondsOver());
+        return sprintf($format, $this->getMinutes() ?: 1, $this->getSecondsOver());
     }
 
     /** @param  \Closure(int, int): string $closure The closure will receive the minutes and seconds as integers and should return a string. */

--- a/packages/framework/src/Support/ReadingTime.php
+++ b/packages/framework/src/Support/ReadingTime.php
@@ -81,7 +81,7 @@ class ReadingTime implements Stringable
 
     public function getFormatted(string $format = '%dmin, %dsec'): string
     {
-        return sprintf($format, $this->getMinutes() ?: 1, $this->getMinutes() < 1 ? 0 : $this->getSecondsOver());
+        return sprintf($format, $this->getMinutes() ?: 1, $this->getMinutes() >= 1 ? $this->getSecondsOver() : 0);
     }
 
     /** @param  \Closure(int, int): string $closure The closure will receive the minutes and seconds as integers and should return a string. */

--- a/packages/framework/src/Support/ReadingTime.php
+++ b/packages/framework/src/Support/ReadingTime.php
@@ -81,7 +81,7 @@ class ReadingTime implements Stringable
 
     public function getFormatted(string $format = '%dmin, %dsec'): string
     {
-        return sprintf($format, $this->getMinutes(), $this->getSecondsOver());
+        return sprintf($format, $this->getMinutes() ?: 1, $this->getSecondsOver());
     }
 
     /** @param  \Closure(int, int): string $closure The closure will receive the minutes and seconds as integers and should return a string. */

--- a/packages/framework/src/Support/ReadingTime.php
+++ b/packages/framework/src/Support/ReadingTime.php
@@ -31,7 +31,6 @@ class ReadingTime implements Stringable
 
     /** @var int The number of seconds it takes to read the text. */
     protected int $seconds;
-    protected bool $roundUp;
 
     public static function fromString(string $text): static
     {
@@ -46,9 +45,8 @@ class ReadingTime implements Stringable
     public function __construct(string $text, bool $roundUp = false)
     {
         $this->text = $text;
-        $this->roundUp = $roundUp;
 
-        $this->generate();
+        $this->generate($roundUp);
     }
 
     public function __toString()
@@ -92,14 +90,14 @@ class ReadingTime implements Stringable
         return $closure($this->getMinutes(), $this->getSecondsOver());
     }
 
-    protected function generate(): void
+    protected function generate(bool $roundUp = false): void
     {
         $wordCount = str_word_count($this->text);
 
         $minutes = $wordCount / static::$wordsPerMinute;
         $seconds = (int) floor($minutes * 60);
 
-        if ($seconds < 60 && $this->roundUp) {
+        if ($seconds < 60 && $roundUp) {
             $seconds = 60;
         }
 

--- a/packages/framework/src/Support/ReadingTime.php
+++ b/packages/framework/src/Support/ReadingTime.php
@@ -97,7 +97,7 @@ class ReadingTime implements Stringable
         $minutes = $wordCount / static::$wordsPerMinute;
         $seconds = (int) floor($minutes * 60);
 
-        if ($seconds < 60 && $roundUp) {
+        if ($roundUp && $seconds < 60) {
             $seconds = 60;
         }
 

--- a/packages/framework/src/Support/ReadingTime.php
+++ b/packages/framework/src/Support/ReadingTime.php
@@ -81,7 +81,7 @@ class ReadingTime implements Stringable
 
     public function getFormatted(string $format = '%dmin, %dsec'): string
     {
-        return sprintf($format, $this->getMinutes() ?: 1, $this->getSecondsOver());
+        return sprintf($format, $this->getMinutes() ?: 1, $this->getMinutes() < 1 ? 0 : $this->getSecondsOver());
     }
 
     /** @param  \Closure(int, int): string $closure The closure will receive the minutes and seconds as integers and should return a string. */

--- a/packages/framework/tests/Feature/ReadingTimeTest.php
+++ b/packages/framework/tests/Feature/ReadingTimeTest.php
@@ -57,7 +57,7 @@ class ReadingTimeTest extends UnitTestCase
     public function test_getSecondsOver()
     {
         $this->assertSame(0, (new ReadingTime($this->words(0)))->getSecondsOver());
-        $this->assertSame(30, (new ReadingTime($this->words(120)))->getSecondsOver());
+        $this->assertSame(0, (new ReadingTime($this->words(120)))->getSecondsOver());
         $this->assertSame(0, (new ReadingTime($this->words(240)))->getSecondsOver());
         $this->assertSame(30, (new ReadingTime($this->words(360)))->getSecondsOver());
     }

--- a/packages/framework/tests/Feature/ReadingTimeTest.php
+++ b/packages/framework/tests/Feature/ReadingTimeTest.php
@@ -57,7 +57,7 @@ class ReadingTimeTest extends UnitTestCase
     public function test_getSecondsOver()
     {
         $this->assertSame(0, (new ReadingTime($this->words(0)))->getSecondsOver());
-        $this->assertSame(0, (new ReadingTime($this->words(120)))->getSecondsOver());
+        $this->assertSame(30, (new ReadingTime($this->words(120)))->getSecondsOver());
         $this->assertSame(0, (new ReadingTime($this->words(240)))->getSecondsOver());
         $this->assertSame(30, (new ReadingTime($this->words(360)))->getSecondsOver());
     }

--- a/packages/framework/tests/Feature/ReadingTimeTest.php
+++ b/packages/framework/tests/Feature/ReadingTimeTest.php
@@ -65,7 +65,7 @@ class ReadingTimeTest extends UnitTestCase
     public function test_getFormatted()
     {
         $this->assertSame('1min, 0sec', (new ReadingTime($this->words(0)))->getFormatted());
-        $this->assertSame('1min, 30sec', (new ReadingTime($this->words(120)))->getFormatted());
+        $this->assertSame('1min, 0sec', (new ReadingTime($this->words(120)))->getFormatted());
         $this->assertSame('1min, 0sec', (new ReadingTime($this->words(240)))->getFormatted());
         $this->assertSame('1min, 30sec', (new ReadingTime($this->words(360)))->getFormatted());
     }
@@ -73,7 +73,7 @@ class ReadingTimeTest extends UnitTestCase
     public function test_getFormattedWithCustomFormatting()
     {
         $this->assertSame('1:00', (new ReadingTime($this->words(0)))->getFormatted('%d:%02d'));
-        $this->assertSame('1:30', (new ReadingTime($this->words(120)))->getFormatted('%d:%0d'));
+        $this->assertSame('1:00', (new ReadingTime($this->words(120)))->getFormatted('%d:%02d'));
         $this->assertSame('1:00', (new ReadingTime($this->words(240)))->getFormatted('%d:%02d'));
         $this->assertSame('1:30', (new ReadingTime($this->words(360)))->getFormatted('%d:%02d'));
     }

--- a/packages/framework/tests/Feature/ReadingTimeTest.php
+++ b/packages/framework/tests/Feature/ReadingTimeTest.php
@@ -80,10 +80,10 @@ class ReadingTimeTest extends UnitTestCase
 
     public function test_getFormattedFormatsUpToOneMinuteWhenRoundUpIsSet()
     {
-        $this->assertSame('1min, 0sec', (new ReadingTime($this->words(0), true))->getFormatted());
-        $this->assertSame('1min, 0sec', (new ReadingTime($this->words(120), true))->getFormatted());
-        $this->assertSame('1min, 0sec', (new ReadingTime($this->words(240), true))->getFormatted());
-        $this->assertSame('1min, 30sec', (new ReadingTime($this->words(360), true))->getFormatted());
+        $this->assertSame('1min, 0sec', (new ReadingTime($this->words(0)))->getFormatted());
+        $this->assertSame('1min, 0sec', (new ReadingTime($this->words(120)))->getFormatted());
+        $this->assertSame('1min, 0sec', (new ReadingTime($this->words(240)))->getFormatted());
+        $this->assertSame('1min, 30sec', (new ReadingTime($this->words(360)))->getFormatted());
     }
 
     public function test_formatUsingClosure()

--- a/packages/framework/tests/Feature/ReadingTimeTest.php
+++ b/packages/framework/tests/Feature/ReadingTimeTest.php
@@ -27,7 +27,7 @@ class ReadingTimeTest extends UnitTestCase
 
     public function test__toString()
     {
-        $this->assertSame('0min, 0sec', (string) new ReadingTime('Hello world'));
+        $this->assertSame('1min, 0sec', (string) new ReadingTime('Hello world'));
     }
 
     public function test_getWordCount()
@@ -64,16 +64,16 @@ class ReadingTimeTest extends UnitTestCase
 
     public function test_getFormatted()
     {
-        $this->assertSame('0min, 0sec', (new ReadingTime($this->words(0)))->getFormatted());
-        $this->assertSame('0min, 30sec', (new ReadingTime($this->words(120)))->getFormatted());
+        $this->assertSame('1min, 0sec', (new ReadingTime($this->words(0)))->getFormatted());
+        $this->assertSame('1min, 30sec', (new ReadingTime($this->words(120)))->getFormatted());
         $this->assertSame('1min, 0sec', (new ReadingTime($this->words(240)))->getFormatted());
         $this->assertSame('1min, 30sec', (new ReadingTime($this->words(360)))->getFormatted());
     }
 
     public function test_getFormattedWithCustomFormatting()
     {
-        $this->assertSame('0:00', (new ReadingTime($this->words(0)))->getFormatted('%d:%02d'));
-        $this->assertSame('0:30', (new ReadingTime($this->words(120)))->getFormatted('%d:%0d'));
+        $this->assertSame('1:00', (new ReadingTime($this->words(0)))->getFormatted('%d:%02d'));
+        $this->assertSame('1:30', (new ReadingTime($this->words(120)))->getFormatted('%d:%0d'));
         $this->assertSame('1:00', (new ReadingTime($this->words(240)))->getFormatted('%d:%02d'));
         $this->assertSame('1:30', (new ReadingTime($this->words(360)))->getFormatted('%d:%02d'));
     }

--- a/packages/framework/tests/Feature/ReadingTimeTest.php
+++ b/packages/framework/tests/Feature/ReadingTimeTest.php
@@ -78,6 +78,14 @@ class ReadingTimeTest extends UnitTestCase
         $this->assertSame('1:30', (new ReadingTime($this->words(360)))->getFormatted('%d:%02d'));
     }
 
+    public function test_getFormattedFormatsUpToOneMinuteWhenRoundUpIsSet()
+    {
+        $this->assertSame('1min, 0sec', (new ReadingTime($this->words(0), true))->getFormatted());
+        $this->assertSame('1min, 0sec', (new ReadingTime($this->words(120), true))->getFormatted());
+        $this->assertSame('1min, 0sec', (new ReadingTime($this->words(240), true))->getFormatted());
+        $this->assertSame('1min, 30sec', (new ReadingTime($this->words(360), true))->getFormatted());
+    }
+
     public function test_formatUsingClosure()
     {
         /**


### PR DESCRIPTION
Fixes https://github.com/hydephp/develop/issues/1286 by rounding up the `Stringable` results of the `getFormatted` method in the `ReadingTime` class.