### PR TITLE
Improve type and IDE support

### DIFF
--- a/packages/framework/src/Console/Commands/DebugCommand.php
+++ b/packages/framework/src/Console/Commands/DebugCommand.php
@@ -38,12 +38,12 @@ class DebugCommand extends Command
         $this->info('HydePHP Debug Screen');
 
         $this->newLine();
-        $this->comment('Git Version: '.app('git.version'));
+        $this->comment('Git Version: '.(string) app('git.version'));
         $this->comment('Hyde Version: '.(InstalledVersions::getPrettyVersion('hyde/hyde') ?: 'unreleased'));
         $this->comment('Framework Version: '.(InstalledVersions::getPrettyVersion('hyde/framework') ?: 'unreleased'));
 
         $this->newLine();
-        $this->comment('App Env: '.app('env'));
+        $this->comment('App Env: '.(string) app('env'));
 
         $this->newLine();
         if ($this->getOutput()->isVerbose()) {

--- a/packages/framework/src/Console/Commands/RouteListCommand.php
+++ b/packages/framework/src/Console/Commands/RouteListCommand.php
@@ -49,7 +49,7 @@ class RouteListCommand extends Command
                         $page = $this->route->getPage();
                         /** @experimental The typeLabel macro is experimental */
                         if ($page instanceof InMemoryPage && $page->hasMacro('typeLabel')) {
-                            $type .= sprintf(' <fg=gray>(%s)</>', $page->__call('typeLabel', []));
+                            $type .= sprintf(' <fg=gray>(%s)</>', (string) $page->__call('typeLabel', []));
                         }
 
                         return $type;

--- a/packages/framework/src/Console/Commands/VendorPublishCommand.php
+++ b/packages/framework/src/Console/Commands/VendorPublishCommand.php
@@ -32,7 +32,7 @@ class VendorPublishCommand extends BaseCommand
 
         // Rename the config group to be more helpful
         if (isset(ServiceProvider::$publishGroups['config'])) {
-            ServiceProvider::$publishGroups['vendor-configs'] = ServiceProvider::$publishGroups['config'];
+            ServiceProvider::$publishGroups['vendor-configs'] = (array) ServiceProvider::$publishGroups['config'];
             unset(ServiceProvider::$publishGroups['config']);
         }
 

--- a/packages/framework/src/Foundation/ConsoleKernel.php
+++ b/packages/framework/src/Foundation/ConsoleKernel.php
@@ -28,7 +28,7 @@ class ConsoleKernel extends Kernel
         // the default LoadConfiguration bootstrapper class with our implementation.
         // We do this by swapping out the LoadConfiguration class with our own.
 
-        return array_values(tap(array_combine($bootstrappers, $bootstrappers), function (array &$array): void {
+        return array_values((array) tap(array_combine($bootstrappers, $bootstrappers), function (array &$array): void {
             $array[\LaravelZero\Framework\Bootstrap\LoadConfiguration::class] = \Hyde\Foundation\Internal\LoadConfiguration::class;
         }));
     }

--- a/packages/framework/src/Foundation/Internal/LoadConfiguration.php
+++ b/packages/framework/src/Foundation/Internal/LoadConfiguration.php
@@ -72,6 +72,7 @@ class LoadConfiguration extends BaseLoadConfiguration
         // If we're running in a Phar and no project config directory exists,
         // we need to adjust the path to use the bundled static Phar config file.
 
+        /** @var array{app: string} $files */
         if (Phar::running() && (! is_dir($files['app']))) {
             $files['app'] = dirname(__DIR__, 6).DIRECTORY_SEPARATOR.'config'.DIRECTORY_SEPARATOR.'app.php';
         }

--- a/packages/framework/src/Foundation/Internal/LoadConfiguration.php
+++ b/packages/framework/src/Foundation/Internal/LoadConfiguration.php
@@ -76,7 +76,7 @@ class LoadConfiguration extends BaseLoadConfiguration
         }
     }
 
-    private function loadRuntimeConfiguration(Application $app, RepositoryContract $repository)
+    private function loadRuntimeConfiguration(Application $app, RepositoryContract $repository): void
     {
         if ($app->runningInConsole() && isset($_SERVER['argv'])) {
             // Check if the `--pretty-urls` CLI argument is set, and if so, set the config value accordingly.

--- a/packages/framework/src/Foundation/Internal/LoadConfiguration.php
+++ b/packages/framework/src/Foundation/Internal/LoadConfiguration.php
@@ -20,7 +20,7 @@ class LoadConfiguration extends BaseLoadConfiguration
     /** Get all the configuration files for the application. */
     protected function getConfigurationFiles(Application $app): array
     {
-        return tap(parent::getConfigurationFiles($app), function (array &$files) use ($app): void {
+        return (array) tap(parent::getConfigurationFiles($app), function (array &$files) use ($app): void {
             // Inject our custom config file which is stored in `app/config.php`.
             $files['app'] = $app->basePath().DIRECTORY_SEPARATOR.'app'.DIRECTORY_SEPARATOR.'config.php';
 

--- a/packages/framework/src/Foundation/Internal/LoadConfiguration.php
+++ b/packages/framework/src/Foundation/Internal/LoadConfiguration.php
@@ -55,7 +55,7 @@ class LoadConfiguration extends BaseLoadConfiguration
         // if they're present, so we'll merge their changes here.
 
         $repository->set($file, array_merge(
-            require __DIR__."/../../../config/$file.php",
+            (array) require __DIR__."/../../../config/$file.php",
             (array) $repository->get($file, [])
         ));
     }

--- a/packages/framework/src/Foundation/Kernel/FileCollection.php
+++ b/packages/framework/src/Foundation/Kernel/FileCollection.php
@@ -21,6 +21,8 @@ use function glob;
  *
  * @property array<string, SourceFile> $items The files in the collection.
  *
+ * @method SourceFile|null get(string $key, SourceFile $default = null)
+ *
  * This class is stored as a singleton in the HydeKernel.
  * You would commonly access it via the facade or Hyde helper:
  *

--- a/packages/framework/src/Foundation/Kernel/PageCollection.php
+++ b/packages/framework/src/Foundation/Kernel/PageCollection.php
@@ -67,4 +67,16 @@ final class PageCollection extends BaseFoundationCollection
             return $page instanceof $pageClass;
         }) : $this;
     }
+
+    /**
+     * Get an item from the collection by key.
+     *
+     * @param  string  $key
+     * @param  \Hyde\Pages\Concerns\HydePage $default
+     * @return \Hyde\Pages\Concerns\HydePage|null
+     */
+    public function get($key, $default = null): ?HydePage
+    {
+        return parent::get($key, $default);
+    }
 }

--- a/packages/framework/src/Foundation/Kernel/PageCollection.php
+++ b/packages/framework/src/Foundation/Kernel/PageCollection.php
@@ -69,16 +69,4 @@ final class PageCollection extends BaseFoundationCollection
             return $page instanceof $pageClass;
         }) : $this;
     }
