### PR TITLE
Internal: Update test runner statistics server script version

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -68,7 +68,7 @@ jobs:
 
       - name: Ping statistics server with test results
         run: |
-          curl https://raw.githubusercontent.com/hydephp/develop/4acc82cfb5ff431302dcbb2b11c5331efd47c872/monorepo/scripts/ping-openanalytics-testrunner.php -o ping.php
+          curl https://raw.githubusercontent.com/hydephp/develop/cfbf8fb97505359266f849edef4757ae76a922b5/monorepo/scripts/ping-openanalytics-testrunner.php -o ping.php
           php ping.php "Monorepo CI Matrix" ${{ secrets.OPENANALYTICS_TOKEN }} ${{ github.ref_name  }}
 
   system-testing:
@@ -208,7 +208,7 @@ jobs:
       - name: Ping statistics server with test results
         run: |
           cp build/junit.xml report.xml
-          curl https://raw.githubusercontent.com/hydephp/develop/4acc82cfb5ff431302dcbb2b11c5331efd47c872/monorepo/scripts/ping-openanalytics-testrunner.php -o ping.php
+          curl https://raw.githubusercontent.com/hydephp/develop/cfbf8fb97505359266f849edef4757ae76a922b5/monorepo/scripts/ping-openanalytics-testrunner.php -o ping.php
           php ping.php "Monorepo PR Test" ${{ secrets.OPENANALYTICS_TOKEN }} ${{ github.ref_name  }}
 
       - name: Upload coverage artifacts

--- a/.github/workflows/smoke-tests.yml
+++ b/.github/workflows/smoke-tests.yml
@@ -29,7 +29,7 @@ jobs:
 
       - name: Ping statistics server with test results
         run: |
-          curl https://raw.githubusercontent.com/hydephp/develop/4acc82cfb5ff431302dcbb2b11c5331efd47c872/monorepo/scripts/ping-openanalytics-testrunner.php -o ping.php
+          curl https://raw.githubusercontent.com/hydephp/develop/cfbf8fb97505359266f849edef4757ae76a922b5/monorepo/scripts/ping-openanalytics-testrunner.php -o ping.php
           php ping.php "Monorepo Smoke Tests" ${{ secrets.OPENANALYTICS_TOKEN }} ${{ github.ref_name  }}
 
 
@@ -68,5 +68,5 @@ jobs:
 
       - name: Ping statistics server with test results
         run: |
-          curl https://raw.githubusercontent.com/hydephp/develop/4acc82cfb5ff431302dcbb2b11c5331efd47c872/monorepo/scripts/ping-openanalytics-testrunner.php -o ping.php
+          curl https://raw.githubusercontent.com/hydephp/develop/cfbf8fb97505359266f849edef4757ae76a922b5/monorepo/scripts/ping-openanalytics-testrunner.php -o ping.php
           php ping.php "Monorepo Smoke Tests - Coverage" ${{ secrets.OPENANALYTICS_TOKEN }} ${{ github.ref_name  }}

--- a/.github/workflows/test-pull-requests.yml
+++ b/.github/workflows/test-pull-requests.yml
@@ -51,7 +51,7 @@ jobs:
       - name: Ping statistics server with test results
         run: |
           cp build/junit.xml report.xml
-          curl https://raw.githubusercontent.com/hydephp/develop/4acc82cfb5ff431302dcbb2b11c5331efd47c872/monorepo/scripts/ping-openanalytics-testrunner.php -o ping.php
+          curl https://raw.githubusercontent.com/hydephp/develop/cfbf8fb97505359266f849edef4757ae76a922b5/monorepo/scripts/ping-openanalytics-testrunner.php -o ping.php
           php ping.php "Monorepo PR Test" ${{ secrets.OPENANALYTICS_TOKEN }} ${{ github.ref_name  }}
 
   test-matrix:
@@ -77,5 +77,5 @@ jobs:
 
       - name: Ping statistics server with test results
         run: |
-          curl https://raw.githubusercontent.com/hydephp/develop/4acc82cfb5ff431302dcbb2b11c5331efd47c872/monorepo/scripts/ping-openanalytics-testrunner.php -o ping.php
+          curl https://raw.githubusercontent.com/hydephp/develop/cfbf8fb97505359266f849edef4757ae76a922b5/monorepo/scripts/ping-openanalytics-testrunner.php -o ping.php
           php ping.php "Monorepo PR Matrix" ${{ secrets.OPENANALYTICS_TOKEN }} ${{ github.ref_name  }}

--- a/packages/framework/.github/workflows/run-tests.yml
+++ b/packages/framework/.github/workflows/run-tests.yml
@@ -61,5 +61,5 @@ jobs:
       - name: Ping statistics server with test results
         run: |
           cd hyde
-          curl https://gist.githubusercontent.com/caendesilva/d76fc6d73cb488863a8f6fda18a7c8c4/raw/1d22747e5064b40e4da05e7666d1ab1d2766de7a/ping-openanalytics-testrunner.php -o ping.php
+          curl https://raw.githubusercontent.com/hydephp/develop/cfbf8fb97505359266f849edef4757ae76a922b5/monorepo/scripts/ping-openanalytics-testrunner.php -o ping.php
           php ping.php "Framework CI Matrix" ${{ secrets.OPENANALYTICS_TOKEN }}


### PR DESCRIPTION
Realised we have been using the old version for a while (and thus not receiving statistics, as the old script uses the old CI server) This updates the script to the latest one.