### PR TITLE
Update AssetService::injectTailwindConfig method to handle missing config file gracefully

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -26,6 +26,7 @@ This release is the first since the official release of HydePHP 1.0.0. It contai
 - Fixed https://github.com/hydephp/develop/issues/1320 in https://github.com/hydephp/develop/pull/1321
 - Fixed https://github.com/hydephp/develop/issues/1322 in https://github.com/hydephp/develop/issues/1323
 - Fixed https://github.com/hydephp/develop/issues/1324 in https://github.com/hydephp/develop/pull/1325
+- Fixed https://github.com/hydephp/develop/issues/1326 in https://github.com/hydephp/develop/pull/1327
 - Added missing function imports in https://github.com/hydephp/develop/pull/1309
 
 ### Security

--- a/packages/framework/src/Framework/Services/AssetService.php
+++ b/packages/framework/src/Framework/Services/AssetService.php
@@ -67,6 +67,10 @@ class AssetService
 
     public function injectTailwindConfig(): string
     {
+        if (! file_exists(Hyde::path('tailwind.config.js'))) {
+            return '';
+        }
+
         $config = Str::between(file_get_contents(Hyde::path('tailwind.config.js')), '{', '}');
 
         // Remove the plugins array, as it is not used in the frontend.

--- a/packages/framework/tests/Unit/AssetServiceUnitTest.php
+++ b/packages/framework/tests/Unit/AssetServiceUnitTest.php
@@ -6,6 +6,7 @@ namespace Hyde\Framework\Testing\Unit;
 
 use Hyde\Framework\Services\AssetService;
 use Hyde\Testing\UnitTestCase;
+use Hyde\Hyde;
 
 /**
  * @covers \Hyde\Framework\Services\AssetService
@@ -106,5 +107,13 @@ class AssetServiceUnitTest extends UnitTestCase
         $this->assertStringContainsString('extend: {', $config);
         $this->assertStringContainsString('typography: {', $config);
         $this->assertStringNotContainsString('plugins', $config);
+    }
+
+    public function testInjectTailwindConfigHandlesMissingConfigFileGracefully()
+    {
+        rename(Hyde::path('tailwind.config.js'), Hyde::path('tailwind.config.js.bak'));
+        $this->assertIsString((new AssetService())->injectTailwindConfig());
+        $this->assertSame('', (new AssetService())->injectTailwindConfig());
+        rename(Hyde::path('tailwind.config.js.bak'), Hyde::path('tailwind.config.js'));
     }
 }


### PR DESCRIPTION
Fixes https://github.com/hydephp/develop/issues/1326