### PR TITLE
Clean up publications code

### DIFF
--- a/packages/publications/src/Actions/CreateAction.php
+++ b/packages/publications/src/Actions/CreateAction.php
@@ -4,12 +4,13 @@ declare(strict_types=1);
 
 namespace Hyde\Publications\Actions;
 
-use function file_exists;
-
-use Hyde\Framework\Concerns\InteractsWithDirectories;
-use Hyde\Framework\Exceptions\FileConflictException;
 use Hyde\Hyde;
 use Illuminate\Support\Str;
+use Hyde\Framework\Exceptions\FileConflictException;
+use Hyde\Framework\Concerns\InteractsWithDirectories;
+
+use function file_exists;
+use function file_put_contents;
 
 /**
  * @see \Hyde\Publications\Testing\Feature\CreateActionTest

--- a/packages/publications/src/Actions/CreatesNewPublicationPage.php
+++ b/packages/publications/src/Actions/CreatesNewPublicationPage.php
@@ -11,10 +11,9 @@ use Hyde\Publications\PublicationFieldTypes;
 use Illuminate\Support\Carbon;
 use Illuminate\Support\Collection;
 use RuntimeException;
+use Symfony\Component\Yaml\Yaml;
 
 use function substr;
-
-use Symfony\Component\Yaml\Yaml;
 
 /**
  * Scaffold a publication file.

--- a/packages/publications/src/Actions/CreatesNewPublicationPage.php
+++ b/packages/publications/src/Actions/CreatesNewPublicationPage.php
@@ -4,14 +4,14 @@ declare(strict_types=1);
 
 namespace Hyde\Publications\Actions;
 
-use Hyde\Framework\Actions\ConvertsArrayToFrontMatter;
-use Hyde\Publications\Models\PublicationFieldValue;
-use Hyde\Publications\Models\PublicationType;
-use Hyde\Publications\PublicationFieldTypes;
-use Illuminate\Support\Carbon;
-use Illuminate\Support\Collection;
 use RuntimeException;
+use Illuminate\Support\Carbon;
 use Symfony\Component\Yaml\Yaml;
+use Illuminate\Support\Collection;
+use Hyde\Publications\Models\PublicationType;
+use Hyde\Publications\Models\PublicationFieldValue;
+use Hyde\Publications\Concerns\PublicationFieldTypes;
+use Hyde\Framework\Actions\ConvertsArrayToFrontMatter;
 
 use function substr;
 

--- a/packages/publications/src/Actions/CreatesNewPublicationType.php
+++ b/packages/publications/src/Actions/CreatesNewPublicationType.php
@@ -5,8 +5,10 @@ declare(strict_types=1);
 namespace Hyde\Publications\Actions;
 
 use Hyde\Hyde;
-use Hyde\Publications\Models\PublicationType;
 use Illuminate\Contracts\Support\Arrayable;
+use Hyde\Publications\Models\PublicationType;
+
+use function copy;
 
 /**
  * Scaffold a new publication type schema.

--- a/packages/publications/src/Actions/GeneratesPublicationTagPages.php
+++ b/packages/publications/src/Actions/GeneratesPublicationTagPages.php
@@ -6,7 +6,7 @@ namespace Hyde\Publications\Actions;
 
 use Hyde\Foundation\Kernel\PageCollection;
 use Hyde\Pages\InMemoryPage;
-use Hyde\Publications\PublicationService;
+use Hyde\Publications\Publications;
 
 use function arsort;
 
@@ -31,7 +31,7 @@ class GeneratesPublicationTagPages
         $collection = $this->collection;
 
         // Retrieve publication types
-        $publicationTypes = PublicationService::getPublicationTypes();
+        $publicationTypes = Publications::getPublicationTypes();
 
         // Initialize arrays to hold tag counts and pages by tag
         $tagCounts = [];
@@ -53,7 +53,7 @@ class GeneratesPublicationTagPages
             }
 
             // Retrieve publications for the current publication type
-            $publications = PublicationService::getPublicationsForType($publicationType);
+            $publications = Publications::getPublicationsForType($publicationType);
 
             // Loop through each publication to retrieve associated tags
             foreach ($publications as $publication) {

--- a/packages/publications/src/Actions/GeneratesPublicationTagPages.php
+++ b/packages/publications/src/Actions/GeneratesPublicationTagPages.php
@@ -8,6 +8,8 @@ use Hyde\Foundation\Kernel\PageCollection;
 use Hyde\Pages\InMemoryPage;
 use Hyde\Publications\PublicationService;
 
+use function arsort;
+
 /**
  * Called by the PublicationsExtension::discoverPages method,
  * during the HydePHP autodiscovery boot process.

--- a/packages/publications/src/Actions/PublicationFieldValidator.php
+++ b/packages/publications/src/Actions/PublicationFieldValidator.php
@@ -7,7 +7,7 @@ namespace Hyde\Publications\Actions;
 use Hyde\Publications\Concerns\PublicationFieldTypes;
 use Hyde\Publications\Models\PublicationFieldDefinition;
 use Hyde\Publications\Models\PublicationType;
-use Hyde\Publications\PublicationService;
+use Hyde\Publications\Publications;
 use Illuminate\Contracts\Validation\Validator;
 
 use function array_merge;
@@ -45,14 +45,14 @@ class PublicationFieldValidator
     protected function makeDynamicRules(): array
     {
         if ($this->fieldDefinition->type == PublicationFieldTypes::Media) {
-            $mediaFiles = PublicationService::getMediaForType($this->publicationType);
+            $mediaFiles = Publications::getMediaForType($this->publicationType);
             $valueList = $mediaFiles->implode(',');
 
             return ["in:$valueList"];
         }
 
         if ($this->fieldDefinition->type == PublicationFieldTypes::Tag) {
-            $tagValues = PublicationService::getValuesForTagName($this->publicationType->getIdentifier()) ?? collect([]);
+            $tagValues = Publications::getValuesForTagName($this->publicationType->getIdentifier()) ?? collect([]);
             $valueList = $tagValues->implode(',');
 
             return ["in:$valueList"];

--- a/packages/publications/src/Actions/PublicationFieldValidator.php
+++ b/packages/publications/src/Actions/PublicationFieldValidator.php
@@ -4,16 +4,15 @@ declare(strict_types=1);
 
 namespace Hyde\Publications\Actions;
 
-use function array_merge;
-use function collect;
-
-use Hyde\Publications\Models\PublicationFieldDefinition;
-use Hyde\Publications\Models\PublicationType;
-use Hyde\Publications\PublicationFieldTypes;
 use Hyde\Publications\PublicationService;
+use Hyde\Publications\PublicationFieldTypes;
+use Hyde\Publications\Models\PublicationType;
 use Illuminate\Contracts\Validation\Validator;
+use Hyde\Publications\Models\PublicationFieldDefinition;
 
+use function collect;
 use function validator;
+use function array_merge;
 
 /**
  * @see \Hyde\Publications\Testing\Feature\PublicationFieldValidatorTest

--- a/packages/publications/src/Actions/PublicationFieldValidator.php
+++ b/packages/publications/src/Actions/PublicationFieldValidator.php
@@ -4,15 +4,15 @@ declare(strict_types=1);
 
 namespace Hyde\Publications\Actions;
 
-use Hyde\Publications\PublicationService;
-use Hyde\Publications\PublicationFieldTypes;
-use Hyde\Publications\Models\PublicationType;
-use Illuminate\Contracts\Validation\Validator;
+use Hyde\Publications\Concerns\PublicationFieldTypes;
 use Hyde\Publications\Models\PublicationFieldDefinition;
+use Hyde\Publications\Models\PublicationType;
+use Hyde\Publications\PublicationService;
+use Illuminate\Contracts\Validation\Validator;
 
+use function array_merge;
 use function collect;
 use function validator;
-use function array_merge;
 
 /**
  * @see \Hyde\Publications\Testing\Feature\PublicationFieldValidatorTest

--- a/packages/publications/src/Actions/PublicationPageCompiler.php
+++ b/packages/publications/src/Actions/PublicationPageCompiler.php
@@ -4,11 +4,12 @@ declare(strict_types=1);
 
 namespace Hyde\Publications\Actions;
 
+use Illuminate\Support\Facades\View;
+use Hyde\Publications\Models\PublicationPage;
 use Hyde\Framework\Actions\AnonymousViewCompiler;
 use Hyde\Publications\Models\PublicationListPage;
-use Hyde\Publications\Models\PublicationPage;
-use Illuminate\Support\Facades\View;
 
+use function basename;
 use function str_ends_with;
 
 /**

--- a/packages/publications/src/Actions/PublicationPageValidator.php
+++ b/packages/publications/src/Actions/PublicationPageValidator.php
@@ -4,15 +4,16 @@ declare(strict_types=1);
 
 namespace Hyde\Publications\Actions;
 
-use function array_flip;
-use function array_merge;
-
 use Hyde\Markdown\Models\MarkdownDocument;
 use Hyde\Publications\Models\PublicationFieldDefinition;
 use Hyde\Publications\Models\PublicationType;
 use Illuminate\Contracts\Validation\Validator;
 use Illuminate\Support\Str;
 
+use function array_flip;
+use function array_merge;
+use function collect;
+use function implode;
 use function in_array;
 use function lcfirst;
 use function sprintf;

--- a/packages/publications/src/Actions/PublicationSchemaValidator.php
+++ b/packages/publications/src/Actions/PublicationSchemaValidator.php
@@ -4,14 +4,14 @@ declare(strict_types=1);
 
 namespace Hyde\Publications\Actions;
 
+use stdClass;
 use Hyde\Facades\Filesystem;
 use Illuminate\Contracts\Validation\Validator;
 
-use function json_decode;
-
-use stdClass;
-
+use function collect;
+use function is_array;
 use function validator;
+use function json_decode;
 
 /**
  * @see \Hyde\Publications\Testing\Feature\PublicationSchemaValidatorTest

--- a/packages/publications/src/Actions/SeedsPublicationFiles.php
+++ b/packages/publications/src/Actions/SeedsPublicationFiles.php
@@ -12,6 +12,8 @@ use Illuminate\Support\Arr;
 use Illuminate\Support\Carbon;
 use Illuminate\Support\Str;
 
+use function date;
+use function implode;
 use function in_array;
 use function mt_getrandmax;
 use function mt_rand;

--- a/packages/publications/src/Actions/SeedsPublicationFiles.php
+++ b/packages/publications/src/Actions/SeedsPublicationFiles.php
@@ -7,7 +7,7 @@ namespace Hyde\Publications\Actions;
 use Hyde\Publications\Models\PublicationFieldDefinition;
 use Hyde\Publications\Models\PublicationPage;
 use Hyde\Publications\Models\PublicationType;
-use Hyde\Publications\PublicationService;
+use Hyde\Publications\Publications;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Carbon;
 use Illuminate\Support\Str;
@@ -133,7 +133,7 @@ class SeedsPublicationFiles
 
     protected function getTags(string $tagGroup): string
     {
-        $tags = PublicationService::getValuesForTagName($tagGroup);
+        $tags = Publications::getValuesForTagName($tagGroup);
 
         return $tags->isEmpty() ? '' : $tags->random();
     }

--- a/packages/publications/src/Commands/Helpers/InputStreamHandler.php
+++ b/packages/publications/src/Commands/Helpers/InputStreamHandler.php
@@ -4,14 +4,14 @@ declare(strict_types=1);
 
 namespace Hyde\Publications\Commands\Helpers;
 
-use function array_shift;
-use function explode;
-use function fgets;
-
 use Hyde\Hyde;
 
-use function str_contains;
 use function trim;
+use function fgets;
+use function sprintf;
+use function explode;
+use function array_shift;
+use function str_contains;
 
 /**
  * Collects an array of lines from the standard input stream. Feed is terminated by a blank line.

--- a/packages/publications/src/Commands/MakePublicationCommand.php
+++ b/packages/publications/src/Commands/MakePublicationCommand.php
@@ -6,20 +6,20 @@ namespace Hyde\Publications\Commands;
 
 use Closure;
 use Hyde\Hyde;
-use Hyde\Publications\Actions\CreatesNewPublicationPage;
-use Hyde\Publications\Commands\Helpers\InputStreamHandler;
-use Hyde\Publications\Models\PublicationFieldDefinition;
-use Hyde\Publications\Models\PublicationFieldValue;
-use Hyde\Publications\Models\PublicationType;
-use Hyde\Publications\PublicationFieldTypes;
-use Hyde\Publications\PublicationService;
-use Illuminate\Support\Collection;
 use InvalidArgumentException;
+use Illuminate\Support\Collection;
+use Hyde\Publications\PublicationService;
 use LaravelZero\Framework\Commands\Command;
+use Hyde\Publications\Models\PublicationType;
+use Hyde\Publications\Models\PublicationFieldValue;
+use Hyde\Publications\Concerns\PublicationFieldTypes;
+use Hyde\Publications\Actions\CreatesNewPublicationPage;
+use Hyde\Publications\Models\PublicationFieldDefinition;
+use Hyde\Publications\Commands\Helpers\InputStreamHandler;
 
 use function implode;
-use function in_array;
 use function sprintf;
+use function in_array;
 use function str_starts_with;
 
 /**

--- a/packages/publications/src/Commands/MakePublicationCommand.php
+++ b/packages/publications/src/Commands/MakePublicationCommand.php
@@ -8,7 +8,7 @@ use Closure;
 use Hyde\Hyde;
 use InvalidArgumentException;
 use Illuminate\Support\Collection;
-use Hyde\Publications\PublicationService;
+use Hyde\Publications\Publications;
 use LaravelZero\Framework\Commands\Command;
 use Hyde\Publications\Models\PublicationType;
 use Hyde\Publications\Models\PublicationFieldValue;
@@ -72,7 +72,7 @@ class MakePublicationCommand extends ValidatingCommand
 
     protected function getPublicationTypeSelection(): PublicationType
     {
-        $publicationTypes = PublicationService::getPublicationTypes();
+        $publicationTypes = Publications::getPublicationTypes();
         if ($this->argument('publicationType')) {
             $publicationTypeSelection = $this->argument('publicationType');
         } else {
@@ -147,7 +147,7 @@ class MakePublicationCommand extends ValidatingCommand
     {
         $this->infoComment("Select file for image field [$field->name]");
 
-        $mediaFiles = PublicationService::getMediaForType($this->publicationType);
+        $mediaFiles = Publications::getMediaForType($this->publicationType);
         if ($mediaFiles->isEmpty()) {
             return $this->handleEmptyOptionsCollection($field, 'media file',
                 sprintf('No media files found in directory %s/%s/', Hyde::getMediaDirectory(),
@@ -164,7 +164,7 @@ class MakePublicationCommand extends ValidatingCommand
         $tagGroup = $field->tagGroup ?? throw new InvalidArgumentException("Tag field '$field->name' is missing the 'tagGroup' property");
         $this->infoComment(/** @lang Text */ "Select a tag for field [$field->name] from the $tagGroup group");
 
