### PR TITLE
Trim leading slashes from the documentation search index location string

### DIFF
--- a/packages/framework/resources/views/components/docs/search-scripts.blade.php
+++ b/packages/framework/resources/views/components/docs/search-scripts.blade.php
@@ -1,7 +1,7 @@
 <script src="https://cdn.jsdelivr.net/npm/hydesearch@0.2.1/dist/HydeSearch.min.js" defer></script>
 <script>
     window.addEventListener('load', function () {
-        const searchIndexLocation = '{{ Hyde::relativeLink(DocumentationPage::outputDirectory().'/search.json') }}';
+        const searchIndexLocation = '{{ Hyde::relativeLink(ltrim(DocumentationPage::outputDirectory().'/search.json', '/')) }}';
         const Search = new HydeSearch(searchIndexLocation);
 
         Search.init();


### PR DESCRIPTION
This change makes so that the search index supports sites where documentation is output to the root output directory, and fixes https://github.com/hydephp/develop/issues/1340