### PR TITLE
Improve the Yaml configuration file feature to support multiple config namespaces

### DIFF
--- a/docs/digging-deeper/customization.md
+++ b/docs/digging-deeper/customization.md
@@ -440,3 +440,26 @@ rss:
 language: en
 output_directory: _site
 ```
+
+### Namespaced YAML Configuration
+
+If you are running `v1.2` or higher, you can also use namespaced configuration options in the YAML file.
+
+This allows you to set the settings of **any** configuration file normally found in the `config` directory.
+
+This feature is automatically enabled when you have a `hyde:` entry **first** in your `hyde.yml` file
+
+```yaml
+# filepath hyde.yml
+hyde:
+  name: HydePHP
+
+docs:
+  sidebar:
+    header: "My Docs"
+```
+
+This would set the `name` setting in the `config/hyde.php` file, and the `sidebar.header` setting in the `config/docs.php` file.
+
+Each top level key in the YAML file is treated as a namespace, and the settings are set in the corresponding configuration file.
+You can of course use arrays like normal even in namespaced configuration.

--- a/packages/framework/src/Foundation/Internal/LoadYamlConfiguration.php
+++ b/packages/framework/src/Foundation/Internal/LoadYamlConfiguration.php
@@ -16,6 +16,10 @@ use function file_exists;
 /**
  * @internal Bootstrap service that loads the YAML configuration file.
  *
+ * It also supports loading multiple configuration namespaces, where a configuration namespace is defined
+ * as the first level in the service container configuration repository array, and usually corresponds
+ * one-to-one with a file in the config directory.
+ *
  * @see docs/digging-deeper/customization.md#yaml-configuration
  */
 class LoadYamlConfiguration
@@ -55,8 +59,6 @@ class LoadYamlConfiguration
 
         // If the Yaml file contains namespaces, we merge those using more granular logic
         // that only applies the namespace data to each configuration namespace.
-        // (A configuration namespace is defined as the first level in the service container
-        // configuration repository array, and usually corresponds 1:1 with a file in the config directory.)
         if ($this->configurationContainsNamespaces($yaml)) {
             foreach ($yaml as $namespace => $data) {
                 $this->mergeConfiguration($namespace, (array) $data);

--- a/packages/framework/src/Foundation/Internal/LoadYamlConfiguration.php
+++ b/packages/framework/src/Foundation/Internal/LoadYamlConfiguration.php
@@ -62,11 +62,6 @@ class LoadYamlConfiguration
         }
 
         // Otherwise, we can merge using the default strategy, which is simply applying all the data.
-        $this->mergeUsingDefaultStrategy($yaml);
-    }
-
-    protected function mergeUsingDefaultStrategy(array $yaml): void
-    {
         $this->mergeConfiguration('hyde', $yaml);
     }
 

--- a/packages/framework/src/Foundation/Internal/LoadYamlConfiguration.php
+++ b/packages/framework/src/Foundation/Internal/LoadYamlConfiguration.php
@@ -8,6 +8,7 @@ use Hyde\Hyde;
 use Hyde\Facades\Config;
 use Symfony\Component\Yaml\Yaml;
 
+use function array_keys;
 use function file_get_contents;
 use function array_merge;
 use function file_exists;
@@ -51,6 +52,12 @@ class LoadYamlConfiguration
     protected function mergeParsedConfiguration(): void
     {
         $yaml = $this->getYaml();
+
+        if (array_keys($yaml) === ['hyde']) {
+            $this->mergeUsingDefaultStrategy($yaml['hyde']);
+
+            return;
+        }
 
         $this->mergeUsingDefaultStrategy($yaml);
     }

--- a/packages/framework/src/Foundation/Internal/LoadYamlConfiguration.php
+++ b/packages/framework/src/Foundation/Internal/LoadYamlConfiguration.php
@@ -38,6 +38,7 @@ class LoadYamlConfiguration
             || file_exists(Hyde::path('hyde.yaml'));
     }
 
+    /** @return array|array<string, array> */
     protected function getYaml(): array
     {
         return (array) Yaml::parse(file_get_contents($this->getFile()));

--- a/packages/framework/src/Foundation/Internal/LoadYamlConfiguration.php
+++ b/packages/framework/src/Foundation/Internal/LoadYamlConfiguration.php
@@ -54,7 +54,7 @@ class LoadYamlConfiguration
         $yaml = $this->getYaml();
 
         if (array_keys($yaml) === ['hyde']) {
-            $this->mergeUsingDefaultStrategy($yaml['hyde']);
+            $this->mergeConfiguration('hyde', $yaml['hyde']);
 
             return;
         }
@@ -64,9 +64,14 @@ class LoadYamlConfiguration
 
     protected function mergeUsingDefaultStrategy(array $yaml): void
     {
-        Config::set('hyde', array_merge(
-            Config::getArray('hyde', []),
-            $yaml
+        $this->mergeConfiguration('hyde', $yaml);
+    }
+
+    protected function mergeConfiguration(string $namespace, array $yamlData): void
+    {
+        Config::set($namespace, array_merge(
+            Config::getArray($namespace, []),
+            $yamlData
         ));
     }
 }

--- a/packages/framework/src/Foundation/Internal/LoadYamlConfiguration.php
+++ b/packages/framework/src/Foundation/Internal/LoadYamlConfiguration.php
@@ -71,7 +71,7 @@ class LoadYamlConfiguration
             return;
         }
 
-        // Otherwise, we can merge using the default strategy, which is simply applying all the data.
+        // Otherwise, we can merge using the default strategy, which is simply applying all the data to the hyde namespace.
         $this->mergeConfiguration('hyde', $yaml);
     }
 

--- a/packages/framework/src/Foundation/Internal/LoadYamlConfiguration.php
+++ b/packages/framework/src/Foundation/Internal/LoadYamlConfiguration.php
@@ -36,13 +36,6 @@ class LoadYamlConfiguration
             || file_exists(Hyde::path('hyde.yaml'));
     }
 
-    protected function mergeParsedConfiguration(): void
-    {
-        $yaml = $this->getYaml();
-
-        $this->mergeUsingDefaultStrategy($yaml);
-    }
-
     protected function getYaml(): array
     {
         return (array) Yaml::parse(file_get_contents($this->getFile()));
@@ -53,6 +46,13 @@ class LoadYamlConfiguration
         return file_exists(Hyde::path('hyde.yml'))
             ? Hyde::path('hyde.yml')
             : Hyde::path('hyde.yaml');
+    }
+
+    protected function mergeParsedConfiguration(): void
+    {
+        $yaml = $this->getYaml();
+
+        $this->mergeUsingDefaultStrategy($yaml);
     }
 
     protected function mergeUsingDefaultStrategy(array $yaml): void

--- a/packages/framework/src/Foundation/Internal/LoadYamlConfiguration.php
+++ b/packages/framework/src/Foundation/Internal/LoadYamlConfiguration.php
@@ -77,6 +77,7 @@ class LoadYamlConfiguration
 
     protected function configurationContainsNamespaces(array $yaml): bool
     {
+        // Todo support namespaces without hyde key
         return array_keys($yaml) === ['hyde'];
     }
 }

--- a/packages/framework/src/Foundation/Internal/LoadYamlConfiguration.php
+++ b/packages/framework/src/Foundation/Internal/LoadYamlConfiguration.php
@@ -61,7 +61,7 @@ class LoadYamlConfiguration
         // configuration repository array, and usually corresponds 1:1 with a file in the config directory.)
         if ($this->configurationContainsNamespaces($yaml)) {
             foreach ($yaml as $namespace => $data) {
-                $this->mergeConfiguration($namespace, $data ?? []);
+                $this->mergeConfiguration($namespace, $data ?: []);
             }
 
             return;

--- a/packages/framework/src/Foundation/Internal/LoadYamlConfiguration.php
+++ b/packages/framework/src/Foundation/Internal/LoadYamlConfiguration.php
@@ -40,10 +40,7 @@ class LoadYamlConfiguration
     {
         $yaml = $this->getYaml();
 
-        Config::set('hyde', array_merge(
-            Config::getArray('hyde', []),
-            $yaml
-        ));
+        $this->mergeUsingDefaultStrategy($yaml);
     }
 
     protected function getYaml(): array
@@ -56,5 +53,13 @@ class LoadYamlConfiguration
         return file_exists(Hyde::path('hyde.yml'))
             ? Hyde::path('hyde.yml')
             : Hyde::path('hyde.yaml');
+    }
+
+    protected function mergeUsingDefaultStrategy(array $yaml): void
+    {
+        Config::set('hyde', array_merge(
+            Config::getArray('hyde', []),
+            $yaml
+        ));
     }
 }

--- a/packages/framework/src/Foundation/Internal/LoadYamlConfiguration.php
+++ b/packages/framework/src/Foundation/Internal/LoadYamlConfiguration.php
@@ -57,7 +57,7 @@ class LoadYamlConfiguration
         // that only applies the namespace data to each configuration namespace.
         // (A configuration namespace is defined as the first level in the service container
         // configuration repository array, and usually corresponds 1:1 with a file in the config directory.)
-        if (array_keys($yaml) === ['hyde']) {
+        if ($this->configurationContainsNamespaces($yaml)) {
             $this->mergeConfiguration('hyde', $yaml['hyde']);
 
             return;
@@ -73,5 +73,10 @@ class LoadYamlConfiguration
             Config::getArray($namespace, []),
             $yamlData
         ));
+    }
+
+    protected function configurationContainsNamespaces(array $yaml): bool
+    {
+        return array_keys($yaml) === ['hyde'];
     }
 }

--- a/packages/framework/src/Foundation/Internal/LoadYamlConfiguration.php
+++ b/packages/framework/src/Foundation/Internal/LoadYamlConfiguration.php
@@ -59,7 +59,9 @@ class LoadYamlConfiguration
         // (A configuration namespace is defined as the first level in the service container
         // configuration repository array, and usually corresponds 1:1 with a file in the config directory.)
         if ($this->configurationContainsNamespaces($yaml)) {
-            $this->mergeConfiguration('hyde', $yaml['hyde']);
+            foreach ($yaml as $namespace => $data) {
+                $this->mergeConfiguration($namespace, $data);
+            }
 
             return;
         }

--- a/packages/framework/src/Foundation/Internal/LoadYamlConfiguration.php
+++ b/packages/framework/src/Foundation/Internal/LoadYamlConfiguration.php
@@ -38,9 +38,11 @@ class LoadYamlConfiguration
 
     protected function mergeParsedConfiguration(): void
     {
+        $yaml = $this->getYaml();
+
         Config::set('hyde', array_merge(
             Config::getArray('hyde', []),
-            $this->getYaml()
+            $yaml
         ));
     }
 

--- a/packages/framework/src/Foundation/Internal/LoadYamlConfiguration.php
+++ b/packages/framework/src/Foundation/Internal/LoadYamlConfiguration.php
@@ -55,6 +55,8 @@ class LoadYamlConfiguration
 
         // If the Yaml file contains namespaces, we merge those using more granular logic
         // that only applies the namespace data to each configuration namespace.
+        // (A configuration namespace is defined as the first level in the service container
+        // configuration repository array, and usually corresponds 1:1 with a file in the config directory.)
         if (array_keys($yaml) === ['hyde']) {
             $this->mergeConfiguration('hyde', $yaml['hyde']);
 

--- a/packages/framework/src/Foundation/Internal/LoadYamlConfiguration.php
+++ b/packages/framework/src/Foundation/Internal/LoadYamlConfiguration.php
@@ -61,7 +61,7 @@ class LoadYamlConfiguration
         // configuration repository array, and usually corresponds 1:1 with a file in the config directory.)
         if ($this->configurationContainsNamespaces($yaml)) {
             foreach ($yaml as $namespace => $data) {
-                $this->mergeConfiguration($namespace, $data);
+                $this->mergeConfiguration($namespace, $data ?? []);
             }
 
             return;

--- a/packages/framework/src/Foundation/Internal/LoadYamlConfiguration.php
+++ b/packages/framework/src/Foundation/Internal/LoadYamlConfiguration.php
@@ -12,6 +12,7 @@ use function array_keys;
 use function file_get_contents;
 use function array_merge;
 use function file_exists;
+use function in_array;
 
 /**
  * @internal Bootstrap service that loads the YAML configuration file.
@@ -78,6 +79,6 @@ class LoadYamlConfiguration
     protected function configurationContainsNamespaces(array $yaml): bool
     {
         // Todo support namespaces without hyde key
-        return array_keys($yaml) === ['hyde'];
+        return in_array('hyde', array_keys($yaml));
     }
 }

--- a/packages/framework/src/Foundation/Internal/LoadYamlConfiguration.php
+++ b/packages/framework/src/Foundation/Internal/LoadYamlConfiguration.php
@@ -18,7 +18,11 @@ use function file_exists;
  *
  * It also supports loading multiple configuration namespaces, where a configuration namespace is defined
  * as the first level in the service container configuration repository array, and usually corresponds
- * one-to-one with a file in the config directory.
+ * one-to-one with a file in the config directory. This feature, by design, requires a top-level
+ * configuration entry to be present as 'hyde' in the YAML file. Existing config files
+ * will be parsed as normal, but can be migrated by indenting all entries by one
+ * level, and adding a top-level 'hyde' key. Then additional namespaces can
+ * be added underneath as needed.
  *
  * @see docs/digging-deeper/customization.md#yaml-configuration
  */

--- a/packages/framework/src/Foundation/Internal/LoadYamlConfiguration.php
+++ b/packages/framework/src/Foundation/Internal/LoadYamlConfiguration.php
@@ -12,7 +12,6 @@ use function array_key_first;
 use function file_get_contents;
 use function array_merge;
 use function file_exists;
-use function in_array;
 
 /**
  * @internal Bootstrap service that loads the YAML configuration file.

--- a/packages/framework/src/Foundation/Internal/LoadYamlConfiguration.php
+++ b/packages/framework/src/Foundation/Internal/LoadYamlConfiguration.php
@@ -79,6 +79,6 @@ class LoadYamlConfiguration
     protected function configurationContainsNamespaces(array $yaml): bool
     {
         // Todo support namespaces without hyde key
-        return in_array('hyde', array_keys($yaml));
+        return in_array('hyde', array_keys($yaml), true);
     }
 }

--- a/packages/framework/src/Foundation/Internal/LoadYamlConfiguration.php
+++ b/packages/framework/src/Foundation/Internal/LoadYamlConfiguration.php
@@ -61,7 +61,7 @@ class LoadYamlConfiguration
         // configuration repository array, and usually corresponds 1:1 with a file in the config directory.)
         if ($this->configurationContainsNamespaces($yaml)) {
             foreach ($yaml as $namespace => $data) {
-                $this->mergeConfiguration($namespace, $data ?: []);
+                $this->mergeConfiguration($namespace, (array) $data);
             }
 
             return;

--- a/packages/framework/src/Foundation/Internal/LoadYamlConfiguration.php
+++ b/packages/framework/src/Foundation/Internal/LoadYamlConfiguration.php
@@ -80,7 +80,6 @@ class LoadYamlConfiguration
 
     protected function configurationContainsNamespaces(array $yaml): bool
     {
-        // Todo support namespaces without hyde key
         return in_array('hyde', array_keys($yaml), true);
     }
 }

--- a/packages/framework/src/Foundation/Internal/LoadYamlConfiguration.php
+++ b/packages/framework/src/Foundation/Internal/LoadYamlConfiguration.php
@@ -16,6 +16,8 @@ use function file_exists;
 /**
  * @internal Bootstrap service that loads the YAML configuration file.
  *
+ * @see docs/digging-deeper/customization.md#yaml-configuration
+ *
  * It also supports loading multiple configuration namespaces, where a configuration namespace is defined
  * as the first level in the service container configuration repository array, and usually corresponds
  * one-to-one with a file in the config directory. This feature, by design, requires a top-level
@@ -23,8 +25,6 @@ use function file_exists;
  * will be parsed as normal, but can be migrated by indenting all entries by one
  * level, and adding a top-level 'hyde' key. Then additional namespaces can
  * be added underneath as needed.
- *
- * @see docs/digging-deeper/customization.md#yaml-configuration
  */
 class LoadYamlConfiguration
 {

--- a/packages/framework/src/Foundation/Internal/LoadYamlConfiguration.php
+++ b/packages/framework/src/Foundation/Internal/LoadYamlConfiguration.php
@@ -37,7 +37,6 @@ class LoadYamlConfiguration
             || file_exists(Hyde::path('hyde.yaml'));
     }
 
-    /** @return array|array<string, array> */
     protected function getYaml(): array
     {
         return (array) Yaml::parse(file_get_contents($this->getFile()));

--- a/packages/framework/src/Foundation/Internal/LoadYamlConfiguration.php
+++ b/packages/framework/src/Foundation/Internal/LoadYamlConfiguration.php
@@ -53,12 +53,15 @@ class LoadYamlConfiguration
     {
         $yaml = $this->getYaml();
 
+        // If the Yaml file contains namespaces, we merge those using more granular logic
+        // that only applies the namespace data to each configuration namespace.
         if (array_keys($yaml) === ['hyde']) {
             $this->mergeConfiguration('hyde', $yaml['hyde']);
 
             return;
         }
 
+        // Otherwise, we can merge using the default strategy, which is simply applying all the data.
         $this->mergeUsingDefaultStrategy($yaml);
     }
 

--- a/packages/framework/src/Foundation/Internal/LoadYamlConfiguration.php
+++ b/packages/framework/src/Foundation/Internal/LoadYamlConfiguration.php
@@ -8,7 +8,7 @@ use Hyde\Hyde;
 use Hyde\Facades\Config;
 use Symfony\Component\Yaml\Yaml;
 
-use function array_keys;
+use function array_key_first;
 use function file_get_contents;
 use function array_merge;
 use function file_exists;
@@ -81,6 +81,6 @@ class LoadYamlConfiguration
 
     protected function configurationContainsNamespaces(array $yaml): bool
     {
-        return in_array('hyde', array_keys($yaml), true);
+        return array_key_first($yaml) === 'hyde';
     }
 }

--- a/packages/framework/tests/Feature/LoadYamlConfigurationTest.php
+++ b/packages/framework/tests/Feature/LoadYamlConfigurationTest.php
@@ -44,6 +44,27 @@ class LoadYamlConfigurationTest extends TestCase
         $this->assertSame('_site', Config::get('hyde.output_directory'));
     }
 
+    public function testCanDefineMultipleConfigSettingsInHydeYmlFile()
+    {
+        config(['hyde' => []]);
+        config(['docs' => []]);
+
+        $this->file('hyde.yml', <<<'YAML'
+        hyde:
+            name: HydePHP
+            url: "http://localhost"
+        docs:
+            sidebar: 
+                header: "My Docs"
+        YAML);
+
+        $this->runBootstrapper();
+
+        $this->assertSame('HydePHP', Config::get('hyde.name'));
+        $this->assertSame('http://localhost', Config::get('hyde.url'));
+        $this->assertSame('My Docs', Config::get('docs.sidebar.header'));
+    }
+
     public function testBootstrapperAppliesYamlConfigurationWhenPresent()
     {
         $this->file('hyde.yml', 'name: Foo');

--- a/packages/framework/tests/Feature/LoadYamlConfigurationTest.php
+++ b/packages/framework/tests/Feature/LoadYamlConfigurationTest.php
@@ -150,6 +150,21 @@ class LoadYamlConfigurationTest extends TestCase
         $this->assertNull(Config::get('foo.bar'));
     }
 
+    public function testAdditionalNamespacesRequiresHydeNamespaceToBeTheFirstEntry()
+    {
+        config(['hyde' => []]);
+
+        $this->file('hyde.yml', <<<'YAML'
+        foo:
+          bar: baz
+        hyde:
+          some: thing
+        YAML);
+        $this->runBootstrapper();
+
+        $this->assertNull(Config::get('foo.bar'));
+    }
+
     protected function runBootstrapper(): void
     {
         $this->app->bootstrapWith([LoadYamlConfiguration::class]);

--- a/packages/framework/tests/Feature/LoadYamlConfigurationTest.php
+++ b/packages/framework/tests/Feature/LoadYamlConfigurationTest.php
@@ -179,6 +179,21 @@ class LoadYamlConfigurationTest extends TestCase
        $this->assertSame('baz', Config::get('foo.bar'));
     }
 
+    public function testHydeNamespaceCanBeNull()
+    {
+        // This is essentially the same as the empty state test above, at least according to the YAML spec.
+        config(['hyde' => []]);
+
+        $this->file('hyde.yml', <<<'YAML'
+        hyde: null
+        foo:
+          bar: baz
+        YAML);
+        $this->runBootstrapper();
+
+        $this->assertSame('baz', Config::get('foo.bar'));
+    }
+
     protected function runBootstrapper(): void
     {
         $this->app->bootstrapWith([LoadYamlConfiguration::class]);

--- a/packages/framework/tests/Feature/LoadYamlConfigurationTest.php
+++ b/packages/framework/tests/Feature/LoadYamlConfigurationTest.php
@@ -167,16 +167,16 @@ class LoadYamlConfigurationTest extends TestCase
 
     public function testHydeNamespaceCanBeEmpty()
     {
-       config(['hyde' => []]);
+        config(['hyde' => []]);
 
-       $this->file('hyde.yml', <<<'YAML'
+        $this->file('hyde.yml', <<<'YAML'
         hyde:
         foo:
           bar: baz
         YAML);
-       $this->runBootstrapper();
+        $this->runBootstrapper();
 
-       $this->assertSame('baz', Config::get('foo.bar'));
+        $this->assertSame('baz', Config::get('foo.bar'));
     }
 
     public function testHydeNamespaceCanBeNull()

--- a/packages/framework/tests/Feature/LoadYamlConfigurationTest.php
+++ b/packages/framework/tests/Feature/LoadYamlConfigurationTest.php
@@ -104,6 +104,24 @@ class LoadYamlConfigurationTest extends TestCase
         $this->assertSame('bar', Config::get('hyde.foo'));
     }
 
+    public function testCanAddConfigurationOptionsInPrefixedArray()
+    {
+        config(['hyde' => []]);
+
+        $this->file('hyde.yml', <<<'YAML'
+        hyde:
+          name: HydePHP
+          foo: bar
+          bar:
+            baz: qux
+        YAML);
+        $this->runBootstrapper();
+
+        $this->assertSame('HydePHP', Config::get('hyde.name'));
+        $this->assertSame('bar', Config::get('hyde.foo'));
+        $this->assertSame('qux', Config::get('hyde.bar.baz'));
+    }
+
     protected function runBootstrapper(): void
     {
         $this->app->bootstrapWith([LoadYamlConfiguration::class]);

--- a/packages/framework/tests/Feature/LoadYamlConfigurationTest.php
+++ b/packages/framework/tests/Feature/LoadYamlConfigurationTest.php
@@ -137,6 +137,19 @@ class LoadYamlConfigurationTest extends TestCase
         $this->assertSame('baz', Config::get('foo.bar'));
     }
 
+    public function testAdditionalNamespacesRequireTheHydeNamespaceToBePresent()
+    {
+        config(['hyde' => []]);
+
+        $this->file('hyde.yml', <<<'YAML'
+        foo:
+          bar: baz
+        YAML);
+        $this->runBootstrapper();
+
+        $this->assertNull(Config::get('foo.bar'));
+    }
+
     protected function runBootstrapper(): void
     {
         $this->app->bootstrapWith([LoadYamlConfiguration::class]);

--- a/packages/framework/tests/Feature/LoadYamlConfigurationTest.php
+++ b/packages/framework/tests/Feature/LoadYamlConfigurationTest.php
@@ -122,6 +122,21 @@ class LoadYamlConfigurationTest extends TestCase
         $this->assertSame('qux', Config::get('hyde.bar.baz'));
     }
 
+    public function testCanAddArbitraryNamespacedData()
+    {
+        config(['hyde' => []]);
+
+        $this->file('hyde.yml', <<<'YAML'
+        hyde:
+          some: thing 
+        foo:
+          bar: baz
+        YAML);
+        $this->runBootstrapper();
+
+        $this->assertSame('baz', Config::get('foo.bar'));
+    }
+
     protected function runBootstrapper(): void
     {
         $this->app->bootstrapWith([LoadYamlConfiguration::class]);

--- a/packages/framework/tests/Feature/LoadYamlConfigurationTest.php
+++ b/packages/framework/tests/Feature/LoadYamlConfigurationTest.php
@@ -165,6 +165,20 @@ class LoadYamlConfigurationTest extends TestCase
         $this->assertNull(Config::get('foo.bar'));
     }
 
+    public function testHydeNamespaceCanBeEmpty()
+    {
+       config(['hyde' => []]);
+
+       $this->file('hyde.yml', <<<'YAML'
+        hyde:
+        foo:
+          bar: baz
+        YAML);
+       $this->runBootstrapper();
+
+       $this->assertSame('baz', Config::get('foo.bar'));
+    }
+
     protected function runBootstrapper(): void
     {
         $this->app->bootstrapWith([LoadYamlConfiguration::class]);

--- a/packages/framework/tests/Feature/LoadYamlConfigurationTest.php
+++ b/packages/framework/tests/Feature/LoadYamlConfigurationTest.php
@@ -104,7 +104,7 @@ class LoadYamlConfigurationTest extends TestCase
         $this->assertSame('bar', Config::get('hyde.foo'));
     }
 
-    public function testCanAddConfigurationOptionsInPrefixedArray()
+    public function testCanAddConfigurationOptionsInNamespacedArray()
     {
         config(['hyde' => []]);
 

--- a/packages/framework/tests/Feature/LoadYamlConfigurationTest.php
+++ b/packages/framework/tests/Feature/LoadYamlConfigurationTest.php
@@ -194,6 +194,20 @@ class LoadYamlConfigurationTest extends TestCase
         $this->assertSame('baz', Config::get('foo.bar'));
     }
 
+    public function testHydeNamespaceCanBlank()
+    {
+        config(['hyde' => []]);
+
+        $this->file('hyde.yml', <<<'YAML'
+        hyde: ''
+        foo:
+          bar: baz
+        YAML);
+        $this->runBootstrapper();
+
+        $this->assertSame('baz', Config::get('foo.bar'));
+    }
+
     protected function runBootstrapper(): void
     {
         $this->app->bootstrapWith([LoadYamlConfiguration::class]);

--- a/packages/framework/tests/Feature/LoadYamlConfigurationTest.php
+++ b/packages/framework/tests/Feature/LoadYamlConfigurationTest.php
@@ -4,11 +4,9 @@ declare(strict_types=1);
 
 namespace Hyde\Framework\Testing\Feature;
 
-use Hyde\Foundation\Internal\LoadYamlConfiguration;
 use Hyde\Testing\TestCase;
+use Hyde\Foundation\Internal\LoadYamlConfiguration;
 use Illuminate\Support\Facades\Config;
-
-use function config;
 
 /**
  * @covers \Hyde\Foundation\Internal\LoadYamlConfiguration


### PR DESCRIPTION
### Namespaced YAML Configuration

If you are running `v1.2` or higher, you can also use namespaced configuration options in the YAML file.

This allows you to set the settings of **any** configuration file normally found in the `config` directory.

This feature is automatically enabled when you have a `hyde:` entry **first** in your `hyde.yml` file

```yaml
# filepath hyde.yml
hyde:
  name: HydePHP

docs:
  sidebar:
    header: "My Docs"
```

This would set the `name` setting in the `config/hyde.php` file, and the `sidebar.header` setting in the `config/docs.php` file.

Each top level key in the YAML file is treated as a namespace, and the settings are set in the corresponding configuration file.
You can of course use arrays like normal even in namespaced configuration.
