### PR TITLE
Unslash documentation page home route name

### DIFF
--- a/packages/framework/src/Pages/DocumentationPage.php
+++ b/packages/framework/src/Pages/DocumentationPage.php
@@ -36,7 +36,7 @@ class DocumentationPage extends BaseMarkdownPage
 
     public static function homeRouteName(): string
     {
-        return static::baseRouteKey().'/index';
+        return unslash(static::baseRouteKey().'/index');
     }
 
     /** @see https://hydephp.com/docs/1.x/documentation-pages#automatic-edit-page-button */


### PR DESCRIPTION
This fixes a bug where the sidebar header brand is not clickable when setting the documentation page output path to `''`.