### PR TITLE
Update the featured image factory to specify the file causing an exception

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -20,6 +20,7 @@ This serves two purposes:
 - Updated the realtime compiler server configuration options in https://github.com/hydephp/develop/pull/1395 (backwards compatible)
 - Updated the realtime compiler to generate the documentation search index each time it's requested in https://github.com/hydephp/develop/pull/1405 (fixes https://github.com/hydephp/develop/issues/1404)
 - Updated the navigation menu generator to remove duplicates after running the sorting method in https://github.com/hydephp/develop/pull/1407 (fixes https://github.com/hydephp/develop/issues/1406)
+- Updated the exception message caused by missing source option for featured images to include the path of the file that caused the error in https://github.com/hydephp/develop/pull/1409
 
 ### Deprecated
 - for soon-to-be removed features.

--- a/packages/framework/src/Framework/Factories/BlogPostDataFactory.php
+++ b/packages/framework/src/Framework/Factories/BlogPostDataFactory.php
@@ -41,10 +41,13 @@ class BlogPostDataFactory extends Concerns\PageDataFactory implements BlogPostSc
     protected readonly ?PostAuthor $author;
     protected readonly ?FeaturedImage $image;
 
+    private readonly string $filePath;
+
     public function __construct(CoreDataObject $pageData)
     {
         $this->matter = $pageData->matter;
         $this->markdown = $pageData->markdown;
+        $this->filePath = $pageData->sourcePath;
 
         $this->description = $this->makeDescription();
         $this->category = $this->makeCategory();
@@ -98,7 +101,7 @@ class BlogPostDataFactory extends Concerns\PageDataFactory implements BlogPostSc
     protected function makeImage(): ?FeaturedImage
     {
         if ($this->getMatter('image')) {
-            return FeaturedImageFactory::make($this->matter);
+            return FeaturedImageFactory::make($this->matter, $this->filePath);
         }
 
         return null;

--- a/packages/framework/src/Framework/Factories/FeaturedImageFactory.php
+++ b/packages/framework/src/Framework/Factories/FeaturedImageFactory.php
@@ -30,6 +30,7 @@ class FeaturedImageFactory extends Concerns\PageDataFactory implements FeaturedI
 
     public function __construct(
         private readonly FrontMatter $matter,
+        private readonly ?string $filePath = null,
     ) {
         $this->source = $this->makeSource();
         $this->altText = $this->getStringMatter('image.altText');
@@ -58,9 +59,9 @@ class FeaturedImageFactory extends Concerns\PageDataFactory implements FeaturedI
         ];
     }
 
-    public static function make(FrontMatter $matter): FeaturedImage
+    public static function make(FrontMatter $matter, ?string $filePath = null): FeaturedImage
     {
-        return new FeaturedImage(...(new static($matter))->toArray());
+        return new FeaturedImage(...(new static($matter, $filePath))->toArray());
     }
 
     protected function makeSource(): string
@@ -68,9 +69,7 @@ class FeaturedImageFactory extends Concerns\PageDataFactory implements FeaturedI
         $value = $this->getStringMatter('image') ?? $this->getStringMatter('image.source');
 
         if (empty($value)) {
-            // Todo, we might want to add a note about which file caused the error.
-            // We could also check for these before calling the factory, and just ignore the image if it's not valid.
-            throw new RuntimeException('No featured image source was found');
+            throw new RuntimeException(sprintf('No featured image source was found in "%s"', $this->filePath ?? 'unknown file'));
         }
 
         if (FeaturedImage::isRemote($value)) {

--- a/packages/framework/src/Framework/Features/Blogging/Models/FeaturedImage.php
+++ b/packages/framework/src/Framework/Features/Blogging/Models/FeaturedImage.php
@@ -225,9 +225,7 @@ class FeaturedImage implements Stringable, FeaturedImageSchema
 
     protected function getContentLengthForRemoteImage(): int
     {
-        // TODO: We may want to globalize this check in the config, but for now,
-        // we just check the server arguments and skip remote requests if
-        // the --no-api flag is present (in the build command call)
+        // Check if the --no-api flag is set when running the build command, and if so, skip the API call.
         if (! (isset($_SERVER['argv']) && in_array('--no-api', $_SERVER['argv'], true))) {
             $headers = Http::withHeaders([
                 'User-Agent' => Config::getString('hyde.http_user_agent', 'RSS Request Client'),


### PR DESCRIPTION
We throw an exception when an image without a source is specified, but we don't mention which file. Now we do.

```
// Old
No featured image source was found
// New
No featured image source was found in "_posts/my-new-post.md"
```