### PR TITLE
HydePHP version v1.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,16 @@ HydePHP consists of two primary components, Hyde/Hyde and Hyde/Framework. Develo
 
 <!-- CHANGELOG_START -->
 
+## [v1.0.0](https://github.com/hydephp/develop/releases/tag/v1.0.0) - 2023-03-14
+
+### Changed
+- Compiled TailwindCSS and HydeFront for production [#1295](https://github.com/hydephp/develop/pull/1295)
+- Updated to HydeFront v3.2 [#1297](https://github.com/hydephp/develop/pull/1297)
+
+### Security
+- Bumped Webpack from 5.73.0 to 5.76.1 [#1292](https://github.com/hydephp/develop/pull/1292)
+
+
 ## [v1.0.0-RC.8](https://github.com/hydephp/develop/releases/tag/v1.0.0-RC.8) - 2023-03-14
 
 ### Changed

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -13,8 +13,7 @@ This serves two purposes:
 - for new features.
 
 ### Changed
-- Compiled TailwindCSS and HydeFront for production [#1295](https://github.com/hydephp/develop/pull/1295)
-- Updated to HydeFront v3.2 [#1297](https://github.com/hydephp/develop/pull/1297)
+- for changes in existing functionality.
 
 ### Deprecated
 - for soon-to-be removed features.
@@ -26,4 +25,4 @@ This serves two purposes:
 - for any bug fixes.
 
 ### Security
-- Bumped Webpack from 5.73.0 to 5.76.1 [#1292](https://github.com/hydephp/develop/pull/1292)
+- in case of vulnerabilities.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "hyde",
-    "version": "1.0.0-RC.8",
+    "version": "1.0.0",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "hyde",
-            "version": "1.0.0-RC.8",
+            "version": "1.0.0",
             "license": "MIT",
             "devDependencies": {
                 "@tailwindcss/typography": "^0.5.2",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     },
     "name": "hyde",
     "description": "Elegant and Powerful Static App Builder",
-    "version": "1.0.0-RC.8",
+    "version": "1.0.0",
     "main": "hyde",
     "directories": {
         "test": "tests"

--- a/packages/framework/src/Foundation/HydeKernel.php
+++ b/packages/framework/src/Foundation/HydeKernel.php
@@ -49,7 +49,7 @@ class HydeKernel implements SerializableContract
     use Serializable;
     use Macroable;
 
-    final public const VERSION = '1.0.0-RC.8';
+    final public const VERSION = '1.0.0';
 
     protected static self $instance;
 


### PR DESCRIPTION
# Release Announcement 

We're thrilled to announce HydePHP v1.0.0, the first general availability release of the Laravel-based static site generator you've been waiting for! HydePHP allows you to build lightning-fast static websites with ease, using the familiar syntax and functionality of the Laravel framework.

## What is HydePHP?

HydePHP is a powerful static site generator that is built on top of Laravel, one of the most popular PHP frameworks out there. HydePHP's architecture and design principles allow for a flexible and intuitive development experience, making it a great choice for developers looking to create static websites quickly and efficiently.

## What's New in v1.0.0?

This release marks the first stable version of HydePHP, with many exciting new features and improvements. Here are some of the highlights:

- Upgraded to Laravel 10 and requires PHP 8.1
- Made several services and sub-namespaces modular and configurable
- Major improvements to several key features and code APIs, including the new Extensions API
- See the Changelog for a full list of changes, either [on GitHub](https://github.com/hydephp/develop/blob/master/CHANGELOG.md) or on the [HydePHP website](https://hydephp.com/changelog)


## How to Install

To get started with HydePHP, you can install it using Composer with the following command:

```bash
composer create-project hyde/hyde
```

## Thank You!

We want to extend a huge thank you to everyone who contributed to this release, whether through code contributions, bug reports, or feature requests. We couldn't have done it without your help!

## More Information

You can also visit our website at [HydePHP.com](https://hydephp.com/) for more information, or follow us on Twitter at [@HydeFramework](https://twitter.com/HydeFramework) for updates and news.

