### PR TITLE
Update article excerpt component to use route helper method instead of legacy link formatter

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -21,6 +21,7 @@ This release is the first since the official release of HydePHP 1.0.0. It contai
 ### Fixed
 - Fixed https://github.com/hydephp/develop/issues/1301 in https://github.com/hydephp/develop/pull/1302
 - Fixed https://github.com/hydephp/develop/issues/1313 in https://github.com/hydephp/develop/commit/134776a1e4af395dab5c15d611fc64c9ebce8596
+- Fixed https://github.com/hydephp/develop/issues/1316 in https://github.com/hydephp/develop/pull/1317
 - Added missing function imports in https://github.com/hydephp/develop/pull/1309
 
 ### Security

--- a/packages/framework/resources/views/components/article-excerpt.blade.php
+++ b/packages/framework/resources/views/components/article-excerpt.blade.php
@@ -6,7 +6,7 @@
     @endif
 
     <header>
-        <a href="posts/{{ Hyde::formatLink($post->identifier . '.html') }}" class="block w-fit">
+        <a href="{{ $post->getRoute() }}" class="block w-fit">
             <h2 class="text-2xl font-bold text-gray-700 hover:text-gray-900 dark:text-gray-200 dark:hover:text-white transition-colors duration-75">
                 {{ $post->data('title') ?? $post->title }}
             </h2>
@@ -39,7 +39,7 @@
     @endisset
 
     <footer>
-        <a href="posts/{{ Hyde::formatLink($post->identifier . '.html') }}"
+        <a href="{{ $post->getRoute() }}"
            class="text-indigo-500 hover:underline font-medium">
             Read post</a>
     </footer>


### PR DESCRIPTION
Description
-----------

This PR fixes the issue where the blog post feed component was not working on nested pages due to incorrect link formatting. The issue was caused by the use of the legacy style of links in `article-excerpt.blade.php`. The fix changes the link format to use `$post->getRoute`, which dynamically resolves relative paths.

The change was made by replacing the following code:

```blade
- <a href="posts/{{ Hyde::formatLink($post->identifier . '.html') }}"> Read post</a>
+ <a href="{{ $post->getRoute() }}" > Read post</a>
```


This PR has been tested and verified to resolve the issue. This fixes https://github.com/hydephp/develop/issues/1316