### PR TITLE
Refactor colored blockquote internals to extract class name from signature

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -22,7 +22,7 @@ This serves two purposes:
 - Updated the navigation menu generator to remove duplicates after running the sorting method in https://github.com/hydephp/develop/pull/1407 (fixes https://github.com/hydephp/develop/issues/1406)
 - Updated the exception message caused by missing source option for featured images to include the path of the file that caused the error in https://github.com/hydephp/develop/pull/1409
 - Narrows down parsed `BladeMatter` array types to `array<string, scalar>` (Experimental feature not covered by BC promise) in https://github.com/hydephp/develop/pull/1410
-- Internal code refactors and improvements in https://github.com/hydephp/develop/pull/1410 and https://github.com/hydephp/develop/pull/1411
+- Internal code refactors and improvements in https://github.com/hydephp/develop/pull/1410, https://github.com/hydephp/develop/pull/1411, and https://github.com/hydephp/develop/pull/1413
 
 ### Deprecated
 - for soon-to-be removed features.

--- a/packages/framework/src/Markdown/Processing/ColoredBlockquotes.php
+++ b/packages/framework/src/Markdown/Processing/ColoredBlockquotes.php
@@ -23,16 +23,6 @@ class ColoredBlockquotes implements MarkdownShortcodeContract
 
     protected static array $signatures = ['>danger', '>info', '>success', '>warning'];
 
-    /**
-     * @internal
-     *
-     * @return string[]
-     */
-    public static function getSignatures(): array
-    {
-        return self::$signatures;
-    }
-
     public static function signature(): string
     {
         return static::$signature;
@@ -43,6 +33,16 @@ class ColoredBlockquotes implements MarkdownShortcodeContract
         return self::stringStartsWithSignature($input)
             ? static::expand($input)
             : $input;
+    }
+
+    /**
+     * @internal
+     *
+     * @return string[]
+     */
+    public static function getSignatures(): array
+    {
+        return self::$signatures;
     }
 
     protected static function expand(string $input): string

--- a/packages/framework/src/Markdown/Processing/ColoredBlockquotes.php
+++ b/packages/framework/src/Markdown/Processing/ColoredBlockquotes.php
@@ -7,21 +7,31 @@ namespace Hyde\Markdown\Processing;
 use Hyde\Markdown\Contracts\MarkdownShortcodeContract;
 use Hyde\Markdown\Models\Markdown;
 
-use function str_replace;
+use function ltrim;
+use function explode;
 use function sprintf;
 use function str_starts_with;
-use function strlen;
-use function substr;
 use function trim;
 
 /**
- * @internal This class may be refactored to work with a single class instead of five, thus extending this class is discouraged.
- *
- * @todo See if we can extract an arbitrary class name from the signature.
+ * @internal This class may be refactored further, thus extending this class is discouraged.
  */