-        $options = PublicationService::getValuesForTagName($tagGroup);
+        $options = Publications::getValuesForTagName($tagGroup);
         if ($options->isEmpty()) {
             return $this->handleEmptyOptionsCollection($field, 'tag', 'No tags for this publication type found in tags.yml');
         }
@@ -220,7 +220,7 @@ class MakePublicationCommand extends ValidatingCommand
     protected function getReloadableTagValuesArrayClosure(string $tagGroup): Closure
     {
         return function () use ($tagGroup): array {
-            return PublicationService::getValuesForTagName($tagGroup)->toArray();
+            return Publications::getValuesForTagName($tagGroup)->toArray();
         };
     }
 }

--- a/packages/publications/src/Commands/MakePublicationCommand.php
+++ b/packages/publications/src/Commands/MakePublicationCommand.php
@@ -14,13 +14,12 @@ use Hyde\Publications\Models\PublicationType;
 use Hyde\Publications\PublicationFieldTypes;
 use Hyde\Publications\PublicationService;
 use Illuminate\Support\Collection;
-
-use function implode;
-use function in_array;
-
 use InvalidArgumentException;
 use LaravelZero\Framework\Commands\Command;
 
+use function implode;
+use function in_array;
+use function sprintf;
 use function str_starts_with;
 
 /**

--- a/packages/publications/src/Commands/MakePublicationTagCommand.php
+++ b/packages/publications/src/Commands/MakePublicationTagCommand.php
@@ -7,12 +7,10 @@ namespace Hyde\Publications\Commands;
 use Hyde\Publications\Commands\Helpers\InputStreamHandler;
 use Hyde\Publications\Models\PublicationTags;
 use Hyde\Publications\PublicationService;
-
-use function implode;
-
 use LaravelZero\Framework\Commands\Command;
 use RuntimeException;
 
+use function implode;
 use function sprintf;
 
 /**

--- a/packages/publications/src/Commands/MakePublicationTagCommand.php
+++ b/packages/publications/src/Commands/MakePublicationTagCommand.php
@@ -6,7 +6,7 @@ namespace Hyde\Publications\Commands;
 
 use Hyde\Publications\Commands\Helpers\InputStreamHandler;
 use Hyde\Publications\Models\PublicationTags;
-use Hyde\Publications\PublicationService;
+use Hyde\Publications\Publications;
 use LaravelZero\Framework\Commands\Command;
 use RuntimeException;
 
@@ -66,7 +66,7 @@ class MakePublicationTagCommand extends ValidatingCommand
 
     protected function validateTagName(): void
     {
-        if (PublicationService::getAllTags()->has($this->tagName)) {
+        if (Publications::getAllTags()->has($this->tagName)) {
             throw new RuntimeException("Tag [$this->tagName] already exists");
         }
     }

--- a/packages/publications/src/Commands/MakePublicationTypeCommand.php
+++ b/packages/publications/src/Commands/MakePublicationTypeCommand.php
@@ -5,24 +5,24 @@ declare(strict_types=1);
 namespace Hyde\Publications\Commands;
 
 use Hyde\Hyde;
-use Hyde\Publications\Actions\CreatesNewPublicationType;
-use Hyde\Publications\Models\PublicationFieldDefinition;
-use Hyde\Publications\Models\PublicationTags;
-use Hyde\Publications\PublicationFieldTypes;
-use Illuminate\Support\Collection;
 use Illuminate\Support\Str;
 use InvalidArgumentException;
+use Illuminate\Support\Collection;
 use LaravelZero\Framework\Commands\Command;
+use Hyde\Publications\Models\PublicationTags;
+use Hyde\Publications\Concerns\PublicationFieldTypes;
+use Hyde\Publications\Actions\CreatesNewPublicationType;
+use Hyde\Publications\Models\PublicationFieldDefinition;
 
-use function array_keys;
+use function trim;
 use function count;
-use function in_array;
 use function is_dir;
 use function is_file;
 use function scandir;
 use function sprintf;
+use function in_array;
+use function array_keys;
 use function strtolower;
-use function trim;
 
 /**
  * Hyde Command to create a new publication type.

--- a/packages/publications/src/Commands/MakePublicationTypeCommand.php
+++ b/packages/publications/src/Commands/MakePublicationTypeCommand.php
@@ -4,9 +4,6 @@ declare(strict_types=1);
 
 namespace Hyde\Publications\Commands;
 
-use function array_keys;
-use function count;
-
 use Hyde\Hyde;
 use Hyde\Publications\Actions\CreatesNewPublicationType;
 use Hyde\Publications\Models\PublicationFieldDefinition;
@@ -14,17 +11,16 @@ use Hyde\Publications\Models\PublicationTags;
 use Hyde\Publications\PublicationFieldTypes;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Str;
-
-use function in_array;
-
 use InvalidArgumentException;
-
-use function is_dir;
-use function is_file;
-
 use LaravelZero\Framework\Commands\Command;
 
+use function array_keys;
+use function count;
+use function in_array;
+use function is_dir;
+use function is_file;
 use function scandir;
+use function sprintf;
 use function strtolower;
 use function trim;
 

--- a/packages/publications/src/Commands/SeedPublicationCommand.php
+++ b/packages/publications/src/Commands/SeedPublicationCommand.php
@@ -6,7 +6,7 @@ namespace Hyde\Publications\Commands;
 
 use Hyde\Publications\Actions\SeedsPublicationFiles;
 use Hyde\Publications\Models\PublicationType;
-use Hyde\Publications\PublicationService;
+use Hyde\Publications\Publications;
 use Illuminate\Support\Collection;
 use InvalidArgumentException;
 use LaravelZero\Framework\Commands\Command;
@@ -93,7 +93,7 @@ class SeedPublicationCommand extends ValidatingCommand
      */
     protected function getPublicationTypes(): Collection
     {
-        $publicationTypes = PublicationService::getPublicationTypes();
+        $publicationTypes = Publications::getPublicationTypes();
         if ($publicationTypes->isEmpty()) {
             throw new InvalidArgumentException('Unable to locate any publication types. Did you create any?');
         }

--- a/packages/publications/src/Commands/SeedPublicationCommand.php
+++ b/packages/publications/src/Commands/SeedPublicationCommand.php
@@ -11,6 +11,10 @@ use Illuminate\Support\Collection;
 use InvalidArgumentException;
 use LaravelZero\Framework\Commands\Command;
 
+use function microtime;
+use function round;
+use function sprintf;
+
 /**
  * Hyde Command to seed publication files for a publication type.
  *

--- a/packages/publications/src/Commands/ValidatePublicationTypesCommand.php
+++ b/packages/publications/src/Commands/ValidatePublicationTypesCommand.php
@@ -4,20 +4,18 @@ declare(strict_types=1);
 
 namespace Hyde\Publications\Commands;
 
-use function array_filter;
-use function basename;
-use function dirname;
-use function glob;
-
 use Hyde\Hyde;
 use Hyde\Publications\Actions\PublicationSchemaValidator;
 use Hyde\Publications\PublicationService;
 use InvalidArgumentException;
-
-use function json_encode;
-
 use LaravelZero\Framework\Commands\Command;
 
+use function array_filter;
+use function basename;
+use function count;
+use function dirname;
+use function glob;
+use function json_encode;
 use function memory_get_peak_usage;
 use function microtime;
 use function next;

--- a/packages/publications/src/Commands/ValidatePublicationTypesCommand.php
+++ b/packages/publications/src/Commands/ValidatePublicationTypesCommand.php
@@ -6,7 +6,7 @@ namespace Hyde\Publications\Commands;
 
 use Hyde\Hyde;
 use Hyde\Publications\Actions\PublicationSchemaValidator;
-use Hyde\Publications\PublicationService;
+use Hyde\Publications\Publications;
 use InvalidArgumentException;
 use LaravelZero\Framework\Commands\Command;
 
@@ -67,7 +67,7 @@ class ValidatePublicationTypesCommand extends ValidatingCommand
 
     protected function validateSchemaFiles(): void
     {
-        /** Uses the same glob pattern as {@see PublicationService::getSchemaFiles()} */
+        /** Uses the same glob pattern as {@see Publications::getSchemaFiles()} */
         $schemaFiles = glob(Hyde::path(Hyde::getSourceRoot()).'/*/schema.json');
 
         if (empty($schemaFiles)) {

--- a/packages/publications/src/Commands/ValidatePublicationsCommand.php
+++ b/packages/publications/src/Commands/ValidatePublicationsCommand.php
@@ -4,6 +4,15 @@ declare(strict_types=1);
 
 namespace Hyde\Publications\Commands;
 
+use Hyde\Hyde;
+use Hyde\Publications\Actions\PublicationPageValidator;
+use Hyde\Publications\Models\PublicationType;
+use Hyde\Publications\PublicationService;
+use Illuminate\Support\Collection;
+use InvalidArgumentException;
+use LaravelZero\Framework\Commands\Command;
+
+use function array_key_last;
 use function array_map;
 use function array_values;
 use function basename;
@@ -12,23 +21,14 @@ use function count;
 use function explode;
 use function filled;
 use function glob;
-
-use Hyde\Hyde;
-use Hyde\Publications\Actions\PublicationPageValidator;
-use Hyde\Publications\Models\PublicationType;
-use Hyde\Publications\PublicationService;
-use Illuminate\Support\Collection;
-use InvalidArgumentException;
-
+use function in_array;
 use function json_encode;
-
-use LaravelZero\Framework\Commands\Command;
-
 use function memory_get_peak_usage;
 use function microtime;
 use function round;
 use function sprintf;
 use function str_repeat;
+use function str_replace;
 use function str_starts_with;
 use function strlen;
 use function substr_count;

--- a/packages/publications/src/Commands/ValidatePublicationsCommand.php
+++ b/packages/publications/src/Commands/ValidatePublicationsCommand.php
@@ -7,7 +7,7 @@ namespace Hyde\Publications\Commands;
 use Hyde\Hyde;
 use Hyde\Publications\Actions\PublicationPageValidator;
 use Hyde\Publications\Models\PublicationType;
-use Hyde\Publications\PublicationService;
+use Hyde\Publications\Publications;
 use Illuminate\Support\Collection;
 use InvalidArgumentException;
 use LaravelZero\Framework\Commands\Command;
@@ -95,7 +95,7 @@ class ValidatePublicationsCommand extends ValidatingCommand
 
     protected function getPublicationTypesToValidate(): Collection
     {
-        $publicationTypes = PublicationService::getPublicationTypes();
+        $publicationTypes = Publications::getPublicationTypes();
         $name = $this->argument('publicationType');
 
         if (filled($name)) {

--- a/packages/publications/src/Commands/ValidatingCommand.php
+++ b/packages/publications/src/Commands/ValidatingCommand.php
@@ -4,16 +4,16 @@ declare(strict_types=1);
 
 namespace Hyde\Publications\Commands;
 
-use function __;
-use function array_merge;
-
 use Hyde\Console\Concerns\Command;
 use Illuminate\Support\Facades\Validator;
-
-use function in_array;
-
 use RuntimeException;
 
+use function __;
+use function array_merge;
+use function implode;
+use function in_array;
+use function sprintf;
+use function trim;
 use function ucfirst;
 
 /**

--- a/packages/publications/src/Concerns/ParsesPublicationFieldInputs.php
+++ b/packages/publications/src/Concerns/ParsesPublicationFieldInputs.php
@@ -5,11 +5,9 @@ declare(strict_types=1);
 namespace Hyde\Publications\Concerns;
 
 use DateTime;
-
-use function filter_var;
-
 use InvalidArgumentException;
 
+use function filter_var;
 use function is_numeric;
 use function substr_count;
 use function trim;

--- a/packages/publications/src/Concerns/PublicationFieldTypes.php
+++ b/packages/publications/src/Concerns/PublicationFieldTypes.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Hyde\Publications;
+namespace Hyde\Publications\Concerns;
 
 use Illuminate\Support\Collection;
 

--- a/packages/publications/src/Models/PublicationFieldDefinition.php
+++ b/packages/publications/src/Models/PublicationFieldDefinition.php
@@ -4,14 +4,13 @@ declare(strict_types=1);
 
 namespace Hyde\Publications\Models;
 
-use function array_filter;
-use function array_merge;
-
-use Hyde\Publications\PublicationFieldTypes;
+use Hyde\Publications\Concerns\PublicationFieldTypes;
 use Hyde\Support\Concerns\Serializable;
 use Hyde\Support\Contracts\SerializableContract;
 use Illuminate\Support\Str;
 
+use function array_filter;
+use function array_merge;
 use function str_contains;
 use function strtolower;
 
@@ -19,7 +18,7 @@ use function strtolower;
  * Represents an entry in the "fields" array of a publication type schema.
  *
  * @see \Hyde\Publications\Models\PublicationFieldValue
- * @see \Hyde\Publications\PublicationFieldTypes
+ * @see \Hyde\Publications\Concerns\PublicationFieldTypes
  * @see \Hyde\Publications\Testing\Feature\PublicationFieldDefinitionTest
  */
 class PublicationFieldDefinition implements SerializableContract

--- a/packages/publications/src/Models/PublicationFieldValue.php
+++ b/packages/publications/src/Models/PublicationFieldValue.php
@@ -7,8 +7,8 @@ declare(strict_types=1);
 namespace Hyde\Publications\Models;
 
 use DateTime;
+use Hyde\Publications\Concerns\PublicationFieldTypes;
 use Hyde\Publications\Concerns\ParsesPublicationFieldInputs;
-use Hyde\Publications\PublicationFieldTypes;
 
 use function is_array;
 
@@ -17,7 +17,7 @@ use function is_array;
  * following rules defined in the "fields" array of the publication type's schema.
  *
  * @see \Hyde\Publications\Models\PublicationFieldDefinition
- * @see \Hyde\Publications\PublicationFieldTypes
+ * @see \Hyde\Publications\Concerns\PublicationFieldTypes
  * @see \Hyde\Publications\Testing\Feature\PublicationFieldValueTest
  */
 final class PublicationFieldValue

--- a/packages/publications/src/Models/PublicationListPage.php
+++ b/packages/publications/src/Models/PublicationListPage.php
@@ -7,6 +7,9 @@ namespace Hyde\Publications\Models;
 use Hyde\Pages\InMemoryPage;
 use Hyde\Publications\Actions\PublicationPageCompiler;
 
+use function config;
+use function in_array;
+
 /**
  * @see \Hyde\Publications\Models\PublicationPage
  * @see \Hyde\Publications\Testing\Feature\PublicationListPageTest

--- a/packages/publications/src/Models/PublicationTags.php
+++ b/packages/publications/src/Models/PublicationTags.php
@@ -106,7 +106,7 @@ class PublicationTags
      *
      * @return array<string>
      */
-    public static function getValuesForTagName(string $tagName): array
+    public static function getValuesForTagGroup(string $tagName): array
     {
         return self::getAllTags()->get($tagName) ?? [];
     }

--- a/packages/publications/src/Models/PublicationTags.php
+++ b/packages/publications/src/Models/PublicationTags.php
@@ -93,7 +93,7 @@ class PublicationTags
     }
 
     /**
-     * Get all available tags.
+     * Get all available tags, arranged by their tag group.
      *
      * @return Collection<string, array<string>>
      */
@@ -103,7 +103,7 @@ class PublicationTags
     }
 
     /**
-     * Get all values for a given tag name.
+     * Get all values for a given tag group, by its name.
      *
      * @return array<string>
      */
@@ -113,7 +113,7 @@ class PublicationTags
     }
 
     /**
-     * Get all tag names.
+     * Get all tag group names.
      *
      * @return array<string>
      */

--- a/packages/publications/src/Models/PublicationTags.php
+++ b/packages/publications/src/Models/PublicationTags.php
@@ -4,14 +4,18 @@ declare(strict_types=1);
 
 namespace Hyde\Publications\Models;
 
-use function file_exists;
-
-use Hyde\Facades\Filesystem;
-use Hyde\Framework\Exceptions\FileNotFoundException;
 use Hyde\Hyde;
-use Illuminate\Support\Collection;
-use Symfony\Component\Yaml\Exception\ParseException;
+use Hyde\Facades\Filesystem;
 use Symfony\Component\Yaml\Yaml;
+use Illuminate\Support\Collection;
+use Hyde\Framework\Exceptions\FileNotFoundException;
+use Symfony\Component\Yaml\Exception\ParseException;
+use function assert;
+use function is_int;
+use function is_array;
+use function is_string;
+use function array_merge;
+use function file_exists;
 
 /**
  * Object representation for the tags.yml file.

--- a/packages/publications/src/Models/PublicationTags.php
+++ b/packages/publications/src/Models/PublicationTags.php
@@ -10,6 +10,7 @@ use Symfony\Component\Yaml\Yaml;
 use Illuminate\Support\Collection;
 use Hyde\Framework\Exceptions\FileNotFoundException;
 use Symfony\Component\Yaml\Exception\ParseException;
+
 use function assert;
 use function is_int;
 use function is_array;
@@ -106,9 +107,9 @@ class PublicationTags
      *
      * @return array<string>
      */
-    public static function getValuesForTagGroup(string $tagName): array
+    public static function getValuesForTagGroup(string $groupName): array
     {
-        return self::getAllTags()->get($tagName) ?? [];
+        return self::getAllTags()->get($groupName) ?? [];
     }
 
     /**

--- a/packages/publications/src/Models/PublicationType.php
+++ b/packages/publications/src/Models/PublicationType.php
@@ -4,30 +4,26 @@ declare(strict_types=1);
 
 namespace Hyde\Publications\Models;
 
-use function array_filter;
-use function array_merge;
-use function dirname;
-
 use Exception;
-
-use function file_get_contents;
-use function file_put_contents;
-
 use Hyde\Framework\Concerns\InteractsWithDirectories;
-use Hyde\Support\Paginator;
 use Hyde\Hyde;
 use Hyde\Publications\Actions\PublicationSchemaValidator;
 use Hyde\Publications\PublicationService;
 use Hyde\Support\Concerns\Serializable;
 use Hyde\Support\Contracts\SerializableContract;
+use Hyde\Support\Paginator;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Str;
-
-use function json_decode;
-use function json_encode;
-
 use RuntimeException;
 
+use function array_filter;
+use function array_merge;
+use function dirname;
+use function file_get_contents;
+use function file_put_contents;
+use function is_null;
+use function json_decode;
+use function json_encode;
 use function str_starts_with;
 
 /**

--- a/packages/publications/src/Models/PublicationType.php
+++ b/packages/publications/src/Models/PublicationType.php
@@ -8,7 +8,7 @@ use Exception;
 use Hyde\Framework\Concerns\InteractsWithDirectories;
 use Hyde\Hyde;
 use Hyde\Publications\Actions\PublicationSchemaValidator;
-use Hyde\Publications\PublicationService;
+use Hyde\Publications\Publications;
 use Hyde\Support\Concerns\Serializable;
 use Hyde\Support\Contracts\SerializableContract;
 use Hyde\Support\Paginator;
@@ -192,7 +192,7 @@ class PublicationType implements SerializableContract
     /** @return \Illuminate\Support\Collection<\Hyde\Publications\Models\PublicationPage> */
     public function getPublications(): Collection
     {
-        return PublicationService::getPublicationsForType($this);
+        return Publications::getPublicationsForType($this);
     }
 
     public function getPaginator(int $currentPageNumber = null): Paginator

--- a/packages/publications/src/Providers/TranslationServiceProvider.php
+++ b/packages/publications/src/Providers/TranslationServiceProvider.php
@@ -4,10 +4,9 @@ declare(strict_types=1);
 
 namespace Hyde\Publications\Providers;
 
-use function config;
-
 use Illuminate\Translation\TranslationServiceProvider as IlluminateTranslationServiceProvider;
 
+use function config;
 use function is_dir;
 use function lang_path;
 

--- a/packages/publications/src/PublicationFieldTypes.php
+++ b/packages/publications/src/PublicationFieldTypes.php
@@ -6,6 +6,9 @@ namespace Hyde\Publications;
 
 use Illuminate\Support\Collection;
 
+use function collect;
+use function in_array;
+
 /**
  * The supported field types for publication types.
  *

--- a/packages/publications/src/PublicationService.php
+++ b/packages/publications/src/PublicationService.php
@@ -12,6 +12,8 @@ use Hyde\Publications\Models\PublicationType;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Str;
 
+use function collect;
+
 /**
  * @todo Since this class is now so simplified it may be better suited if renamed to a facade, eg Publications.
  *

--- a/packages/publications/src/Publications.php
+++ b/packages/publications/src/Publications.php
@@ -69,7 +69,7 @@ class Publications
      */
     public static function getValuesForTagName(string $tagName): Collection
     {
-        return collect(PublicationTags::getValuesForTagName($tagName));
+        return collect(PublicationTags::getValuesForTagGroup($tagName));
     }
 
     /**

--- a/packages/publications/src/Publications.php
+++ b/packages/publications/src/Publications.php
@@ -15,11 +15,9 @@ use Illuminate\Support\Str;
 use function collect;
 
 /**
- * @todo Since this class is now so simplified it may be better suited if renamed to a facade, eg Publications.
- *
  * @see \Hyde\Publications\Testing\Feature\PublicationServiceTest
  */
-class PublicationService
+class Publications
 {
     /**
      * Return a collection of all defined publication types, indexed by the directory name.

--- a/packages/publications/src/PublicationsExtension.php
+++ b/packages/publications/src/PublicationsExtension.php
@@ -4,13 +4,13 @@ declare(strict_types=1);
 
 namespace Hyde\Publications;
 
-use Hyde\Hyde;
-use Hyde\Pages\InMemoryPage;
 use Hyde\Facades\Filesystem;
-use Hyde\Foundation\Facades\Files;
 use Hyde\Foundation\Concerns\HydeExtension;
+use Hyde\Foundation\Facades\Files;
 use Hyde\Foundation\Kernel\FileCollection;
 use Hyde\Foundation\Kernel\PageCollection;
+use Hyde\Hyde;
+use Hyde\Pages\InMemoryPage;
 use Hyde\Publications\Actions\GeneratesPublicationTagPages;
 use Hyde\Publications\Models\PublicationListPage;
 use Hyde\Publications\Models\PublicationPage;

--- a/packages/publications/src/PublicationsServiceProvider.php
+++ b/packages/publications/src/PublicationsServiceProvider.php
@@ -5,11 +5,13 @@ declare(strict_types=1);
 namespace Hyde\Publications;
 
 use Hyde\Foundation\HydeKernel;
-use Hyde\Publications\Views\Components\RelatedPublicationsComponent;
-use Hyde\Publications\Providers\TranslationServiceProvider;
 use Illuminate\Support\Facades\Blade;
 use Illuminate\Support\ServiceProvider;
 use Illuminate\Validation\ValidationServiceProvider;
+use Hyde\Publications\Providers\TranslationServiceProvider;
+use Hyde\Publications\Views\Components\RelatedPublicationsComponent;
+
+use function resource_path;
 
 class PublicationsServiceProvider extends ServiceProvider
 {

--- a/packages/publications/src/Views/Components/RelatedPublicationsComponent.php
+++ b/packages/publications/src/Views/Components/RelatedPublicationsComponent.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Hyde\Publications\Views\Components;
 
 use Hyde\Hyde;
+use Hyde\Publications\Models\PublicationFieldDefinition;
 use Hyde\Publications\Models\PublicationPage;
 use Hyde\Publications\Publications;
 use Illuminate\Contracts\View\View;
@@ -47,7 +48,7 @@ class RelatedPublicationsComponent extends Component
         $publicationType = $currentHydePage->getType();
 
         // Get the tag fields for the current publicationType or exit early if there aren't any
-        $publicationTypeTagFields = $publicationType->getFields()->filter(function ($field) {
+        $publicationTypeTagFields = $publicationType->getFields()->filter(function (PublicationFieldDefinition $field): bool {
             return $field->tagGroup !== null;
         });
         if ($publicationTypeTagFields->isEmpty()) {

--- a/packages/publications/src/Views/Components/RelatedPublicationsComponent.php
+++ b/packages/publications/src/Views/Components/RelatedPublicationsComponent.php
@@ -6,7 +6,7 @@ namespace Hyde\Publications\Views\Components;
 
 use Hyde\Hyde;
 use Hyde\Publications\Models\PublicationPage;
-use Hyde\Publications\PublicationService;
+use Hyde\Publications\Publications;
 use Illuminate\Contracts\View\View;
 use Illuminate\Support\Collection;
 use Illuminate\View\Component;
@@ -55,7 +55,7 @@ class RelatedPublicationsComponent extends Component
         }
 
         // Get a list of all pages for this page's publicationType: 1 means we only have current page & no related pages exist
-        $publicationPages = PublicationService::getPublicationsForType($publicationType)->keyBy('identifier');
+        $publicationPages = Publications::getPublicationsForType($publicationType)->keyBy('identifier');
         if ($publicationPages->count() <= 1) {
             return collect();
         }

--- a/packages/publications/src/Views/Components/RelatedPublicationsComponent.php
+++ b/packages/publications/src/Views/Components/RelatedPublicationsComponent.php
@@ -11,6 +11,10 @@ use Illuminate\Contracts\View\View;
 use Illuminate\Support\Collection;
 use Illuminate\View\Component;
 
+use function collect;
+use function count;
+use function view;
+
 class RelatedPublicationsComponent extends Component
 {
     /** @var Collection<string, PublicationPage> */

--- a/packages/publications/tests/Feature/CreatesNewPublicationPageTest.php
+++ b/packages/publications/tests/Feature/CreatesNewPublicationPageTest.php
@@ -4,20 +4,20 @@ declare(strict_types=1);
 
 namespace Hyde\Publications\Testing\Feature;
 
-use function file_get_contents;
-
-use Hyde\Facades\Filesystem;
 use Hyde\Hyde;
-use Hyde\Publications\Actions\CreatesNewPublicationPage;
-use Hyde\Publications\Models\PublicationFieldValue;
-use Hyde\Publications\Models\PublicationType;
-use Hyde\Publications\PublicationFieldTypes;
-use Hyde\Testing\TestCase;
-use Illuminate\Support\Carbon;
-use Illuminate\Support\Collection;
-use Illuminate\Support\Str;
 use RuntimeException;
+use Hyde\Testing\TestCase;
+use Illuminate\Support\Str;
+use Hyde\Facades\Filesystem;
+use Illuminate\Support\Carbon;
 use Symfony\Component\Yaml\Yaml;
+use Illuminate\Support\Collection;
+use Hyde\Publications\Models\PublicationType;
+use Hyde\Publications\Models\PublicationFieldValue;
+use Hyde\Publications\Concerns\PublicationFieldTypes;
+use Hyde\Publications\Actions\CreatesNewPublicationPage;
+
+use function file_get_contents;
 
 /**
  * @covers \Hyde\Publications\Actions\CreatesNewPublicationPage

--- a/packages/publications/tests/Feature/MakePublicationTypeCommandTest.php
+++ b/packages/publications/tests/Feature/MakePublicationTypeCommandTest.php
@@ -4,12 +4,12 @@ declare(strict_types=1);
 
 namespace Hyde\Publications\Testing\Feature;
 
-use Hyde\Facades\Filesystem;
 use Hyde\Hyde;
-use Hyde\Publications\Commands\Helpers\InputStreamHandler;
-use Hyde\Publications\Models\PublicationTags;
-use Hyde\Publications\PublicationFieldTypes;
 use Hyde\Testing\TestCase;
+use Hyde\Facades\Filesystem;
+use Hyde\Publications\Models\PublicationTags;
+use Hyde\Publications\Concerns\PublicationFieldTypes;
+use Hyde\Publications\Commands\Helpers\InputStreamHandler;
 
 /**
  * @covers \Hyde\Publications\Commands\MakePublicationTypeCommand

--- a/packages/publications/tests/Feature/PublicationFieldDefinitionTest.php
+++ b/packages/publications/tests/Feature/PublicationFieldDefinitionTest.php
@@ -4,10 +4,10 @@ declare(strict_types=1);
 
 namespace Hyde\Publications\Testing\Feature;
 
-use Hyde\Publications\Models\PublicationFieldDefinition;
-use Hyde\Publications\PublicationFieldTypes;
-use Hyde\Testing\TestCase;
 use ValueError;
+use Hyde\Testing\TestCase;
+use Hyde\Publications\Concerns\PublicationFieldTypes;
+use Hyde\Publications\Models\PublicationFieldDefinition;
 
 /**
  * @covers \Hyde\Publications\Models\PublicationFieldDefinition

--- a/packages/publications/tests/Feature/PublicationFieldTypesEnumTest.php
+++ b/packages/publications/tests/Feature/PublicationFieldTypesEnumTest.php
@@ -4,11 +4,11 @@ declare(strict_types=1);
 
 namespace Hyde\Publications\Testing\Feature;
 
-use Hyde\Publications\PublicationFieldTypes;
 use Hyde\Testing\TestCase;
+use Hyde\Publications\Concerns\PublicationFieldTypes;
 
 /**
- * @covers \Hyde\Publications\PublicationFieldTypes
+ * @covers \Hyde\Publications\Concerns\PublicationFieldTypes
  */
 class PublicationFieldTypesEnumTest extends TestCase
 {

--- a/packages/publications/tests/Feature/PublicationFieldValueTest.php
+++ b/packages/publications/tests/Feature/PublicationFieldValueTest.php
@@ -6,11 +6,11 @@ namespace Hyde\Publications\Testing\Feature;
 
 use DateTime;
 use Exception;
-use Hyde\Publications\Models\PublicationFieldValue;
-use Hyde\Publications\PublicationFieldTypes;
 use Hyde\Testing\TestCase;
 use InvalidArgumentException;
 use Symfony\Component\Yaml\Yaml;
+use Hyde\Publications\Models\PublicationFieldValue;
+use Hyde\Publications\Concerns\PublicationFieldTypes;
 
 /**
  * @covers \Hyde\Publications\Models\PublicationFieldValue

--- a/packages/publications/tests/Feature/PublicationServiceTest.php
+++ b/packages/publications/tests/Feature/PublicationServiceTest.php
@@ -10,14 +10,14 @@ use Hyde\Framework\Exceptions\FileNotFoundException;
 use Hyde\Hyde;
 use Hyde\Publications\Models\PublicationPage;
 use Hyde\Publications\Models\PublicationType;
-use Hyde\Publications\PublicationService;
+use Hyde\Publications\Publications;
 use Hyde\Testing\TestCase;
 use Illuminate\Support\Collection;
 
 use function json_encode;
 
 /**
- * @covers \Hyde\Publications\PublicationService
+ * @covers \Hyde\Publications\Publications
  * @covers \Hyde\Publications\PublicationsExtension
  */
 class PublicationServiceTest extends TestCase
@@ -31,7 +31,7 @@ class PublicationServiceTest extends TestCase
 
     public function testGetPublicationTypes()
     {
-        $this->assertEquals(new Collection(), PublicationService::getPublicationTypes());
+        $this->assertEquals(new Collection(), Publications::getPublicationTypes());
     }
 
     public function testGetPublicationTypesWithTypes()
@@ -41,14 +41,14 @@ class PublicationServiceTest extends TestCase
 
         $this->assertEquals(new Collection([
             'test-publication' => PublicationType::get('test-publication'),
-        ]), PublicationService::getPublicationTypes());
+        ]), Publications::getPublicationTypes());
     }
 
     public function testGetPublicationTypesMethodReturnsTheSameInstances()
     {
         $this->createPublicationType();
 
-        $this->assertSame(PublicationService::getPublicationTypes(), PublicationService::getPublicationTypes());
+        $this->assertSame(Publications::getPublicationTypes(), Publications::getPublicationTypes());
     }
 
     public function testGetPublicationsForPubType()
