### PR TITLE
Migrate PHPUnit configuration

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit backupGlobals="false"
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         backupGlobals="false"
          backupStaticProperties="false"
          bootstrap="vendor/autoload.php"
          colors="true"
          cacheDirectory=".phpunit.result.cache"
          stopOnFailure="false"
          processIsolation="false"
-         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.0/phpunit.xsd"
-         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.4/phpunit.xsd">
     <testsuites>
         <testsuite name="FeatureHyde">
             <directory suffix="Test.php">./packages/hyde/tests</directory>
@@ -25,13 +25,14 @@
             <directory suffix="Test.php">./packages/realtime-compiler/tests</directory>
         </testsuite>
     </testsuites>
-    <coverage>
+    <coverage/>
+    <php>
+        <env name="ENV" value="testing"/>
+    </php>
+    <source>
         <include>
             <directory suffix=".php">./packages/framework/src</directory>
             <directory suffix=".php">./packages/publications/src</directory>
         </include>
-    </coverage>
-    <php>
-        <env name="ENV" value="testing"/>
-    </php>
+    </source>
 </phpunit>


### PR DESCRIPTION
Fixes the XML configuration being validated against a deprecated schema.