### PR TITLE
Update Framework readme contribution section to match the Hyde package

### DIFF
--- a/packages/framework/README.md
+++ b/packages/framework/README.md
@@ -39,7 +39,9 @@ Please see [CHANGELOG](CHANGELOG.md) for more information on what has changed re
 
 ### Contributing
 
-Please see [CONTRIBUTING](.github/CONTRIBUTING.md) for details.
+HydePHP is an open-source project, contributions are very welcome!
+
+Development is made in the HydePHP Monorepo, which you can find here https://github.com/hydephp/develop.
 
 ### Security
 


### PR DESCRIPTION
Replaces a broken link with the same text as in the `hyde/hyde` readme.