@@ -57,7 +57,7 @@ class PublicationServiceTest extends TestCase
 
         $this->assertEquals(
             new Collection(),
-            PublicationService::getPublicationsForType(PublicationType::get('test-publication'))
+            Publications::getPublicationsForType(PublicationType::get('test-publication'))
         );
     }
 
@@ -70,7 +70,7 @@ class PublicationServiceTest extends TestCase
             new Collection([
                 PublicationPage::parse('test-publication/foo'),
             ]),
-            PublicationService::getPublicationsForType(PublicationType::get('test-publication'))
+            Publications::getPublicationsForType(PublicationType::get('test-publication'))
         );
     }
 
@@ -81,7 +81,7 @@ class PublicationServiceTest extends TestCase
 
         $this->assertContainsOnlyInstancesOf(
             PublicationPage::class,
-            PublicationService::getPublicationsForType(PublicationType::get('test-publication'))
+            Publications::getPublicationsForType(PublicationType::get('test-publication'))
         );
     }
 
@@ -99,7 +99,7 @@ class PublicationServiceTest extends TestCase
                 PublicationPage::parse('test-publication/two'),
                 PublicationPage::parse('test-publication/three'),
             ]),
-            PublicationService::getPublicationsForType(PublicationType::get('test-publication'))
+            Publications::getPublicationsForType(PublicationType::get('test-publication'))
         );
     }
 