-
-    /**
-     * Get an item from the collection by key.
-     *
-     * @param  string  $key
-     * @param  \Hyde\Pages\Concerns\HydePage $default
-     * @return \Hyde\Pages\Concerns\HydePage|null
-     */
-    public function get($key, $default = null): ?HydePage
-    {
-        return parent::get($key, $default);
-    }
 }

--- a/packages/framework/src/Foundation/Kernel/PageCollection.php
+++ b/packages/framework/src/Foundation/Kernel/PageCollection.php
@@ -18,7 +18,7 @@ use Hyde\Support\Filesystem\SourceFile;
  *
  * @property array<string, HydePage> $items The pages in the collection.
  *
- * @method HydePage get(string $key, HydePage $default = null)
+ * @method HydePage|null get(string $key, HydePage $default = null)
  *
  * This class is stored as a singleton in the HydeKernel.
  * You would commonly access it via the facade or Hyde helper:

--- a/packages/framework/src/Foundation/Kernel/PageCollection.php
+++ b/packages/framework/src/Foundation/Kernel/PageCollection.php
@@ -18,6 +18,8 @@ use Hyde\Support\Filesystem\SourceFile;
  *
  * @property array<string, HydePage> $items The pages in the collection.
  *
+ * @method HydePage get(string $key, HydePage $default = null)
+ *
  * This class is stored as a singleton in the HydeKernel.
  * You would commonly access it via the facade or Hyde helper:
  *

--- a/packages/framework/src/Foundation/Kernel/RouteCollection.php
+++ b/packages/framework/src/Foundation/Kernel/RouteCollection.php
@@ -18,6 +18,8 @@ use Hyde\Support\Models\Route;
  *
  * @property array<string, Route> $items The routes in the collection.
  *
+ * @method Route|null get(string $key, Route $default = null)
+ *
  * This class is stored as a singleton in the HydeKernel.
  * You would commonly access it via the facade or Hyde helper:
  *

--- a/packages/framework/src/Framework/Actions/MarkdownFileParser.php
+++ b/packages/framework/src/Framework/Actions/MarkdownFileParser.php
@@ -44,7 +44,7 @@ class MarkdownFileParser
             $document = YamlFrontMatter::markdownCompatibleParse($stream);
 
             if ($document->matter()) {
-                $this->matter = $document->matter();
+                $this->matter = (array) $document->matter();
             }
 
             if ($document->body()) {

--- a/packages/framework/src/Framework/Actions/PreBuildTasks/CleanSiteDirectory.php
+++ b/packages/framework/src/Framework/Actions/PreBuildTasks/CleanSiteDirectory.php
@@ -22,7 +22,7 @@ class CleanSiteDirectory extends PreBuildTask
     public function handle(): void
     {
         if ($this->isItSafeToCleanOutputDirectory()) {
-            array_map('unlink', glob(Hyde::sitePath('*.{html,json}'), GLOB_BRACE));
+            array_map('unlink', (array) glob(Hyde::sitePath('*.{html,json}'), GLOB_BRACE));
             File::cleanDirectory(Hyde::siteMediaPath());
         }
     }

--- a/packages/framework/src/Framework/Actions/PreBuildTasks/CleanSiteDirectory.php
+++ b/packages/framework/src/Framework/Actions/PreBuildTasks/CleanSiteDirectory.php
@@ -22,7 +22,7 @@ class CleanSiteDirectory extends PreBuildTask
     public function handle(): void
     {
         if ($this->isItSafeToCleanOutputDirectory()) {
-            array_map('unlink', (array) glob(Hyde::sitePath('*.{html,json}'), GLOB_BRACE));
+            array_map('unlink', glob(Hyde::sitePath('*.{html,json}'), GLOB_BRACE));
             File::cleanDirectory(Hyde::siteMediaPath());
         }
     }

--- a/packages/framework/src/Framework/Concerns/Internal/ForwardsIlluminateFilesystem.php
+++ b/packages/framework/src/Framework/Concerns/Internal/ForwardsIlluminateFilesystem.php
@@ -109,7 +109,7 @@ trait ForwardsIlluminateFilesystem
     protected static function qualifyPathArgument(array|string $path): string|array
     {
         return is_array($path)
-            ? array_map(fn (string $path): string => self::qualifyPathArgument($path), $path)
+            ? array_map(fn (string $path): string => (string) self::qualifyPathArgument($path), $path)
             : self::absolutePath($path);
     }
 }

