### PR TITLE
Update test matrix to explicitly set the Zip extension for PHP setup

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -57,7 +57,7 @@ jobs:
       - uses: shivammathur/setup-php@d30ad8b1843ace22e6698ab99bbafaa747b6bd0d
         with:
           php-version: ${{ matrix.php }}
-          extensions: fileinfo
+          extensions: fileinfo, zip
       - uses: actions/checkout@v3
 
       - name: Install Composer Dependencies


### PR DESCRIPTION
Should stop this from randomly happening on Windows CI runs:

![image](https://user-images.githubusercontent.com/95144705/225410352-886e706e-d825-4ed1-8f06-5f9d24551355.png)