@@ -117,7 +117,7 @@ class PublicationServiceTest extends TestCase
                 PublicationPage::parse('test-publication/two'),
                 PublicationPage::parse('test-publication/one'),
             ]),
-            PublicationService::getPublicationsForType(PublicationType::get('test-publication'))
+            Publications::getPublicationsForType(PublicationType::get('test-publication'))
         );
     }
 
@@ -135,7 +135,7 @@ class PublicationServiceTest extends TestCase
                 PublicationPage::parse('test-publication/two'),
                 PublicationPage::parse('test-publication/three'),
             ]),
-            PublicationService::getPublicationsForType(PublicationType::get('test-publication'), 'readCount')
+            Publications::getPublicationsForType(PublicationType::get('test-publication'), 'readCount')
         );
     }
 
@@ -153,7 +153,7 @@ class PublicationServiceTest extends TestCase
                 PublicationPage::parse('test-publication/two'),
                 PublicationPage::parse('test-publication/one'),
             ]),
-            PublicationService::getPublicationsForType(PublicationType::get('test-publication'), 'readCount', false)
+            Publications::getPublicationsForType(PublicationType::get('test-publication'), 'readCount', false)
         );
     }
 
@@ -171,7 +171,7 @@ class PublicationServiceTest extends TestCase
                 PublicationPage::parse('test-publication/three'),
                 PublicationPage::parse('test-publication/two'),
             ]),