--- a/packages/framework/src/Framework/Concerns/Internal/ForwardsIlluminateFilesystem.php
+++ b/packages/framework/src/Framework/Concerns/Internal/ForwardsIlluminateFilesystem.php
@@ -85,6 +85,7 @@ trait ForwardsIlluminateFilesystem
         );
     }
 
+    /** @param  string[]  $parameterNames */
     protected static function qualifyArguments(array $parameterNames, array $arguments): Collection
     {
         return collect($arguments)->mapWithKeys(function (string|array|int|bool $argumentValue, int|string $key) use ($parameterNames): string|array|int|bool {

--- a/packages/framework/src/Framework/Concerns/Internal/ForwardsIlluminateFilesystem.php
+++ b/packages/framework/src/Framework/Concerns/Internal/ForwardsIlluminateFilesystem.php
@@ -106,6 +106,10 @@ trait ForwardsIlluminateFilesystem
         });
     }
 
+    /**
+     * @param  string|string[]  $path
+     * @return string|string[]
+     */
     protected static function qualifyPathArgument(array|string $path): string|array
     {
         return is_array($path)

--- a/packages/framework/src/Framework/Concerns/Internal/ForwardsIlluminateFilesystem.php
+++ b/packages/framework/src/Framework/Concerns/Internal/ForwardsIlluminateFilesystem.php
@@ -110,6 +110,6 @@ trait ForwardsIlluminateFilesystem
     {
         return is_array($path)
             ? array_map(fn (string $path): string => (string) self::qualifyPathArgument($path), $path)
-            : self::absolutePath($path);
+            : (string) self::absolutePath($path);
     }
 }

--- a/packages/framework/src/Framework/Concerns/Internal/ForwardsIlluminateFilesystem.php
+++ b/packages/framework/src/Framework/Concerns/Internal/ForwardsIlluminateFilesystem.php
@@ -107,14 +107,10 @@ trait ForwardsIlluminateFilesystem
         });
     }
 
-    /**
-     * @param  string|string[]  $path
-     * @return string|string[]
-     */
     protected static function qualifyPathArgument(array|string $path): string|array
     {
         return is_array($path)
-            ? array_map(fn (string $path): string => (string) self::qualifyPathArgument($path), $path)
-            : (string) self::absolutePath($path);
+            ? array_map(fn (string $path): string => self::qualifyPathArgument($path), $path)
+            : self::absolutePath($path);
     }
 }

--- a/packages/framework/src/Framework/Factories/NavigationDataFactory.php
+++ b/packages/framework/src/Framework/Factories/NavigationDataFactory.php
@@ -76,7 +76,7 @@ class NavigationDataFactory extends Concerns\PageDataFactory implements Navigati
     {
         return $this->searchForLabelInFrontMatter()
             ?? $this->searchForLabelInConfig()
-            ?? $this->matter('title')
+            ?? $this->getMatter('title')
             ?? $this->title;
     }
 
@@ -106,26 +106,26 @@ class NavigationDataFactory extends Concerns\PageDataFactory implements Navigati
 
     private function searchForLabelInFrontMatter(): ?string
     {
-        return $this->matter('navigation.label')
-            ?? $this->matter('navigation.title');
+        return $this->getMatter('navigation.label')
+            ?? $this->getMatter('navigation.title');
     }
 
     private function searchForGroupInFrontMatter(): ?string
     {
-        return $this->matter('navigation.group')
-            ?? $this->matter('navigation.category');
+        return $this->getMatter('navigation.group')
+            ?? $this->getMatter('navigation.category');
     }
 
     private function searchForHiddenInFrontMatter(): ?bool
     {
-        return $this->matter('navigation.hidden')
-            ?? $this->invert($this->matter('navigation.visible'));
+        return $this->getMatter('navigation.hidden')
+            ?? $this->invert($this->getMatter('navigation.visible'));
     }
 
     private function searchForPriorityInFrontMatter(): ?int
     {
-        return $this->matter('navigation.priority')
-            ?? $this->matter('navigation.order');
+        return $this->getMatter('navigation.priority')
+            ?? $this->getMatter('navigation.order');
     }
 
     private function searchForLabelInConfig(): ?string
