### PR TITLE
Update realtime compiler to generate search indexes on demand

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -18,6 +18,7 @@ This serves two purposes:
 ### Changed
 - Realtime Compiler: The `DashboardController` class is now marked as internal, as it is not intended to be used outside of the package https://github.com/hydephp/develop/pull/1394
 - Updated the realtime compiler server configuration options in https://github.com/hydephp/develop/pull/1395 (backwards compatible)
+- Updated the realtime compiler to generate the documentation search index each time it's requested in https://github.com/hydephp/develop/pull/1405 (fixes https://github.com/hydephp/develop/issues/1404)
 
 ### Deprecated
 - for soon-to-be removed features.
@@ -31,6 +32,7 @@ This serves two purposes:
 - Updated the vendor publish command to support parent Laravel Prompts implementation in https://github.com/hydephp/develop/pull/1388
 - Fixed wrong version constant in https://github.com/hydephp/develop/pull/1391
 - Fixed improperly formatted exception message in https://github.com/hydephp/develop/pull/1399
+- Fixed missing support for missing and out of date search indexes when previewing site https://github.com/hydephp/develop/issues/1404 in https://github.com/hydephp/develop/pull/1405
 
 ### Security
 - in case of vulnerabilities.

--- a/docs/creating-content/documentation-pages.md
+++ b/docs/creating-content/documentation-pages.md
@@ -292,12 +292,9 @@ navigation menu items are hidden. The page will still be accessible as normal bu
 ]
 ```
 
-### Search with realtime compiler
+### Live search with the realtime compiler
 
-While the Realtime Compiler (what powers the `php hyde serve` command) serves the search index, however, it does not
-compile the index automatically. So if you're missing the search when previewing your site, run either `php hyde build`
-or `php hyde build:search` to compile the search index.
-
+The Realtime Compiler that powers the `php hyde serve` command will automatically generate a fresh search index each time the browser requests it.
 
 ## Automatic "Edit Page" button
 

--- a/packages/realtime-compiler/src/Routing/Router.php
+++ b/packages/realtime-compiler/src/Routing/Router.php
@@ -74,14 +74,14 @@ class Router
      */
     protected function proxyStatic(): Response
     {
+        if ($this->request->path === '/docs/search.json') {
+            $this->generateSearchIndex();
+        }
+
         $path = AssetFileLocator::find($this->request->path);
 
         if ($path === null) {
-            if ($this->request->path === '/docs/search.json') {
-                $path = $this->generateSearchIndex();
-            } else {
-                return $this->notFound();
-            }
+            return $this->notFound();
         }
 
         $file = new FileObject($path);
@@ -95,16 +95,12 @@ class Router
     }
 
     /**
-     * Generate and serve the documentation search index.
-     *
-     * Note that this only gets called if the index is not
-     * yet generated. It does not keep track of if the
-     * index is up-to-date or not.
+     * Generate the documentation search index.
      */
-    protected function generateSearchIndex(): string
+    protected function generateSearchIndex(): void
     {
         $this->bootApplication();
 
-        return GeneratesDocumentationSearchIndex::handle();
+        GeneratesDocumentationSearchIndex::handle();
     }
 }


### PR DESCRIPTION
Previously we required a site build to generate the documentation search index, leaving the realtime compiler to return a 404. This update automatically generates the index on each request.

I decided against caching because of how fast the generator is. The request time (which is asynchronous) is increased to `~160ms` instead of `~30ms` for the entire HydePHP documentation. Considering that this happens in the background, I find this an entirely acceptable tradeoff. 

Fixes https://github.com/hydephp/develop/issues/1404