### PR TITLE
Skip unit test when not running in the monorepo

### DIFF
--- a/packages/framework/tests/Unit/HydeConfigFilesAreMatchingTest.php
+++ b/packages/framework/tests/Unit/HydeConfigFilesAreMatchingTest.php
@@ -14,6 +14,15 @@ use Hyde\Testing\TestCase;
  */
 class HydeConfigFilesAreMatchingTest extends TestCase
 {
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        if (file_exists(Hyde::path('README.md')) && ! str_contains(file_get_contents(Hyde::path('README.md')), 'HydePHP - Source Monorepo')) {
+            $this->markTestSkipped('Test skipped when not running in the monorepo.');
+        }
+    }
+
     public function test_hyde_config_files_are_matching()
     {
         $this->assertFileEqualsIgnoringNewlineType(


### PR DESCRIPTION
Fixes unrelated test failures in https://github.com/hydephp/framework/pull/572. We mostly have this check to catch any mistakes before merging config changes when developing in the monorepo.