@@ -205,5 +205,10 @@ class NavigationDataFactory extends Concerns\PageDataFactory implements Navigati
     protected function offset(?int $value, int $offset): ?int
     {
         return $value === null ? null : $value + $offset;
+    }
+
+    protected function getMatter(string $key): string|null|int|bool
+    {
+        return $this->matter->get($key);
     }
 }

--- a/packages/framework/src/Framework/Factories/NavigationDataFactory.php
+++ b/packages/framework/src/Framework/Factories/NavigationDataFactory.php
@@ -149,10 +149,7 @@ class NavigationDataFactory extends Concerns\PageDataFactory implements Navigati
         // This is all to make it easier to mix ways of adding priorities.
 
         return $this->offset(
-            Arr::get(
-                array_flip(Config::getArray('docs.sidebar_order', [])),
-                $this->identifier
-            ),
+            array_flip(Config::getArray('docs.sidebar_order', []))[$this->identifier] ?? null,
             self::CONFIG_OFFSET
         );
     }

--- a/packages/framework/src/Framework/Factories/NavigationDataFactory.php
+++ b/packages/framework/src/Framework/Factories/NavigationDataFactory.php
@@ -148,7 +148,7 @@ class NavigationDataFactory extends Concerns\PageDataFactory implements Navigati
         // Adding an offset makes so that pages with a front matter priority that is lower can be shown first.
         // This is all to make it easier to mix ways of adding priorities.
 
