### PR TITLE
Improve navigation priority discovery to allow sidebars and main navigation to support both list and keyed config syntax

### DIFF
--- a/packages/framework/src/Framework/Factories/NavigationDataFactory.php
+++ b/packages/framework/src/Framework/Factories/NavigationDataFactory.php
@@ -12,9 +12,11 @@ use Hyde\Markdown\Models\FrontMatter;
 use Hyde\Framework\Factories\Concerns\CoreDataObject;
 use Hyde\Markdown\Contracts\FrontMatter\SubSchemas\NavigationSchema;
 
+use function basename;
 use function array_flip;
 use function in_array;
 use function is_a;
+use function array_key_exists;
 
 /**
  * Discover data used for navigation menus and the documentation sidebar.

--- a/packages/framework/src/Framework/Factories/NavigationDataFactory.php
+++ b/packages/framework/src/Framework/Factories/NavigationDataFactory.php
@@ -157,19 +157,21 @@ class NavigationDataFactory extends Concerns\PageDataFactory implements Navigati
 
     private function searchForPriorityInSidebarConfig(): ?int
     {
-        // Sidebars uses a special syntax where the keys are just the page identifiers in a flat array.
-        // TODO: In the future we could normalize this with the standard navigation config so both strategies can be auto-detected and used.
-
         // Adding an offset makes so that pages with a front matter priority that is lower can be shown first.
         // This is all to make it easier to mix ways of adding priorities.
 
-        /** @var array<string> $config */
+        /** @var array<string>|array<string, int> $config */
         $config = Config::getArray('docs.sidebar_order', []);
 
-        return $this->offset(
-            array_flip($config)[$this->identifier] ?? null,
-            self::CONFIG_OFFSET
-        );
+        // Check if the config entry is a flat array or a keyed array.
+        if (! array_key_exists($this->identifier, $config)) {
+            return $this->offset(
+                array_flip($config)[$this->identifier] ?? null,
+                self::CONFIG_OFFSET
+            );
+        }
+
+        return $config[$this->identifier] ?? null;
     }
 
     private function searchForPriorityInNavigationConfig(): ?int

--- a/packages/framework/src/Framework/Factories/NavigationDataFactory.php
+++ b/packages/framework/src/Framework/Factories/NavigationDataFactory.php
@@ -174,12 +174,20 @@ class NavigationDataFactory extends Concerns\PageDataFactory implements Navigati
 
     private function searchForPriorityInNavigationConfig(): ?int
     {
-        /** @var array<string, int> $config */
+        /** @var array<string, int>|array<string> $config */
         $config = Config::getArray('hyde.navigation.order', [
             'index' => 0,
             'posts' => 10,
             'docs/index' => 100,
         ]);
+
+        // Check if type is array<string>
+        if (collect($config)->every(fn (string|int $item): bool => is_string($item))) {
+            return $this->offset(
+                array_flip($config)[$this->routeKey] ?? null,
+                self::CONFIG_OFFSET
+            );
+        }
 
         return $config[$this->routeKey] ?? null;
     }

--- a/packages/framework/src/Framework/Factories/NavigationDataFactory.php
+++ b/packages/framework/src/Framework/Factories/NavigationDataFactory.php
@@ -181,8 +181,8 @@ class NavigationDataFactory extends Concerns\PageDataFactory implements Navigati
             'docs/index' => 100,
         ]);
 
