### PR TITLE
Revert Webpack public path to include media subdirectory

### DIFF
--- a/webpack.mix.js
+++ b/webpack.mix.js
@@ -4,9 +4,9 @@
 
 let mix = require('laravel-mix');
 
-mix.js('resources/assets/app.js', 'media/app.js')
-    .postCss('resources/assets/app.css', 'media/app.css', [
+mix.js('resources/assets/app.js', 'app.js')
+    .postCss('resources/assets/app.css', 'app.css', [
         require('tailwindcss'),
         require('autoprefixer'),
-    ]).setPublicPath('_site')
+    ]).setPublicPath('_site/media')
     .copyDirectory('_site/media', '_media')


### PR DESCRIPTION
Fixes accidental BC break in https://github.com/hydephp/develop/pull/1376. **This commit has not yet made it into a release as it was caught immediately.** The original issue still seems to be fixed by this.


> System testing CI caught a side effect I missed, the mix manifest ends up in a different location.

https://github.com/hydephp/develop/actions/runs/5047110370/jobs/9053512838

_Originally posted by @caendesilva in https://github.com/hydephp/develop/issues/1376#issuecomment-1557660162_
            