-abstract class ColoredBlockquotes implements MarkdownShortcodeContract
+class ColoredBlockquotes implements MarkdownShortcodeContract
 {
-    protected static string $signature = '>color';
+    /** @var string The core signature. We combine this with an additional check for color later. */
+    protected static string $signature = '>';
+
+    protected static array $signatures = ['>danger', '>info', '>success', '>warning'];
+
+    /**
+     * @internal
+     *
+     * @return string[]
+     */
+    public static function getSignatures(): array
+    {
+        return self::$signatures;
+    }
 
     public static function signature(): string
     {
@@ -30,49 +40,30 @@ abstract class ColoredBlockquotes implements MarkdownShortcodeContract
 
     public static function resolve(string $input): string
     {
-        return str_starts_with($input, static::signature())
+        return self::stringStartsWithSignature($input)
             ? static::expand($input)
             : $input;
     }
 
     protected static function expand(string $input): string
     {
-        return sprintf(
-            '<blockquote class="%s">%s</blockquote>',
-            static::getClassNameFromSignature(static::signature()),
-            trim(Markdown::render(trim(substr($input, strlen(static::signature())), ' ')))
+        $parts = explode(' ', $input, 2);
+        $class = ltrim($parts[0], '>');
+        $contents = trim($parts[1] ?? '', ' ');
+
+        return sprintf('<blockquote class="%s">%s</blockquote>',
+            $class, trim(Markdown::render($contents))
         );
     }
 
-    protected static function getClassNameFromSignature(string $signature): string
+    protected static function stringStartsWithSignature(string $input): bool
     {
-        return str_replace('>', '', $signature);
-    }
+        foreach (static::$signatures as $signature) {
+            if (str_starts_with($input, $signature)) {
+                return true;
+            }
+        }
 
-    /** @return ColoredBlockquotes[] */
-    public static function get(): array
-    {
-        return [
-            /** @internal */
-            new class extends ColoredBlockquotes
-            {
-                protected static string $signature = '>danger';
-            },
-            /** @internal */
-            new class extends ColoredBlockquotes
-            {
-                protected static string $signature = '>info';
-            },
-            /** @internal */
-            new class extends ColoredBlockquotes
-            {
-                protected static string $signature = '>success';
-            },
-            /** @internal */
-            new class extends ColoredBlockquotes
-            {
-                protected static string $signature = '>warning';
-            },
-        ];
+        return false;
     }
 }

--- a/packages/framework/src/Markdown/Processing/ColoredBlockquotes.php
+++ b/packages/framework/src/Markdown/Processing/ColoredBlockquotes.php
@@ -16,6 +16,8 @@ use function trim;
 
 /**
  * @internal This class may be refactored to work with a single class instead of five, thus extending this class is discouraged.
+ *
+ * @todo See if we can extract an arbitrary class name from the signature.
  */
 abstract class ColoredBlockquotes implements MarkdownShortcodeContract
 {

--- a/packages/framework/src/Markdown/Processing/ColoredBlockquotes.php
+++ b/packages/framework/src/Markdown/Processing/ColoredBlockquotes.php
@@ -21,6 +21,7 @@ class ColoredBlockquotes implements MarkdownShortcodeContract
     /** @var string The core signature. We combine this with an additional check for color later. */
     protected static string $signature = '>';
 
+    /** @var array<string> */
     protected static array $signatures = ['>danger', '>info', '>success', '>warning'];
 
     public static function signature(): string
@@ -38,7 +39,7 @@ class ColoredBlockquotes implements MarkdownShortcodeContract
     /**
      * @internal
      *
-     * @return string[]
+     * @return array<string>
      */
     public static function getSignatures(): array
     {

--- a/packages/framework/src/Markdown/Processing/ShortcodeProcessor.php
+++ b/packages/framework/src/Markdown/Processing/ShortcodeProcessor.php
@@ -97,9 +97,15 @@ class ShortcodeProcessor implements MarkdownPreProcessorContract
 
     protected function discoverShortcodes(): void
     {
-        $this->addShortcodesFromArray(
-            ColoredBlockquotes::get()
-        );
+        // Add the built-in shortcodes.
+
+        foreach (ColoredBlockquotes::getSignatures() as $signature) {
+            $this->shortcodes[$signature] = new ColoredBlockquotes();
+        }
+
+        $this->addShortcodesFromArray([
+            //
+        ]);
     }
 
     protected function getOutput(): string

--- a/packages/framework/tests/Feature/ColoredBlockquoteShortcodesTest.php
+++ b/packages/framework/tests/Feature/ColoredBlockquoteShortcodesTest.php
@@ -29,4 +29,12 @@ class ColoredBlockquoteShortcodesTest extends UnitTestCase
             ColoredBlockquotes::resolve('>info foo **bar**')
         );
     }
+
+    public function testWithUnrelatedClass()
+    {
+        $this->assertSame(
+            '>foo foo',
+            ColoredBlockquotes::resolve('>foo foo')
+        );
+    }
 }

--- a/packages/framework/tests/Feature/ColoredBlockquoteShortcodesTest.php
+++ b/packages/framework/tests/Feature/ColoredBlockquoteShortcodesTest.php
@@ -14,27 +14,19 @@ use Hyde\Testing\UnitTestCase;
  */
 class ColoredBlockquoteShortcodesTest extends UnitTestCase
 {
-    public function testGetMethod()
-    {
-        $this->assertCount(4, ColoredBlockquotes::get());
-        $this->assertContainsOnlyInstancesOf(ColoredBlockquotes::class,
-            ColoredBlockquotes::get()
-        );
-    }
-
     public function testResolveMethod()
     {
         $this->assertSame(
-            '<blockquote class="color"><p>foo</p></blockquote>',
-            ColoredBlockquotes::resolve('>color foo')
+            '<blockquote class="info"><p>foo</p></blockquote>',
+            ColoredBlockquotes::resolve('>info foo')
         );
     }
 
     public function testCanUseMarkdownWithinBlockquote()
     {
         $this->assertSame(
-            '<blockquote class="color"><p>foo <strong>bar</strong></p></blockquote>',
-            ColoredBlockquotes::resolve('>color foo **bar**')
+            '<blockquote class="info"><p>foo <strong>bar</strong></p></blockquote>',
+            ColoredBlockquotes::resolve('>info foo **bar**')
         );
     }
 }

--- a/packages/framework/tests/Feature/ColoredBlockquoteShortcodesTest.php
+++ b/packages/framework/tests/Feature/ColoredBlockquoteShortcodesTest.php
@@ -14,6 +14,19 @@ use Hyde\Testing\UnitTestCase;
  */
 class ColoredBlockquoteShortcodesTest extends UnitTestCase
 {
+    public function testSignature()
+    {
+        $this->assertSame('>', ColoredBlockquotes::signature());
+    }
+
+    public function testSignatures()
+    {
+        $this->assertSame(
+            ['>danger', '>info', '>success', '>warning'],
+            ColoredBlockquotes::getSignatures()
+        );
+    }
+
     public function testResolveMethod()
     {
         $this->assertSame(

--- a/packages/framework/tests/Feature/Services/Markdown/ShortcodeProcessorTest.php
+++ b/packages/framework/tests/Feature/Services/Markdown/ShortcodeProcessorTest.php
@@ -62,4 +62,25 @@ class ShortcodeProcessorTest extends UnitTestCase
         $this->assertArrayHasKey('foo', $processor->getShortcodes());
         $this->assertEquals('bar', $processor->run());
     }
+
+    public function test_shortcodes_can_be_added_to_processor_using_array()
+    {
+        $processor = new ShortcodeProcessor('foo');
+
+        $processor->addShortcodesFromArray([new class implements MarkdownShortcodeContract
+        {
+            public static function signature(): string
+            {
+                return 'foo';
+            }
+
+            public static function resolve(string $input): string
+            {
+                return 'bar';
+            }
+        }]);
+
+        $this->assertArrayHasKey('foo', $processor->getShortcodes());
+        $this->assertEquals('bar', $processor->run());
+    }
 }


### PR DESCRIPTION
Refactors the internal class to extract blockquote class names from the signature, instead of creating new anonymous classes. This is not breaking, as the class was marked internal for this very reason before the first stable release.