### PR TITLE
Update navigation menu generator to remove duplicates after sorting

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -19,6 +19,7 @@ This serves two purposes:
 - Realtime Compiler: The `DashboardController` class is now marked as internal, as it is not intended to be used outside of the package https://github.com/hydephp/develop/pull/1394
 - Updated the realtime compiler server configuration options in https://github.com/hydephp/develop/pull/1395 (backwards compatible)
 - Updated the realtime compiler to generate the documentation search index each time it's requested in https://github.com/hydephp/develop/pull/1405 (fixes https://github.com/hydephp/develop/issues/1404)
+- Updated the navigation menu generator to remove duplicates after running the sorting method in https://github.com/hydephp/develop/pull/1407 (fixes https://github.com/hydephp/develop/issues/1406)
 
 ### Deprecated
 - for soon-to-be removed features.
@@ -33,6 +34,7 @@ This serves two purposes:
 - Fixed wrong version constant in https://github.com/hydephp/develop/pull/1391
 - Fixed improperly formatted exception message in https://github.com/hydephp/develop/pull/1399
 - Fixed missing support for missing and out of date search indexes when previewing site https://github.com/hydephp/develop/issues/1404 in https://github.com/hydephp/develop/pull/1405
+- Fixed duplicate navigation items not giving precedence to config defined items https://github.com/hydephp/develop/issues/1406 in https://github.com/hydephp/develop/pull/1407
 
 ### Security
 - in case of vulnerabilities.

--- a/packages/framework/src/Framework/Features/Navigation/BaseNavigationMenu.php
+++ b/packages/framework/src/Framework/Features/Navigation/BaseNavigationMenu.php
@@ -26,8 +26,8 @@ abstract class BaseNavigationMenu
         $menu = new static();
 
         $menu->generate();
-        $menu->removeDuplicateItems();
         $menu->sortByPriority();
+        $menu->removeDuplicateItems();
 
         return $menu;
     }

--- a/packages/framework/tests/Feature/NavigationMenuTest.php
+++ b/packages/framework/tests/Feature/NavigationMenuTest.php
@@ -161,7 +161,22 @@ class NavigationMenuTest extends TestCase
         $this->assertEquals($expected, $menu->items);
     }
 
-    // TODO test when there are duplicates, config items take precedence
+    public function test_config_items_take_precedence_over_generated_items()
+    {
+        $this->file('_pages/foo.md');
+
+        config(['hyde.navigation.custom' => [NavItem::forLink('bar', 'Foo')]]);
+
+        $menu = NavigationMenu::create();
+
+        $expected = collect([
+            NavItem::fromRoute(Routes::get('index')),
+            NavItem::forLink('bar', 'Foo'),
+        ]);
+
+        $this->assertCount(count($expected), $menu->items);
+        $this->assertEquals($expected, $menu->items);
+    }
 
     public function test_documentation_pages_that_are_not_index_are_not_added_to_the_menu()
     {


### PR DESCRIPTION
This means that the duplication filter will run based on the defined item priorities, giving config items precedence, fixing https://github.com/hydephp/develop/issues/1406