### PR TITLE
Change HydePage return types to static

### DIFF
--- a/packages/framework/src/Pages/Concerns/HydePage.php
+++ b/packages/framework/src/Pages/Concerns/HydePage.php
@@ -105,7 +105,7 @@ abstract class HydePage implements PageSchema, SerializableContract
      *
      * @throws \Hyde\Framework\Exceptions\FileNotFoundException If the page does not exist.
      */
-    public static function get(string $identifier): HydePage
+    public static function get(string $identifier): static
     {
         return Pages::getPage(static::sourcePath($identifier));
     }
@@ -118,7 +118,7 @@ abstract class HydePage implements PageSchema, SerializableContract
      *
      * @throws \Hyde\Framework\Exceptions\FileNotFoundException If the file does not exist.
      */
-    public static function parse(string $identifier): HydePage
+    public static function parse(string $identifier): static
     {
         return (new SourceFileParser(static::class, $identifier))->get();
     }


### PR DESCRIPTION
Gives better IDE support, and unifies the class return types as other methods also return static.