### PR TITLE
Mark DashboardController as internal

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -14,7 +14,7 @@ This serves two purposes:
 - Added support for setting a custom post date when calling post file creator action directly in https://github.com/hydephp/develop/pull/1393
 
 ### Changed
-- for changes in existing functionality.
+- Realtime Compiler: The `DashboardController` class is now marked as internal, as it is not intended to be used outside of the package.
 
 ### Deprecated
 - for soon-to-be removed features.

--- a/packages/realtime-compiler/src/Http/DashboardController.php
+++ b/packages/realtime-compiler/src/Http/DashboardController.php
@@ -20,6 +20,9 @@ use function sprintf;
 use function config;
 use function app;
 
+/**
+ * @internal This class is not intended to be edited outside the Hyde Realtime Compiler.
+ */
 class DashboardController
 {
     public string $title;


### PR DESCRIPTION
Marks the `DashboardController` class as internal, as it is not intended to be used outside of the package.

RFC: https://twitter.com/CodeWithCaen/status/1716145658426519821