### PR TITLE
Add "whitespace-nowrap" class to dropdown list item and align it right

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -25,6 +25,7 @@ This release is the first since the official release of HydePHP 1.0.0. It contai
 - Fixed https://github.com/hydephp/develop/issues/1318 in https://github.com/hydephp/develop/pull/1319
 - Fixed https://github.com/hydephp/develop/issues/1320 in https://github.com/hydephp/develop/pull/1321
 - Fixed https://github.com/hydephp/develop/issues/1322 in https://github.com/hydephp/develop/issues/1323
+- Fixed https://github.com/hydephp/develop/issues/1324 in https://github.com/hydephp/develop/pull/1325
 - Added missing function imports in https://github.com/hydephp/develop/pull/1309
 
 ### Security

--- a/packages/framework/resources/views/components/navigation/dropdown.blade.php
+++ b/packages/framework/resources/views/components/navigation/dropdown.blade.php
@@ -4,7 +4,7 @@
         {{ $label }}
         <svg class="inline transition-all dark:fill-white" x-bind:style="open ? { transform: 'rotate(180deg)' } : ''" xmlns="http://www.w3.org/2000/svg" height="24px" viewBox="0 0 24 24" width="24px" fill="#000000"><path d="M0 0h24v24H0z" fill="none"/><path d="M7 10l5 5 5-5z"/></svg>
     </button>
-    <div class="dropdown absolute shadow-lg bg-white dark:bg-gray-700 z-50" :class="open ? '' : 'hidden'">
+    <div class="dropdown absolute shadow-lg bg-white dark:bg-gray-700 z-50 right-0" :class="open ? '' : 'hidden'">
         <ul class="dropdown-items px-3 py-2">
             @isset($items)
                 @foreach ($items as $item)

--- a/packages/framework/resources/views/components/navigation/dropdown.blade.php
+++ b/packages/framework/resources/views/components/navigation/dropdown.blade.php
@@ -8,7 +8,7 @@
         <ul class="dropdown-items px-3 py-2">
             @isset($items)
                 @foreach ($items as $item)
-                    <li>
+                    <li class="whitespace-nowrap">
                         @include('hyde::components.navigation.navigation-link')
                     </li>
                 @endforeach


### PR DESCRIPTION
Fixes https://github.com/hydephp/develop/issues/1324, but requires a minor HydeFront bump.

Now looks like this:
![image](https://user-images.githubusercontent.com/95144705/226100509-599587b3-9a4d-469a-ab5f-f8bfcbc4dfaa.png)

But we probably need to offset it left: Edit: done,
![image](https://user-images.githubusercontent.com/95144705/226100919-e338d117-7afd-4858-9df2-51851ca3c05f.png)