-        // Check if type is array<string>
-        if (collect($config)->every(fn (string|int $item): bool => is_string($item))) {
+        // Check if the config entry is a flat array or a keyed array.
+        if (! array_key_exists($this->routeKey, $config)) {
             return $this->offset(
                 array_flip($config)[$this->routeKey] ?? null,
                 self::CONFIG_OFFSET

--- a/packages/framework/tests/Unit/NavigationDataFactoryUnitTest.php
+++ b/packages/framework/tests/Unit/NavigationDataFactoryUnitTest.php
@@ -51,7 +51,7 @@ class NavigationDataFactoryUnitTest extends UnitTestCase
         $this->assertSame(501, $factory->makePriority());
     }
 
-    public function testSearchForPriorityInNavigationConfigForMarkdownPageUsesKeyedConfigWhenOnlyOneItemIsKeyed()
+    public function testSearchForPriorityInNavigationConfigForMarkdownPageSupportsMixingKeyedAndListConfig()
     {
         self::mockConfig(['hyde.navigation.order' => [
             'foo',
@@ -60,12 +60,15 @@ class NavigationDataFactoryUnitTest extends UnitTestCase
         ]]);
 
         $factory = new NavigationConfigTestClass($this->makeCoreDataObject(routeKey: 'foo'));
-        $this->assertSame(999, $factory->makePriority());
+        $this->assertSame(500, $factory->makePriority());
 
         $factory = new NavigationConfigTestClass($this->makeCoreDataObject(routeKey: 'bar'));
         $this->assertSame(10, $factory->makePriority());
 
         $factory = new NavigationConfigTestClass($this->makeCoreDataObject(routeKey: 'baz'));
+        $this->assertSame(501, $factory->makePriority());
+
+        $factory = new NavigationConfigTestClass($this->makeCoreDataObject(routeKey: 'qux'));
         $this->assertSame(999, $factory->makePriority());
     }
 

--- a/packages/framework/tests/Unit/NavigationDataFactoryUnitTest.php
+++ b/packages/framework/tests/Unit/NavigationDataFactoryUnitTest.php
@@ -37,6 +37,38 @@ class NavigationDataFactoryUnitTest extends UnitTestCase
         $this->assertSame(10, $factory->makePriority());
     }
 
+    public function testSearchForPriorityInNavigationConfigForMarkdownPageWithListConfig()
+    {
+        self::mockConfig(['hyde.navigation.order' => [
+            'foo',
+            'bar',
+        ]]);
+
+        $factory = new NavigationConfigTestClass($this->makeCoreDataObject(routeKey: 'foo'));
+        $this->assertSame(500, $factory->makePriority());
+
+        $factory = new NavigationConfigTestClass($this->makeCoreDataObject(routeKey: 'bar'));
+        $this->assertSame(501, $factory->makePriority());
+    }
+
+    public function testSearchForPriorityInNavigationConfigForMarkdownPageUsesKeyedConfigWhenOnlyOneItemIsKeyed()
+    {
+        self::mockConfig(['hyde.navigation.order' => [
+            'foo',
+            'bar' => 10,
+            'baz',
+        ]]);
+
+        $factory = new NavigationConfigTestClass($this->makeCoreDataObject(routeKey: 'foo'));
+        $this->assertSame(999, $factory->makePriority());
+
+        $factory = new NavigationConfigTestClass($this->makeCoreDataObject(routeKey: 'bar'));
+        $this->assertSame(10, $factory->makePriority());
+
+        $factory = new NavigationConfigTestClass($this->makeCoreDataObject(routeKey: 'baz'));
+        $this->assertSame(999, $factory->makePriority());
+    }
+
     public function testSearchForPriorityInNavigationConfigForDocumentationPageWithListConfig()
     {
         self::mockConfig(['docs.sidebar_order' => [

--- a/packages/framework/tests/Unit/NavigationDataFactoryUnitTest.php
+++ b/packages/framework/tests/Unit/NavigationDataFactoryUnitTest.php
@@ -29,7 +29,7 @@ class NavigationDataFactoryUnitTest extends UnitTestCase
             'foo' => 15
         ]]);
 
-        $factory = new NavigationConfigTestClass(new CoreDataObject(new FrontMatter(), new Markdown(), MarkdownPage::class, '', '', '', 'foo'), '');
+        $factory = new NavigationConfigTestClass($this->makeCoreDataObject(routeKey: 'foo'));
 
         $this->assertSame(15, $factory->makePriority());
     }
@@ -41,16 +41,26 @@ class NavigationDataFactoryUnitTest extends UnitTestCase
             'bar',
         ]]);
 
-        $factory = new NavigationConfigTestClass(new CoreDataObject(new FrontMatter(), new Markdown(), DocumentationPage::class, 'foo', '', '', ''), '');
+        $factory = new NavigationConfigTestClass($this->makeCoreDataObject('foo', pageClass: DocumentationPage::class));
         $this->assertSame(500, $factory->makePriority());
 
-        $factory = new NavigationConfigTestClass(new CoreDataObject(new FrontMatter(), new Markdown(), DocumentationPage::class, 'bar', '', '', ''), '');
+        $factory = new NavigationConfigTestClass($this->makeCoreDataObject('bar', pageClass: DocumentationPage::class));
         $this->assertSame(501, $factory->makePriority());