-            PublicationService::getPublicationsForType(PublicationType::get('test-publication'), 'invalid')
+            Publications::getPublicationsForType(PublicationType::get('test-publication'), 'invalid')
         );
     }
 
@@ -181,7 +181,7 @@ class PublicationServiceTest extends TestCase
 
         $this->assertEquals(
             new Collection(),
-            PublicationService::getMediaForType(PublicationType::get('test-publication'))
+            Publications::getMediaForType(PublicationType::get('test-publication'))
         );
     }
 
@@ -195,7 +195,7 @@ class PublicationServiceTest extends TestCase
             new Collection([
                 'test-publication/image.png',
             ]),
-            PublicationService::getMediaForType(PublicationType::get('test-publication'))
+            Publications::getMediaForType(PublicationType::get('test-publication'))
         );
     }
 
@@ -210,7 +210,7 @@ class PublicationServiceTest extends TestCase
             new Collection([
                 'test-publication/image.png',
             ]),
-            PublicationService::getMediaForType(PublicationType::get('test-publication'))
+            Publications::getMediaForType(PublicationType::get('test-publication'))
         );
     }
 
@@ -238,8 +238,8 @@ class PublicationServiceTest extends TestCase
     {
         $this->createPublicationType();
 
-        $this->assertTrue(PublicationService::publicationTypeExists('test-publication'));
-        $this->assertFalse(PublicationService::publicationTypeExists('foo'));
+        $this->assertTrue(Publications::publicationTypeExists('test-publication'));
+        $this->assertFalse(Publications::publicationTypeExists('foo'));
     }
 
     public function testGetAllTags()
