### PR TITLE
Make the MetadataBag serializable

### DIFF
--- a/packages/framework/src/Framework/Features/Metadata/MetadataBag.php
+++ b/packages/framework/src/Framework/Features/Metadata/MetadataBag.php
@@ -19,7 +19,7 @@ use function implode;
  * @see \Hyde\Framework\Features\Metadata\PageMetadataBag
  * @see \Hyde\Framework\Features\Metadata\GlobalMetadataBag
  */
-class MetadataBag implements Htmlable, SerializableContract
+class MetadataBag implements SerializableContract, Htmlable
 {
     protected array $links = [];
     protected array $metadata = [];

--- a/packages/framework/src/Framework/Features/Metadata/MetadataBag.php
+++ b/packages/framework/src/Framework/Features/Metadata/MetadataBag.php
@@ -7,6 +7,7 @@ namespace Hyde\Framework\Features\Metadata;
 use Hyde\Framework\Features\Metadata\Elements\LinkElement;
 use Hyde\Framework\Features\Metadata\Elements\MetadataElement;
 use Hyde\Framework\Features\Metadata\Elements\OpenGraphElement;
+use Hyde\Support\Concerns\Serializable;
 use Hyde\Support\Contracts\SerializableContract;
 use Illuminate\Contracts\Support\Htmlable;
 
@@ -21,6 +22,8 @@ use function implode;
  */
 class MetadataBag implements SerializableContract, Htmlable
 {
+    use Serializable;
+
     protected array $links = [];
     protected array $metadata = [];
     protected array $properties = [];

--- a/packages/framework/src/Framework/Features/Metadata/MetadataBag.php
+++ b/packages/framework/src/Framework/Features/Metadata/MetadataBag.php
@@ -46,6 +46,11 @@ class MetadataBag implements SerializableContract, Htmlable
         );
     }
 
+    public function toArray(): array
+    {
+        return $this->get();
+    }
+
     public function add(MetadataElementContract|string $element): static
     {
         if ($element instanceof LinkElement) {

--- a/packages/framework/src/Framework/Features/Metadata/MetadataBag.php
+++ b/packages/framework/src/Framework/Features/Metadata/MetadataBag.php
@@ -7,6 +7,7 @@ namespace Hyde\Framework\Features\Metadata;
 use Hyde\Framework\Features\Metadata\Elements\LinkElement;
 use Hyde\Framework\Features\Metadata\Elements\MetadataElement;
 use Hyde\Framework\Features\Metadata\Elements\OpenGraphElement;
+use Hyde\Support\Contracts\SerializableContract;
 use Illuminate\Contracts\Support\Htmlable;
 
 use function array_merge;
@@ -18,7 +19,7 @@ use function implode;
  * @see \Hyde\Framework\Features\Metadata\PageMetadataBag
  * @see \Hyde\Framework\Features\Metadata\GlobalMetadataBag
  */
-class MetadataBag implements Htmlable
+class MetadataBag implements Htmlable, SerializableContract
 {
     protected array $links = [];
     protected array $metadata = [];

--- a/packages/framework/tests/Feature/MetadataTest.php
+++ b/packages/framework/tests/Feature/MetadataTest.php
@@ -468,4 +468,15 @@ class MetadataTest extends TestCase
 
         $this->assertPageDoesNotHaveMetadata($page, '<meta name="author"');
     }
+
+    public function test_to_array_method_returns_same_result_as_get_method()
+    {
+        $page = MarkdownPost::make(matter: [
+            'author' => [
+                'name' => 'Name',
+            ],
+        ]);
+
+        $this->assertSame($page->metadata->toArray(), $page->metadata->get());
+    }
 }

--- a/packages/framework/tests/Feature/MetadataTest.php
+++ b/packages/framework/tests/Feature/MetadataTest.php
@@ -469,6 +469,20 @@ class MetadataTest extends TestCase
         $this->assertPageDoesNotHaveMetadata($page, '<meta name="author"');
     }
 
+    public function test_metadata_bag_is_arrayable()
+    {
+        $page = MarkdownPost::make(matter: [
+            'author' => [
+                'name' => 'Name',
+            ],
+        ]);
+
+        $this->assertEquals([
+            'metadata:author' => Meta::name('author', 'Name'),
+            'properties:type' => Meta::property('og:type', 'article'),
+        ], $page->metadata->toArray());
+    }
+
     public function test_to_array_method_returns_same_result_as_get_method()
     {
         $page = MarkdownPost::make(matter: [
@@ -478,5 +492,16 @@ class MetadataTest extends TestCase
         ]);
 
         $this->assertSame($page->metadata->toArray(), $page->metadata->get());
+    }
+
+    public function test_metadata_bag_is_jsonable()
+    {
+        $page = MarkdownPost::make(matter: [
+            'author' => [
+                'name' => 'Name',
+            ],
+        ]);
+
+        $this->assertSame('{"metadata:author":{},"properties:type":{}}', $page->metadata->toJson());
     }
 }