+    }
+
+    protected function makeCoreDataObject(string $identifier = '', string $routeKey = '', string $pageClass = MarkdownPage::class): CoreDataObject
+    {
+        return new CoreDataObject(new FrontMatter(), new Markdown(), $pageClass, $identifier, '', '', $routeKey);
     }
 }
 
 class NavigationConfigTestClass extends NavigationDataFactory
 {
+    public function __construct(CoreDataObject $pageData)
+    {
+        parent::__construct($pageData, '');
+    }
+
     public function makePriority(): int
     {
         return parent::makePriority();

--- a/packages/framework/tests/Unit/NavigationDataFactoryUnitTest.php
+++ b/packages/framework/tests/Unit/NavigationDataFactoryUnitTest.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Hyde\Framework\Testing\Unit;
+
+use Hyde\Testing\UnitTestCase;
+
+/**
+ * @covers \Hyde\Framework\Factories\NavigationDataFactory
+ */
+class NavigationDataFactoryUnitTest extends UnitTestCase
+{
+    protected function setUp(): void
+    {
+        self::needsKernel();
+        self::mockConfig();
+    }
+
+    //
+}

--- a/packages/framework/tests/Unit/NavigationDataFactoryUnitTest.php
+++ b/packages/framework/tests/Unit/NavigationDataFactoryUnitTest.php
@@ -4,7 +4,13 @@ declare(strict_types=1);
 
 namespace Hyde\Framework\Testing\Unit;
 
+use Hyde\Pages\MarkdownPage;
 use Hyde\Testing\UnitTestCase;
+use Hyde\Pages\DocumentationPage;
+use Hyde\Markdown\Models\Markdown;
+use Hyde\Markdown\Models\FrontMatter;
+use Hyde\Framework\Factories\NavigationDataFactory;
+use Hyde\Framework\Factories\Concerns\CoreDataObject;
 
 /**
  * @covers \Hyde\Framework\Factories\NavigationDataFactory
@@ -17,5 +23,36 @@ class NavigationDataFactoryUnitTest extends UnitTestCase
         self::mockConfig();
     }
 
-    //
+    public function testSearchForPriorityInNavigationConfigForMarkdownPageWithKeyedConfig()
+    {
+        self::mockConfig(['hyde.navigation.order' => [
+            'foo' => 15
+        ]]);
+
+        $factory = new NavigationConfigTestClass(new CoreDataObject(new FrontMatter(), new Markdown(), MarkdownPage::class, '', '', '', 'foo'), '');
+
+        $this->assertSame(15, $factory->makePriority());
+    }
+
+    public function testSearchForPriorityInNavigationConfigForDocumentationPageWithList()
+    {
+        self::mockConfig(['docs.sidebar_order' => [
+            'foo',
+            'bar',
+        ]]);
+
+        $factory = new NavigationConfigTestClass(new CoreDataObject(new FrontMatter(), new Markdown(), DocumentationPage::class, 'foo', '', '', ''), '');
+        $this->assertSame(500, $factory->makePriority());
+
+        $factory = new NavigationConfigTestClass(new CoreDataObject(new FrontMatter(), new Markdown(), DocumentationPage::class, 'bar', '', '', ''), '');
+        $this->assertSame(501, $factory->makePriority());
+    }
+}
+
+class NavigationConfigTestClass extends NavigationDataFactory
+{
+    public function makePriority(): int
+    {
+        return parent::makePriority();
+    }
 }

--- a/packages/framework/tests/Unit/NavigationDataFactoryUnitTest.php
+++ b/packages/framework/tests/Unit/NavigationDataFactoryUnitTest.php
@@ -37,7 +37,7 @@ class NavigationDataFactoryUnitTest extends UnitTestCase
         $this->assertSame(10, $factory->makePriority());
     }
 
-    public function testSearchForPriorityInNavigationConfigForDocumentationPageWithList()
+    public function testSearchForPriorityInNavigationConfigForDocumentationPageWithListConfig()
     {
         self::mockConfig(['docs.sidebar_order' => [
             'foo',

--- a/packages/framework/tests/Unit/NavigationDataFactoryUnitTest.php
+++ b/packages/framework/tests/Unit/NavigationDataFactoryUnitTest.php
@@ -91,7 +91,7 @@ class NavigationDataFactoryUnitTest extends UnitTestCase
         self::mockConfig(['docs.sidebar_order' => [
             'foo',
             'bar' => 10,
-            'baz'
+            'baz',
         ]]);
 
         $factory = new NavigationConfigTestClass($this->makeCoreDataObject('foo', pageClass: DocumentationPage::class));
@@ -112,7 +112,7 @@ class NavigationDataFactoryUnitTest extends UnitTestCase
         self::mockConfig(['docs.sidebar_order' => [
             'foo',
             'bar' => 10,
-            'baz'
+            'baz',
         ]]);
 
         $factory = new NavigationConfigTestClass($this->makeCoreDataObject('foo', pageClass: DocumentationPage::class));

--- a/packages/framework/tests/Unit/NavigationDataFactoryUnitTest.php
+++ b/packages/framework/tests/Unit/NavigationDataFactoryUnitTest.php
@@ -75,15 +75,57 @@ class NavigationDataFactoryUnitTest extends UnitTestCase
     public function testSearchForPriorityInNavigationConfigForDocumentationPageWithListConfig()
     {
         self::mockConfig(['docs.sidebar_order' => [
+            'foo' => 15,
+            'bar' => 10,
+        ]]);
+
+        $factory = new NavigationConfigTestClass($this->makeCoreDataObject('foo', pageClass: DocumentationPage::class));
+        $this->assertSame(15, $factory->makePriority());
+
+        $factory = new NavigationConfigTestClass($this->makeCoreDataObject('bar', pageClass: DocumentationPage::class));
+        $this->assertSame(10, $factory->makePriority());
+    }
+
+    public function testSearchForPriorityInNavigationConfigForDocumentationPageWithKeyedConfig()
+    {
+        self::mockConfig(['docs.sidebar_order' => [
             'foo',
-            'bar',
+            'bar' => 10,
+            'baz'
         ]]);
 
         $factory = new NavigationConfigTestClass($this->makeCoreDataObject('foo', pageClass: DocumentationPage::class));
         $this->assertSame(500, $factory->makePriority());
 
         $factory = new NavigationConfigTestClass($this->makeCoreDataObject('bar', pageClass: DocumentationPage::class));
+        $this->assertSame(10, $factory->makePriority());
+
+        $factory = new NavigationConfigTestClass($this->makeCoreDataObject('baz', pageClass: DocumentationPage::class));
         $this->assertSame(501, $factory->makePriority());
+
+        $factory = new NavigationConfigTestClass($this->makeCoreDataObject('qux', pageClass: DocumentationPage::class));
+        $this->assertSame(999, $factory->makePriority());
+    }
+
+    public function testSearchForPriorityInNavigationConfigForDocumentationPageSupportsMixingKeyedAndListConfig()
+    {
+        self::mockConfig(['docs.sidebar_order' => [
+            'foo',
+            'bar' => 10,
+            'baz'
+        ]]);
+
+        $factory = new NavigationConfigTestClass($this->makeCoreDataObject('foo', pageClass: DocumentationPage::class));
+        $this->assertSame(500, $factory->makePriority());
+
+        $factory = new NavigationConfigTestClass($this->makeCoreDataObject('bar', pageClass: DocumentationPage::class));
+        $this->assertSame(10, $factory->makePriority());
+
+        $factory = new NavigationConfigTestClass($this->makeCoreDataObject('baz', pageClass: DocumentationPage::class));
+        $this->assertSame(501, $factory->makePriority());
+
+        $factory = new NavigationConfigTestClass($this->makeCoreDataObject('qux', pageClass: DocumentationPage::class));
+        $this->assertSame(999, $factory->makePriority());
     }
 
     protected function makeCoreDataObject(string $identifier = '', string $routeKey = '', string $pageClass = MarkdownPage::class): CoreDataObject

--- a/packages/framework/tests/Unit/NavigationDataFactoryUnitTest.php
+++ b/packages/framework/tests/Unit/NavigationDataFactoryUnitTest.php
@@ -26,12 +26,15 @@ class NavigationDataFactoryUnitTest extends UnitTestCase
     public function testSearchForPriorityInNavigationConfigForMarkdownPageWithKeyedConfig()
     {
         self::mockConfig(['hyde.navigation.order' => [
-            'foo' => 15
+            'foo' => 15,
+            'bar' => 10,
         ]]);
 
         $factory = new NavigationConfigTestClass($this->makeCoreDataObject(routeKey: 'foo'));
-
         $this->assertSame(15, $factory->makePriority());
+
+        $factory = new NavigationConfigTestClass($this->makeCoreDataObject(routeKey: 'bar'));
+        $this->assertSame(10, $factory->makePriority());
     }
 
     public function testSearchForPriorityInNavigationConfigForDocumentationPageWithList()


### PR DESCRIPTION
Previously, documentation pages supported the following for setting navigation priorities in the config:

```php
'foo', // Gets priority 500
'bar', // Gets priority 501
'baz', // Gets priority 502
```

And the main navigation menu supported the following syntax:

```php
'foo' => 10,
'bar' => 50,
'baz' => 75,
```

This PR makes it so both menu types support both config syntaxes, and even a combination of both:

```php
'foo',        // Gets priority 500
'bar' => 100, // Gets priority 100
'baz',        // Gets priority 501
```