@@ -251,7 +251,7 @@ class PublicationServiceTest extends TestCase
             ],
         ];
         $this->file('tags.yml', json_encode($tags));
-        $this->assertSame($tags, PublicationService::getAllTags()->toArray());
+        $this->assertSame($tags, Publications::getAllTags()->toArray());
     }
 
     public function testGetValuesForTagName()
@@ -269,7 +269,7 @@ class PublicationServiceTest extends TestCase
 
         $this->file('tags.yml', json_encode($tags));
 
-        $this->assertSame(['bar', 'baz'], PublicationService::getValuesForTagName('foo')->toArray());
+        $this->assertSame(['bar', 'baz'], Publications::getValuesForTagName('foo')->toArray());
     }
 
     protected function createPublicationType(): void

--- a/packages/publications/tests/Feature/PublicationTagsTest.php
+++ b/packages/publications/tests/Feature/PublicationTagsTest.php
@@ -239,7 +239,7 @@ class PublicationTagsTest extends TestCase
 
         $this->file('tags.yml', json_encode($tags));
 
-        $this->assertSame(['bar', 'baz'], PublicationTags::getValuesForTagName('foo'));
+        $this->assertSame(['bar', 'baz'], PublicationTags::getValuesForTagGroup('foo'));
     }
 
     public function testGetValuesForTagNameWithMissingTagName()
