### PR TITLE
Change root monorepo Composer name to `hyde/monorepo`

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -14,7 +14,7 @@ This serves two purposes:
 - Added `prose-img:inline` to bundled TailwindCSS classes in https://github.com/hydephp/develop/pull/1359
 
 ### Changed
-- for changes in existing functionality.
+- Internal: Decoupled the monorepo `composer.json` settings in https://github.com/hydephp/develop/pull/1361
 
 ### Deprecated
 - for soon-to-be removed features.

--- a/composer.json
+++ b/composer.json
@@ -5,8 +5,8 @@
     "type": "project",
     "license": "MIT",
     "support": {
-        "issues": "https://github.com/hydephp/hyde/issues",
-        "source": "https://github.com/hydephp/hyde"
+        "issues": "https://github.com/hydephp/develop/issues",
+        "source": "https://github.com/hydephp/develop"
     },
     "authors": [
         {

--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
     "name": "hyde/monorepo",
-    "description": "Static Site Generator to rapidly create Blogs, Documentation, and more, using Markdown and Blade.",
+    "description": "The HydePHP source code monorepo.",
     "keywords": ["framework", "hyde", "hyde framework"],
     "homepage": "https://hydephp.com",
     "type": "project",

--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,6 @@
 {
     "name": "hyde/monorepo",
     "description": "The HydePHP source code monorepo.",
-    "keywords": ["framework", "hyde", "hyde framework"],
     "homepage": "https://hydephp.com",
     "type": "project",
     "license": "MIT",

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "hyde/hyde",
+    "name": "hyde/monorepo",
     "description": "Static Site Generator to rapidly create Blogs, Documentation, and more, using Markdown and Blade.",
     "keywords": ["framework", "hyde", "hyde framework"],
     "homepage": "https://hydephp.com",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "d13fdebb0012781fa14004703bb937d9",
+    "content-hash": "1079329c91d1cb29d3a8e38b2c29f27d",
     "packages": [
         {
             "name": "brick/math",

--- a/packages/framework/src/Console/Commands/DebugCommand.php
+++ b/packages/framework/src/Console/Commands/DebugCommand.php
@@ -39,7 +39,7 @@ class DebugCommand extends Command
 
         $this->newLine();
         $this->comment('Git Version: '.(string) app('git.version'));
-        $this->comment('Hyde Version: '.(InstalledVersions::getPrettyVersion('hyde/hyde') ?: 'unreleased'));
+        $this->comment('Hyde Version: '.((InstalledVersions::isInstalled('hyde/hyde') ? InstalledVersions::getPrettyVersion('hyde/hyde') : null) ?: 'unreleased'));
         $this->comment('Framework Version: '.(InstalledVersions::getPrettyVersion('hyde/framework') ?: 'unreleased'));
 
         $this->newLine();


### PR DESCRIPTION
This composer file has become widely different from the actual hyde/hyde composer file, so it doesn't make semantic sense for this project to be branded the same way as the hyde/hyde package. This change is not breaking, as the monorepo structure is not included in the HydePHP BC promise.