### PR TITLE
Invert Webpack asset synchronization flow

### DIFF
--- a/webpack.mix.js
+++ b/webpack.mix.js
@@ -4,9 +4,9 @@
 
 let mix = require('laravel-mix');
 
-mix.js('resources/assets/app.js', 'app.js')
-    .postCss('resources/assets/app.css', 'app.css', [
+mix.js('resources/assets/app.js', 'media/app.js')
+    .postCss('resources/assets/app.css', 'media/app.css', [
         require('tailwindcss'),
         require('autoprefixer'),
-    ]).setPublicPath('_media')
-    .copyDirectory('_media', '_site/media');
+    ]).setPublicPath('_site')
+    .copyDirectory('_site/media', '_media')


### PR DESCRIPTION
This method seems more reliable than existing behaviour, and should provide a better fix for https://github.com/hydephp/hyde/issues/224 than https://github.com/hydephp/develop/pull/1375.