@@ -253,12 +253,12 @@ class PublicationTagsTest extends TestCase
 
         $this->file('tags.yml', json_encode($tags));
 
-        $this->assertSame([], PublicationTags::getValuesForTagName('bar'));
+        $this->assertSame([], PublicationTags::getValuesForTagGroup('bar'));
     }
 
     public function testGetValuesForTagNameWithNoTags()
     {
-        $this->assertSame([], PublicationTags::getValuesForTagName('foo'));
+        $this->assertSame([], PublicationTags::getValuesForTagGroup('foo'));
     }
 
     public function testValidateTagsFileWithValidFile()

--- a/packages/publications/tests/Feature/PublicationTypeTest.php
+++ b/packages/publications/tests/Feature/PublicationTypeTest.php
@@ -13,7 +13,7 @@ use Hyde\Publications\Models\PublicationFieldDefinition;
 use Hyde\Publications\Models\PublicationListPage;
 use Hyde\Publications\Models\PublicationPage;
 use Hyde\Publications\Models\PublicationType;
-use Hyde\Publications\PublicationService;
+use Hyde\Publications\Publications;
 use Hyde\Testing\TestCase;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\File;
@@ -286,7 +286,7 @@ class PublicationTypeTest extends TestCase
     {
         $publicationType = new PublicationType(...$this->getTestData());
         $this->assertEquals(
-            PublicationService::getPublicationsForType($publicationType),
+            Publications::getPublicationsForType($publicationType),
             $publicationType->getPublications()
         );
     }

