### PR TITLE
Use a custom exception message when failing to get image size

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -30,6 +30,7 @@ This serves two purposes:
 - Updated dropdown navigation menus to support setting priority in config in https://github.com/hydephp/develop/pull/1387 (fixing https://github.com/hydephp/hyde/issues/229)
 - Updated the vendor publish command to support parent Laravel Prompts implementation in https://github.com/hydephp/develop/pull/1388
 - Fixed wrong version constant in https://github.com/hydephp/develop/pull/1391
+- Fixed improperly formatted exception message in https://github.com/hydephp/develop/pull/1399
 
 ### Security
 - in case of vulnerabilities.

--- a/packages/framework/src/Framework/Features/Blogging/Models/FeaturedImage.php
+++ b/packages/framework/src/Framework/Features/Blogging/Models/FeaturedImage.php
@@ -217,7 +217,7 @@ class FeaturedImage implements Stringable, FeaturedImageSchema
         $storagePath = Hyde::mediaPath($this->source);
 
         if (! file_exists($storagePath)) {
-            throw new FileNotFoundException(sprintf('Image at %s does not exist', Hyde::pathToRelative($storagePath)));
+            throw new FileNotFoundException(customMessage: sprintf('Featured image [%s] not found.', Hyde::pathToRelative($storagePath)));
         }
 
         return filesize($storagePath);

--- a/packages/framework/tests/Unit/FeaturedImageUnitTest.php
+++ b/packages/framework/tests/Unit/FeaturedImageUnitTest.php
@@ -124,7 +124,7 @@ class FeaturedImageUnitTest extends UnitTestCase
     public function testFeaturedImageGetContentLengthWithNoSource()
     {
         $this->expectException(FileNotFoundException::class);
-        $this->expectExceptionMessage('Image at _media/foo does not exist');
+        $this->expectExceptionMessage('Featured image [_media/foo] not found.');
 
         $image = new FeaturedImage('_media/foo', ...$this->defaultArguments());
         $this->assertEquals(0, $image->getContentLength());


### PR DESCRIPTION
Fixes an embarrassing bug in error output, that I missed due to PHPUnit (for some reason) using substring comparisons for testing exception messages.

This lead to the following:

    File [Image at _media/foo does not exist] not found.

This uses the new custom message feature from https://github.com/hydephp/develop/pull/1398 so it instead looks like this:

    Featured image [_media/default] not found.