### PR TITLE
Remove test class references from main codebase

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -19,7 +19,7 @@ This serves two purposes:
 - for soon-to-be removed features.
 
 ### Removed
-- for now removed features.
+- Removed test class references from main codebase https://github.com/hydephp/develop/pull/1287
 
 ### Fixed
 - Fixed "ReadingTime calculation should never be under one minute" [#1286](https://github.com/hydephp/develop/issues/1286) in [#1285](https://github.com/hydephp/develop/pull/1285)

--- a/monorepo/HydeStan/HydeStan.php
+++ b/monorepo/HydeStan/HydeStan.php
@@ -103,6 +103,12 @@ class HydeStan
                 }
                 $this->errors[] = $error;
             }
+
+            foreach (explode("\n", $contents) as $lineNumber => $line) {
+                if (str_starts_with($line, ' * @see') && str_ends_with($line, 'Test')) {
+                    $this->errors[] = sprintf('Test class %s is referenced in %s:%s', trim(substr($line, 7)), realpath(__DIR__.'/../../packages/framework/'.$file) ?: $file, $lineNumber + 1);
+                }
+            }
         }
 
         $this->scannedLines += substr_count($contents, "\n");

--- a/packages/framework/src/Console/Commands/BuildRssFeedCommand.php
+++ b/packages/framework/src/Console/Commands/BuildRssFeedCommand.php
@@ -9,7 +9,6 @@ use LaravelZero\Framework\Commands\Command;
 
 /**
  * Hyde command to run the build process for the RSS feed.
- *
  */
 class BuildRssFeedCommand extends Command
 {

--- a/packages/framework/src/Console/Commands/BuildRssFeedCommand.php
+++ b/packages/framework/src/Console/Commands/BuildRssFeedCommand.php
@@ -10,7 +10,6 @@ use LaravelZero\Framework\Commands\Command;
 /**
  * Hyde command to run the build process for the RSS feed.
  *
- * @see \Hyde\Framework\Testing\Feature\Commands\BuildRssFeedCommandTest
  */
 class BuildRssFeedCommand extends Command
 {

--- a/packages/framework/src/Console/Commands/BuildSearchCommand.php
+++ b/packages/framework/src/Console/Commands/BuildSearchCommand.php
@@ -9,7 +9,6 @@ use LaravelZero\Framework\Commands\Command;
 
 /**
  * Hyde command to run the build process for the documentation search index.
- *
  */
 class BuildSearchCommand extends Command
 {

--- a/packages/framework/src/Console/Commands/BuildSearchCommand.php
+++ b/packages/framework/src/Console/Commands/BuildSearchCommand.php
@@ -10,7 +10,6 @@ use LaravelZero\Framework\Commands\Command;
 /**
  * Hyde command to run the build process for the documentation search index.
  *
- * @see \Hyde\Framework\Testing\Feature\Commands\BuildSearchCommandTest
  */
 class BuildSearchCommand extends Command
 {

--- a/packages/framework/src/Console/Commands/BuildSiteCommand.php
+++ b/packages/framework/src/Console/Commands/BuildSiteCommand.php
@@ -22,7 +22,6 @@ use function app;
 /**
  * Hyde Command to run the Build Process.
  *
- * @see \Hyde\Framework\Testing\Feature\StaticSiteServiceTest
  */
 class BuildSiteCommand extends Command
 {

--- a/packages/framework/src/Console/Commands/BuildSiteCommand.php
+++ b/packages/framework/src/Console/Commands/BuildSiteCommand.php
@@ -21,7 +21,6 @@ use function app;
 
 /**
  * Hyde Command to run the Build Process.
- *
  */
 class BuildSiteCommand extends Command
 {

--- a/packages/framework/src/Console/Commands/BuildSitemapCommand.php
+++ b/packages/framework/src/Console/Commands/BuildSitemapCommand.php
@@ -9,7 +9,6 @@ use LaravelZero\Framework\Commands\Command;
 
 /**
  * Hyde command to run the build process for the sitemap.
- *
  */
 class BuildSitemapCommand extends Command
 {

--- a/packages/framework/src/Console/Commands/BuildSitemapCommand.php
+++ b/packages/framework/src/Console/Commands/BuildSitemapCommand.php
@@ -10,7 +10,6 @@ use LaravelZero\Framework\Commands\Command;
 /**
  * Hyde command to run the build process for the sitemap.
  *
- * @see \Hyde\Framework\Testing\Feature\Commands\BuildSitemapCommandTest
  */
 class BuildSitemapCommand extends Command
 {

--- a/packages/framework/src/Console/Commands/ChangeSourceDirectoryCommand.php
+++ b/packages/framework/src/Console/Commands/ChangeSourceDirectoryCommand.php
@@ -21,7 +21,6 @@ use function basename;
 use function realpath;
 
 /**
- * @see \Hyde\Framework\Testing\Feature\Commands\ChangeSourceDirectoryCommandTest
  */
 class ChangeSourceDirectoryCommand extends Command
 {

--- a/packages/framework/src/Console/Commands/ChangeSourceDirectoryCommand.php
+++ b/packages/framework/src/Console/Commands/ChangeSourceDirectoryCommand.php
@@ -20,8 +20,6 @@ use function str_replace;
 use function basename;
 use function realpath;
 
-/**
- */
 class ChangeSourceDirectoryCommand extends Command
 {
     /** @var string */

--- a/packages/framework/src/Console/Commands/MakePageCommand.php
+++ b/packages/framework/src/Console/Commands/MakePageCommand.php
@@ -16,7 +16,6 @@ use function ucfirst;
 
 /**
  * Hyde Command to scaffold a new Markdown or Blade page file.
- *
  */
 class MakePageCommand extends Command
 {

--- a/packages/framework/src/Console/Commands/MakePageCommand.php
+++ b/packages/framework/src/Console/Commands/MakePageCommand.php
@@ -17,7 +17,6 @@ use function ucfirst;
 /**
  * Hyde Command to scaffold a new Markdown or Blade page file.
  *
- * @see \Hyde\Framework\Testing\Feature\Commands\MakePageCommandTest
  */
 class MakePageCommand extends Command
 {

--- a/packages/framework/src/Console/Commands/PackageDiscoverCommand.php
+++ b/packages/framework/src/Console/Commands/PackageDiscoverCommand.php
@@ -9,7 +9,6 @@ use Illuminate\Foundation\Console\PackageDiscoverCommand as BaseCommand;
 use Illuminate\Foundation\PackageManifest;
 
 /**
- * @see \Hyde\Framework\Testing\Feature\Commands\PackageDiscoverCommandTest
  */
 class PackageDiscoverCommand extends BaseCommand
 {

--- a/packages/framework/src/Console/Commands/PackageDiscoverCommand.php
+++ b/packages/framework/src/Console/Commands/PackageDiscoverCommand.php
@@ -8,8 +8,6 @@ use Hyde\Hyde;
 use Illuminate\Foundation\Console\PackageDiscoverCommand as BaseCommand;
 use Illuminate\Foundation\PackageManifest;
 
-/**
- */
 class PackageDiscoverCommand extends BaseCommand
 {
     /** @var true */

--- a/packages/framework/src/Console/Commands/PublishConfigsCommand.php
+++ b/packages/framework/src/Console/Commands/PublishConfigsCommand.php
@@ -13,7 +13,6 @@ use function sprintf;
 
 /**
  * Publish the Hyde Config Files.
- *
  */
 class PublishConfigsCommand extends Command
 {

--- a/packages/framework/src/Console/Commands/PublishConfigsCommand.php
+++ b/packages/framework/src/Console/Commands/PublishConfigsCommand.php
@@ -14,7 +14,6 @@ use function sprintf;
 /**
  * Publish the Hyde Config Files.
  *
- * @see \Hyde\Framework\Testing\Feature\Commands\UpdateConfigsCommandTest
  */
 class PublishConfigsCommand extends Command
 {

--- a/packages/framework/src/Console/Commands/PublishHomepageCommand.php
+++ b/packages/framework/src/Console/Commands/PublishHomepageCommand.php
@@ -19,7 +19,6 @@ use function strstr;
 
 /**
  * Publish one of the default homepages.
- *
  */
 class PublishHomepageCommand extends Command
 {

--- a/packages/framework/src/Console/Commands/PublishHomepageCommand.php
+++ b/packages/framework/src/Console/Commands/PublishHomepageCommand.php
@@ -20,7 +20,6 @@ use function strstr;
 /**
  * Publish one of the default homepages.
  *
- * @see \Hyde\Framework\Testing\Feature\Commands\PublishHomepageCommandTest
  */
 class PublishHomepageCommand extends Command
 {

--- a/packages/framework/src/Console/Commands/PublishViewsCommand.php
+++ b/packages/framework/src/Console/Commands/PublishViewsCommand.php
@@ -13,7 +13,6 @@ use function strstr;
 
 /**
  * Publish the Hyde Blade views.
- *
  */
 class PublishViewsCommand extends Command
 {

--- a/packages/framework/src/Console/Commands/PublishViewsCommand.php
+++ b/packages/framework/src/Console/Commands/PublishViewsCommand.php
@@ -14,7 +14,6 @@ use function strstr;
 /**
  * Publish the Hyde Blade views.
  *
- * @see \Hyde\Framework\Testing\Feature\Commands\PublishViewsCommandTest
  */
 class PublishViewsCommand extends Command
 {

--- a/packages/framework/src/Console/Commands/RebuildPageCommand.php
+++ b/packages/framework/src/Console/Commands/RebuildPageCommand.php
@@ -26,7 +26,6 @@ use function unslash;
 /**
  * Hyde Command to build a single static site file.
  *
- * @see \Hyde\Framework\Testing\Feature\Commands\RebuildPageCommandTest
  */
 class RebuildPageCommand extends Command
 {

--- a/packages/framework/src/Console/Commands/RebuildPageCommand.php
+++ b/packages/framework/src/Console/Commands/RebuildPageCommand.php
@@ -25,7 +25,6 @@ use function unslash;
 
 /**
  * Hyde Command to build a single static site file.
- *
  */
 class RebuildPageCommand extends Command
 {

--- a/packages/framework/src/Console/Commands/RouteListCommand.php
+++ b/packages/framework/src/Console/Commands/RouteListCommand.php
@@ -16,7 +16,6 @@ use function sprintf;
 
 /**
  * Hyde command to display the list of site routes.
- *
  */
 class RouteListCommand extends Command
 {

--- a/packages/framework/src/Console/Commands/RouteListCommand.php
+++ b/packages/framework/src/Console/Commands/RouteListCommand.php
@@ -17,7 +17,6 @@ use function sprintf;
 /**
  * Hyde command to display the list of site routes.
  *
- * @see \Hyde\Framework\Testing\Feature\Commands\RouteListCommandTest
  */
 class RouteListCommand extends Command
 {

--- a/packages/framework/src/Console/Commands/ValidateCommand.php
+++ b/packages/framework/src/Console/Commands/ValidateCommand.php
@@ -12,8 +12,6 @@ use function number_format;
 use function microtime;
 use function sprintf;
 
-/**
- */
 class ValidateCommand extends Command
 {
     use TracksExecutionTime;

--- a/packages/framework/src/Console/Commands/ValidateCommand.php
+++ b/packages/framework/src/Console/Commands/ValidateCommand.php
@@ -13,7 +13,6 @@ use function microtime;
 use function sprintf;
 
 /**
- * @see \Hyde\Framework\Testing\Feature\Commands\ValidateCommandTest
  */
 class ValidateCommand extends Command
 {

--- a/packages/framework/src/Console/Commands/VendorPublishCommand.php
+++ b/packages/framework/src/Console/Commands/VendorPublishCommand.php
@@ -16,7 +16,6 @@ use function str_replace;
 
 /**
  * Publish any publishable assets from vendor packages.
- *
  */
 class VendorPublishCommand extends BaseCommand
 {

--- a/packages/framework/src/Console/Commands/VendorPublishCommand.php
+++ b/packages/framework/src/Console/Commands/VendorPublishCommand.php
@@ -17,7 +17,6 @@ use function str_replace;
 /**
  * Publish any publishable assets from vendor packages.
  *
- * @see \Hyde\Framework\Testing\Feature\Commands\VendorPublishCommandTest
  */
 class VendorPublishCommand extends BaseCommand
 {

--- a/packages/framework/src/Console/Concerns/Command.php
+++ b/packages/framework/src/Console/Concerns/Command.php
@@ -19,7 +19,6 @@ use function str_replace;
 /**
  * A base class for HydeCLI command that adds some extra functionality and output
  * helpers to reduce repeated code and to provide a consistent user interface.
- *
  */
 abstract class Command extends BaseCommand
 {

--- a/packages/framework/src/Console/Concerns/Command.php
+++ b/packages/framework/src/Console/Concerns/Command.php
@@ -20,7 +20,6 @@ use function str_replace;
  * A base class for HydeCLI command that adds some extra functionality and output
  * helpers to reduce repeated code and to provide a consistent user interface.
  *
- * @see \Hyde\Framework\Testing\Feature\CommandTest
  */
 abstract class Command extends BaseCommand
 {

--- a/packages/framework/src/Facades/Config.php
+++ b/packages/framework/src/Facades/Config.php
@@ -12,7 +12,6 @@ use TypeError;
  *
  * @see \Illuminate\Config\Repository
  * @see \Illuminate\Support\Facades\Config
- * @see \Hyde\Framework\Testing\Feature\TypedConfigFacadeTest
  */
 class Config extends \Illuminate\Support\Facades\Config
 {

--- a/packages/framework/src/Facades/Features.php
+++ b/packages/framework/src/Facades/Features.php
@@ -28,7 +28,6 @@ use function app;
  *
  * @todo Split facade logic to service/manager class. (Initial and mock data could be set with boot/set methods)
  *
- * @see \Hyde\Framework\Testing\Feature\ConfigurableFeaturesTest
  *
  * Based entirely on Laravel Jetstream (License MIT)
  * @see https://jetstream.laravel.com/

--- a/packages/framework/src/Facades/Features.php
+++ b/packages/framework/src/Facades/Features.php
@@ -27,8 +27,6 @@ use function app;
  * @internal Until this class is split into a service/manager class, it should not be used outside of Hyde as the API is subject to change.
  *
  * @todo Split facade logic to service/manager class. (Initial and mock data could be set with boot/set methods)
- *
- *
  * Based entirely on Laravel Jetstream (License MIT)
  * @see https://jetstream.laravel.com/
  */

--- a/packages/framework/src/Facades/Filesystem.php
+++ b/packages/framework/src/Facades/Filesystem.php
@@ -17,7 +17,6 @@ use Illuminate\Support\Facades\File;
  *
  * @see \Hyde\Foundation\Kernel\Filesystem
  * @see \Illuminate\Filesystem\Filesystem
- * @see \Hyde\Framework\Testing\Feature\FilesystemFacadeTest
  */
 class Filesystem
 {

--- a/packages/framework/src/Facades/Meta.php
+++ b/packages/framework/src/Facades/Meta.php
@@ -11,7 +11,6 @@ use Hyde\Framework\Features\Metadata\GlobalMetadataBag;
 
 /**
  * Helpers to fluently declare HTML meta elements using their object representations.
- *
  */
 class Meta
 {

--- a/packages/framework/src/Facades/Meta.php
+++ b/packages/framework/src/Facades/Meta.php
@@ -12,7 +12,6 @@ use Hyde\Framework\Features\Metadata\GlobalMetadataBag;
 /**
  * Helpers to fluently declare HTML meta elements using their object representations.
  *
- * @see \Hyde\Framework\Testing\Feature\MetadataHelperTest
  */
 class Meta
 {

--- a/packages/framework/src/Facades/Site.php
+++ b/packages/framework/src/Facades/Site.php
@@ -8,7 +8,6 @@ use Hyde\Framework\Features\Metadata\GlobalMetadataBag;
 
 /**
  * Facade to quickly get data for the HydePHP site and its configuration.
- *
  */
 class Site
 {

--- a/packages/framework/src/Facades/Site.php
+++ b/packages/framework/src/Facades/Site.php
@@ -9,7 +9,6 @@ use Hyde\Framework\Features\Metadata\GlobalMetadataBag;
 /**
  * Facade to quickly get data for the HydePHP site and its configuration.
  *
- * @see \Hyde\Framework\Testing\Feature\SiteTest
  */
 class Site
 {

--- a/packages/framework/src/Foundation/Concerns/HydeExtension.php
+++ b/packages/framework/src/Foundation/Concerns/HydeExtension.php
@@ -26,7 +26,6 @@ use Hyde\Foundation\Kernel\RouteCollection;
  * which you can access via the Hyde\Hyde facade, or via the service container.
  *
  * @example `$this->app->make(HydeKernel::class)->registerExtension(MyExtension::class);`
- *
  */
 abstract class HydeExtension
 {

--- a/packages/framework/src/Foundation/Concerns/HydeExtension.php
+++ b/packages/framework/src/Foundation/Concerns/HydeExtension.php
@@ -27,7 +27,6 @@ use Hyde\Foundation\Kernel\RouteCollection;
  *
  * @example `$this->app->make(HydeKernel::class)->registerExtension(MyExtension::class);`
  *
- * @see \Hyde\Framework\Testing\Feature\HydeExtensionTest
  */
 abstract class HydeExtension
 {

--- a/packages/framework/src/Foundation/HydeCoreExtension.php
+++ b/packages/framework/src/Foundation/HydeCoreExtension.php
@@ -15,8 +15,6 @@ use Hyde\Facades\Features;
 use function array_filter;
 use function array_keys;
 
-/**
- */
 class HydeCoreExtension extends HydeExtension
 {
     /** @return array<class-string<\Hyde\Pages\Concerns\HydePage>> */

--- a/packages/framework/src/Foundation/HydeCoreExtension.php
+++ b/packages/framework/src/Foundation/HydeCoreExtension.php
@@ -16,7 +16,6 @@ use function array_filter;
 use function array_keys;
 
 /**
- * @see \Hyde\Framework\Testing\Feature\HydeCoreExtensionTest
  */
 class HydeCoreExtension extends HydeExtension
 {

--- a/packages/framework/src/Foundation/Internal/LoadYamlConfiguration.php
+++ b/packages/framework/src/Foundation/Internal/LoadYamlConfiguration.php
@@ -14,7 +14,6 @@ use function file_exists;
 
 /**
  * @internal
- *
  */
 class LoadYamlConfiguration
 {

--- a/packages/framework/src/Foundation/Internal/LoadYamlConfiguration.php
+++ b/packages/framework/src/Foundation/Internal/LoadYamlConfiguration.php
@@ -15,7 +15,6 @@ use function file_exists;
 /**
  * @internal
  *
- * @see \Hyde\Framework\Testing\Feature\YamlConfigurationServiceTest
  */
 class LoadYamlConfiguration
 {

--- a/packages/framework/src/Foundation/Kernel/Filesystem.php
+++ b/packages/framework/src/Foundation/Kernel/Filesystem.php
@@ -26,7 +26,6 @@ use function touch;
  *
  * All paths arguments are relative to the root of the application,
  * and will be automatically resolved to absolute paths.
- *
  */
 class Filesystem
 {

--- a/packages/framework/src/Foundation/Kernel/Filesystem.php
+++ b/packages/framework/src/Foundation/Kernel/Filesystem.php
@@ -27,7 +27,6 @@ use function touch;
  * All paths arguments are relative to the root of the application,
  * and will be automatically resolved to absolute paths.
  *
- * @see \Hyde\Framework\Testing\Feature\Foundation\FilesystemTest
  */
 class Filesystem
 {

--- a/packages/framework/src/Foundation/Kernel/Hyperlinks.php
+++ b/packages/framework/src/Foundation/Kernel/Hyperlinks.php
@@ -24,7 +24,6 @@ use function trim;
  *
  * It's bound to the HydeKernel instance, and is an integral part of the framework.
  *
- * @see \Hyde\Framework\Testing\Feature\Foundation\HyperlinksTest
  */
 class Hyperlinks
 {

--- a/packages/framework/src/Foundation/Kernel/Hyperlinks.php
+++ b/packages/framework/src/Foundation/Kernel/Hyperlinks.php
@@ -23,7 +23,6 @@ use function trim;
  * Contains helpers and logic for resolving web paths for compiled files.
  *
  * It's bound to the HydeKernel instance, and is an integral part of the framework.
- *
  */
 class Hyperlinks
 {

--- a/packages/framework/src/Foundation/PharSupport.php
+++ b/packages/framework/src/Foundation/PharSupport.php
@@ -19,7 +19,6 @@ use function str_replace;
  * @experimental
  *
  * @internal
- *
  */
 class PharSupport
 {

--- a/packages/framework/src/Foundation/PharSupport.php
+++ b/packages/framework/src/Foundation/PharSupport.php
@@ -20,7 +20,6 @@ use function str_replace;
  *
  * @internal
  *
- * @see \Hyde\Framework\Testing\Feature\PharSupportTest
  */
 class PharSupport
 {

--- a/packages/framework/src/Framework/Actions/BladeMatterParser.php
+++ b/packages/framework/src/Framework/Actions/BladeMatterParser.php
@@ -21,7 +21,6 @@ use function trim;
  *
  * Accepts a string to make it easier to mock when testing.
  *
- * @see \Hyde\Framework\Testing\Feature\BladeMatterParserTest
  *
  * @phpstan-consistent-constructor
  *

--- a/packages/framework/src/Framework/Actions/BladeMatterParser.php
+++ b/packages/framework/src/Framework/Actions/BladeMatterParser.php
@@ -21,7 +21,6 @@ use function trim;
  *
  * Accepts a string to make it easier to mock when testing.
  *
- *
  * @phpstan-consistent-constructor
  *
  * === DOCUMENTATION (draft) ===

--- a/packages/framework/src/Framework/Actions/ConvertsArrayToFrontMatter.php
+++ b/packages/framework/src/Framework/Actions/ConvertsArrayToFrontMatter.php
@@ -9,7 +9,6 @@ use Symfony\Component\Yaml\Yaml;
 /**
  * Convert an array into YAML Front Matter.
  *
- * @see \Hyde\Framework\Testing\Feature\ConvertsArrayToFrontMatterTest
  */
 class ConvertsArrayToFrontMatter
 {

--- a/packages/framework/src/Framework/Actions/ConvertsArrayToFrontMatter.php
+++ b/packages/framework/src/Framework/Actions/ConvertsArrayToFrontMatter.php
@@ -8,7 +8,6 @@ use Symfony\Component\Yaml\Yaml;
 
 /**
  * Convert an array into YAML Front Matter.
- *
  */
 class ConvertsArrayToFrontMatter
 {

--- a/packages/framework/src/Framework/Actions/ConvertsMarkdownToPlainText.php
+++ b/packages/framework/src/Framework/Actions/ConvertsMarkdownToPlainText.php
@@ -15,7 +15,6 @@ use function preg_replace;
 
 /**
  * Converts Markdown to plain text.
- *
  */
 class ConvertsMarkdownToPlainText
 {

--- a/packages/framework/src/Framework/Actions/ConvertsMarkdownToPlainText.php
+++ b/packages/framework/src/Framework/Actions/ConvertsMarkdownToPlainText.php
@@ -16,7 +16,6 @@ use function preg_replace;
 /**
  * Converts Markdown to plain text.
  *
- * @see \Hyde\Framework\Testing\Feature\Actions\ConvertsMarkdownToPlainTextTest
  */
 class ConvertsMarkdownToPlainText
 {

--- a/packages/framework/src/Framework/Actions/CreatesNewPageSourceFile.php
+++ b/packages/framework/src/Framework/Actions/CreatesNewPageSourceFile.php
@@ -23,7 +23,6 @@ use function rtrim;
 /**
  * Scaffold a new Markdown, Blade, or documentation page.
  *
- * @see \Hyde\Framework\Testing\Feature\Actions\CreatesNewPageSourceFileTest
  */
 class CreatesNewPageSourceFile
 {

--- a/packages/framework/src/Framework/Actions/CreatesNewPageSourceFile.php
+++ b/packages/framework/src/Framework/Actions/CreatesNewPageSourceFile.php
@@ -22,7 +22,6 @@ use function rtrim;
 
 /**
  * Scaffold a new Markdown, Blade, or documentation page.
- *
  */
 class CreatesNewPageSourceFile
 {

--- a/packages/framework/src/Framework/Actions/GeneratesDocumentationSearchIndex.php
+++ b/packages/framework/src/Framework/Actions/GeneratesDocumentationSearchIndex.php
@@ -18,7 +18,6 @@ use function trim;
 /**
  * @internal Generate a JSON file that can be used as a search index for documentation pages.
  *
- * @see \Hyde\Framework\Testing\Feature\Services\DocumentationSearchServiceTest
  */
 class GeneratesDocumentationSearchIndex
 {

--- a/packages/framework/src/Framework/Actions/GeneratesDocumentationSearchIndex.php
+++ b/packages/framework/src/Framework/Actions/GeneratesDocumentationSearchIndex.php
@@ -17,7 +17,6 @@ use function trim;
 
 /**
  * @internal Generate a JSON file that can be used as a search index for documentation pages.
- *
  */
 class GeneratesDocumentationSearchIndex
 {

--- a/packages/framework/src/Framework/Actions/GeneratesTableOfContents.php
+++ b/packages/framework/src/Framework/Actions/GeneratesTableOfContents.php
@@ -17,7 +17,6 @@ use function substr;
 
 /**
  * Generates a table of contents for the Markdown document, most commonly used for the sidebar.
- *
  */
 class GeneratesTableOfContents
 {

--- a/packages/framework/src/Framework/Actions/GeneratesTableOfContents.php
+++ b/packages/framework/src/Framework/Actions/GeneratesTableOfContents.php
@@ -18,7 +18,6 @@ use function substr;
 /**
  * Generates a table of contents for the Markdown document, most commonly used for the sidebar.
  *
- * @see \Hyde\Framework\Testing\Feature\Actions\GeneratesSidebarTableOfContentsTest
  */
 class GeneratesTableOfContents
 {

--- a/packages/framework/src/Framework/Actions/MarkdownFileParser.php
+++ b/packages/framework/src/Framework/Actions/MarkdownFileParser.php
@@ -11,7 +11,6 @@ use Spatie\YamlFrontMatter\YamlFrontMatter;
 /**
  * Prepares a Markdown file for further usage by extracting the Front Matter
  * and Markdown body, and creating MarkdownDocument object from them.
- *
  */
 class MarkdownFileParser
 {

--- a/packages/framework/src/Framework/Actions/MarkdownFileParser.php
+++ b/packages/framework/src/Framework/Actions/MarkdownFileParser.php
@@ -12,7 +12,6 @@ use Spatie\YamlFrontMatter\YamlFrontMatter;
  * Prepares a Markdown file for further usage by extracting the Front Matter
  * and Markdown body, and creating MarkdownDocument object from them.
  *
- * @see \Hyde\Framework\Testing\Feature\MarkdownFileParserTest
  */
 class MarkdownFileParser
 {

--- a/packages/framework/src/Framework/Actions/PostBuildTasks/GenerateBuildManifest.php
+++ b/packages/framework/src/Framework/Actions/PostBuildTasks/GenerateBuildManifest.php
@@ -28,7 +28,6 @@ use function now;
  * However, a great alternate location is in `_site/build-manifest.json`,
  * if you don't mind it the file being publicly accessible.
  *
- * @see \Hyde\Framework\Testing\Unit\GenerateBuildManifestTest
  */
 class GenerateBuildManifest extends PostBuildTask
 {

--- a/packages/framework/src/Framework/Actions/PostBuildTasks/GenerateBuildManifest.php
+++ b/packages/framework/src/Framework/Actions/PostBuildTasks/GenerateBuildManifest.php
@@ -27,7 +27,6 @@ use function now;
  * may not want to commit the manifest file to their repository or their deployed site.
  * However, a great alternate location is in `_site/build-manifest.json`,
  * if you don't mind it the file being publicly accessible.
- *
  */
 class GenerateBuildManifest extends PostBuildTask
 {

--- a/packages/framework/src/Framework/Actions/SourceFileParser.php
+++ b/packages/framework/src/Framework/Actions/SourceFileParser.php
@@ -18,7 +18,6 @@ use function is_subclass_of;
  * and may also conduct pre-processing and/or data validation/assembly.
  *
  * Note that the Page Parsers do not compile any HTML or Markdown.
- *
  */
 class SourceFileParser
 {

--- a/packages/framework/src/Framework/Actions/SourceFileParser.php
+++ b/packages/framework/src/Framework/Actions/SourceFileParser.php
@@ -19,7 +19,6 @@ use function is_subclass_of;
  *
  * Note that the Page Parsers do not compile any HTML or Markdown.
  *
- * @see \Hyde\Framework\Testing\Feature\SourceFileParserTest
  */
 class SourceFileParser
 {

--- a/packages/framework/src/Framework/Actions/StaticPageBuilder.php
+++ b/packages/framework/src/Framework/Actions/StaticPageBuilder.php
@@ -11,8 +11,6 @@ use Hyde\Pages\Concerns\HydePage;
 
 /**
  * Converts a Page Model into a static HTML page.
- *
- * @see \Hyde\Framework\Testing\Feature\StaticPageBuilderTest
  */
 class StaticPageBuilder
 {

--- a/packages/framework/src/Framework/Concerns/InteractsWithDirectories.php
+++ b/packages/framework/src/Framework/Concerns/InteractsWithDirectories.php
@@ -8,8 +8,6 @@ use Hyde\Facades\Filesystem;
 
 use function dirname;
 
-/**
- */
 trait InteractsWithDirectories
 {
     /**

--- a/packages/framework/src/Framework/Concerns/InteractsWithDirectories.php
+++ b/packages/framework/src/Framework/Concerns/InteractsWithDirectories.php
@@ -9,7 +9,6 @@ use Hyde\Facades\Filesystem;
 use function dirname;
 
 /**
- * @see \Hyde\Framework\Testing\Unit\InteractsWithDirectoriesConcernTest
  */
 trait InteractsWithDirectories
 {

--- a/packages/framework/src/Framework/Concerns/ValidatesExistence.php
+++ b/packages/framework/src/Framework/Concerns/ValidatesExistence.php
@@ -9,7 +9,6 @@ use Hyde\Framework\Exceptions\FileNotFoundException;
 
 /**
  * Validate the existence of a Page class's source file.
- *
  */
 trait ValidatesExistence
 {

--- a/packages/framework/src/Framework/Concerns/ValidatesExistence.php
+++ b/packages/framework/src/Framework/Concerns/ValidatesExistence.php
@@ -10,7 +10,6 @@ use Hyde\Framework\Exceptions\FileNotFoundException;
 /**
  * Validate the existence of a Page class's source file.
  *
- * @see \Hyde\Framework\Testing\Unit\ValidatesExistenceTest
  */
 trait ValidatesExistence
 {

--- a/packages/framework/src/Framework/Features/Blogging/Models/PostAuthor.php
+++ b/packages/framework/src/Framework/Features/Blogging/Models/PostAuthor.php
@@ -15,7 +15,6 @@ use function is_string;
 /**
  * The Post Author model object.
  *
- * @see \Hyde\Framework\Testing\Unit\PostAuthorTest
  */
 class PostAuthor implements Stringable
 {

--- a/packages/framework/src/Framework/Features/Blogging/Models/PostAuthor.php
+++ b/packages/framework/src/Framework/Features/Blogging/Models/PostAuthor.php
@@ -14,7 +14,6 @@ use function is_string;
 
 /**
  * The Post Author model object.
- *
  */
 class PostAuthor implements Stringable
 {

--- a/packages/framework/src/Framework/Features/BuildTasks/BuildTask.php
+++ b/packages/framework/src/Framework/Features/BuildTasks/BuildTask.php
@@ -14,8 +14,6 @@ use Illuminate\Console\Concerns\InteractsWithIO;
 use function str_replace;
 use function sprintf;
 
-/**
- */
 abstract class BuildTask
 {
     use InteractsWithIO;

--- a/packages/framework/src/Framework/Features/BuildTasks/BuildTask.php
+++ b/packages/framework/src/Framework/Features/BuildTasks/BuildTask.php
@@ -15,7 +15,6 @@ use function str_replace;
 use function sprintf;
 
 /**
- * @see \Hyde\Framework\Testing\Feature\Services\BuildTaskServiceTest
  */
 abstract class BuildTask
 {

--- a/packages/framework/src/Framework/Features/Documentation/DocumentationSearchPage.php
+++ b/packages/framework/src/Framework/Features/Documentation/DocumentationSearchPage.php
@@ -17,7 +17,6 @@ use function view;
  * It is not based on a source file, but is dynamically generated when the Search feature is enabled.
  * If you want to override this page, you can create a page with the route key "docs/search",
  * then this class will not be applied. For example, `_pages/docs/search.blade.php`.
- *
  */
 class DocumentationSearchPage extends DocumentationPage
 {

--- a/packages/framework/src/Framework/Features/Documentation/DocumentationSearchPage.php
+++ b/packages/framework/src/Framework/Features/Documentation/DocumentationSearchPage.php
@@ -18,7 +18,6 @@ use function view;
  * If you want to override this page, you can create a page with the route key "docs/search",
  * then this class will not be applied. For example, `_pages/docs/search.blade.php`.
  *
- * @see \Hyde\Framework\Testing\Feature\DocumentationSearchPageTest
  */
 class DocumentationSearchPage extends DocumentationPage
 {

--- a/packages/framework/src/Framework/Features/Documentation/SemanticDocumentationArticle.php
+++ b/packages/framework/src/Framework/Features/Documentation/SemanticDocumentationArticle.php
@@ -19,7 +19,6 @@ use function view;
 /**
  * Class to make Hyde documentation pages smarter,
  * by dynamically enriching them with semantic HTML.
- *
  */
 class SemanticDocumentationArticle
 {

--- a/packages/framework/src/Framework/Features/Documentation/SemanticDocumentationArticle.php
+++ b/packages/framework/src/Framework/Features/Documentation/SemanticDocumentationArticle.php
@@ -20,7 +20,6 @@ use function view;
  * Class to make Hyde documentation pages smarter,
  * by dynamically enriching them with semantic HTML.
  *
- * @see \Hyde\Framework\Testing\Feature\Services\HydeSmartDocsTest
  */
 class SemanticDocumentationArticle
 {

--- a/packages/framework/src/Framework/Features/Metadata/GlobalMetadataBag.php
+++ b/packages/framework/src/Framework/Features/Metadata/GlobalMetadataBag.php
@@ -18,7 +18,6 @@ use function array_map;
 use function in_array;
 
 /**
- * @see \Hyde\Framework\Testing\Feature\GlobalMetadataBagTest
  */
 class GlobalMetadataBag extends MetadataBag
 {

--- a/packages/framework/src/Framework/Features/Metadata/GlobalMetadataBag.php
+++ b/packages/framework/src/Framework/Features/Metadata/GlobalMetadataBag.php
@@ -17,8 +17,6 @@ use function array_filter;
 use function array_map;
 use function in_array;
 
-/**
- */
 class GlobalMetadataBag extends MetadataBag
 {
     public static function make(): static

--- a/packages/framework/src/Framework/Features/Metadata/MetadataBag.php
+++ b/packages/framework/src/Framework/Features/Metadata/MetadataBag.php
@@ -15,7 +15,6 @@ use function implode;
 /**
  * Holds the metadata tags for a page or the site model.
  *
- * @see \Hyde\Framework\Testing\Feature\MetadataTest
  * @see \Hyde\Framework\Features\Metadata\PageMetadataBag
  * @see \Hyde\Framework\Features\Metadata\GlobalMetadataBag
  */

--- a/packages/framework/src/Framework/Features/Navigation/BaseNavigationMenu.php
+++ b/packages/framework/src/Framework/Features/Navigation/BaseNavigationMenu.php
@@ -12,7 +12,6 @@ use Illuminate\Support\Collection;
 use function collect;
 
 /**
- * @see \Hyde\Framework\Testing\Feature\NavigationMenuTest
  */
 abstract class BaseNavigationMenu
 {

--- a/packages/framework/src/Framework/Features/Navigation/BaseNavigationMenu.php
+++ b/packages/framework/src/Framework/Features/Navigation/BaseNavigationMenu.php
@@ -11,8 +11,6 @@ use Illuminate\Support\Collection;
 
 use function collect;
 
-/**
- */
 abstract class BaseNavigationMenu
 {
     /** @var \Illuminate\Support\Collection<\Hyde\Framework\Features\Navigation\NavItem> */

--- a/packages/framework/src/Framework/Features/Navigation/DocumentationSidebar.php
+++ b/packages/framework/src/Framework/Features/Navigation/DocumentationSidebar.php
@@ -14,7 +14,6 @@ use Illuminate\Support\Str;
 use function collect;
 
 /**
- * @see \Hyde\Framework\Testing\Feature\Services\DocumentationSidebarTest
  */
 class DocumentationSidebar extends BaseNavigationMenu
 {

--- a/packages/framework/src/Framework/Features/Navigation/DocumentationSidebar.php
+++ b/packages/framework/src/Framework/Features/Navigation/DocumentationSidebar.php
@@ -13,8 +13,6 @@ use Illuminate\Support\Str;
 
 use function collect;
 
-/**
- */
 class DocumentationSidebar extends BaseNavigationMenu
 {
     protected function generate(): void

--- a/packages/framework/src/Framework/Features/Navigation/DropdownNavItem.php
+++ b/packages/framework/src/Framework/Features/Navigation/DropdownNavItem.php
@@ -12,7 +12,6 @@ use function collect;
  * A navigation item that contains other navigation items.
  *
  * Unlike a regular navigation items, a dropdown item does not have a route or URL destination.
- *
  */
 class DropdownNavItem extends NavItem
 {

--- a/packages/framework/src/Framework/Features/Navigation/DropdownNavItem.php
+++ b/packages/framework/src/Framework/Features/Navigation/DropdownNavItem.php
@@ -13,7 +13,6 @@ use function collect;
  *
  * Unlike a regular navigation items, a dropdown item does not have a route or URL destination.
  *
- * @see \Hyde\Framework\Testing\Unit\DropdownNavItemTest
  */
 class DropdownNavItem extends NavItem
 {

--- a/packages/framework/src/Framework/Features/Navigation/NavigationMenu.php
+++ b/packages/framework/src/Framework/Features/Navigation/NavigationMenu.php
@@ -9,8 +9,6 @@ use Hyde\Support\Models\Route;
 use Hyde\Pages\DocumentationPage;
 use BadMethodCallException;
 
-/**
- */
 class NavigationMenu extends BaseNavigationMenu
 {
     protected function generate(): void

--- a/packages/framework/src/Framework/Features/Navigation/NavigationMenu.php
+++ b/packages/framework/src/Framework/Features/Navigation/NavigationMenu.php
@@ -10,7 +10,6 @@ use Hyde\Pages\DocumentationPage;
 use BadMethodCallException;
 
 /**
- * @see \Hyde\Framework\Testing\Feature\NavigationMenuTest
  */
 class NavigationMenu extends BaseNavigationMenu
 {

--- a/packages/framework/src/Framework/Features/XmlGenerators/RssFeedGenerator.php
+++ b/packages/framework/src/Framework/Features/XmlGenerators/RssFeedGenerator.php
@@ -18,7 +18,6 @@ use Hyde\Framework\Features\Blogging\Models\FeaturedImage;
 use function date;
 
 /**
- * @see \Hyde\Framework\Testing\Feature\Services\RssFeedServiceTest
  * @see https://validator.w3.org/feed/docs/rss2.html
  */
 class RssFeedGenerator extends BaseXmlGenerator

--- a/packages/framework/src/Framework/Features/XmlGenerators/SitemapGenerator.php
+++ b/packages/framework/src/Framework/Features/XmlGenerators/SitemapGenerator.php
@@ -23,7 +23,6 @@ use function date;
 use function time;
 
 /**
- * @see \Hyde\Framework\Testing\Feature\Services\SitemapServiceTest
  * @see https://www.sitemaps.org/protocol.html
  */
 class SitemapGenerator extends BaseXmlGenerator

--- a/packages/framework/src/Framework/Services/BuildService.php
+++ b/packages/framework/src/Framework/Services/BuildService.php
@@ -26,7 +26,6 @@ use function copy;
  * Handles the build loop which generates the static site.
  *
  * @see \Hyde\Console\Commands\BuildSiteCommand
- * @see \Hyde\Framework\Testing\Feature\StaticSiteServiceTest
  */
 class BuildService
 {

--- a/packages/framework/src/Framework/Services/BuildTaskService.php
+++ b/packages/framework/src/Framework/Services/BuildTaskService.php
@@ -31,8 +31,6 @@ use function str_replace;
  * Build Tasks can be registered programmatically, through the config, and through autodiscovery.
  * The service determines when to run a task depending on which class it extends.
  *
- * @see \Hyde\Framework\Testing\Feature\Services\BuildTaskServiceTest
- * @see \Hyde\Framework\Testing\Unit\BuildTaskServiceUnitTest
  */
 class BuildTaskService
 {

--- a/packages/framework/src/Framework/Services/BuildTaskService.php
+++ b/packages/framework/src/Framework/Services/BuildTaskService.php
@@ -30,7 +30,6 @@ use function str_replace;
  * The class is registered as a singleton in the Laravel service container and is run by the build command.
  * Build Tasks can be registered programmatically, through the config, and through autodiscovery.
  * The service determines when to run a task depending on which class it extends.
- *
  */
 class BuildTaskService
 {

--- a/packages/framework/src/Framework/Services/MarkdownService.php
+++ b/packages/framework/src/Framework/Services/MarkdownService.php
@@ -29,7 +29,6 @@ use function trim;
 /**
  * Dynamically creates a Markdown converter tailored for the target model and setup,
  * then converts the Markdown to HTML using both pre- and post-processors.
- *
  */
 class MarkdownService
 {

--- a/packages/framework/src/Framework/Services/MarkdownService.php
+++ b/packages/framework/src/Framework/Services/MarkdownService.php
@@ -30,7 +30,6 @@ use function trim;
  * Dynamically creates a Markdown converter tailored for the target model and setup,
  * then converts the Markdown to HTML using both pre- and post-processors.
  *
- * @see \Hyde\Framework\Testing\Feature\MarkdownServiceTest
  */
 class MarkdownService
 {

--- a/packages/framework/src/Framework/Services/ValidationService.php
+++ b/packages/framework/src/Framework/Services/ValidationService.php
@@ -18,8 +18,6 @@ use function file_exists;
 use function implode;
 use function sprintf;
 
-/**
- */
 class ValidationService
 {
     /** @return string[] */

--- a/packages/framework/src/Framework/Services/ValidationService.php
+++ b/packages/framework/src/Framework/Services/ValidationService.php
@@ -19,8 +19,6 @@ use function implode;
 use function sprintf;
 
 /**
- * @see \Hyde\Framework\Testing\Feature\Services\ValidationServiceTest
- * @see \Hyde\Framework\Testing\Feature\Commands\ValidateCommandTest
  */
 class ValidationService
 {

--- a/packages/framework/src/Framework/Services/ViewDiffService.php
+++ b/packages/framework/src/Framework/Services/ViewDiffService.php
@@ -18,7 +18,6 @@ use function glob;
  * Helper methods to interact with the virtual filecache that is used to compare
  * published Blade views with the original Blade views in the Hyde Framework
  * so the user can be warned before overwriting their customizations.
- *
  */
 class ViewDiffService
 {

--- a/packages/framework/src/Framework/Services/ViewDiffService.php
+++ b/packages/framework/src/Framework/Services/ViewDiffService.php
@@ -19,7 +19,6 @@ use function glob;
  * published Blade views with the original Blade views in the Hyde Framework
  * so the user can be warned before overwriting their customizations.
  *
- * @see \Hyde\Framework\Testing\Feature\Services\ViewDiffServiceTest
  */
 class ViewDiffService
 {

--- a/packages/framework/src/Markdown/Models/FrontMatter.php
+++ b/packages/framework/src/Markdown/Models/FrontMatter.php
@@ -22,7 +22,6 @@ use Stringable;
  * Use $page->matter('foo') to access front matter only
  * You can also get the front matter object using $page->matter (which is an instance of this class)
  *
- * @see \Hyde\Framework\Testing\Unit\FrontMatterModelTest
  *
  * @phpstan-consistent-constructor
  */

--- a/packages/framework/src/Markdown/Models/Markdown.php
+++ b/packages/framework/src/Markdown/Models/Markdown.php
@@ -13,7 +13,6 @@ use Stringable;
 
 /**
  * A simple object representation of a Markdown file, with helpful methods to interact with it.
- *
  */
 class Markdown implements Arrayable, Stringable, Htmlable
 {

--- a/packages/framework/src/Markdown/Models/Markdown.php
+++ b/packages/framework/src/Markdown/Models/Markdown.php
@@ -14,7 +14,6 @@ use Stringable;
 /**
  * A simple object representation of a Markdown file, with helpful methods to interact with it.
  *
- * @see \Hyde\Framework\Testing\Unit\MarkdownDocumentTest
  */
 class Markdown implements Arrayable, Stringable, Htmlable
 {

--- a/packages/framework/src/Markdown/Models/MarkdownDocument.php
+++ b/packages/framework/src/Markdown/Models/MarkdownDocument.php
@@ -14,7 +14,6 @@ use Stringable;
  *
  * It's an object that contains a parsed FrontMatter split from the body of the Markdown file.
  *
- * @see \Hyde\Framework\Testing\Unit\MarkdownDocumentTest
  */
 class MarkdownDocument implements MarkdownDocumentContract, Stringable
 {

--- a/packages/framework/src/Markdown/Models/MarkdownDocument.php
+++ b/packages/framework/src/Markdown/Models/MarkdownDocument.php
@@ -13,7 +13,6 @@ use Stringable;
  * A MarkdownDocument is a simpler alternative to a MarkdownPage.
  *
  * It's an object that contains a parsed FrontMatter split from the body of the Markdown file.
- *
  */
 class MarkdownDocument implements MarkdownDocumentContract, Stringable
 {

--- a/packages/framework/src/Markdown/Processing/BladeDownProcessor.php
+++ b/packages/framework/src/Markdown/Processing/BladeDownProcessor.php
@@ -27,7 +27,6 @@ use function e;
  *
  * @example: [Blade]: @include('path/to/view.blade.php')
  *
- *
  * @phpstan-consistent-constructor
  */
 class BladeDownProcessor implements MarkdownPreProcessorContract, MarkdownPostProcessorContract

--- a/packages/framework/src/Markdown/Processing/BladeDownProcessor.php
+++ b/packages/framework/src/Markdown/Processing/BladeDownProcessor.php
@@ -27,7 +27,6 @@ use function e;
  *
  * @example: [Blade]: @include('path/to/view.blade.php')
  *
- * @see \Hyde\Framework\Testing\Feature\Services\BladeDownProcessorTest
  *
  * @phpstan-consistent-constructor
  */

--- a/packages/framework/src/Markdown/Processing/CodeblockFilepathProcessor.php
+++ b/packages/framework/src/Markdown/Processing/CodeblockFilepathProcessor.php
@@ -21,7 +21,6 @@ use function view;
 
 /**
  * Resolves file path comments found in Markdown code blocks into a neat badge shown in the top right corner.
- *
  */
 class CodeblockFilepathProcessor implements MarkdownPreProcessorContract, MarkdownPostProcessorContract
 {

--- a/packages/framework/src/Markdown/Processing/CodeblockFilepathProcessor.php
+++ b/packages/framework/src/Markdown/Processing/CodeblockFilepathProcessor.php
@@ -22,7 +22,6 @@ use function view;
 /**
  * Resolves file path comments found in Markdown code blocks into a neat badge shown in the top right corner.
  *
- * @see \Hyde\Framework\Testing\Feature\Services\Markdown\CodeblockFilepathProcessorTest
  */
 class CodeblockFilepathProcessor implements MarkdownPreProcessorContract, MarkdownPostProcessorContract
 {

--- a/packages/framework/src/Markdown/Processing/ColoredBlockquotes.php
+++ b/packages/framework/src/Markdown/Processing/ColoredBlockquotes.php
@@ -14,7 +14,6 @@ use function substr;
 use function trim;
 
 /**
- * @see \Hyde\Framework\Testing\Feature\ColoredBlockquoteShortcodesTest
  *
  * @internal This class may be refactored to work with a single class instead of five, thus extending this class is discouraged.
  */

--- a/packages/framework/src/Markdown/Processing/ColoredBlockquotes.php
+++ b/packages/framework/src/Markdown/Processing/ColoredBlockquotes.php
@@ -14,7 +14,6 @@ use function substr;
 use function trim;
 
 /**
- *
  * @internal This class may be refactored to work with a single class instead of five, thus extending this class is discouraged.
  */
 abstract class ColoredBlockquotes implements MarkdownShortcodeContract

--- a/packages/framework/src/Markdown/Processing/ShortcodeProcessor.php
+++ b/packages/framework/src/Markdown/Processing/ShortcodeProcessor.php
@@ -25,7 +25,6 @@ use function substr;
  * that is used to identify the shortcode. The built-in shortcodes
  * do not use regex, as that would make them harder to read.
  *
- * @see \Hyde\Framework\Testing\Feature\Services\Markdown\ShortcodeProcessorTest
  *
  * @phpstan-consistent-constructor
  */

--- a/packages/framework/src/Pages/Concerns/BaseMarkdownPage.php
+++ b/packages/framework/src/Pages/Concerns/BaseMarkdownPage.php
@@ -16,7 +16,6 @@ use Hyde\Markdown\Models\Markdown;
  * @see \Hyde\Pages\MarkdownPost
  * @see \Hyde\Pages\DocumentationPage
  * @see \Hyde\Pages\Concerns\HydePage
- * @see \Hyde\Framework\Testing\Feature\HydePageTest
  */
 abstract class BaseMarkdownPage extends HydePage implements MarkdownDocumentContract
 {

--- a/packages/framework/src/Pages/Concerns/HydePage.php
+++ b/packages/framework/src/Pages/Concerns/HydePage.php
@@ -47,7 +47,6 @@ use function rtrim;
  * In Blade views, you can always access the current page instance being rendered using the $page variable.
  *
  * @see \Hyde\Pages\Concerns\BaseMarkdownPage
- * @see \Hyde\Framework\Testing\Feature\HydePageTest
  */
 abstract class HydePage implements PageSchema, SerializableContract
 {

--- a/packages/framework/src/Support/BuildWarnings.php
+++ b/packages/framework/src/Support/BuildWarnings.php
@@ -15,7 +15,6 @@ use function sprintf;
 /**
  * @experimental
  *
- * @see \Hyde\Framework\Testing\Unit\BuildWarningsTest
  */
 class BuildWarnings
 {

--- a/packages/framework/src/Support/BuildWarnings.php
+++ b/packages/framework/src/Support/BuildWarnings.php
@@ -14,7 +14,6 @@ use function sprintf;
 
 /**
  * @experimental
- *
  */
 class BuildWarnings
 {

--- a/packages/framework/src/Support/Concerns/Serializable.php
+++ b/packages/framework/src/Support/Concerns/Serializable.php
@@ -11,7 +11,6 @@ use function collect;
  * Automatically serializes an Arrayable implementation when JSON is requested.
  *
  * @see \Hyde\Support\Contracts\SerializableContract
- * @see \Hyde\Framework\Testing\Unit\SerializableTest
  */
 trait Serializable
 {

--- a/packages/framework/src/Support/Filesystem/ProjectFile.php
+++ b/packages/framework/src/Support/Filesystem/ProjectFile.php
@@ -16,7 +16,6 @@ use function pathinfo;
 /**
  * Filesystem abstraction for a file stored in the project.
  *
- * @see \Hyde\Framework\Testing\Feature\Support\ProjectFileTest
  */
 abstract class ProjectFile implements SerializableContract
 {

--- a/packages/framework/src/Support/Filesystem/ProjectFile.php
+++ b/packages/framework/src/Support/Filesystem/ProjectFile.php
@@ -15,7 +15,6 @@ use function pathinfo;
 
 /**
  * Filesystem abstraction for a file stored in the project.
- *
  */
 abstract class ProjectFile implements SerializableContract
 {

--- a/packages/framework/src/Support/Models/DateString.php
+++ b/packages/framework/src/Support/Models/DateString.php
@@ -9,7 +9,6 @@ use Stringable;
 
 /**
  * Parse a date string and create normalized formats.
- *
  */
 class DateString implements Stringable
 {

--- a/packages/framework/src/Support/Models/DateString.php
+++ b/packages/framework/src/Support/Models/DateString.php
@@ -10,7 +10,6 @@ use Stringable;
 /**
  * Parse a date string and create normalized formats.
  *
- * @see \Hyde\Framework\Testing\Unit\DateStringTest
  */
 class DateString implements Stringable
 {

--- a/packages/framework/src/Support/Models/RenderData.php
+++ b/packages/framework/src/Support/Models/RenderData.php
@@ -15,7 +15,6 @@ use InvalidArgumentException;
  * All public data here will be available in the Blade views through {@see ManagesViewData::shareViewData()}.
  *
  * @see \Hyde\Support\Facades\Render
- * @see \Hyde\Framework\Testing\Feature\RenderHelperTest
  */
 class RenderData implements Arrayable
 {

--- a/packages/framework/src/Support/Models/Route.php
+++ b/packages/framework/src/Support/Models/Route.php
@@ -17,7 +17,6 @@ use Stringable;
  *
  * If you visualize a web of this class's properties, you should be able to see how this
  * class links them all together, and what powerful information you can gain from it.
- *
  */
 class Route implements Stringable, SerializableContract
 {

--- a/packages/framework/src/Support/Models/Route.php
+++ b/packages/framework/src/Support/Models/Route.php
@@ -18,7 +18,6 @@ use Stringable;
  * If you visualize a web of this class's properties, you should be able to see how this
  * class links them all together, and what powerful information you can gain from it.
  *
- * @see \Hyde\Framework\Testing\Unit\RouteTest
  */
 class Route implements Stringable, SerializableContract
 {

--- a/packages/framework/src/Support/Models/RouteList.php
+++ b/packages/framework/src/Support/Models/RouteList.php
@@ -12,7 +12,6 @@ use Illuminate\Contracts\Support\Arrayable;
  *
  * @experimental This class is experimental and is subject to change.
  *
- * @see \Hyde\Framework\Testing\Feature\RouteListTest
  */
 class RouteList implements Arrayable
 {

--- a/packages/framework/src/Support/Models/RouteList.php
+++ b/packages/framework/src/Support/Models/RouteList.php
@@ -11,7 +11,6 @@ use Illuminate\Contracts\Support\Arrayable;
  * @internal This class is experimental and is subject to change.
  *
  * @experimental This class is experimental and is subject to change.
- *
  */
 class RouteList implements Arrayable
 {

--- a/packages/framework/src/Support/Models/ValidationResult.php
+++ b/packages/framework/src/Support/Models/ValidationResult.php
@@ -4,8 +4,6 @@ declare(strict_types=1);
 
 namespace Hyde\Support\Models;
 
-/**
- */
 class ValidationResult
 {
     final public const PASSED = 0;

--- a/packages/framework/src/Support/Models/ValidationResult.php
+++ b/packages/framework/src/Support/Models/ValidationResult.php
@@ -5,8 +5,6 @@ declare(strict_types=1);
 namespace Hyde\Support\Models;
 
 /**
- * @see \Hyde\Framework\Testing\Feature\Services\ValidationServiceTest
- * @see \Hyde\Framework\Testing\Feature\Commands\ValidateCommandTest
  */
 class ValidationResult
 {

--- a/packages/framework/src/Support/Paginator.php
+++ b/packages/framework/src/Support/Paginator.php
@@ -16,7 +16,6 @@ use function sprintf;
 use function range;
 
 /**
- * @see \Hyde\Framework\Testing\Feature\PaginatorTest
  */
 class Paginator
 {

--- a/packages/framework/src/Support/Paginator.php
+++ b/packages/framework/src/Support/Paginator.php
@@ -15,8 +15,6 @@ use function collect;
 use function sprintf;
 use function range;
 
-/**
- */
 class Paginator
 {
     protected Collection $paginatedItems;

--- a/packages/framework/src/Support/ReadingTime.php
+++ b/packages/framework/src/Support/ReadingTime.php
@@ -16,7 +16,6 @@ use function str_word_count;
 /**
  * Calculate the estimated reading time for a text.
  *
- * @see \Hyde\Framework\Testing\Feature\ReadingTimeTest
  */
 class ReadingTime implements Stringable
 {

--- a/packages/framework/src/Support/ReadingTime.php
+++ b/packages/framework/src/Support/ReadingTime.php
@@ -15,7 +15,6 @@ use function str_word_count;
 
 /**
  * Calculate the estimated reading time for a text.
- *
  */
 class ReadingTime implements Stringable
 {


### PR DESCRIPTION
We've had a lot of links to test classes, which has been useful for the rapid development, but look pretty ugly in the actual downstream code. This PR removes them.