--- a/packages/publications/tests/Feature/StaticSiteBuilderPublicationModuleTest.php
+++ b/packages/publications/tests/Feature/StaticSiteBuilderPublicationModuleTest.php
@@ -4,18 +4,17 @@ declare(strict_types=1);
 
 namespace Hyde\Publications\Testing\Feature;
 
-use function collect;
-
-use Hyde\Facades\Filesystem;
 use Hyde\Hyde;
-use Hyde\Publications\Actions\CreatesNewPublicationType;
-use Hyde\Publications\Actions\SeedsPublicationFiles;
-use Hyde\Publications\Models\PublicationType;
-use Hyde\Publications\PublicationFieldTypes;
 use Hyde\Testing\TestCase;
+use Hyde\Facades\Filesystem;
 use Illuminate\Support\Collection;
+use Hyde\Publications\Models\PublicationType;
+use Hyde\Publications\Actions\SeedsPublicationFiles;
+use Hyde\Publications\Concerns\PublicationFieldTypes;
+use Hyde\Publications\Actions\CreatesNewPublicationType;
 
 use function range;
+use function collect;
 
 /**
  * Tests that publication pages are compiled properly when building the static site.


### PR DESCRIPTION
## Changes

While the Publications package is not yet released, and thus does not have a BC promise yet, I'm documenting the changes here as the package is being used by production sites.

### Minor

- Clean up function imports

### Move PublicationFieldTypes into Concerns namespace

After conferring with ChatGPT I think this makes the most semantic sense, as it defines shared logic and data for multiple domains, while not being a "true" concern, the Concerns namespace feels like the least bad of options available.

#### Upgrade guide

Replace the following import/namespace usage

```php
- Hyde\Publications\PublicationFieldTypes::class
+ Hyde\Publications\Concerns\PublicationFieldTypes::class
```

### Rename class PublicationsService to Publications

Since this class is now so simplified it works better as a facade.

#### Upgrade guide

Replace the following usages of the following class

```php
- Hyde\Publications\PublicationService::class
+ Hyde\Publications\Publications::class
```