### PR TITLE
Use dynamic PHP setup action version for test runners

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: shivammathur/setup-php@a36e1e52ff4a1c9e9c9be31551ee4712a6cb6bd0
+      - uses: shivammathur/setup-php@v2
         with:
           php-version: "8.1"
           extensions: fileinfo
@@ -54,7 +54,7 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     steps:
-      - uses: shivammathur/setup-php@a36e1e52ff4a1c9e9c9be31551ee4712a6cb6bd0
+      - uses: shivammathur/setup-php@v2
         with:
           php-version: ${{ matrix.php }}
           extensions: fileinfo, zip
@@ -169,7 +169,7 @@ jobs:
     needs: run-smoke-tests
 
     steps:
-      - uses: shivammathur/setup-php@a36e1e52ff4a1c9e9c9be31551ee4712a6cb6bd0
+      - uses: shivammathur/setup-php@v2
         with:
           php-version: "8.1"
           coverage: xdebug
@@ -263,7 +263,7 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
-      - uses: shivammathur/setup-php@a36e1e52ff4a1c9e9c9be31551ee4712a6cb6bd0
+      - uses: shivammathur/setup-php@v2
         with:
           php-version: "8.1"
 
@@ -311,7 +311,7 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
-      - uses: shivammathur/setup-php@a36e1e52ff4a1c9e9c9be31551ee4712a6cb6bd0
+      - uses: shivammathur/setup-php@v2
         with:
           php-version: "8.1"
 
@@ -362,7 +362,7 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
-      - uses: shivammathur/setup-php@a36e1e52ff4a1c9e9c9be31551ee4712a6cb6bd0
+      - uses: shivammathur/setup-php@v2
         with:
           php-version: "8.1"
 
@@ -468,7 +468,7 @@ jobs:
   check-coding-standards:
     runs-on: ubuntu-latest
     steps:
-      - uses: shivammathur/setup-php@a36e1e52ff4a1c9e9c9be31551ee4712a6cb6bd0
+      - uses: shivammathur/setup-php@v2
         with:
           php-version: "8.1"
       - uses: actions/checkout@v3
@@ -486,7 +486,7 @@ jobs:
   run-static-analysis-psalm:
     runs-on: ubuntu-latest
     steps:
-      - uses: shivammathur/setup-php@a36e1e52ff4a1c9e9c9be31551ee4712a6cb6bd0
+      - uses: shivammathur/setup-php@v2
         with:
           php-version: "8.1"
       - uses: actions/checkout@v3
@@ -504,7 +504,7 @@ jobs:
   run-static-analysis-phpstan:
     runs-on: ubuntu-latest
     steps:
-      - uses: shivammathur/setup-php@a36e1e52ff4a1c9e9c9be31551ee4712a6cb6bd0
+      - uses: shivammathur/setup-php@v2
         with:
           php-version: "8.1"
       - uses: actions/checkout@v3

--- a/.github/workflows/deploy-documentation-preview.yml
+++ b/.github/workflows/deploy-documentation-preview.yml
@@ -21,7 +21,7 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
-      - uses: shivammathur/setup-php@a36e1e52ff4a1c9e9c9be31551ee4712a6cb6bd0
+      - uses: shivammathur/setup-php@v2
         with:
           php-version: "8.1"
 

--- a/.github/workflows/smoke-tests.yml
+++ b/.github/workflows/smoke-tests.yml
@@ -36,7 +36,7 @@ jobs:
   test-coverage:
     runs-on: ubuntu-latest
     steps:
-      - uses: shivammathur/setup-php@a36e1e52ff4a1c9e9c9be31551ee4712a6cb6bd0
+      - uses: shivammathur/setup-php@v2
         with:
           php-version: "8.1"
           coverage: xdebug

--- a/.github/workflows/test-pull-requests.yml
+++ b/.github/workflows/test-pull-requests.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: shivammathur/setup-php@a36e1e52ff4a1c9e9c9be31551ee4712a6cb6bd0
+      - uses: shivammathur/setup-php@v2
         with:
           php-version: "8.1"
           coverage: xdebug
@@ -63,7 +63,7 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     steps:
-      - uses: shivammathur/setup-php@a36e1e52ff4a1c9e9c9be31551ee4712a6cb6bd0
+      - uses: shivammathur/setup-php@v2
         with:
           php-version: ${{ matrix.php }}
           extensions: fileinfo, zip

--- a/packages/framework/.github/workflows/run-tests.yml
+++ b/packages/framework/.github/workflows/run-tests.yml
@@ -17,7 +17,7 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
-      - uses: shivammathur/setup-php@a36e1e52ff4a1c9e9c9be31551ee4712a6cb6bd0
+      - uses: shivammathur/setup-php@v2
         with:
           php-version: ${{ matrix.php }}
           extensions: fileinfo, zip

--- a/packages/testing/stubs/hyde-testing-workflow.stub
+++ b/packages/testing/stubs/hyde-testing-workflow.stub
@@ -17,7 +17,7 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     steps:
-    - uses: shivammathur/setup-php@a36e1e52ff4a1c9e9c9be31551ee4712a6cb6bd0
+    - uses: shivammathur/setup-php@v2
       with:
         php-version: '8.0'
         extensions: fileinfo


### PR DESCRIPTION
Now uses the same version as Laravel, instead of pinning to a hash.