--- a/packages/framework/tests/Unit/HydePageSerializableUnitTest.php
+++ b/packages/framework/tests/Unit/HydePageSerializableUnitTest.php
@@ -315,7 +315,9 @@ class HydePageSerializableUnitTest extends UnitTestCase
                 "identifier": "",
                 "routeKey": "posts",
                 "matter": [],
-                "metadata": [],
+                "metadata": {
+                    "properties:type": {}
+                },
                 "navigation": {
                     "label": "",
                     "priority": 10,
@@ -389,7 +391,10 @@ class HydePageSerializableUnitTest extends UnitTestCase
                         "group": "test"
                     }
                 },
-                "metadata": [],
+                "metadata": {
+                    "metadata:twitter:title": {},
+                    "properties:title": {}
+                },
                 "navigation": {
                     "label": "Test Label",
                     "priority": 20,

--- a/packages/framework/tests/Unit/HydePageSerializableUnitTest.php
+++ b/packages/framework/tests/Unit/HydePageSerializableUnitTest.php
@@ -227,7 +227,7 @@ class HydePageSerializableUnitTest extends UnitTestCase
                 "identifier": "",
                 "routeKey": "",
                 "matter": [],
-                "metadata": {},
+                "metadata": [],
                 "navigation": {
                     "label": "",
                     "priority": 999,
@@ -249,7 +249,7 @@ class HydePageSerializableUnitTest extends UnitTestCase
                 "identifier": "",
                 "routeKey": "",
                 "matter": [],
-                "metadata": {},
+                "metadata": [],
                 "navigation": {
                     "label": "",
                     "priority": 999,
@@ -271,7 +271,7 @@ class HydePageSerializableUnitTest extends UnitTestCase
                 "identifier": "",
                 "routeKey": "",
                 "matter": [],
-                "metadata": {},
+                "metadata": [],
                 "navigation": {
                     "label": "",
                     "priority": 999,
@@ -293,7 +293,7 @@ class HydePageSerializableUnitTest extends UnitTestCase
                 "identifier": "",
                 "routeKey": "",
                 "matter": [],
-                "metadata": {},
+                "metadata": [],
                 "navigation": {
                     "label": "",
                     "priority": 999,
@@ -315,7 +315,7 @@ class HydePageSerializableUnitTest extends UnitTestCase
                 "identifier": "",
                 "routeKey": "posts",
                 "matter": [],
-                "metadata": {},
+                "metadata": [],
                 "navigation": {
                     "label": "",
                     "priority": 10,
@@ -342,7 +342,7 @@ class HydePageSerializableUnitTest extends UnitTestCase
                 "identifier": "",
                 "routeKey": "docs",
                 "matter": [],
-                "metadata": {},
+                "metadata": [],
                 "navigation": {
                     "label": "",
                     "priority": 999,
@@ -389,7 +389,7 @@ class HydePageSerializableUnitTest extends UnitTestCase
                         "group": "test"
                     }
                 },
-                "metadata": {},
+                "metadata": [],
                 "navigation": {
                     "label": "Test Label",
                     "priority": 20,

--- a/packages/framework/tests/Unit/HydePageSerializableUnitTest.php
+++ b/packages/framework/tests/Unit/HydePageSerializableUnitTest.php
@@ -205,7 +205,7 @@ class HydePageSerializableUnitTest extends UnitTestCase
                 "identifier": "",
                 "routeKey": "",
                 "matter": [],
-                "metadata": {},
+                "metadata": [],
                 "navigation": {
                     "label": "",
                     "priority": 999,


### PR DESCRIPTION
Experimental for now, as I need to figure out how to serialize the metadata items without it being breaking.

While the base MetadataBag class now implements a new interface, it also adds all the needed methods, so I don't consider that change to be breaking. However since the elements are not extending a base class but instead depend on an interface I can't change that without breaking SemVer even though the impact would be minimal as the feature is undocumented and I can't imagine anyone having created custom element implementations, I am committed to not having any breaking changed between major releases.

Side effects:
- Since the class is now Jsonable, any Json representations of the kernel, it's page collection, or any individual pages, will of course include the new Json output.
- It also means that page Json uses `"metadata": []` instead of `"metadata": {}`.