-        return $this->offset((int) Arr::get(
+        return $this->offset(Arr::get(
             array_flip(Config::getArray('docs.sidebar_order', [])), $this->identifier),
             self::CONFIG_OFFSET
         );

--- a/packages/framework/src/Framework/Factories/NavigationDataFactory.php
+++ b/packages/framework/src/Framework/Factories/NavigationDataFactory.php
@@ -148,8 +148,11 @@ class NavigationDataFactory extends Concerns\PageDataFactory implements Navigati
         // Adding an offset makes so that pages with a front matter priority that is lower can be shown first.
         // This is all to make it easier to mix ways of adding priorities.
 
-        return $this->offset(Arr::get(
-            array_flip(Config::getArray('docs.sidebar_order', [])), $this->identifier),
+        return $this->offset(
+            Arr::get(
+                array_flip(Config::getArray('docs.sidebar_order', [])),
+                $this->identifier
+            ),
             self::CONFIG_OFFSET
         );
     }

--- a/packages/framework/src/Framework/Factories/NavigationDataFactory.php
+++ b/packages/framework/src/Framework/Factories/NavigationDataFactory.php
@@ -148,7 +148,7 @@ class NavigationDataFactory extends Concerns\PageDataFactory implements Navigati
         // Adding an offset makes so that pages with a front matter priority that is lower can be shown first.
         // This is all to make it easier to mix ways of adding priorities.
 
-        return $this->offset(Arr::get(
+        return $this->offset((int) Arr::get(
             array_flip(Config::getArray('docs.sidebar_order', [])), $this->identifier),
             self::CONFIG_OFFSET
         );

--- a/packages/framework/src/Framework/Factories/NavigationDataFactory.php
+++ b/packages/framework/src/Framework/Factories/NavigationDataFactory.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Hyde\Framework\Factories;
 
 use Hyde\Facades\Config;
-use Illuminate\Support\Arr;
 use Illuminate\Support\Str;
 use Hyde\Pages\MarkdownPost;
 use Hyde\Pages\DocumentationPage;
@@ -127,10 +126,10 @@ class NavigationDataFactory extends Concerns\PageDataFactory implements Navigati
 
     private function searchForLabelInConfig(): ?string
     {
-        return Arr::get(Config::getArray('hyde.navigation.labels', [
+        return Config::getArray('hyde.navigation.labels', [
             'index' => 'Home',
             DocumentationPage::homeRouteName() => 'Docs',
-        ]), $this->routeKey);
+        ])[$this->routeKey] ?? null;
     }
 
     private function searchForPriorityInConfigs(): ?int

--- a/packages/framework/src/Framework/Features/Blogging/Models/PostAuthor.php
+++ b/packages/framework/src/Framework/Features/Blogging/Models/PostAuthor.php
@@ -72,7 +72,7 @@ class PostAuthor implements Stringable
         return static::all()->firstWhere('username', strtolower($username)) ?? Author::create($username);
     }
 
-    /** @return \Illuminate\Support\Collection<\Hyde\Framework\Features\Blogging\Models\PostAuthor> */
+    /** @return \Illuminate\Support\Collection<string, \Hyde\Framework\Features\Blogging\Models\PostAuthor> */
     public static function all(): Collection
     {
         return (new Collection(Config::getArray('hyde.authors', [])))->mapWithKeys(function (self $author): array {

--- a/packages/framework/src/Framework/Features/Blogging/Models/PostAuthor.php
+++ b/packages/framework/src/Framework/Features/Blogging/Models/PostAuthor.php
@@ -90,7 +90,7 @@ class PostAuthor implements Stringable
         return $this->name ?? $this->username;
     }
 
-    /** @param array{username?: string, name?: string} $data  */
+    /** @param array{username?: string, name?: string, website?: string} $data */
     protected static function findUsername(array $data): string
     {
         return $data['username'] ?? $data['name'] ?? 'Guest';

--- a/packages/framework/src/Framework/Features/Blogging/Models/PostAuthor.php
+++ b/packages/framework/src/Framework/Features/Blogging/Models/PostAuthor.php
@@ -55,7 +55,7 @@ class PostAuthor implements Stringable
     /**
      * Dynamically get or create an author based on a username string or front matter array.
      *
-     * @param  string|array{name?: string, website?: string}  $data
+     * @param  string|array{username?: string, name?: string, website?: string}  $data
      */
     public static function getOrCreate(string|array $data): static
     {

--- a/packages/framework/src/Framework/Features/Blogging/Models/PostAuthor.php
+++ b/packages/framework/src/Framework/Features/Blogging/Models/PostAuthor.php
@@ -53,9 +53,9 @@ class PostAuthor implements Stringable
     }
 
     /**
-     * Dynamically get or create an author based on a username string or front matter array
+     * Dynamically get or create an author based on a username string or front matter array.
      *
-     * @param string|array{name?: string, website?: string} $data
+     * @param  string|array{name?: string, website?: string}  $data
      */
     public static function getOrCreate(string|array $data): static
     {

--- a/packages/framework/src/Framework/Features/Documentation/DocumentationSearchPage.php
+++ b/packages/framework/src/Framework/Features/Documentation/DocumentationSearchPage.php
@@ -8,7 +8,6 @@ use Hyde\Hyde;
 use Hyde\Pages\DocumentationPage;
 use Hyde\Framework\Actions\StaticPageBuilder;
 use Hyde\Facades\Config;
-
 use Illuminate\Support\Facades\View;
 
 /**

--- a/packages/framework/src/Framework/Features/Documentation/DocumentationSearchPage.php
+++ b/packages/framework/src/Framework/Features/Documentation/DocumentationSearchPage.php
@@ -9,7 +9,7 @@ use Hyde\Pages\DocumentationPage;
 use Hyde\Framework\Actions\StaticPageBuilder;
 use Hyde\Facades\Config;
 
-use function view;
+use Illuminate\Support\Facades\View;
 
 /**
  * @internal This page is used to render the search page for the documentation.
@@ -42,7 +42,7 @@ class DocumentationSearchPage extends DocumentationPage
 
     public function compile(): string
     {
-        return view('hyde::pages.documentation-search')->render();
+        return View::make('hyde::pages.documentation-search')->render();
     }
 
     public static function enabled(): bool

--- a/packages/framework/src/Framework/Features/Metadata/GlobalMetadataBag.php
+++ b/packages/framework/src/Framework/Features/Metadata/GlobalMetadataBag.php
@@ -52,8 +52,8 @@ class GlobalMetadataBag extends MetadataBag
         // Reject any metadata from the global metadata bag that is already present in the page metadata bag.
 
         foreach (['links', 'metadata', 'properties', 'generics'] as $type) {
-            $global->$type = array_filter($global->$type, fn (Element $element): bool => ! in_array($element->uniqueKey(),
-                array_map(fn (Element $element): string => $element->uniqueKey(), $page->metadata->$type)
+            $global->$type = array_filter((array) $global->$type, fn (Element $element): bool => ! in_array($element->uniqueKey(),
+                array_map(fn (Element $element): string => $element->uniqueKey(), (array) $page->metadata->$type)
             ));
         }
     }

--- a/packages/framework/src/Framework/Features/Navigation/BaseNavigationMenu.php
+++ b/packages/framework/src/Framework/Features/Navigation/BaseNavigationMenu.php
@@ -13,7 +13,7 @@ use function collect;
 
 abstract class BaseNavigationMenu
 {
-    /** @var \Illuminate\Support\Collection<\Hyde\Framework\Features\Navigation\NavItem> */
+    /** @var \Illuminate\Support\Collection<string, \Hyde\Framework\Features\Navigation\NavItem> */
     public Collection $items;
 
     final protected function __construct()

--- a/packages/framework/src/Framework/Features/XmlGenerators/RssFeedGenerator.php
+++ b/packages/framework/src/Framework/Features/XmlGenerators/RssFeedGenerator.php
@@ -43,7 +43,7 @@ class RssFeedGenerator extends BaseXmlGenerator
 
     protected function addItem(MarkdownPost $post): void
     {
-        $item = $this->xmlElement->channel->addChild('item');
+        $item = $this->getChannel()->addChild('item');
         $this->addChild($item, 'title', $post->title);
         $this->addChild($item, 'description', $post->description);
 
@@ -79,7 +79,7 @@ class RssFeedGenerator extends BaseXmlGenerator
 
     protected function addBaseChannelItems(): void
     {
-        $channel = $this->xmlElement->channel;
+        $channel = $this->getChannel();
 
         $this->addChild($channel, 'title', Site::name());
         $this->addChild($channel, 'link', Site::url());
@@ -91,7 +91,7 @@ class RssFeedGenerator extends BaseXmlGenerator
 
     protected function addAtomLinkItem(): void
     {
-        $atomLink = $this->xmlElement->channel->addChild('atom:link', namespace: 'http://www.w3.org/2005/Atom');
+        $atomLink = $this->getChannel()->addChild('atom:link', namespace: 'http://www.w3.org/2005/Atom');
         $atomLink->addAttribute('href', $this->escape(Hyde::url($this->getFilename())));
         $atomLink->addAttribute('rel', 'self');
         $atomLink->addAttribute('type', 'application/rss+xml');
@@ -116,5 +116,10 @@ class RssFeedGenerator extends BaseXmlGenerator
     public static function getDescription(): string
     {
         return Config::getString('hyde.rss.description', Site::name().' RSS Feed');
+    }
+
+    protected function getChannel(): SimpleXMLElement
+    {
+        return $this->xmlElement->channel;
     }
 }

--- a/packages/framework/src/Framework/Services/MarkdownService.php
+++ b/packages/framework/src/Framework/Services/MarkdownService.php
@@ -242,9 +242,9 @@ class MarkdownService
     }
 
     /**
-     * Find the indentation level and position of the first line that has content
+     * Find the indentation level and position of the first line that has content.
      *
-     * @param array<int, string> $lines
+     * @param  array<int, string>  $lines
      * @return array<int, int>
      */
     protected static function findLineContentPositions(array $lines): array

--- a/packages/framework/src/Framework/Services/MarkdownService.php
+++ b/packages/framework/src/Framework/Services/MarkdownService.php
@@ -241,7 +241,7 @@ class MarkdownService
         return explode("\n", str_replace(["\t", "\r\n"], ['    ', "\n"], $string));
     }
 
-    /** @return int[]  Find the indentation level and position of the first line that has content */
+    /** @return array<int, int>  Find the indentation level and position of the first line that has content */
     protected static function findLineContentPositions(array $lines): array
     {
         foreach ($lines as $lineNumber => $line) {

--- a/packages/framework/src/Framework/Services/MarkdownService.php
+++ b/packages/framework/src/Framework/Services/MarkdownService.php
@@ -250,9 +250,9 @@ class MarkdownService
     protected static function findLineContentPositions(array $lines): array
     {
         foreach ($lines as $lineNumber => $line) {
-            if (filled(trim((string) $line))) {
-                $lineLen = strlen((string) $line);
-                $stripLen = strlen(ltrim((string) $line)); // Length of the line without indentation lets us know its indentation level, and thus how much to strip from each line
+            if (filled(trim($line))) {
+                $lineLen = strlen($line);
+                $stripLen = strlen(ltrim($line)); // Length of the line without indentation lets us know its indentation level, and thus how much to strip from each line
 
                 if ($lineLen !== $stripLen) {
                     return [$lineNumber, $lineLen - $stripLen];

--- a/packages/framework/src/Framework/Services/MarkdownService.php
+++ b/packages/framework/src/Framework/Services/MarkdownService.php
@@ -97,7 +97,7 @@ class MarkdownService
 
     protected function runPreProcessing(): void
     {
-        /** @var PreProcessor $processor */
+        /** @var class-string<PreProcessor> $processor */
         foreach ($this->preprocessors as $preprocessor) {
             $this->markdown = $preprocessor::preprocess($this->markdown);
         }
@@ -109,7 +109,7 @@ class MarkdownService
             $this->html .= $this->injectTorchlightAttribution();
         }
 
-        /** @var PostProcessor $postprocessor */
+        /** @var class-string<PostProcessor> $postprocessor */
         foreach ($this->postprocessors as $postprocessor) {
             $this->html = $postprocessor::postprocess($this->html);
         }

--- a/packages/framework/src/Framework/Services/MarkdownService.php
+++ b/packages/framework/src/Framework/Services/MarkdownService.php
@@ -237,6 +237,7 @@ class MarkdownService
         return implode("\n", $lines);
     }
 
+    /** @return array<int, string> */
     protected static function getNormalizedLines(string $string): array
     {
         return explode("\n", str_replace(["\t", "\r\n"], ['    ', "\n"], $string));

--- a/packages/framework/src/Framework/Services/MarkdownService.php
+++ b/packages/framework/src/Framework/Services/MarkdownService.php
@@ -39,6 +39,8 @@ class MarkdownService
     protected ?string $pageClass = null;
 
     protected array $config = [];
+
+    /** @var array<class-string<\League\CommonMark\Extension\ExtensionInterface>> */
     protected array $extensions = [];
     protected MarkdownConverter $converter;
 

--- a/packages/framework/src/Framework/Services/MarkdownService.php
+++ b/packages/framework/src/Framework/Services/MarkdownService.php
@@ -242,8 +242,10 @@ class MarkdownService
     }
 
     /**
+     * Find the indentation level and position of the first line that has content
+     *
      * @param array<int, string> $lines
-     * @return array<int, int>  Find the indentation level and position of the first line that has content
+     * @return array<int, int>
      */
     protected static function findLineContentPositions(array $lines): array
     {

--- a/packages/framework/src/Framework/Services/MarkdownService.php
+++ b/packages/framework/src/Framework/Services/MarkdownService.php
@@ -14,6 +14,7 @@ use Hyde\Markdown\Contracts\MarkdownPostProcessorContract as PostProcessor;
 use League\CommonMark\Extension\HeadingPermalink\HeadingPermalinkExtension;
 use League\CommonMark\Extension\DisallowedRawHtml\DisallowedRawHtmlExtension;
 
+use function str_contains;
 use function str_replace;
 use function array_merge;
 use function array_diff;

--- a/packages/framework/src/Framework/Services/MarkdownService.php
+++ b/packages/framework/src/Framework/Services/MarkdownService.php
@@ -241,7 +241,10 @@ class MarkdownService
         return explode("\n", str_replace(["\t", "\r\n"], ['    ', "\n"], $string));
     }
 
-    /** @return array<int, int>  Find the indentation level and position of the first line that has content */
+    /**
+     * @param array<int, string> $lines
+     * @return array<int, int>  Find the indentation level and position of the first line that has content
+     */
     protected static function findLineContentPositions(array $lines): array
     {
         foreach ($lines as $lineNumber => $line) {

--- a/packages/framework/src/Framework/Services/MarkdownService.php
+++ b/packages/framework/src/Framework/Services/MarkdownService.php
@@ -45,7 +45,10 @@ class MarkdownService
     protected string $html;
     protected array $features = [];
 
+    /** @var array<class-string<\Hyde\Markdown\Contracts\MarkdownPreProcessorContract>> */
     protected array $preprocessors = [];
+
+    /** @var array<class-string<\Hyde\Markdown\Contracts\MarkdownPostProcessorContract>> */
     protected array $postprocessors = [];
 
     public function __construct(string $markdown, ?string $pageClass = null)

--- a/packages/framework/src/Framework/Services/MarkdownService.php
+++ b/packages/framework/src/Framework/Services/MarkdownService.php
@@ -230,7 +230,7 @@ class MarkdownService
 
         foreach ($lines as $lineNumber => $line) {
             if ($lineNumber >= $startNumber) {
-                $lines[$lineNumber] = substr((string) $line, $indentationLevel);
+                $lines[$lineNumber] = substr($line, $indentationLevel);
             }
         }
 

--- a/packages/framework/src/Framework/Services/MarkdownService.php
+++ b/packages/framework/src/Framework/Services/MarkdownService.php
@@ -97,7 +97,7 @@ class MarkdownService
 
     protected function runPreProcessing(): void
     {
-        /** @var class-string<PreProcessor> $processor */
+        /** @var class-string<PreProcessor> $preprocessor */
         foreach ($this->preprocessors as $preprocessor) {
             $this->markdown = $preprocessor::preprocess($this->markdown);
         }

--- a/packages/framework/src/Pages/Concerns/BaseMarkdownPage.php
+++ b/packages/framework/src/Pages/Concerns/BaseMarkdownPage.php
@@ -13,7 +13,6 @@ use Illuminate\Support\Facades\View;
 use function dirname;
 use function ltrim;
 use function trim;
-use function view;
 
 /**
  * The base class for all Markdown-based page models.

--- a/packages/framework/src/Pages/Concerns/BaseMarkdownPage.php
+++ b/packages/framework/src/Pages/Concerns/BaseMarkdownPage.php
@@ -8,6 +8,7 @@ use Hyde\Facades\Filesystem;
 use Hyde\Markdown\Contracts\MarkdownDocumentContract;
 use Hyde\Markdown\Models\FrontMatter;
 use Hyde\Markdown\Models\Markdown;
+use Illuminate\Support\Facades\View;
 
 /**
  * The base class for all Markdown-based page models.
@@ -46,7 +47,7 @@ abstract class BaseMarkdownPage extends HydePage implements MarkdownDocumentCont
     /** @inheritDoc */
     public function compile(): string
     {
-        return view($this->getBladeView())->with([
+        return View::make($this->getBladeView())->with([
             'title' => $this->title,
             'content' => $this->markdown->toHtml(static::class),
         ])->render();

--- a/packages/framework/src/Support/BuildWarnings.php
+++ b/packages/framework/src/Support/BuildWarnings.php
@@ -18,7 +18,7 @@ use function sprintf;
  */
 class BuildWarnings
 {
-    /** @var array<array-key<int>, \Hyde\Framework\Exceptions\BuildWarning> */
+    /** @var array<int, \Hyde\Framework\Exceptions\BuildWarning> */
     protected array $warnings = [];
 
     public static function getInstance(): static
@@ -37,7 +37,7 @@ class BuildWarnings
         static::getInstance()->warnings[] = $warning instanceof BuildWarning ? $warning : new BuildWarning($warning);
     }
 
-    /** @return array<array-key<int>, \Hyde\Framework\Exceptions\BuildWarning> */
+    /** @return array<int, \Hyde\Framework\Exceptions\BuildWarning> */
     public static function getWarnings(): array
     {
         return static::getInstance()->warnings;

--- a/packages/framework/src/Support/BuildWarnings.php
+++ b/packages/framework/src/Support/BuildWarnings.php
@@ -17,7 +17,7 @@ use function sprintf;
  */
 class BuildWarnings
 {
-    /** @var array<\Hyde\Framework\Exceptions\BuildWarning> */
+    /** @var array<array-key<int>, \Hyde\Framework\Exceptions\BuildWarning> */
     protected array $warnings = [];
 
     public static function getInstance(): static
@@ -34,7 +34,7 @@ class BuildWarnings
         static::getInstance()->warnings[] = $warning instanceof BuildWarning ? $warning : new BuildWarning($warning);
     }
 
-    /** @return array<\Hyde\Framework\Exceptions\BuildWarning> */
+    /** @return array<array-key<int>, \Hyde\Framework\Exceptions\BuildWarning> */
     public static function getWarnings(): array
     {
         return static::getInstance()->warnings;

--- a/packages/framework/src/Support/BuildWarnings.php
+++ b/packages/framework/src/Support/BuildWarnings.php
@@ -6,6 +6,7 @@ namespace Hyde\Support;
 
 use Hyde\Facades\Config;
 use Hyde\Framework\Exceptions\BuildWarning;
+use Illuminate\Container\Container;
 use Illuminate\Contracts\Debug\ExceptionHandler;
 use Symfony\Component\Console\Style\OutputStyle;
 
@@ -22,11 +23,13 @@ class BuildWarnings
 
     public static function getInstance(): static
     {
-        if (! app()->bound(self::class)) {
-            app()->singleton(self::class);
+        $app = Container::getInstance();
+
+        if (! $app->bound(self::class)) {
+            $app->singleton(self::class);
         }
 
-        return app(self::class);
+        return $app->make(self::class);
     }
 
     public static function report(BuildWarning|string $warning): void

--- a/packages/framework/src/Support/Models/RenderData.php
+++ b/packages/framework/src/Support/Models/RenderData.php
@@ -70,7 +70,7 @@ class RenderData implements Arrayable
     }
 
     /**
-     * @return array{render: $this, page: \Hyde\Pages\Concerns\HydePage|null, currentRoute: \Hyde\Support\Models\Route|null, currentPage: string|null}
+     * @return array{render: \Hyde\Support\Models\RenderData, page: \Hyde\Pages\Concerns\HydePage|null, currentRoute: \Hyde\Support\Models\Route|null, currentPage: string|null}
      */
     public function toArray(): array
     {

--- a/packages/framework/src/Support/Models/RenderData.php
+++ b/packages/framework/src/Support/Models/RenderData.php
@@ -70,7 +70,7 @@ class RenderData implements Arrayable
     }
 
     /**
-     * @return array{render: \Hyde\Support\Models\RenderData, page: \Hyde\Pages\Concerns\HydePage|null, currentRoute: \Hyde\Support\Models\Route|null, currentPage: string|null}
+     * @return array{render: \Hyde\Support\Models\RenderData, page: \Hyde\Pages\Concerns\HydePage|null, route: \Hyde\Support\Models\Route|null, routeKey: string|null}
      */
     public function toArray(): array
     {

--- a/packages/framework/src/Support/Models/RouteList.php
+++ b/packages/framework/src/Support/Models/RouteList.php
@@ -20,6 +20,7 @@ use function ucwords;
  */
 class RouteList implements Arrayable
 {
+    /** @var array<integer, array<string, string>> */
     protected array $routes;
 
     public function __construct()

--- a/packages/framework/src/helpers.php
+++ b/packages/framework/src/helpers.php
@@ -11,7 +11,7 @@ namespace {
          */
         function hyde(): HydeKernel
         {
-            return app(HydeKernel::class);
+            return HydeKernel::getInstance();
         }
     }
 
@@ -37,7 +37,6 @@ use function function_exists;
     use function str_replace;
     use function implode;
     use function trim;
-    use function app;
     use function md5;
 
     if (! function_exists('\Hyde\hyde')) {
@@ -46,7 +45,7 @@ use function function_exists;
          */
         function hyde(): HydeKernel
         {
-            return app(HydeKernel::class);
+            return HydeKernel::getInstance();
         }
     }
 


### PR DESCRIPTION
Increases type coverage from 98.25% to 99.25% by adding type annotations, generics, and type casts. This not only improves type coverage but also provides better IDE support and may eliminate type related bugs.

| Class          | Start   | End    |
|----------------|---------|--------|
| PostAuthor     | 90.48%  | 100%   |
| ConsoleKernel  | 92.31%  | 100%   |
| BuildWarnings  | 91.67%  | 95.74% |
| PageCollection | 93.10%  | 96.55% |
| RssFeedGenerator | 93.33% | 99.35% |
| LoadConfiguration | 93.62% | 95.74% |
| DocumentationSearchPage | 93.33%	| 100% |
| **Total**      | 98.25%  | 99.25% |

Note that more classes than this are improved, I just haven't noted them in the table.