### PR TITLE
Clean up page data factories

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -14,12 +14,13 @@ This serves two purposes:
 
 ### Changed
 - Updated discovery exception message to include the causing exception message in https://github.com/hydephp/develop/pull/1305
+- Cleaned up NavigationDataFactory internals for better type safety in https://github.com/hydephp/develop/pull/1312
 
 ### Deprecated
 - for soon-to-be removed features.
 
 ### Removed
-- for now removed features.
+- Class NavigationDataFactory no longer uses InteractsWithFrontMatter trait
 
 ### Fixed
 - Fixed https://github.com/hydephp/develop/issues/1301 in https://github.com/hydephp/develop/pull/1302

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -14,13 +14,13 @@ This serves two purposes:
 
 ### Changed
 - Updated discovery exception message to include the causing exception message in https://github.com/hydephp/develop/pull/1305
-- Cleaned up NavigationDataFactory internals for better type safety in https://github.com/hydephp/develop/pull/1312
+- Cleaned up PageDataFactory, and NavigationDataFactory internals for better type safety in https://github.com/hydephp/develop/pull/1312
 
 ### Deprecated
 - for soon-to-be removed features.
 
 ### Removed
-- Class NavigationDataFactory no longer uses InteractsWithFrontMatter trait
+- Classes PageDataFactory, and NavigationDataFactory no longer use the InteractsWithFrontMatter trait
 
 ### Fixed
 - Fixed https://github.com/hydephp/develop/issues/1301 in https://github.com/hydephp/develop/pull/1302

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -14,13 +14,13 @@ This serves two purposes:
 
 ### Changed
 - Updated discovery exception message to include the causing exception message in https://github.com/hydephp/develop/pull/1305
-- Cleaned up PageDataFactory, and NavigationDataFactory internals for better type safety in https://github.com/hydephp/develop/pull/1312
+- Cleaned up PageDataFactory, NavigationDataFactory, and BlogPostDataFactory internals for better type safety in https://github.com/hydephp/develop/pull/1312
 
 ### Deprecated
 - for soon-to-be removed features.
 
 ### Removed
-- Classes PageDataFactory, and NavigationDataFactory no longer use the InteractsWithFrontMatter trait
+- Classes PageDataFactory, NavigationDataFactory, and BlogPostDataFactory no longer use the InteractsWithFrontMatter trait
 
 ### Fixed
 - Fixed https://github.com/hydephp/develop/issues/1301 in https://github.com/hydephp/develop/pull/1302

