### PR TITLE
Use "HydePHP" as the application logo when running without ANSI formatting

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -23,6 +23,7 @@ This serves two purposes:
 
 ### Fixed
 - Fixed "ReadingTime calculation should never be under one minute" [#1286](https://github.com/hydephp/develop/issues/1286) in [#1285](https://github.com/hydephp/develop/pull/1285)
+- Fixed "The HydeCLI list command logo should respect the --no-ansi setting" [#1127](https://github.com/hydephp/develop/issues/1127) in [#1288](https://github.com/hydephp/develop/pull/1288)
 
 ### Security
 - in case of vulnerabilities.

--- a/packages/framework/src/Console/ConsoleServiceProvider.php
+++ b/packages/framework/src/Console/ConsoleServiceProvider.php
@@ -45,6 +45,11 @@ class ConsoleServiceProvider extends ServiceProvider
 
     protected static function logo(): string
     {
+        // Check if no-ansi flag is set
+        if (isset($_SERVER['argv']) && in_array('--no-ansi', $_SERVER['argv'], true)) {
+            return 'HydePHP';
+        }
+
         return <<<ASCII
         
         \033[34m     __ __        __   \033[33m ___  __ _____

--- a/packages/framework/tests/Unit/ConsoleServiceProviderUnitTest.php
+++ b/packages/framework/tests/Unit/ConsoleServiceProviderUnitTest.php
@@ -25,6 +25,13 @@ class ConsoleServiceProviderUnitTest extends UnitTestCase
         \033[0m
         ASCII, ConsoleServiceProviderTestClass::logo());
     }
+
+    public function testProviderRegistersNoAnsiLogo()
+    {
+        $_SERVER['argv'] = ['--no-ansi'];
+
+        $this->assertSame('HydePHP', ConsoleServiceProviderTestClass::logo());
+    }
 }
 
 class ConsoleServiceProviderTestClass extends ConsoleServiceProvider

--- a/packages/framework/tests/Unit/ConsoleServiceProviderUnitTest.php
+++ b/packages/framework/tests/Unit/ConsoleServiceProviderUnitTest.php
@@ -5,12 +5,12 @@ declare(strict_types=1);
 namespace Hyde\Framework\Testing\Unit;
 
 use Hyde\Console\ConsoleServiceProvider;
-use Hyde\Testing\TestCase;
+use Hyde\Testing\UnitTestCase;
 
 /**
  * @covers \Hyde\Console\ConsoleServiceProvider
  */
-class ConsoleServiceProviderUnitTest extends TestCase
+class ConsoleServiceProviderUnitTest extends UnitTestCase
 {
     //
 }

--- a/packages/framework/tests/Unit/ConsoleServiceProviderUnitTest.php
+++ b/packages/framework/tests/Unit/ConsoleServiceProviderUnitTest.php
@@ -12,5 +12,25 @@ use Hyde\Testing\UnitTestCase;
  */
 class ConsoleServiceProviderUnitTest extends UnitTestCase
 {
-    //
+    public function testProviderRegistersLogo()
+    {
+        $this->assertSame(<<<ASCII
+        
+        \033[34m     __ __        __   \033[33m ___  __ _____
+        \033[34m    / // /_ _____/ /__ \033[33m/ _ \/ // / _ \
+        \033[34m   / _  / // / _  / -_)\033[33m ___/ _  / ___/
+        \033[34m  /_//_/\_, /\_,_/\__/\033[33m_/  /_//_/_/
+        \033[34m       /___/
+            
+        \033[0m
+        ASCII, ConsoleServiceProviderTestClass::logo());
+    }
+}
+
+class ConsoleServiceProviderTestClass extends ConsoleServiceProvider
+{
+    public static function logo(): string
+    {
+        return parent::logo();
+    }
 }

--- a/packages/framework/tests/Unit/ConsoleServiceProviderUnitTest.php
+++ b/packages/framework/tests/Unit/ConsoleServiceProviderUnitTest.php
@@ -28,9 +28,13 @@ class ConsoleServiceProviderUnitTest extends UnitTestCase
 
     public function testProviderRegistersNoAnsiLogo()
     {
+        $serverBackup = $_SERVER;
+
         $_SERVER['argv'] = ['--no-ansi'];
 
         $this->assertSame('HydePHP', ConsoleServiceProviderTestClass::logo());
+
+        $_SERVER = $serverBackup;
     }
 }
 

--- a/packages/framework/tests/Unit/ConsoleServiceProviderUnitTest.php
+++ b/packages/framework/tests/Unit/ConsoleServiceProviderUnitTest.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Hyde\Framework\Testing\Unit;
+
+use Hyde\Console\ConsoleServiceProvider;
+use Hyde\Testing\TestCase;
+
+/**
+ * @covers \Hyde\Console\ConsoleServiceProvider
+ */
+class ConsoleServiceProviderUnitTest extends TestCase
+{
+    //
+}


### PR DESCRIPTION
Fixes https://github.com/hydephp/develop/issues/1127