### PR TITLE
Update realtime compiler dashboard configuration schema

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -16,6 +16,7 @@ This serves two purposes:
 
 ### Changed
 - Realtime Compiler: The `DashboardController` class is now marked as internal, as it is not intended to be used outside of the package https://github.com/hydephp/develop/pull/1394
+- Updated the realtime compiler server configuration options in https://github.com/hydephp/develop/pull/1395 (backwards compatible)
 
 ### Deprecated
 - for soon-to-be removed features.

--- a/config/hyde.php
+++ b/config/hyde.php
@@ -399,6 +399,8 @@ return [
     |--------------------------------------------------------------------------
     |
     | Here you can configure settings for the built-in realtime compiler server.
+    | The server also includes a magic dashboard feature that supercharges
+    | your local development! This feature can alo be customised here.
     |
     */
 
@@ -412,14 +414,17 @@ return [
         // Should preview pages be saved to the output directory?
         'save_preview' => true,
 
-        // Should the realtime compiler dashboard be enabled?
-        'dashboard' => env('SERVER_DASHBOARD', true),
+        // Configure the realtime compiler dashboard
+        'dashboard' => [
+            // Should the realtime compiler dashboard be enabled?
+            'enabled' => env('SERVER_DASHBOARD', true),
 
-        // Can the dashboard make edits to the project file system?
-        'dashboard_editor' => true,
+            // Can the dashboard make edits to the project file system?
+            'interactive' => true,
 
-        // Should the dashboard show tips?
-        'dashboard_tips' => true,
+            // Should the dashboard show tips?
+            'tips' => true,
+        ],
 
     ],
 

--- a/packages/framework/config/hyde.php
+++ b/packages/framework/config/hyde.php
@@ -399,6 +399,8 @@ return [
     |--------------------------------------------------------------------------
     |
     | Here you can configure settings for the built-in realtime compiler server.
+    | The server also includes a magic dashboard feature that supercharges
+    | your local development! This feature can alo be customised here.
     |
     */
 
@@ -412,14 +414,17 @@ return [
         // Should preview pages be saved to the output directory?
         'save_preview' => true,
 
-        // Should the realtime compiler dashboard be enabled?
-        'dashboard' => env('SERVER_DASHBOARD', true),
+        // Configure the realtime compiler dashboard
+        'dashboard' => [
+            // Should the realtime compiler dashboard be enabled?
+            'enabled' => env('SERVER_DASHBOARD', true),
 
-        // Can the dashboard make edits to the project file system?
-        'dashboard_editor' => true,
+            // Can the dashboard make edits to the project file system?
+            'interactive' => true,
 
-        // Should the dashboard show tips?
-        'dashboard_tips' => true,
+            // Should the dashboard show tips?
+            'tips' => true,
+        ],
 
     ],
 

--- a/packages/realtime-compiler/src/Http/DashboardController.php
+++ b/packages/realtime-compiler/src/Http/DashboardController.php
@@ -36,12 +36,14 @@ use function round;
 use function rtrim;
 use function strlen;
 use function substr;
+use function is_bool;
 use function basename;
 use function in_array;
 use function json_decode;
 use function json_encode;
 use function substr_count;
 use function array_combine;
+use function trigger_error;
 use function escapeshellarg;
 use function file_get_contents;
 use function str_starts_with;
@@ -67,8 +69,8 @@ class DashboardController
         'This dashboard won\'t be saved to your static site.',
         'Got stuck? Ask for help on [GitHub](https://github.com/hydephp/hyde)!',
         'Found a bug? Please report it on [GitHub](https://github.com/hydephp/hyde)!',
-        'You can disable tips using by setting `server.dashboard_tips` to `false` in `config/hyde.php`.',
-        'The dashboard update your project files. You can disable this by setting `server.dashboard_editor` to `false` in `config/hyde.php`.',
+        'You can disable tips using by setting `server.dashboard.tips` to `false` in `config/hyde.php`.',
+        'The dashboard update your project files. You can disable this by setting `server.dashboard.interactive` to `false` in `config/hyde.php`.',
     ];
 
     public function __construct()
@@ -227,7 +229,7 @@ class DashboardController
 
     public function showTips(): bool
     {
-        return config('hyde.server.dashboard_tips', true);
+        return config('hyde.server.dashboard.tips', true);
     }
 
     public function getTip(): HtmlString
@@ -237,7 +239,14 @@ class DashboardController
 
     public static function enabled(): bool
     {
-        return config('hyde.server.dashboard', true);
+        // Previously, the setting was hyde.server.dashboard, so for backwards compatability we need this
+        if (is_bool($oldConfig = config('hyde.server.dashboard'))) {
+            trigger_error('Using `hyde.server.dashboard` as boolean is deprecated. Please use `hyde.server.dashboard.enabled` instead.', E_USER_DEPRECATED);
+
+            return $oldConfig;
+        }
+
+        return config('hyde.server.dashboard.enabled', true);
     }
 
     // This method is called from the PageRouter and allows us to serve a dynamic welcome page
@@ -273,7 +282,7 @@ class DashboardController
 
     public function isInteractive(): bool
     {
-        return config('hyde.server.dashboard_editor', true);
+        return config('hyde.server.dashboard.interactive', true);
     }
 
     public function getScripts(): string


### PR DESCRIPTION
This moves the dashboard settings into an array. While this is a somewhat intrusive change, requiring user intervention due to the implicit deprecation, it helps make the configuration file cleaner by grouping semantically related elements. An added check makes sure to provide backwards compatibility with older configuration options.

The shortened editor/tips keys are not breaking, as they have not been released yet.

To upgrade, replace the following in `config/hyde.php`:
```php
'server' => [
    // ...

    'enabled' => env('SERVER_DASHBOARD', true),
],
```
With this:
```php
'server' => [
    // ...

    'dashboard' => [
        'enabled' => env('SERVER_DASHBOARD', true),
    ],
],
```