--- a/packages/framework/src/Framework/Factories/BlogPostDataFactory.php
+++ b/packages/framework/src/Framework/Factories/BlogPostDataFactory.php
@@ -72,18 +72,18 @@ class BlogPostDataFactory extends Concerns\PageDataFactory implements BlogPostSc
 
     protected function makeDescription(): string
     {
-        return $this->matter('description') ?? $this->getTruncatedMarkdown($this->markdown->body());
+        return $this->getMatter('description') ?? $this->getTruncatedMarkdown($this->markdown->body());
     }
 
     protected function makeCategory(): ?string
     {
-        return $this->matter('category');
+        return $this->getMatter('category');
     }
 
     protected function makeDate(): ?DateString
     {
-        if ($this->matter('date')) {
-            return new DateString($this->matter('date'));
+        if ($this->getMatter('date')) {
+            return new DateString($this->getMatter('date'));
         }
 
         return null;
@@ -91,8 +91,8 @@ class BlogPostDataFactory extends Concerns\PageDataFactory implements BlogPostSc
 
     protected function makeAuthor(): ?PostAuthor
     {
-        if ($this->matter('author')) {
-            return PostAuthor::getOrCreate($this->matter('author'));
+        if ($this->getMatter('author')) {
+            return PostAuthor::getOrCreate($this->getMatter('author'));
         }
 
         return null;
@@ -100,7 +100,7 @@ class BlogPostDataFactory extends Concerns\PageDataFactory implements BlogPostSc
 
     protected function makeImage(): ?FeaturedImage
     {
-        if ($this->matter('image')) {
+        if ($this->getMatter('image')) {
             return FeaturedImageFactory::make($this->matter);
         }
 
@@ -114,5 +114,10 @@ class BlogPostDataFactory extends Concerns\PageDataFactory implements BlogPostSc
         }
 
         return $markdown;
+    }
+
+    protected function getMatter(string $key): string|null|array
+    {
+        return $this->matter->get($key);
     }
 }

--- a/packages/framework/src/Framework/Factories/BlogPostDataFactory.php
+++ b/packages/framework/src/Framework/Factories/BlogPostDataFactory.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Hyde\Framework\Factories;
 
-use Hyde\Framework\Concerns\InteractsWithFrontMatter;
 use Hyde\Framework\Factories\Concerns\CoreDataObject;
 use Hyde\Framework\Features\Blogging\Models\FeaturedImage;
 use Hyde\Framework\Features\Blogging\Models\PostAuthor;
@@ -26,8 +25,6 @@ use function substr;
  */
 class BlogPostDataFactory extends Concerns\PageDataFactory implements BlogPostSchema
 {
-    use InteractsWithFrontMatter;
-
     /**
      * The front matter properties supported by this factory.
      *

--- a/packages/framework/src/Framework/Factories/HydePageDataFactory.php
+++ b/packages/framework/src/Framework/Factories/HydePageDataFactory.php
@@ -8,7 +8,6 @@ use Hyde\Hyde;
 use Hyde\Markdown\Models\Markdown;
 use Hyde\Markdown\Models\FrontMatter;
 use Hyde\Markdown\Contracts\FrontMatter\PageSchema;
-use Hyde\Framework\Concerns\InteractsWithFrontMatter;
 use Hyde\Framework\Factories\Concerns\CoreDataObject;
 use Hyde\Framework\Features\Navigation\NavigationData;
 
@@ -22,8 +21,6 @@ use function trim;
 
 class HydePageDataFactory extends Concerns\PageDataFactory implements PageSchema
 {
-    use InteractsWithFrontMatter;
-
     /**
      * The front matter properties supported by this factory.
      */

--- a/packages/framework/src/Framework/Factories/HydePageDataFactory.php
+++ b/packages/framework/src/Framework/Factories/HydePageDataFactory.php
@@ -74,7 +74,7 @@ class HydePageDataFactory extends Concerns\PageDataFactory implements PageSchema
 
     private function findTitleForPage(): string
     {
-        return $this->matter('title')
+        return $this->getMatter('title')
             ?? $this->findTitleFromMarkdownHeadings()
             ?? $this->findTitleFromParentIdentifier()
             ?? Hyde::makeTitle(basename($this->identifier));
@@ -100,5 +100,10 @@ class HydePageDataFactory extends Concerns\PageDataFactory implements PageSchema
         }
 
         return null;
+    }
+
+    protected function getMatter(string $key): string|null
+    {
+        return $this->matter->get($key);
     }
 }

--- a/packages/framework/src/Framework/Factories/NavigationDataFactory.php
+++ b/packages/framework/src/Framework/Factories/NavigationDataFactory.php
@@ -76,7 +76,7 @@ class NavigationDataFactory extends Concerns\PageDataFactory implements Navigati
     {
         return $this->searchForLabelInFrontMatter()
             ?? $this->searchForLabelInConfig()
-            ?? $this->matter('title')
+            ?? $this->getMatter('title')
             ?? $this->title;
     }
 
@@ -106,26 +106,26 @@ class NavigationDataFactory extends Concerns\PageDataFactory implements Navigati
 
     private function searchForLabelInFrontMatter(): ?string
     {
-        return $this->matter('navigation.label')
-            ?? $this->matter('navigation.title');
+        return $this->getMatter('navigation.label')
+            ?? $this->getMatter('navigation.title');
     }
 
     private function searchForGroupInFrontMatter(): ?string
     {
-        return $this->matter('navigation.group')
-            ?? $this->matter('navigation.category');
+        return $this->getMatter('navigation.group')
+            ?? $this->getMatter('navigation.category');
     }
 
     private function searchForHiddenInFrontMatter(): ?bool
     {
-        return $this->matter('navigation.hidden')
-            ?? $this->invert($this->matter('navigation.visible'));
+        return $this->getMatter('navigation.hidden')
+            ?? $this->invert($this->getMatter('navigation.visible'));
     }
 
     private function searchForPriorityInFrontMatter(): ?int
     {
-        return $this->matter('navigation.priority')
-            ?? $this->matter('navigation.order');
+        return $this->getMatter('navigation.priority')
+            ?? $this->getMatter('navigation.order');
     }
 
     private function searchForLabelInConfig(): ?string
@@ -205,5 +205,10 @@ class NavigationDataFactory extends Concerns\PageDataFactory implements Navigati
     protected function offset(?int $value, int $offset): ?int
     {
         return $value === null ? null : $value + $offset;
+    }
+
+    protected function getMatter(string $key): string|null|int|bool
+    {
+        return $this->matter->get($key);
     }
 }

--- a/packages/framework/src/Framework/Factories/NavigationDataFactory.php
+++ b/packages/framework/src/Framework/Factories/NavigationDataFactory.php
@@ -10,7 +10,6 @@ use Illuminate\Support\Str;
 use Hyde\Pages\MarkdownPost;
 use Hyde\Pages\DocumentationPage;
 use Hyde\Markdown\Models\FrontMatter;
-use Hyde\Framework\Concerns\InteractsWithFrontMatter;
 use Hyde\Framework\Factories\Concerns\CoreDataObject;
 use Hyde\Markdown\Contracts\FrontMatter\SubSchemas\NavigationSchema;
 
@@ -23,8 +22,6 @@ use function is_a;
  */
 class NavigationDataFactory extends Concerns\PageDataFactory implements NavigationSchema
 {
-    use InteractsWithFrontMatter;
-
     /**
      * The front matter properties supported by this factory.
      *


### PR DESCRIPTION
- **Changed:** Cleaned up PageDataFactory, NavigationDataFactory, and BlogPostDataFactory internals for better type safety
- **Removed:** Classes PageDataFactory, NavigationDataFactory, and BlogPostDataFactory no longer use the InteractsWithFrontMatter trait