### PR TITLE
Fix nested index pages not showing in navigation 

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -22,6 +22,7 @@ This release is the first since the official release of HydePHP 1.0.0. It contai
 - Fixed https://github.com/hydephp/develop/issues/1301 in https://github.com/hydephp/develop/pull/1302
 - Fixed https://github.com/hydephp/develop/issues/1313 in https://github.com/hydephp/develop/commit/134776a1e4af395dab5c15d611fc64c9ebce8596
 - Fixed https://github.com/hydephp/develop/issues/1316 in https://github.com/hydephp/develop/pull/1317
+- Fixed https://github.com/hydephp/develop/issues/1318 in https://github.com/hydephp/develop/pull/1319
 - Added missing function imports in https://github.com/hydephp/develop/pull/1309
 
 ### Security

--- a/packages/framework/src/Framework/Factories/NavigationDataFactory.php
+++ b/packages/framework/src/Framework/Factories/NavigationDataFactory.php
@@ -90,7 +90,7 @@ class NavigationDataFactory extends Concerns\PageDataFactory implements Navigati
         return $this->isInstanceOf(MarkdownPost::class)
             || $this->searchForHiddenInFrontMatter()
             || in_array($this->routeKey, Config::getArray('hyde.navigation.exclude', ['404']))
-            || ! $this->isInstanceOf(DocumentationPage::class) && $this->pageIsInSubdirectory() && ($this->getSubdirectoryConfiguration() === 'hidden');
+            || (!$this->isInstanceOf(DocumentationPage::class) && $this->pageIsInSubdirectory() && ($this->getSubdirectoryConfiguration() === 'hidden'));
     }
 
     protected function makePriority(): int

--- a/packages/framework/src/Framework/Factories/NavigationDataFactory.php
+++ b/packages/framework/src/Framework/Factories/NavigationDataFactory.php
@@ -90,7 +90,7 @@ class NavigationDataFactory extends Concerns\PageDataFactory implements Navigati
         return $this->isInstanceOf(MarkdownPost::class)
             || $this->searchForHiddenInFrontMatter()
             || in_array($this->routeKey, Config::getArray('hyde.navigation.exclude', ['404']))
-            || (!$this->isInstanceOf(DocumentationPage::class) && $this->pageIsInSubdirectory() && ($this->getSubdirectoryConfiguration() === 'hidden'))
+            || (! $this->isInstanceOf(DocumentationPage::class) && $this->pageIsInSubdirectory() && ($this->getSubdirectoryConfiguration() === 'hidden'))
             && (basename($this->identifier) !== 'index');
     }
 

--- a/packages/framework/src/Framework/Factories/NavigationDataFactory.php
+++ b/packages/framework/src/Framework/Factories/NavigationDataFactory.php
@@ -90,7 +90,8 @@ class NavigationDataFactory extends Concerns\PageDataFactory implements Navigati
         return $this->isInstanceOf(MarkdownPost::class)
             || $this->searchForHiddenInFrontMatter()
             || in_array($this->routeKey, Config::getArray('hyde.navigation.exclude', ['404']))
-            || (!$this->isInstanceOf(DocumentationPage::class) && $this->pageIsInSubdirectory() && ($this->getSubdirectoryConfiguration() === 'hidden'));
+            || (!$this->isInstanceOf(DocumentationPage::class) && $this->pageIsInSubdirectory() && ($this->getSubdirectoryConfiguration() === 'hidden'))
+            && (basename($this->identifier) !== 'index');
     }
 
     protected function makePriority(): int

--- a/packages/framework/tests/Feature/HydePageTest.php
+++ b/packages/framework/tests/Feature/HydePageTest.php
@@ -1224,6 +1224,13 @@ class HydePageTest extends TestCase
         }
     }
 
+    public function test_nested_index_pages_show_up_in_navigation()
+    {
+        $page = MarkdownPage::make('foo/index');
+        $this->assertTrue($page->showInNavigation());
+        $this->assertSame('Foo', $page->navigationMenuLabel());
+    }
+
     protected function assertSameIgnoringDirSeparatorType(string $expected, string $actual): void
     {
         $this->assertSame(


### PR DESCRIPTION
Adds a check in the navigation data factory so that a page like `_pages/posts/index.md` is considered internally as `_pages/posts.md`, as I think that closest matches the served site. This means this case is excluded from the default "hidden" setting for nested pages, but I think this better follows the principle of least astonishment since the page does not appear to be nested the same way, from a user's perspective. Fixes https://github.com/hydephp/develop/issues/1318