### PR TITLE
Check for config flags in server globals when loading the configuration

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -22,7 +22,7 @@ This serves two purposes:
 - for now removed features.
 
 ### Fixed
-- for any bug fixes.
+- Fixed https://github.com/hydephp/develop/issues/1301 in https://github.com/hydephp/develop/pull/1302
 
 ### Security
 - in case of vulnerabilities.

--- a/packages/framework/src/Foundation/Internal/LoadConfiguration.php
+++ b/packages/framework/src/Foundation/Internal/LoadConfiguration.php
@@ -78,7 +78,7 @@ class LoadConfiguration extends BaseLoadConfiguration
 
     private function loadRuntimeConfiguration(Application $app, RepositoryContract $repository)
     {
-        if ($app->runningInConsole()) {
+        if ($app->runningInConsole() && isset($_SERVER['argv'])) {
             // Check if the `--pretty-urls` CLI argument is set, and if so, set the config value accordingly.
             if (in_array('--pretty-urls', $_SERVER['argv'], true)) {
                 $repository->set('hyde.pretty_urls', true);

--- a/packages/framework/src/Foundation/Internal/LoadConfiguration.php
+++ b/packages/framework/src/Foundation/Internal/LoadConfiguration.php
@@ -34,6 +34,8 @@ class LoadConfiguration extends BaseLoadConfiguration
         parent::loadConfigurationFiles($app, $repository);
 
         $this->mergeConfigurationFiles($repository);
+
+        $this->loadRuntimeConfiguration($repository);
     }
 
     private function mergeConfigurationFiles(RepositoryContract $repository): void
@@ -72,5 +74,10 @@ class LoadConfiguration extends BaseLoadConfiguration
         if (Phar::running() && (! is_dir($files['app']))) {
             $files['app'] = dirname(__DIR__, 6).DIRECTORY_SEPARATOR.'config'.DIRECTORY_SEPARATOR.'app.php';
         }
+    }
+
+    private function loadRuntimeConfiguration(RepositoryContract $repository)
+    {
+        //
     }
 }

--- a/packages/framework/src/Foundation/Internal/LoadConfiguration.php
+++ b/packages/framework/src/Foundation/Internal/LoadConfiguration.php
@@ -35,7 +35,7 @@ class LoadConfiguration extends BaseLoadConfiguration
 
         $this->mergeConfigurationFiles($repository);
 
-        $this->loadRuntimeConfiguration($repository);
+        $this->loadRuntimeConfiguration($app, $repository);
     }
 
     private function mergeConfigurationFiles(RepositoryContract $repository): void
@@ -76,7 +76,7 @@ class LoadConfiguration extends BaseLoadConfiguration
         }
     }
 
-    private function loadRuntimeConfiguration(RepositoryContract $repository)
+    private function loadRuntimeConfiguration(Application $app, RepositoryContract $repository)
     {
         //
     }

--- a/packages/framework/src/Foundation/Internal/LoadConfiguration.php
+++ b/packages/framework/src/Foundation/Internal/LoadConfiguration.php
@@ -78,6 +78,8 @@ class LoadConfiguration extends BaseLoadConfiguration
 
     private function loadRuntimeConfiguration(Application $app, RepositoryContract $repository)
     {
-        //
+        if ($app->runningInConsole()) {
+            //
+        }
     }
 }

--- a/packages/framework/src/Foundation/Internal/LoadConfiguration.php
+++ b/packages/framework/src/Foundation/Internal/LoadConfiguration.php
@@ -79,7 +79,10 @@ class LoadConfiguration extends BaseLoadConfiguration
     private function loadRuntimeConfiguration(Application $app, RepositoryContract $repository)
     {
         if ($app->runningInConsole()) {
-            //
+            // Check if the `--pretty-urls` CLI argument is set, and if so, set the config value accordingly.
+            if (in_array('--pretty-urls', $_SERVER['argv'], true)) {
+                $repository->set('hyde.pretty_urls', true);
+            }
         }
     }
 }

--- a/packages/framework/tests/Unit/LoadConfigurationTest.php
+++ b/packages/framework/tests/Unit/LoadConfigurationTest.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Hyde\Framework\Testing\Unit;
+
+use Hyde\Foundation\Internal\LoadConfiguration;
+use Hyde\Testing\UnitTestCase;
+
+/**
+ * @covers \Hyde\Foundation\Internal\LoadConfiguration
+ */
+class LoadConfigurationTest extends UnitTestCase
+{
+    //
+}

--- a/packages/framework/tests/Unit/LoadConfigurationTest.php
+++ b/packages/framework/tests/Unit/LoadConfigurationTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Hyde\Framework\Testing\Unit;
 
+use Hyde\Foundation\Application;
 use Hyde\Foundation\Internal\LoadConfiguration;
 use Hyde\Testing\UnitTestCase;
 
@@ -12,5 +13,22 @@ use Hyde\Testing\UnitTestCase;
  */
 class LoadConfigurationTest extends UnitTestCase
 {
-    //
+    public function testItLoadsRuntimeConfiguration()
+    {
+        $serverBackup = $_SERVER;
+
+        $_SERVER['argv'] = ['--pretty-urls'];
+
+        $app = new Application(getcwd());
+
+        $loader = new LoadConfiguration();
+        $loader->bootstrap($app);
+
+        $this->assertTrue(config('hyde.pretty_urls'));
+
+        $_SERVER = $serverBackup;
+
+        $loader->bootstrap($app);
+        $this->assertFalse(config('hyde.pretty_urls'));
+    }
 }


### PR DESCRIPTION
Updates the custom configuration loader to check for CLI flags in the server globals. This allows us to collect information very early on in the internal application lifecycle. It contains a flag check which fixes https://github.com/hydephp/develop/issues/1301

