### PR TITLE
Clean up and refactor the internal LoadYamlConfiguration test

### DIFF
--- a/packages/framework/src/Foundation/Internal/LoadYamlConfiguration.php
+++ b/packages/framework/src/Foundation/Internal/LoadYamlConfiguration.php
@@ -14,6 +14,7 @@ use function file_exists;
 
 /**
  * @internal Bootstrap service that loads the YAML configuration file.
+ * @see docs/digging-deeper/customization.md#yaml-configuration
  */
 class LoadYamlConfiguration
 {

--- a/packages/framework/src/Foundation/Internal/LoadYamlConfiguration.php
+++ b/packages/framework/src/Foundation/Internal/LoadYamlConfiguration.php
@@ -13,7 +13,7 @@ use function array_merge;
 use function file_exists;
 
 /**
- * @internal
+ * @internal Bootstrap service that loads the YAML configuration file.
  */
 class LoadYamlConfiguration
 {

--- a/packages/framework/src/Foundation/Internal/LoadYamlConfiguration.php
+++ b/packages/framework/src/Foundation/Internal/LoadYamlConfiguration.php
@@ -14,6 +14,7 @@ use function file_exists;
 
 /**
  * @internal Bootstrap service that loads the YAML configuration file.
+ *
  * @see docs/digging-deeper/customization.md#yaml-configuration
  */
 class LoadYamlConfiguration

--- a/packages/framework/tests/Feature/LoadYamlConfigurationTest.php
+++ b/packages/framework/tests/Feature/LoadYamlConfigurationTest.php
@@ -17,8 +17,6 @@ class LoadYamlConfigurationTest extends TestCase
 {
     public function test_bootstrapper_applies_yaml_configuration_when_present()
     {
-        $this->assertSame('HydePHP', config('hyde.name'));
-
         $this->file('hyde.yml', 'name: Foo');
         $this->app->bootstrapWith([LoadYamlConfiguration::class]);
         $this->assertSame('Foo', config('hyde.name'));
@@ -26,8 +24,6 @@ class LoadYamlConfigurationTest extends TestCase
 
     public function test_changes_in_yaml_file_override_changes_in_site_config()
     {
-        $this->assertSame('HydePHP', Config::get('hyde.name'));
-
         $this->file('hyde.yml', 'name: Foo');
         $this->app->bootstrapWith([LoadYamlConfiguration::class]);
         $this->assertSame('Foo', Config::get('hyde.name'));
@@ -35,8 +31,6 @@ class LoadYamlConfigurationTest extends TestCase
 
     public function test_changes_in_yaml_file_override_changes_in_site_config_when_using_yaml_extension()
     {
-        $this->assertSame('HydePHP', Config::get('hyde.name'));
-
         $this->file('hyde.yaml', 'name: Foo');
         $this->app->bootstrapWith([LoadYamlConfiguration::class]);
         $this->assertSame('Foo', Config::get('hyde.name'));

--- a/packages/framework/tests/Feature/LoadYamlConfigurationTest.php
+++ b/packages/framework/tests/Feature/LoadYamlConfigurationTest.php
@@ -19,6 +19,7 @@ class LoadYamlConfigurationTest extends TestCase
     {
         $this->file('hyde.yml', 'name: Foo');
         $this->app->bootstrapWith([LoadYamlConfiguration::class]);
+
         $this->assertSame('Foo', config('hyde.name'));
     }
 
@@ -26,6 +27,7 @@ class LoadYamlConfigurationTest extends TestCase
     {
         $this->file('hyde.yml', 'name: Foo');
         $this->app->bootstrapWith([LoadYamlConfiguration::class]);
+
         $this->assertSame('Foo', Config::get('hyde.name'));
     }
 
@@ -33,12 +35,14 @@ class LoadYamlConfigurationTest extends TestCase
     {
         $this->file('hyde.yaml', 'name: Foo');
         $this->app->bootstrapWith([LoadYamlConfiguration::class]);
+
         $this->assertSame('Foo', Config::get('hyde.name'));
     }
 
     public function test_service_gracefully_handles_missing_file()
     {
         $this->app->bootstrapWith([LoadYamlConfiguration::class]);
+
         $this->assertSame('HydePHP', Config::get('hyde.name'));
     }
 
@@ -47,6 +51,7 @@ class LoadYamlConfigurationTest extends TestCase
         $this->file('hyde.yml', '');
 
         $this->app->bootstrapWith([LoadYamlConfiguration::class]);
+
         $this->assertSame('HydePHP', Config::get('hyde.name'));
     }
 }

--- a/packages/framework/tests/Feature/LoadYamlConfigurationTest.php
+++ b/packages/framework/tests/Feature/LoadYamlConfigurationTest.php
@@ -49,7 +49,6 @@ class LoadYamlConfigurationTest extends TestCase
     public function test_service_gracefully_handles_empty_file()
     {
         $this->file('hyde.yml', '');
-
         $this->app->bootstrapWith([LoadYamlConfiguration::class]);
 
         $this->assertSame('HydePHP', Config::get('hyde.name'));

--- a/packages/framework/tests/Feature/LoadYamlConfigurationTest.php
+++ b/packages/framework/tests/Feature/LoadYamlConfigurationTest.php
@@ -91,6 +91,19 @@ class LoadYamlConfigurationTest extends TestCase
         $this->assertSame('bar', Config::get('hyde.foo'));
     }
 
+    public function testConfigurationOptionsAreMerged()
+    {
+        config(['hyde' => [
+            'foo' => 'bar',
+            'baz' => 'qux',
+        ]]);
+
+        $this->file('hyde.yml', 'baz: hat');
+        $this->runBootstrapper();
+
+        $this->assertSame('bar', Config::get('hyde.foo'));
+    }
+
     protected function runBootstrapper(): void
     {
         $this->app->bootstrapWith([LoadYamlConfiguration::class]);

--- a/packages/framework/tests/Feature/LoadYamlConfigurationTest.php
+++ b/packages/framework/tests/Feature/LoadYamlConfigurationTest.php
@@ -15,6 +15,35 @@ use function config;
  */
 class LoadYamlConfigurationTest extends TestCase
 {
+    public function testCanDefineHydeConfigSettingsInHydeYmlFile()
+    {
+        config(['hyde' => []]);
+
+        $this->file('hyde.yml', <<<'YAML'
+        name: HydePHP
+        url: "http://localhost"
+        pretty_urls: false
+        generate_sitemap: true
+        rss:
+          enabled: true
+          filename: feed.xml
+          description: HydePHP RSS Feed
+        language: en
+        output_directory: _site
+        YAML);
+        $this->runBootstrapper();
+
+        $this->assertSame('HydePHP', Config::get('hyde.name'));
+        $this->assertSame('http://localhost', Config::get('hyde.url'));
+        $this->assertSame(false, Config::get('hyde.pretty_urls'));
+        $this->assertSame(true, Config::get('hyde.generate_sitemap'));
+        $this->assertSame(true, Config::get('hyde.rss.enabled'));
+        $this->assertSame('feed.xml', Config::get('hyde.rss.filename'));
+        $this->assertSame('HydePHP RSS Feed', Config::get('hyde.rss.description'));
+        $this->assertSame('en', Config::get('hyde.language'));
+        $this->assertSame('_site', Config::get('hyde.output_directory'));
+    }
+
     public function testBootstrapperAppliesYamlConfigurationWhenPresent()
     {
         $this->file('hyde.yml', 'name: Foo');

--- a/packages/framework/tests/Feature/LoadYamlConfigurationTest.php
+++ b/packages/framework/tests/Feature/LoadYamlConfigurationTest.php
@@ -22,14 +22,14 @@ class LoadYamlConfigurationTest extends TestCase
         $this->assertSame('Foo', config('hyde.name'));
     }
 
-    public function test_changes_in_yaml_file_override_changes_in_site_config()
+    public function test_changes_in_yaml_file_override_changes_in_hyde_config()
     {
         $this->file('hyde.yml', 'name: Foo');
         $this->app->bootstrapWith([LoadYamlConfiguration::class]);
         $this->assertSame('Foo', Config::get('hyde.name'));
     }
 
-    public function test_changes_in_yaml_file_override_changes_in_site_config_when_using_yaml_extension()
+    public function test_changes_in_yaml_file_override_changes_in_hyde_config_when_using_yaml_extension()
     {
         $this->file('hyde.yaml', 'name: Foo');
         $this->app->bootstrapWith([LoadYamlConfiguration::class]);

--- a/packages/framework/tests/Feature/LoadYamlConfigurationTest.php
+++ b/packages/framework/tests/Feature/LoadYamlConfigurationTest.php
@@ -18,6 +18,7 @@ class LoadYamlConfigurationTest extends TestCase
     public function test_bootstrapper_applies_yaml_configuration_when_present()
     {
         $this->assertSame('HydePHP', config('hyde.name'));
+
         $this->file('hyde.yml', 'name: Foo');
         $this->app->bootstrapWith([LoadYamlConfiguration::class]);
         $this->assertSame('Foo', config('hyde.name'));
@@ -26,6 +27,7 @@ class LoadYamlConfigurationTest extends TestCase
     public function test_changes_in_yaml_file_override_changes_in_site_config()
     {
         $this->assertSame('HydePHP', Config::get('hyde.name'));
+
         $this->file('hyde.yml', 'name: Foo');
         $this->app->bootstrapWith([LoadYamlConfiguration::class]);
         $this->assertSame('Foo', Config::get('hyde.name'));
@@ -34,6 +36,7 @@ class LoadYamlConfigurationTest extends TestCase
     public function test_changes_in_yaml_file_override_changes_in_site_config_when_using_yaml_extension()
     {
         $this->assertSame('HydePHP', Config::get('hyde.name'));
+
         $this->file('hyde.yaml', 'name: Foo');
         $this->app->bootstrapWith([LoadYamlConfiguration::class]);
         $this->assertSame('Foo', Config::get('hyde.name'));
@@ -48,6 +51,7 @@ class LoadYamlConfigurationTest extends TestCase
     public function test_service_gracefully_handles_empty_file()
     {
         $this->file('hyde.yml', '');
+
         $this->app->bootstrapWith([LoadYamlConfiguration::class]);
         $this->assertSame('HydePHP', Config::get('hyde.name'));
     }

--- a/packages/framework/tests/Feature/LoadYamlConfigurationTest.php
+++ b/packages/framework/tests/Feature/LoadYamlConfigurationTest.php
@@ -15,7 +15,7 @@ use function config;
  */
 class LoadYamlConfigurationTest extends TestCase
 {
-    public function test_bootstrapper_applies_yaml_configuration_when_present()
+    public function testBootstrapperAppliesYamlConfigurationWhenPresent()
     {
         $this->file('hyde.yml', 'name: Foo');
         $this->runBootstrapper();
@@ -23,7 +23,7 @@ class LoadYamlConfigurationTest extends TestCase
         $this->assertSame('Foo', config('hyde.name'));
     }
 
-    public function test_changes_in_yaml_file_override_changes_in_hyde_config()
+    public function testChangesInYamlFileOverrideChangesInHydeConfig()
     {
         $this->file('hyde.yml', 'name: Foo');
         $this->runBootstrapper();
@@ -31,7 +31,7 @@ class LoadYamlConfigurationTest extends TestCase
         $this->assertSame('Foo', Config::get('hyde.name'));
     }
 
-    public function test_changes_in_yaml_file_override_changes_in_hyde_config_when_using_yaml_extension()
+    public function testChangesInYamlFileOverrideChangesInHydeConfigWhenUsingYamlExtension()
     {
         $this->file('hyde.yaml', 'name: Foo');
         $this->runBootstrapper();
@@ -39,14 +39,14 @@ class LoadYamlConfigurationTest extends TestCase
         $this->assertSame('Foo', Config::get('hyde.name'));
     }
 
-    public function test_service_gracefully_handles_missing_file()
+    public function testServiceGracefullyHandlesMissingFile()
     {
         $this->runBootstrapper();
 
         $this->assertSame('HydePHP', Config::get('hyde.name'));
     }
 
-    public function test_service_gracefully_handles_empty_file()
+    public function testServiceGracefullyHandlesEmptyFile()
     {
         $this->file('hyde.yml', '');
         $this->runBootstrapper();

--- a/packages/framework/tests/Feature/LoadYamlConfigurationTest.php
+++ b/packages/framework/tests/Feature/LoadYamlConfigurationTest.php
@@ -18,7 +18,7 @@ class LoadYamlConfigurationTest extends TestCase
     public function test_bootstrapper_applies_yaml_configuration_when_present()
     {
         $this->file('hyde.yml', 'name: Foo');
-        $this->app->bootstrapWith([LoadYamlConfiguration::class]);
+        $this->runBootstrapper();
 
         $this->assertSame('Foo', config('hyde.name'));
     }
@@ -26,7 +26,7 @@ class LoadYamlConfigurationTest extends TestCase
     public function test_changes_in_yaml_file_override_changes_in_hyde_config()
     {
         $this->file('hyde.yml', 'name: Foo');
-        $this->app->bootstrapWith([LoadYamlConfiguration::class]);
+        $this->runBootstrapper();
 
         $this->assertSame('Foo', Config::get('hyde.name'));
     }
@@ -34,14 +34,14 @@ class LoadYamlConfigurationTest extends TestCase
     public function test_changes_in_yaml_file_override_changes_in_hyde_config_when_using_yaml_extension()
     {
         $this->file('hyde.yaml', 'name: Foo');
-        $this->app->bootstrapWith([LoadYamlConfiguration::class]);
+        $this->runBootstrapper();
 
         $this->assertSame('Foo', Config::get('hyde.name'));
     }
 
     public function test_service_gracefully_handles_missing_file()
     {
-        $this->app->bootstrapWith([LoadYamlConfiguration::class]);
+        $this->runBootstrapper();
 
         $this->assertSame('HydePHP', Config::get('hyde.name'));
     }
@@ -49,8 +49,13 @@ class LoadYamlConfigurationTest extends TestCase
     public function test_service_gracefully_handles_empty_file()
     {
         $this->file('hyde.yml', '');
-        $this->app->bootstrapWith([LoadYamlConfiguration::class]);
+        $this->runBootstrapper();
 
         $this->assertSame('HydePHP', Config::get('hyde.name'));
+    }
+
+    protected function runBootstrapper(): void
+    {
+        $this->app->bootstrapWith([LoadYamlConfiguration::class]);
     }
 }

--- a/packages/framework/tests/Feature/LoadYamlConfigurationTest.php
+++ b/packages/framework/tests/Feature/LoadYamlConfigurationTest.php
@@ -83,6 +83,14 @@ class LoadYamlConfigurationTest extends TestCase
         $this->assertSame('HydePHP', Config::get('hyde.name'));
     }
 
+    public function testCanAddArbitraryConfigKeys()
+    {
+        $this->file('hyde.yml', 'foo: bar');
+        $this->runBootstrapper();
+
+        $this->assertSame('bar', Config::get('hyde.foo'));
+    }
+
     protected function runBootstrapper(): void
     {
         $this->app->bootstrapWith([LoadYamlConfiguration::class]);


### PR DESCRIPTION
This PR is not breaking, as the actual class is marked as internal. As long as none of the features the class provides change (which they are not by this PR), BC is retained.

Edit: Okay so my plan was to refactor to use the Filesystem facade, but since this runs during the internal framework bootstrapping process, facades are not available yet. So this now just adds some more tests.