### PR TITLE
Pass through settings to realtime compiler

### DIFF
--- a/packages/framework/src/Console/Commands/ServeCommand.php
+++ b/packages/framework/src/Console/Commands/ServeCommand.php
@@ -26,6 +26,7 @@ class ServeCommand extends Command
         {--host= : <comment>[default: "localhost"]</comment>}}
         {--port= : <comment>[default: 8080]</comment>}
         {--dashboard= : Enable the realtime compiler dashboard. (Overrides config setting)}
+        {--pretty-urls= : Enable pretty URLs. (Overrides config setting)}
     ';
 
     /** @var string */
@@ -74,6 +75,9 @@ class ServeCommand extends Command
         ];
         if ($this->option('dashboard') !== null) {
             $vars['HYDE_RC_SERVER_DASHBOARD'] = $this->option('dashboard') !== 'false' ? 'enabled' : 'disabled';
+        }
+        if ($this->option('pretty-urls') !== null) {
+            $vars['HYDE_PRETTY_URLS'] = $this->option('pretty-urls') !== 'false' ? 'enabled' : 'disabled';
         }
 
         return $vars;

--- a/packages/framework/src/Console/Commands/ServeCommand.php
+++ b/packages/framework/src/Console/Commands/ServeCommand.php
@@ -111,8 +111,8 @@ class ServeCommand extends Command
     {
         if ($this->option($name) !== null) {
             return $this->option($name) !== 'false' ? 'enabled' : 'disabled';
-        } else {
-            return null;
         }
+
+        return null;
     }
 }

--- a/packages/framework/src/Console/Commands/ServeCommand.php
+++ b/packages/framework/src/Console/Commands/ServeCommand.php
@@ -57,13 +57,6 @@ class ServeCommand extends Command
         return (int) ($this->option('port') ?: Config::getInt('hyde.server.port', 8080));
     }
 
-    protected function getDashboardSelection(): ?bool
-    {
-        return $this->option('dashboard') !== null
-            ? $this->option('dashboard') !== 'false'
-            : null;
-    }
-
     protected function getExecutablePath(): string
     {
         return Hyde::path('vendor/hyde/realtime-compiler/bin/server.php');
@@ -79,8 +72,8 @@ class ServeCommand extends Command
         $vars = [
             'HYDE_RC_REQUEST_OUTPUT' => ! $this->option('no-ansi'),
         ];
-        if ($this->getDashboardSelection() !== null) {
-            $vars['HYDE_RC_SERVER_DASHBOARD'] = $this->getDashboardSelection() ? 'enabled' : 'disabled';
+        if ($this->option('dashboard') !== null) {
+            $vars['HYDE_RC_SERVER_DASHBOARD'] = $this->option('dashboard') !== 'false' ? 'enabled' : 'disabled';
         }
 
         return $vars;

--- a/packages/framework/src/Console/Commands/ServeCommand.php
+++ b/packages/framework/src/Console/Commands/ServeCommand.php
@@ -8,6 +8,7 @@ use Closure;
 use Hyde\Hyde;
 use Hyde\Facades\Config;
 use Illuminate\Support\Arr;
+use InvalidArgumentException;
 use Hyde\RealtimeCompiler\ConsoleOutput;
 use Illuminate\Support\Facades\Process;
 use LaravelZero\Framework\Commands\Command;
@@ -114,7 +115,7 @@ class ServeCommand extends ValidatingCommand
             return match ($this->option($name)) {
                 'true', '' => 'enabled',
                 'false' => 'disabled',
-                default => null
+                default => throw new InvalidArgumentException(sprintf('Invalid boolean value for --%s option.', $name))
             };
         }
 

--- a/packages/framework/src/Console/Commands/ServeCommand.php
+++ b/packages/framework/src/Console/Commands/ServeCommand.php
@@ -73,9 +73,11 @@ class ServeCommand extends Command
         $vars = [
             'HYDE_RC_REQUEST_OUTPUT' => ! $this->option('no-ansi'),
         ];
+
         if ($this->option('dashboard') !== null) {
             $vars['HYDE_RC_SERVER_DASHBOARD'] = $this->option('dashboard') !== 'false' ? 'enabled' : 'disabled';
         }
+
         if ($this->option('pretty-urls') !== null) {
             $vars['HYDE_PRETTY_URLS'] = $this->option('pretty-urls') !== 'false' ? 'enabled' : 'disabled';
         }

--- a/packages/framework/src/Console/Commands/ServeCommand.php
+++ b/packages/framework/src/Console/Commands/ServeCommand.php
@@ -30,6 +30,7 @@ class ServeCommand extends ValidatingCommand
         {--port= : <comment>[default: 8080]</comment>}
         {--dashboard= : Enable the realtime compiler dashboard. (Overrides config setting)}
         {--pretty-urls= : Enable pretty URLs. (Overrides config setting)}
+        {--play-cdn= : Enable the Tailwind Play CDN. (Overrides config setting)}
     ';
 
     /** @var string */
@@ -77,6 +78,7 @@ class ServeCommand extends ValidatingCommand
             'HYDE_SERVER_REQUEST_OUTPUT' => ! $this->option('no-ansi'),
             'HYDE_SERVER_DASHBOARD' => $this->parseEnvironmentOption('dashboard'),
             'HYDE_PRETTY_URLS' => $this->parseEnvironmentOption('pretty-urls'),
+            'HYDE_PLAY_CDN' => $this->parseEnvironmentOption('play-cdn'),
         ]);
     }
 

--- a/packages/framework/src/Console/Commands/ServeCommand.php
+++ b/packages/framework/src/Console/Commands/ServeCommand.php
@@ -95,7 +95,7 @@ class ServeCommand extends ValidatingCommand
     {
         $this->useBasicOutput()
             ? $this->output->writeln('<info>Starting the HydeRC server...</info> Press Ctrl+C to stop')
-            : $this->console->printStartMessage($this->getHostSelection(), $this->getPortSelection());
+            : $this->console->printStartMessage($this->getHostSelection(), $this->getPortSelection(), $this->getEnvironmentVariables());
     }
 
     protected function getOutputHandler(): Closure

--- a/packages/framework/src/Console/Commands/ServeCommand.php
+++ b/packages/framework/src/Console/Commands/ServeCommand.php
@@ -25,6 +25,7 @@ class ServeCommand extends Command
     protected $signature = 'serve 
         {--host= : <comment>[default: "localhost"]</comment>}}
         {--port= : <comment>[default: 8080]</comment>}
+        {--dashboard= : Enable the realtime compiler dashboard. (Defaults to config option)}
     ';
 
     /** @var string */
@@ -56,6 +57,13 @@ class ServeCommand extends Command
         return (int) ($this->option('port') ?: Config::getInt('hyde.server.port', 8080));
     }
 
+    protected function getDashboardSelection(): bool
+    {
+        return $this->option('dashboard') !== null
+            ? (bool) $this->option('dashboard')
+            : Config::getBool('hyde.server.dashboard.enabled', true);
+    }
+
     protected function getExecutablePath(): string
     {
         return Hyde::path('vendor/hyde/realtime-compiler/bin/server.php');
@@ -70,6 +78,7 @@ class ServeCommand extends Command
     {
         return [
             'HYDE_RC_REQUEST_OUTPUT' => ! $this->option('no-ansi'),
+            'SERVER_DASHBOARD' => $this->getDashboardSelection(),
         ];
     }
 

--- a/packages/framework/src/Console/Commands/ServeCommand.php
+++ b/packages/framework/src/Console/Commands/ServeCommand.php
@@ -111,7 +111,7 @@ class ServeCommand extends ValidatingCommand
 
     protected function parseEnvironmentOption(string $name): ?string
     {
-        $value = $this->option($name);
+        $value = $this->option($name) ?? $this->checkArgvForOption($name);
 
         if ($value !== null) {
             return match ($value) {
@@ -119,6 +119,18 @@ class ServeCommand extends ValidatingCommand
                 'false' => 'disabled',
                 default => throw new InvalidArgumentException(sprintf('Invalid boolean value for --%s option.', $name))
             };
+        }
+
+        return null;
+    }
+
+    /** Fallback check so that an environment option without a value is acknowledged as true. */
+    protected function checkArgvForOption(string $name): ?string
+    {
+        if (isset($_SERVER['argv'])) {
+            if (in_array("--$name", $_SERVER['argv'], true)) {
+                return 'true';
+            }
         }
 
         return null;

--- a/packages/framework/src/Console/Commands/ServeCommand.php
+++ b/packages/framework/src/Console/Commands/ServeCommand.php
@@ -28,6 +28,7 @@ class ServeCommand extends ValidatingCommand
     protected $signature = 'serve 
         {--host= : <comment>[default: "localhost"]</comment>}}
         {--port= : <comment>[default: 8080]</comment>}
+        {--save-preview= : Should the served page be saved to disk? (Overrides config setting)}
         {--dashboard= : Enable the realtime compiler dashboard. (Overrides config setting)}
         {--pretty-urls= : Enable pretty URLs. (Overrides config setting)}
         {--play-cdn= : Enable the Tailwind Play CDN. (Overrides config setting)}
@@ -76,6 +77,7 @@ class ServeCommand extends ValidatingCommand
     {
         return Arr::whereNotNull([
             'HYDE_SERVER_REQUEST_OUTPUT' => ! $this->option('no-ansi'),
+            'HYDE_SERVER_SAVE_PREVIEW' => $this->parseEnvironmentOption('save-preview'),
             'HYDE_SERVER_DASHBOARD' => $this->parseEnvironmentOption('dashboard'),
             'HYDE_PRETTY_URLS' => $this->parseEnvironmentOption('pretty-urls'),
             'HYDE_PLAY_CDN' => $this->parseEnvironmentOption('play-cdn'),

--- a/packages/framework/src/Console/Commands/ServeCommand.php
+++ b/packages/framework/src/Console/Commands/ServeCommand.php
@@ -7,6 +7,7 @@ namespace Hyde\Console\Commands;
 use Closure;
 use Hyde\Hyde;
 use Hyde\Facades\Config;
+use Illuminate\Support\Arr;
 use Hyde\RealtimeCompiler\ConsoleOutput;
 use Illuminate\Support\Facades\Process;
 use LaravelZero\Framework\Commands\Command;
@@ -74,15 +75,10 @@ class ServeCommand extends Command
             'HYDE_RC_REQUEST_OUTPUT' => ! $this->option('no-ansi'),
         ];
 
-        if ($this->option('dashboard') !== null) {
-            $vars['HYDE_RC_SERVER_DASHBOARD'] = $this->option('dashboard') !== 'false' ? 'enabled' : 'disabled';
-        }
+        $vars['HYDE_RC_SERVER_DASHBOARD'] = $this->parseEnvironmentOption('dashboard');
+        $vars['HYDE_PRETTY_URLS'] = $this->parseEnvironmentOption('pretty-urls');
 
-        if ($this->option('pretty-urls') !== null) {
-            $vars['HYDE_PRETTY_URLS'] = $this->option('pretty-urls') !== 'false' ? 'enabled' : 'disabled';
-        }
-
-        return $vars;
+        return Arr::whereNotNull($vars);
     }
 
     protected function configureOutput(): void
@@ -109,5 +105,14 @@ class ServeCommand extends Command
     protected function useBasicOutput(): bool
     {
         return $this->option('no-ansi') || ! class_exists(ConsoleOutput::class);
+    }
+
+    protected function parseEnvironmentOption(string $name): ?string
+    {
+        if ($this->option($name) !== null) {
+            return $this->option($name) !== 'false' ? 'enabled' : 'disabled';
+        } else {
+            return null;
+        }
     }
 }

--- a/packages/framework/src/Console/Commands/ServeCommand.php
+++ b/packages/framework/src/Console/Commands/ServeCommand.php
@@ -74,8 +74,8 @@ class ServeCommand extends ValidatingCommand
     protected function getEnvironmentVariables(): array
     {
         return Arr::whereNotNull([
-            'HYDE_RC_REQUEST_OUTPUT' => ! $this->option('no-ansi'),
-            'HYDE_RC_SERVER_DASHBOARD' => $this->parseEnvironmentOption('dashboard'),
+            'HYDE_SERVER_REQUEST_OUTPUT' => ! $this->option('no-ansi'),
+            'HYDE_SERVER_DASHBOARD' => $this->parseEnvironmentOption('dashboard'),
             'HYDE_PRETTY_URLS' => $this->parseEnvironmentOption('pretty-urls'),
         ]);
     }

--- a/packages/framework/src/Console/Commands/ServeCommand.php
+++ b/packages/framework/src/Console/Commands/ServeCommand.php
@@ -111,7 +111,11 @@ class ServeCommand extends ValidatingCommand
     protected function parseEnvironmentOption(string $name): ?string
     {
         if ($this->option($name) !== null) {
-            return $this->option($name) !== 'false' ? 'enabled' : 'disabled';
+            return match ($this->option($name)) {
+                'true', '' => 'enabled',
+                'false' => 'disabled',
+                default => null
+            };
         }
 
         return null;

--- a/packages/framework/src/Console/Commands/ServeCommand.php
+++ b/packages/framework/src/Console/Commands/ServeCommand.php
@@ -111,8 +111,10 @@ class ServeCommand extends ValidatingCommand
 
     protected function parseEnvironmentOption(string $name): ?string
     {
-        if ($this->option($name) !== null) {
-            return match ($this->option($name)) {
+        $value = $this->option($name);
+
+        if ($value !== null) {
+            return match ($value) {
                 'true', '' => 'enabled',
                 'false' => 'disabled',
                 default => throw new InvalidArgumentException(sprintf('Invalid boolean value for --%s option.', $name))

--- a/packages/framework/src/Console/Commands/ServeCommand.php
+++ b/packages/framework/src/Console/Commands/ServeCommand.php
@@ -11,6 +11,7 @@ use Illuminate\Support\Arr;
 use Hyde\RealtimeCompiler\ConsoleOutput;
 use Illuminate\Support\Facades\Process;
 use LaravelZero\Framework\Commands\Command;
+use Hyde\Publications\Commands\ValidatingCommand;
 
 use function sprintf;
 use function class_exists;
@@ -20,7 +21,7 @@ use function class_exists;
  *
  * @see https://github.com/hydephp/realtime-compiler
  */
-class ServeCommand extends Command
+class ServeCommand extends ValidatingCommand
 {
     /** @var string */
     protected $signature = 'serve 
@@ -35,7 +36,7 @@ class ServeCommand extends Command
 
     protected ConsoleOutput $console;
 
-    public function handle(): int
+    public function safeHandle(): int
     {
         $this->configureOutput();
         $this->printStartMessage();

--- a/packages/framework/src/Console/Commands/ServeCommand.php
+++ b/packages/framework/src/Console/Commands/ServeCommand.php
@@ -46,14 +46,14 @@ class ServeCommand extends Command
         return Command::SUCCESS;
     }
 
-    protected function getPortSelection(): int
-    {
-        return (int) ($this->option('port') ?: Config::getInt('hyde.server.port', 8080));
-    }
-
     protected function getHostSelection(): string
     {
         return (string) $this->option('host') ?: Config::getString('hyde.server.host', 'localhost');
+    }
+
+    protected function getPortSelection(): int
+    {
+        return (int) ($this->option('port') ?: Config::getInt('hyde.server.port', 8080));
     }
 
     protected function getExecutablePath(): string

--- a/packages/framework/src/Console/Commands/ServeCommand.php
+++ b/packages/framework/src/Console/Commands/ServeCommand.php
@@ -73,14 +73,11 @@ class ServeCommand extends ValidatingCommand
 
     protected function getEnvironmentVariables(): array
     {
-        $vars = [
+        return Arr::whereNotNull([
             'HYDE_RC_REQUEST_OUTPUT' => ! $this->option('no-ansi'),
-        ];
-
-        $vars['HYDE_RC_SERVER_DASHBOARD'] = $this->parseEnvironmentOption('dashboard');
-        $vars['HYDE_PRETTY_URLS'] = $this->parseEnvironmentOption('pretty-urls');
-
-        return Arr::whereNotNull($vars);
+            'HYDE_RC_SERVER_DASHBOARD' => $this->parseEnvironmentOption('dashboard'),
+            'HYDE_PRETTY_URLS' => $this->parseEnvironmentOption('pretty-urls'),
+        ]);
     }
 
     protected function configureOutput(): void

--- a/packages/framework/src/Foundation/Internal/LoadConfiguration.php
+++ b/packages/framework/src/Foundation/Internal/LoadConfiguration.php
@@ -98,6 +98,11 @@ class LoadConfiguration extends BaseLoadConfiguration
             if ($this->getEnv('HYDE_RC_SERVER_DASHBOARD') !== false) {
                 $repository->set('hyde.server.dashboard.enabled', $this->getEnv('HYDE_RC_SERVER_DASHBOARD') === 'enabled');
             }
+
+            // Check if HYDE_PRETTY_URLS environment variable is set, and if so, set the config value accordingly.
+            if ($this->getEnv('HYDE_PRETTY_URLS') !== false) {
+                $repository->set('hyde.pretty_urls', $this->getEnv('HYDE_PRETTY_URLS') === 'enabled');
+            }
         }
     }
 

--- a/packages/framework/src/Foundation/Internal/LoadConfiguration.php
+++ b/packages/framework/src/Foundation/Internal/LoadConfiguration.php
@@ -6,7 +6,7 @@ namespace Hyde\Foundation\Internal;
 
 use Phar;
 use Illuminate\Contracts\Foundation\Application;
-use Illuminate\Contracts\Config\Repository as RepositoryContract;
+use Illuminate\Contracts\Config\Repository;
 use Illuminate\Foundation\Bootstrap\LoadConfiguration as BaseLoadConfiguration;
 
 use function getenv;
@@ -31,7 +31,7 @@ class LoadConfiguration extends BaseLoadConfiguration
     }
 
     /** Load the configuration items from all the files. */
-    protected function loadConfigurationFiles(Application $app, RepositoryContract $repository): void
+    protected function loadConfigurationFiles(Application $app, Repository $repository): void
     {
         parent::loadConfigurationFiles($app, $repository);
 
@@ -40,7 +40,7 @@ class LoadConfiguration extends BaseLoadConfiguration
         $this->loadRuntimeConfiguration($app, $repository);
     }
 
-    private function mergeConfigurationFiles(RepositoryContract $repository): void
+    private function mergeConfigurationFiles(Repository $repository): void
     {
         // These files do commonly not need to be customized by the user, so to get them out of the way,
         // we don't include them in the default project install.
@@ -50,7 +50,7 @@ class LoadConfiguration extends BaseLoadConfiguration
         }
     }
 
-    private function mergeConfigurationFile(RepositoryContract $repository, string $file): void
+    private function mergeConfigurationFile(Repository $repository, string $file): void
     {
         // We of course want the user to be able to customize the config files,
         // if they're present, so we'll merge their changes here.
@@ -79,7 +79,7 @@ class LoadConfiguration extends BaseLoadConfiguration
         }
     }
 
-    private function loadRuntimeConfiguration(Application $app, RepositoryContract $repository): void
+    private function loadRuntimeConfiguration(Application $app, Repository $repository): void
     {
         if ($app->runningInConsole()) {
             if ($this->getArgv() !== null) {
@@ -92,14 +92,14 @@ class LoadConfiguration extends BaseLoadConfiguration
         }
     }
 
-    private function mergeCommandLineArguments(RepositoryContract $repository, string $argumentName, string $configKey, bool $value): void
+    private function mergeCommandLineArguments(Repository $repository, string $argumentName, string $configKey, bool $value): void
     {
         if (in_array($argumentName, $this->getArgv(), true)) {
             $repository->set($configKey, $value);
         }
     }
 
-    private function mergeRealtimeCompilerEnvironment(RepositoryContract $repository, string $environmentKey, string $configKey): void
+    private function mergeRealtimeCompilerEnvironment(Repository $repository, string $environmentKey, string $configKey): void
     {
         if ($this->getEnv($environmentKey) !== false) {
             $repository->set($configKey, $this->getEnv($environmentKey) === 'enabled');

--- a/packages/framework/src/Foundation/Internal/LoadConfiguration.php
+++ b/packages/framework/src/Foundation/Internal/LoadConfiguration.php
@@ -89,6 +89,7 @@ class LoadConfiguration extends BaseLoadConfiguration
 
             $this->mergeRealtimeCompilerEnvironment($repository, 'HYDE_SERVER_DASHBOARD', 'hyde.server.dashboard.enabled');
             $this->mergeRealtimeCompilerEnvironment($repository, 'HYDE_PRETTY_URLS', 'hyde.pretty_urls');
+            $this->mergeRealtimeCompilerEnvironment($repository, 'HYDE_PLAY_CDN', 'hyde.use_play_cdn');
         }
     }
 

--- a/packages/framework/src/Foundation/Internal/LoadConfiguration.php
+++ b/packages/framework/src/Foundation/Internal/LoadConfiguration.php
@@ -106,7 +106,7 @@ class LoadConfiguration extends BaseLoadConfiguration
         }
     }
 
-    protected function getEnv(string $name): string|false
+    protected function getEnv(string $name): string|false|null
     {
         return getenv($name);
     }

--- a/packages/framework/src/Foundation/Internal/LoadConfiguration.php
+++ b/packages/framework/src/Foundation/Internal/LoadConfiguration.php
@@ -80,15 +80,17 @@ class LoadConfiguration extends BaseLoadConfiguration
 
     private function loadRuntimeConfiguration(Application $app, RepositoryContract $repository): void
     {
-        if ($app->runningInConsole() && isset($_SERVER['argv'])) {
-            // Check if the `--pretty-urls` CLI argument is set, and if so, set the config value accordingly.
-            if (in_array('--pretty-urls', $_SERVER['argv'], true)) {
-                $repository->set('hyde.pretty_urls', true);
-            }
+        if ($app->runningInConsole()) {
+            if (isset($_SERVER['argv'])) {
+                // Check if the `--pretty-urls` CLI argument is set, and if so, set the config value accordingly.
+                if (in_array('--pretty-urls', $_SERVER['argv'], true)) {
+                    $repository->set('hyde.pretty_urls', true);
+                }
 
-            // Check if the `--no-api` CLI argument is set, and if so, set the config value accordingly.
-            if (in_array('--no-api', $_SERVER['argv'], true)) {
-                $repository->set('hyde.api_calls', false);
+                // Check if the `--no-api` CLI argument is set, and if so, set the config value accordingly.
+                if (in_array('--no-api', $_SERVER['argv'], true)) {
+                    $repository->set('hyde.api_calls', false);
+                }
             }
         }
     }

--- a/packages/framework/src/Foundation/Internal/LoadConfiguration.php
+++ b/packages/framework/src/Foundation/Internal/LoadConfiguration.php
@@ -94,9 +94,9 @@ class LoadConfiguration extends BaseLoadConfiguration
                 }
             }
 
-            // Check if HYDE_RC_SERVER_DASHBOARD environment variable is set, and if so, set the config value accordingly.
-            if ($this->getEnv('HYDE_RC_SERVER_DASHBOARD') !== false) {
-                $repository->set('hyde.server.dashboard.enabled', $this->getEnv('HYDE_RC_SERVER_DASHBOARD') === 'enabled');
+            // Check if HYDE_SERVER_DASHBOARD environment variable is set, and if so, set the config value accordingly.
+            if ($this->getEnv('HYDE_SERVER_DASHBOARD') !== false) {
+                $repository->set('hyde.server.dashboard.enabled', $this->getEnv('HYDE_SERVER_DASHBOARD') === 'enabled');
             }
 
             // Check if HYDE_PRETTY_URLS environment variable is set, and if so, set the config value accordingly.

--- a/packages/framework/src/Foundation/Internal/LoadConfiguration.php
+++ b/packages/framework/src/Foundation/Internal/LoadConfiguration.php
@@ -94,15 +94,15 @@ class LoadConfiguration extends BaseLoadConfiguration
                 }
             }
 
-            // Check if HYDE_SERVER_DASHBOARD environment variable is set, and if so, set the config value accordingly.
-            if ($this->getEnv('HYDE_SERVER_DASHBOARD') !== false) {
-                $repository->set('hyde.server.dashboard.enabled', $this->getEnv('HYDE_SERVER_DASHBOARD') === 'enabled');
-            }
+            $this->mergeRealtimeCompilerEnvironment($repository, 'HYDE_SERVER_DASHBOARD', 'hyde.server.dashboard.enabled');
+            $this->mergeRealtimeCompilerEnvironment($repository, 'HYDE_PRETTY_URLS', 'hyde.pretty_urls');
+        }
+    }
 
-            // Check if HYDE_PRETTY_URLS environment variable is set, and if so, set the config value accordingly.
-            if ($this->getEnv('HYDE_PRETTY_URLS') !== false) {
-                $repository->set('hyde.pretty_urls', $this->getEnv('HYDE_PRETTY_URLS') === 'enabled');
-            }
+    private function mergeRealtimeCompilerEnvironment(RepositoryContract $repository, string $environmentKey, string $configKey): void
+    {
+        if ($this->getEnv($environmentKey) !== false) {
+            $repository->set($configKey, $this->getEnv($environmentKey) === 'enabled');
         }
     }
 

--- a/packages/framework/src/Foundation/Internal/LoadConfiguration.php
+++ b/packages/framework/src/Foundation/Internal/LoadConfiguration.php
@@ -83,19 +83,19 @@ class LoadConfiguration extends BaseLoadConfiguration
     {
         if ($app->runningInConsole()) {
             if ($this->getArgv() !== null) {
-                // Check if the `--pretty-urls` CLI argument is set, and if so, set the config value accordingly.
-                if (in_array('--pretty-urls', $this->getArgv(), true)) {
-                    $repository->set('hyde.pretty_urls', true);
-                }
-
-                // Check if the `--no-api` CLI argument is set, and if so, set the config value accordingly.
-                if (in_array('--no-api', $this->getArgv(), true)) {
-                    $repository->set('hyde.api_calls', false);
-                }
+                $this->mergeCommandLineArguments($repository, '--pretty-urls', 'hyde.pretty_urls', true);
+                $this->mergeCommandLineArguments($repository, '--no-api', 'hyde.api_calls', false);
             }
 
             $this->mergeRealtimeCompilerEnvironment($repository, 'HYDE_SERVER_DASHBOARD', 'hyde.server.dashboard.enabled');
             $this->mergeRealtimeCompilerEnvironment($repository, 'HYDE_PRETTY_URLS', 'hyde.pretty_urls');
+        }
+    }
+
+    private function mergeCommandLineArguments(RepositoryContract $repository, string $argumentName, string $configKey, bool $value): void
+    {
+        if (in_array($argumentName, $this->getArgv(), true)) {
+            $repository->set($configKey, $value);
         }
     }
 

--- a/packages/framework/src/Foundation/Internal/LoadConfiguration.php
+++ b/packages/framework/src/Foundation/Internal/LoadConfiguration.php
@@ -9,6 +9,7 @@ use Illuminate\Contracts\Foundation\Application;
 use Illuminate\Contracts\Config\Repository as RepositoryContract;
 use Illuminate\Foundation\Bootstrap\LoadConfiguration as BaseLoadConfiguration;
 
+use function getenv;
 use function array_merge;
 use function dirname;
 use function in_array;
@@ -90,6 +91,11 @@ class LoadConfiguration extends BaseLoadConfiguration
                 // Check if the `--no-api` CLI argument is set, and if so, set the config value accordingly.
                 if (in_array('--no-api', $_SERVER['argv'], true)) {
                     $repository->set('hyde.api_calls', false);
+                }
+            } else {
+                // Check if HYDE_RC_SERVER_DASHBOARD environment variable is set, and if so, set the config value accordingly.
+                if (getenv('HYDE_RC_SERVER_DASHBOARD') !== false) {
+                    $repository->set('hyde.server.dashboard.enabled', getenv('HYDE_RC_SERVER_DASHBOARD') === 'enabled');
                 }
             }
         }

--- a/packages/framework/src/Foundation/Internal/LoadConfiguration.php
+++ b/packages/framework/src/Foundation/Internal/LoadConfiguration.php
@@ -87,6 +87,7 @@ class LoadConfiguration extends BaseLoadConfiguration
                 $this->mergeCommandLineArguments($repository, '--no-api', 'hyde.api_calls', false);
             }
 
+            $this->mergeRealtimeCompilerEnvironment($repository, 'HYDE_SERVER_SAVE_PREVIEW', 'hyde.server.save_preview');
             $this->mergeRealtimeCompilerEnvironment($repository, 'HYDE_SERVER_DASHBOARD', 'hyde.server.dashboard.enabled');
             $this->mergeRealtimeCompilerEnvironment($repository, 'HYDE_PRETTY_URLS', 'hyde.pretty_urls');
             $this->mergeRealtimeCompilerEnvironment($repository, 'HYDE_PLAY_CDN', 'hyde.use_play_cdn');

--- a/packages/framework/src/Foundation/Internal/LoadConfiguration.php
+++ b/packages/framework/src/Foundation/Internal/LoadConfiguration.php
@@ -92,12 +92,17 @@ class LoadConfiguration extends BaseLoadConfiguration
                 if (in_array('--no-api', $_SERVER['argv'], true)) {
                     $repository->set('hyde.api_calls', false);
                 }
-            } else {
-                // Check if HYDE_RC_SERVER_DASHBOARD environment variable is set, and if so, set the config value accordingly.
-                if (getenv('HYDE_RC_SERVER_DASHBOARD') !== false) {
-                    $repository->set('hyde.server.dashboard.enabled', getenv('HYDE_RC_SERVER_DASHBOARD') === 'enabled');
-                }
+            }
+
+            // Check if HYDE_RC_SERVER_DASHBOARD environment variable is set, and if so, set the config value accordingly.
+            if ($this->getEnv('HYDE_RC_SERVER_DASHBOARD') !== false) {
+                $repository->set('hyde.server.dashboard.enabled', $this->getEnv('HYDE_RC_SERVER_DASHBOARD') === 'enabled');
             }
         }
+    }
+
+    protected function getEnv(string $name): string|false
+    {
+        return getenv($name);
     }
 }

--- a/packages/framework/src/Foundation/Internal/LoadConfiguration.php
+++ b/packages/framework/src/Foundation/Internal/LoadConfiguration.php
@@ -82,14 +82,14 @@ class LoadConfiguration extends BaseLoadConfiguration
     private function loadRuntimeConfiguration(Application $app, RepositoryContract $repository): void
     {
         if ($app->runningInConsole()) {
-            if (isset($_SERVER['argv'])) {
+            if ($this->getArgv() !== null) {
                 // Check if the `--pretty-urls` CLI argument is set, and if so, set the config value accordingly.
-                if (in_array('--pretty-urls', $_SERVER['argv'], true)) {
+                if (in_array('--pretty-urls', $this->getArgv(), true)) {
                     $repository->set('hyde.pretty_urls', true);
                 }
 
                 // Check if the `--no-api` CLI argument is set, and if so, set the config value accordingly.
-                if (in_array('--no-api', $_SERVER['argv'], true)) {
+                if (in_array('--no-api', $this->getArgv(), true)) {
                     $repository->set('hyde.api_calls', false);
                 }
             }
@@ -104,6 +104,11 @@ class LoadConfiguration extends BaseLoadConfiguration
         if ($this->getEnv($environmentKey) !== false) {
             $repository->set($configKey, $this->getEnv($environmentKey) === 'enabled');
         }
+    }
+
+    protected function getArgv(): ?array
+    {
+        return $_SERVER['argv'] ?? null;
     }
 
     protected function getEnv(string $name): string|false|null

--- a/packages/framework/tests/Feature/Commands/ServeCommandTest.php
+++ b/packages/framework/tests/Feature/Commands/ServeCommandTest.php
@@ -13,6 +13,7 @@ use Hyde\RealtimeCompiler\ConsoleOutput;
 
 /**
  * @covers \Hyde\Console\Commands\ServeCommand
+ *
  * @see \Hyde\Framework\Testing\Unit\ServeCommandOptionsUnitTest
  */
 class ServeCommandTest extends TestCase

--- a/packages/framework/tests/Feature/Commands/ServeCommandTest.php
+++ b/packages/framework/tests/Feature/Commands/ServeCommandTest.php
@@ -13,6 +13,7 @@ use Hyde\RealtimeCompiler\ConsoleOutput;
 
 /**
  * @covers \Hyde\Console\Commands\ServeCommand
+ * @see \Hyde\Framework\Testing\Unit\ServeCommandOptionsUnitTest
  */
 class ServeCommandTest extends TestCase
 {

--- a/packages/framework/tests/Feature/Commands/ServeCommandTest.php
+++ b/packages/framework/tests/Feature/Commands/ServeCommandTest.php
@@ -146,7 +146,7 @@ class ServeCommandTest extends TestCase
 
         Process::shouldReceive('env')
             ->once()
-            ->with(['HYDE_RC_REQUEST_OUTPUT' => false])
+            ->with(['HYDE_SERVER_REQUEST_OUTPUT' => false])
             ->andReturnSelf();
 
         Process::shouldReceive('run')

--- a/packages/framework/tests/Unit/LoadConfigurationTest.php
+++ b/packages/framework/tests/Unit/LoadConfigurationTest.php
@@ -33,4 +33,28 @@ class LoadConfigurationTest extends UnitTestCase
         $this->assertFalse(config('hyde.pretty_urls'));
         $this->assertNull(config('hyde.api_calls'));
     }
+
+    public function testItLoadsRealtimeCompilerEnvironmentConfiguration()
+    {
+        (new LoadConfigurationEnvironmentTestClass(['HYDE_RC_SERVER_DASHBOARD' => 'enabled']))->bootstrap(new Application(getcwd()));
+        $this->assertTrue(config('hyde.server.dashboard.enabled'));
+
+        (new LoadConfigurationEnvironmentTestClass(['HYDE_RC_SERVER_DASHBOARD' => 'disabled']))->bootstrap(new Application(getcwd()));
+        $this->assertFalse(config('hyde.server.dashboard.enabled'));
+    }
+}
+
+class LoadConfigurationEnvironmentTestClass extends LoadConfiguration
+{
+    protected array $env;
+
+    public function __construct(array $env)
+    {
+        $this->env = $env;
+    }
+
+    protected function getEnv(string $name): string|false
+    {
+        return $this->env[$name];
+    }
 }

--- a/packages/framework/tests/Unit/LoadConfigurationTest.php
+++ b/packages/framework/tests/Unit/LoadConfigurationTest.php
@@ -15,21 +15,17 @@ class LoadConfigurationTest extends UnitTestCase
 {
     public function testItLoadsRuntimeConfiguration()
     {
-        $serverBackup = $_SERVER;
-
-        $_SERVER['argv'] = ['--pretty-urls', '--no-api'];
-
         $app = new Application(getcwd());
 
-        $loader = new LoadConfiguration();
+        $loader = new LoadConfigurationTestClass(['--pretty-urls', '--no-api']);
         $loader->bootstrap($app);
 
         $this->assertTrue(config('hyde.pretty_urls'));
         $this->assertFalse(config('hyde.api_calls'));
 
-        $_SERVER = $serverBackup;
-
+        $loader = new LoadConfigurationTestClass([]);
         $loader->bootstrap($app);
+
         $this->assertFalse(config('hyde.pretty_urls'));
         $this->assertNull(config('hyde.api_calls'));
     }
@@ -41,6 +37,21 @@ class LoadConfigurationTest extends UnitTestCase
 
         (new LoadConfigurationEnvironmentTestClass(['HYDE_SERVER_DASHBOARD' => 'disabled']))->bootstrap(new Application(getcwd()));
         $this->assertFalse(config('hyde.server.dashboard.enabled'));
+    }
+}
+
+class LoadConfigurationTestClass extends LoadConfiguration
+{
+    protected array $argv;
+
+    public function __construct(array $argv)
+    {
+        $this->argv = $argv;
+    }
+
+    protected function getArgv(): ?array
+    {
+        return $this->argv;
     }
 }
 

--- a/packages/framework/tests/Unit/LoadConfigurationTest.php
+++ b/packages/framework/tests/Unit/LoadConfigurationTest.php
@@ -36,10 +36,10 @@ class LoadConfigurationTest extends UnitTestCase
 
     public function testItLoadsRealtimeCompilerEnvironmentConfiguration()
     {
-        (new LoadConfigurationEnvironmentTestClass(['HYDE_RC_SERVER_DASHBOARD' => 'enabled']))->bootstrap(new Application(getcwd()));
+        (new LoadConfigurationEnvironmentTestClass(['HYDE_SERVER_DASHBOARD' => 'enabled']))->bootstrap(new Application(getcwd()));
         $this->assertTrue(config('hyde.server.dashboard.enabled'));
 
-        (new LoadConfigurationEnvironmentTestClass(['HYDE_RC_SERVER_DASHBOARD' => 'disabled']))->bootstrap(new Application(getcwd()));
+        (new LoadConfigurationEnvironmentTestClass(['HYDE_SERVER_DASHBOARD' => 'disabled']))->bootstrap(new Application(getcwd()));
         $this->assertFalse(config('hyde.server.dashboard.enabled'));
     }
 }

--- a/packages/framework/tests/Unit/LoadConfigurationTest.php
+++ b/packages/framework/tests/Unit/LoadConfigurationTest.php
@@ -53,7 +53,7 @@ class LoadConfigurationEnvironmentTestClass extends LoadConfiguration
         $this->env = $env;
     }
 
-    protected function getEnv(string $name): string|false
+    protected function getEnv(string $name): string|false|null
     {
         return $this->env[$name];
     }

--- a/packages/framework/tests/Unit/LoadConfigurationTest.php
+++ b/packages/framework/tests/Unit/LoadConfigurationTest.php
@@ -17,17 +17,17 @@ class LoadConfigurationTest extends UnitTestCase
     {
         $app = new Application(getcwd());
 
-        $loader = new LoadConfigurationTestClass(['--pretty-urls', '--no-api']);
-        $loader->bootstrap($app);
-
-        $this->assertTrue(config('hyde.pretty_urls'));
-        $this->assertFalse(config('hyde.api_calls'));
-
         $loader = new LoadConfigurationTestClass([]);
         $loader->bootstrap($app);
 
         $this->assertFalse(config('hyde.pretty_urls'));
         $this->assertNull(config('hyde.api_calls'));
+
+        $loader = new LoadConfigurationTestClass(['--pretty-urls', '--no-api']);
+        $loader->bootstrap($app);
+
+        $this->assertTrue(config('hyde.pretty_urls'));
+        $this->assertFalse(config('hyde.api_calls'));
     }
 
     public function testItLoadsRealtimeCompilerEnvironmentConfiguration()

--- a/packages/framework/tests/Unit/ServeCommandOptionsUnitTest.php
+++ b/packages/framework/tests/Unit/ServeCommandOptionsUnitTest.php
@@ -60,24 +60,26 @@ class ServeCommandOptionsUnitTest extends TestCase
 
     public function test_getDashboardSelection()
     {
-        $this->assertSame(true, $this->getMock()->getDashboardSelection());
+        $this->assertSame(null, $this->getMock()->getDashboardSelection());
     }
 
     public function test_getDashboardSelection_withDashboardOption()
     {
-        $this->assertSame(false, $this->getMock(['dashboard' => false])->getDashboardSelection());
+        $this->assertSame(false, $this->getMock(['dashboard' => 'false'])->getDashboardSelection());
+        $this->assertSame(true, $this->getMock(['dashboard' => 'true'])->getDashboardSelection());
+        $this->assertSame(true, $this->getMock(['dashboard' => ''])->getDashboardSelection());
     }
 
     public function test_getDashboardSelection_withConfigOption()
     {
         $this->app['config']->set('hyde.server.dashboard.enabled', false);
-        $this->assertSame(false, $this->getMock()->getDashboardSelection());
+        $this->assertSame(null, $this->getMock()->getDashboardSelection());
     }
 
     public function test_getDashboardSelection_withDashboardOptionAndConfigOption()
     {
         $this->app['config']->set('hyde.server.dashboard.enabled', false);
-        $this->assertSame(true, $this->getMock(['dashboard' => true])->getDashboardSelection());
+        $this->assertSame(true, $this->getMock(['dashboard' => 'true'])->getDashboardSelection());
     }
 
     public function test_getDashboardSelection_propagatesToEnvironmentVariables()
@@ -85,16 +87,16 @@ class ServeCommandOptionsUnitTest extends TestCase
         $command = $this->getMock();
 
         $this->app['config']->set('hyde.server.dashboard.enabled', false);
-        $this->assertSame(false, $command->getEnvironmentVariables()['SERVER_DASHBOARD']);
+        $this->assertSame(false, isset($command->getEnvironmentVariables()['HYDE_RC_SERVER_DASHBOARD']));
 
         $this->app['config']->set('hyde.server.dashboard.enabled', true);
-        $this->assertSame(true, $command->getEnvironmentVariables()['SERVER_DASHBOARD']);
+        $this->assertSame(false, isset($command->getEnvironmentVariables()['HYDE_RC_SERVER_DASHBOARD']));
 
-        $command = $this->getMock(['dashboard' => false]);
-        $this->assertSame(false, $command->getEnvironmentVariables()['SERVER_DASHBOARD']);
+        $command = $this->getMock(['dashboard' => 'false']);
+        $this->assertSame('disabled', $command->getEnvironmentVariables()['HYDE_RC_SERVER_DASHBOARD']);
 
-        $command = $this->getMock(['dashboard' => true]);
-        $this->assertSame(true, $command->getEnvironmentVariables()['SERVER_DASHBOARD']);
+        $command = $this->getMock(['dashboard' => 'true']);
+        $this->assertSame('enabled', $command->getEnvironmentVariables()['HYDE_RC_SERVER_DASHBOARD']);
     }
 
     protected function getMock(array $options = []): ServeCommandMock

--- a/packages/framework/tests/Unit/ServeCommandOptionsUnitTest.php
+++ b/packages/framework/tests/Unit/ServeCommandOptionsUnitTest.php
@@ -73,6 +73,13 @@ class ServeCommandOptionsUnitTest extends UnitTestCase
         ], $this->getMock()->getEnvironmentVariables());
     }
 
+    public function test_getEnvironmentVariables_withNoAnsiOption()
+    {
+        $this->assertSame([
+            'HYDE_RC_REQUEST_OUTPUT' => false,
+        ], $this->getMock(['no-ansi' => true])->getEnvironmentVariables());
+    }
+
     public function testDashboardOptionPropagatesToEnvironmentVariables()
     {
         $command = $this->getMock(['dashboard' => 'false']);

--- a/packages/framework/tests/Unit/ServeCommandOptionsUnitTest.php
+++ b/packages/framework/tests/Unit/ServeCommandOptionsUnitTest.php
@@ -69,33 +69,33 @@ class ServeCommandOptionsUnitTest extends UnitTestCase
     public function test_getEnvironmentVariables()
     {
         $this->assertSame([
-            'HYDE_RC_REQUEST_OUTPUT' => true,
+            'HYDE_SERVER_REQUEST_OUTPUT' => true,
         ], $this->getMock()->getEnvironmentVariables());
     }
 
     public function test_getEnvironmentVariables_withNoAnsiOption()
     {
         $this->assertSame([
-            'HYDE_RC_REQUEST_OUTPUT' => false,
+            'HYDE_SERVER_REQUEST_OUTPUT' => false,
         ], $this->getMock(['no-ansi' => true])->getEnvironmentVariables());
     }
 
     public function testDashboardOptionPropagatesToEnvironmentVariables()
     {
         $command = $this->getMock(['dashboard' => 'false']);
-        $this->assertSame('disabled', $command->getEnvironmentVariables()['HYDE_RC_SERVER_DASHBOARD']);
+        $this->assertSame('disabled', $command->getEnvironmentVariables()['HYDE_SERVER_DASHBOARD']);
 
         $command = $this->getMock(['dashboard' => 'true']);
-        $this->assertSame('enabled', $command->getEnvironmentVariables()['HYDE_RC_SERVER_DASHBOARD']);
+        $this->assertSame('enabled', $command->getEnvironmentVariables()['HYDE_SERVER_DASHBOARD']);
 
         $command = $this->getMock(['dashboard' => '']);
-        $this->assertSame('enabled', $command->getEnvironmentVariables()['HYDE_RC_SERVER_DASHBOARD']);
+        $this->assertSame('enabled', $command->getEnvironmentVariables()['HYDE_SERVER_DASHBOARD']);
 
         $command = $this->getMock(['dashboard' => null]);
-        $this->assertFalse(isset($command->getEnvironmentVariables()['HYDE_RC_SERVER_DASHBOARD']));
+        $this->assertFalse(isset($command->getEnvironmentVariables()['HYDE_SERVER_DASHBOARD']));
 
         $command = $this->getMock();
-        $this->assertFalse(isset($command->getEnvironmentVariables()['HYDE_RC_SERVER_DASHBOARD']));
+        $this->assertFalse(isset($command->getEnvironmentVariables()['HYDE_SERVER_DASHBOARD']));
     }
 
     public function testPrettyUrlsOptionPropagatesToEnvironmentVariables()

--- a/packages/framework/tests/Unit/ServeCommandOptionsUnitTest.php
+++ b/packages/framework/tests/Unit/ServeCommandOptionsUnitTest.php
@@ -80,6 +80,24 @@ class ServeCommandOptionsUnitTest extends UnitTestCase
         ], $this->getMock(['no-ansi' => true])->getEnvironmentVariables());
     }
 
+    public function testSavePreviewOptionPropagatesToEnvironmentVariables()
+    {
+        $command = $this->getMock(['save-preview' => 'false']);
+        $this->assertSame('disabled', $command->getEnvironmentVariables()['HYDE_SERVER_SAVE_PREVIEW']);
+
+        $command = $this->getMock(['save-preview' => 'true']);
+        $this->assertSame('enabled', $command->getEnvironmentVariables()['HYDE_SERVER_SAVE_PREVIEW']);
+
+        $command = $this->getMock(['save-preview' => '']);
+        $this->assertSame('enabled', $command->getEnvironmentVariables()['HYDE_SERVER_SAVE_PREVIEW']);
+
+        $command = $this->getMock(['save-preview' => null]);
+        $this->assertFalse(isset($command->getEnvironmentVariables()['HYDE_SERVER_SAVE_PREVIEW']));
+
+        $command = $this->getMock();
+        $this->assertFalse(isset($command->getEnvironmentVariables()['HYDE_SERVER_SAVE_PREVIEW']));
+    }
+
     public function testDashboardOptionPropagatesToEnvironmentVariables()
     {
         $command = $this->getMock(['dashboard' => 'false']);

--- a/packages/framework/tests/Unit/ServeCommandOptionsUnitTest.php
+++ b/packages/framework/tests/Unit/ServeCommandOptionsUnitTest.php
@@ -76,6 +76,24 @@ class ServeCommandOptionsUnitTest extends TestCase
         $this->assertFalse(isset($command->getEnvironmentVariables()['HYDE_RC_SERVER_DASHBOARD']));
     }
 
+    public function testPrettyUrlsOptionPropagatesToEnvironmentVariables()
+    {
+        $command = $this->getMock(['pretty-urls' => 'false']);
+        $this->assertSame('disabled', $command->getEnvironmentVariables()['HYDE_PRETTY_URLS']);
+
+        $command = $this->getMock(['pretty-urls' => 'true']);
+        $this->assertSame('enabled', $command->getEnvironmentVariables()['HYDE_PRETTY_URLS']);
+
+        $command = $this->getMock(['pretty-urls' => '']);
+        $this->assertSame('enabled', $command->getEnvironmentVariables()['HYDE_PRETTY_URLS']);
+
+        $command = $this->getMock(['pretty-urls' => null]);
+        $this->assertFalse(isset($command->getEnvironmentVariables()['HYDE_PRETTY_URLS']));
+
+        $command = $this->getMock();
+        $this->assertFalse(isset($command->getEnvironmentVariables()['HYDE_PRETTY_URLS']));
+    }
+
     protected function getMock(array $options = []): ServeCommandMock
     {
         return new ServeCommandMock($options);

--- a/packages/framework/tests/Unit/ServeCommandOptionsUnitTest.php
+++ b/packages/framework/tests/Unit/ServeCommandOptionsUnitTest.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Hyde\Framework\Testing\Unit;
 
-use Hyde\Testing\TestCase;
+use Hyde\Testing\UnitTestCase;
 use Hyde\Console\Commands\ServeCommand;
 
 /**
@@ -12,8 +12,16 @@ use Hyde\Console\Commands\ServeCommand;
  *
  * @see \Hyde\Framework\Testing\Feature\Commands\ServeCommandTest
  */
-class ServeCommandOptionsUnitTest extends TestCase
+class ServeCommandOptionsUnitTest extends UnitTestCase
 {
+    protected function setUp(): void
+    {
+        self::mockConfig([
+            'hyde.server.host' => 'localhost',
+            'hyde.server.port' => 8080,
+        ]);
+    }
+
     public function test_getHostSelection()
     {
         $this->assertSame('localhost', $this->getMock()->getHostSelection());
@@ -26,13 +34,13 @@ class ServeCommandOptionsUnitTest extends TestCase
 
     public function test_getHostSelection_withConfigOption()
     {
-        $this->app['config']->set('hyde.server.host', 'foo');
+        self::mockConfig(['hyde.server.host' => 'foo']);
         $this->assertSame('foo', $this->getMock()->getHostSelection());
     }
 
     public function test_getHostSelection_withHostOptionAndConfigOption()
     {
-        $this->app['config']->set('hyde.server.host', 'foo');
+        self::mockConfig(['hyde.server.host' => 'foo']);
         $this->assertSame('bar', $this->getMock(['host' => 'bar'])->getHostSelection());
     }
 
@@ -48,13 +56,13 @@ class ServeCommandOptionsUnitTest extends TestCase
 
     public function test_getPortSelection_withConfigOption()
     {
-        $this->app['config']->set('hyde.server.port', 8082);
+        self::mockConfig(['hyde.server.port' => 8082]);
         $this->assertSame(8082, $this->getMock()->getPortSelection());
     }
 
     public function test_getPortSelection_withPortOptionAndConfigOption()
     {
-        $this->app['config']->set('hyde.server.port', 8082);
+        self::mockConfig(['hyde.server.port' => 8082]);
         $this->assertSame(8081, $this->getMock(['port' => 8081])->getPortSelection());
     }
 

--- a/packages/framework/tests/Unit/ServeCommandOptionsUnitTest.php
+++ b/packages/framework/tests/Unit/ServeCommandOptionsUnitTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Hyde\Framework\Testing\Unit;
 
 use Hyde\Testing\TestCase;
+use Hyde\Console\Commands\ServeCommand;
 
 /**
  * @covers \Hyde\Console\Commands\ServeCommand
@@ -13,5 +14,94 @@ use Hyde\Testing\TestCase;
  */
 class ServeCommandOptionsUnitTest extends TestCase
 {
-    //
+    public function test_getHostSelection()
+    {
+        $command = new ServeCommandMock();
+        $this->assertSame('localhost', $command->getHostSelection());
+    }
+
+    public function test_getHostSelection_withHostOption()
+    {
+        $command = new ServeCommandMock(['host' => 'foo']);
+        $this->assertSame('foo', $command->getHostSelection());
+    }
+
+    public function test_getHostSelection_withConfigOption()
+    {
+        $this->app['config']->set('hyde.server.host', 'foo');
+        $command = new ServeCommandMock();
+        $this->assertSame('foo', $command->getHostSelection());
+    }
+
+    public function test_getHostSelection_withHostOptionAndConfigOption()
+    {
+        $this->app['config']->set('hyde.server.host', 'foo');
+        $command = new ServeCommandMock(['host' => 'bar']);
+        $this->assertSame('bar', $command->getHostSelection());
+    }
+
+    public function test_getPortSelection()
+    {
+        $command = new ServeCommandMock();
+        $this->assertSame(8080, $command->getPortSelection());
+    }
+
+    public function test_getPortSelection_withPortOption()
+    {
+        $command = new ServeCommandMock(['port' => 8081]);
+        $this->assertSame(8081, $command->getPortSelection());
+    }
+
+    public function test_getPortSelection_withConfigOption()
+    {
+        $this->app['config']->set('hyde.server.port', 8082);
+        $command = new ServeCommandMock();
+        $this->assertSame(8082, $command->getPortSelection());
+    }
+
+    public function test_getPortSelection_withPortOptionAndConfigOption()
+    {
+        $this->app['config']->set('hyde.server.port', 8082);
+        $command = new ServeCommandMock(['port' => 8081]);
+        $this->assertSame(8081, $command->getPortSelection());
+    }
+}
+
+/**
+ * @method getHostSelection
+ * @method getPortSelection
+ */
+class ServeCommandMock extends ServeCommand
+{
+    public function __construct(array $options = [])
+    {
+        parent::__construct();
+
+        $this->input = new InputMock($options);
+    }
+
+    public function __call($method, $parameters)
+    {
+        return call_user_func_array([$this, $method], $parameters);
+    }
+
+    public function option($key = null)
+    {
+        return $this->input->getOption($key);
+    }
+}
+
+class InputMock
+{
+    protected array $options;
+
+    public function __construct(array $options = [])
+    {
+        $this->options = $options;
+    }
+
+    public function getOption(string $key)
+    {
+        return $this->options[$key] ?? null;
+    }
 }

--- a/packages/framework/tests/Unit/ServeCommandOptionsUnitTest.php
+++ b/packages/framework/tests/Unit/ServeCommandOptionsUnitTest.php
@@ -58,7 +58,7 @@ class ServeCommandOptionsUnitTest extends TestCase
         $this->assertSame(8081, $this->getMock(['port' => 8081])->getPortSelection());
     }
 
-    public function test_getDashboardSelection_propagatesToEnvironmentVariables()
+    public function testDashboardOptionPropagatesToEnvironmentVariables()
     {
         $command = $this->getMock(['dashboard' => 'false']);
         $this->assertSame('disabled', $command->getEnvironmentVariables()['HYDE_RC_SERVER_DASHBOARD']);

--- a/packages/framework/tests/Unit/ServeCommandOptionsUnitTest.php
+++ b/packages/framework/tests/Unit/ServeCommandOptionsUnitTest.php
@@ -8,6 +8,7 @@ use Hyde\Testing\TestCase;
 
 /**
  * @covers \Hyde\Console\Commands\ServeCommand
+ *
  * @see \Hyde\Framework\Testing\Feature\Commands\ServeCommandTest
  */
 class ServeCommandOptionsUnitTest extends TestCase

--- a/packages/framework/tests/Unit/ServeCommandOptionsUnitTest.php
+++ b/packages/framework/tests/Unit/ServeCommandOptionsUnitTest.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Hyde\Framework\Testing\Unit;
+
+use Hyde\Testing\TestCase;
+
+/**
+ * @covers \Hyde\Console\Commands\ServeCommand
+ * @see \Hyde\Framework\Testing\Feature\Commands\ServeCommandTest
+ */
+class ServeCommandOptionsUnitTest extends TestCase
+{
+    //
+}

--- a/packages/framework/tests/Unit/ServeCommandOptionsUnitTest.php
+++ b/packages/framework/tests/Unit/ServeCommandOptionsUnitTest.php
@@ -16,46 +16,51 @@ class ServeCommandOptionsUnitTest extends TestCase
 {
     public function test_getHostSelection()
     {
-        $this->assertSame('localhost', (new ServeCommandMock())->getHostSelection());
+        $this->assertSame('localhost', $this->getMock()->getHostSelection());
     }
 
     public function test_getHostSelection_withHostOption()
     {
-        $this->assertSame('foo', (new ServeCommandMock(['host' => 'foo']))->getHostSelection());
+        $this->assertSame('foo', $this->getMock(['host' => 'foo'])->getHostSelection());
     }
 
     public function test_getHostSelection_withConfigOption()
     {
         $this->app['config']->set('hyde.server.host', 'foo');
-        $this->assertSame('foo', (new ServeCommandMock())->getHostSelection());
+        $this->assertSame('foo', $this->getMock()->getHostSelection());
     }
 
     public function test_getHostSelection_withHostOptionAndConfigOption()
     {
         $this->app['config']->set('hyde.server.host', 'foo');
-        $this->assertSame('bar', (new ServeCommandMock(['host' => 'bar']))->getHostSelection());
+        $this->assertSame('bar', $this->getMock(['host' => 'bar'])->getHostSelection());
     }
 
     public function test_getPortSelection()
     {
-        $this->assertSame(8080, (new ServeCommandMock())->getPortSelection());
+        $this->assertSame(8080, $this->getMock()->getPortSelection());
     }
 
     public function test_getPortSelection_withPortOption()
     {
-        $this->assertSame(8081, (new ServeCommandMock(['port' => 8081]))->getPortSelection());
+        $this->assertSame(8081, $this->getMock(['port' => 8081])->getPortSelection());
     }
 
     public function test_getPortSelection_withConfigOption()
     {
         $this->app['config']->set('hyde.server.port', 8082);
-        $this->assertSame(8082, (new ServeCommandMock())->getPortSelection());
+        $this->assertSame(8082, $this->getMock()->getPortSelection());
     }
 
     public function test_getPortSelection_withPortOptionAndConfigOption()
     {
         $this->app['config']->set('hyde.server.port', 8082);
-        $this->assertSame(8081, (new ServeCommandMock(['port' => 8081]))->getPortSelection());
+        $this->assertSame(8081, $this->getMock(['port' => 8081])->getPortSelection());
+    }
+
+    protected function getMock(array $options = []): ServeCommandMock
+    {
+        return new ServeCommandMock($options);
     }
 }
 

--- a/packages/framework/tests/Unit/ServeCommandOptionsUnitTest.php
+++ b/packages/framework/tests/Unit/ServeCommandOptionsUnitTest.php
@@ -66,6 +66,13 @@ class ServeCommandOptionsUnitTest extends UnitTestCase
         $this->assertSame(8081, $this->getMock(['port' => 8081])->getPortSelection());
     }
 
+    public function test_getEnvironmentVariables()
+    {
+        $this->assertSame([
+            'HYDE_RC_REQUEST_OUTPUT' => true,
+        ], $this->getMock()->getEnvironmentVariables());
+    }
+
     public function testDashboardOptionPropagatesToEnvironmentVariables()
     {
         $command = $this->getMock(['dashboard' => 'false']);

--- a/packages/framework/tests/Unit/ServeCommandOptionsUnitTest.php
+++ b/packages/framework/tests/Unit/ServeCommandOptionsUnitTest.php
@@ -16,54 +16,46 @@ class ServeCommandOptionsUnitTest extends TestCase
 {
     public function test_getHostSelection()
     {
-        $command = new ServeCommandMock();
-        $this->assertSame('localhost', $command->getHostSelection());
+        $this->assertSame('localhost', (new ServeCommandMock())->getHostSelection());
     }
 
     public function test_getHostSelection_withHostOption()
     {
-        $command = new ServeCommandMock(['host' => 'foo']);
-        $this->assertSame('foo', $command->getHostSelection());
+        $this->assertSame('foo', (new ServeCommandMock(['host' => 'foo']))->getHostSelection());
     }
 
     public function test_getHostSelection_withConfigOption()
     {
         $this->app['config']->set('hyde.server.host', 'foo');
-        $command = new ServeCommandMock();
-        $this->assertSame('foo', $command->getHostSelection());
+        $this->assertSame('foo', (new ServeCommandMock())->getHostSelection());
     }
 
     public function test_getHostSelection_withHostOptionAndConfigOption()
     {
         $this->app['config']->set('hyde.server.host', 'foo');
-        $command = new ServeCommandMock(['host' => 'bar']);
-        $this->assertSame('bar', $command->getHostSelection());
+        $this->assertSame('bar', (new ServeCommandMock(['host' => 'bar']))->getHostSelection());
     }
 
     public function test_getPortSelection()
     {
-        $command = new ServeCommandMock();
-        $this->assertSame(8080, $command->getPortSelection());
+        $this->assertSame(8080, (new ServeCommandMock())->getPortSelection());
     }
 
     public function test_getPortSelection_withPortOption()
     {
-        $command = new ServeCommandMock(['port' => 8081]);
-        $this->assertSame(8081, $command->getPortSelection());
+        $this->assertSame(8081, (new ServeCommandMock(['port' => 8081]))->getPortSelection());
     }
 
     public function test_getPortSelection_withConfigOption()
     {
         $this->app['config']->set('hyde.server.port', 8082);
-        $command = new ServeCommandMock();
-        $this->assertSame(8082, $command->getPortSelection());
+        $this->assertSame(8082, (new ServeCommandMock())->getPortSelection());
     }
 
     public function test_getPortSelection_withPortOptionAndConfigOption()
     {
         $this->app['config']->set('hyde.server.port', 8082);
-        $command = new ServeCommandMock(['port' => 8081]);
-        $this->assertSame(8081, $command->getPortSelection());
+        $this->assertSame(8081, (new ServeCommandMock(['port' => 8081]))->getPortSelection());
     }
 }
 

--- a/packages/framework/tests/Unit/ServeCommandOptionsUnitTest.php
+++ b/packages/framework/tests/Unit/ServeCommandOptionsUnitTest.php
@@ -116,6 +116,24 @@ class ServeCommandOptionsUnitTest extends UnitTestCase
         $this->assertFalse(isset($command->getEnvironmentVariables()['HYDE_PRETTY_URLS']));
     }
 
+    public function testPlayCdnOptionPropagatesToEnvironmentVariables()
+    {
+        $command = $this->getMock(['play-cdn' => 'false']);
+        $this->assertSame('disabled', $command->getEnvironmentVariables()['HYDE_PLAY_CDN']);
+
+        $command = $this->getMock(['play-cdn' => 'true']);
+        $this->assertSame('enabled', $command->getEnvironmentVariables()['HYDE_PLAY_CDN']);
+
+        $command = $this->getMock(['play-cdn' => '']);
+        $this->assertSame('enabled', $command->getEnvironmentVariables()['HYDE_PLAY_CDN']);
+
+        $command = $this->getMock(['play-cdn' => null]);
+        $this->assertFalse(isset($command->getEnvironmentVariables()['HYDE_PLAY_CDN']));
+
+        $command = $this->getMock();
+        $this->assertFalse(isset($command->getEnvironmentVariables()['HYDE_PLAY_CDN']));
+    }
+
     public function test_parseEnvironmentOption()
     {
         $command = $this->getMock(['foo' => 'true']);

--- a/packages/framework/tests/Unit/ServeCommandOptionsUnitTest.php
+++ b/packages/framework/tests/Unit/ServeCommandOptionsUnitTest.php
@@ -58,45 +58,22 @@ class ServeCommandOptionsUnitTest extends TestCase
         $this->assertSame(8081, $this->getMock(['port' => 8081])->getPortSelection());
     }
 
-    public function test_getDashboardSelection()
-    {
-        $this->assertSame(null, $this->getMock()->getDashboardSelection());
-    }
-
-    public function test_getDashboardSelection_withDashboardOption()
-    {
-        $this->assertSame(false, $this->getMock(['dashboard' => 'false'])->getDashboardSelection());
-        $this->assertSame(true, $this->getMock(['dashboard' => 'true'])->getDashboardSelection());
-        $this->assertSame(true, $this->getMock(['dashboard' => ''])->getDashboardSelection());
-    }
-
-    public function test_getDashboardSelection_withConfigOption()
-    {
-        $this->app['config']->set('hyde.server.dashboard.enabled', false);
-        $this->assertSame(null, $this->getMock()->getDashboardSelection());
-    }
-
-    public function test_getDashboardSelection_withDashboardOptionAndConfigOption()
-    {
-        $this->app['config']->set('hyde.server.dashboard.enabled', false);
-        $this->assertSame(true, $this->getMock(['dashboard' => 'true'])->getDashboardSelection());
-    }
-
     public function test_getDashboardSelection_propagatesToEnvironmentVariables()
     {
-        $command = $this->getMock();
-
-        $this->app['config']->set('hyde.server.dashboard.enabled', false);
-        $this->assertSame(false, isset($command->getEnvironmentVariables()['HYDE_RC_SERVER_DASHBOARD']));
-
-        $this->app['config']->set('hyde.server.dashboard.enabled', true);
-        $this->assertSame(false, isset($command->getEnvironmentVariables()['HYDE_RC_SERVER_DASHBOARD']));
-
         $command = $this->getMock(['dashboard' => 'false']);
         $this->assertSame('disabled', $command->getEnvironmentVariables()['HYDE_RC_SERVER_DASHBOARD']);
 
         $command = $this->getMock(['dashboard' => 'true']);
         $this->assertSame('enabled', $command->getEnvironmentVariables()['HYDE_RC_SERVER_DASHBOARD']);
+
+        $command = $this->getMock(['dashboard' => '']);
+        $this->assertSame('enabled', $command->getEnvironmentVariables()['HYDE_RC_SERVER_DASHBOARD']);
+
+        $command = $this->getMock(['dashboard' => null]);
+        $this->assertFalse(isset($command->getEnvironmentVariables()['HYDE_RC_SERVER_DASHBOARD']));
+
+        $command = $this->getMock();
+        $this->assertFalse(isset($command->getEnvironmentVariables()['HYDE_RC_SERVER_DASHBOARD']));
     }
 
     protected function getMock(array $options = []): ServeCommandMock
@@ -108,7 +85,6 @@ class ServeCommandOptionsUnitTest extends TestCase
 /**
  * @method getHostSelection
  * @method getPortSelection
- * @method getDashboardSelection
  * @method getEnvironmentVariables
  */
 class ServeCommandMock extends ServeCommand

--- a/packages/framework/tests/Unit/ServeCommandOptionsUnitTest.php
+++ b/packages/framework/tests/Unit/ServeCommandOptionsUnitTest.php
@@ -58,6 +58,45 @@ class ServeCommandOptionsUnitTest extends TestCase
         $this->assertSame(8081, $this->getMock(['port' => 8081])->getPortSelection());
     }
 
+    public function test_getDashboardSelection()
+    {
+        $this->assertSame(true, $this->getMock()->getDashboardSelection());
+    }
+
+    public function test_getDashboardSelection_withDashboardOption()
+    {
+        $this->assertSame(false, $this->getMock(['dashboard' => false])->getDashboardSelection());
+    }
+
+    public function test_getDashboardSelection_withConfigOption()
+    {
+        $this->app['config']->set('hyde.server.dashboard.enabled', false);
+        $this->assertSame(false, $this->getMock()->getDashboardSelection());
+    }
+
+    public function test_getDashboardSelection_withDashboardOptionAndConfigOption()
+    {
+        $this->app['config']->set('hyde.server.dashboard.enabled', false);
+        $this->assertSame(true, $this->getMock(['dashboard' => true])->getDashboardSelection());
+    }
+
+    public function test_getDashboardSelection_propagatesToEnvironmentVariables()
+    {
+        $command = $this->getMock();
+
+        $this->app['config']->set('hyde.server.dashboard.enabled', false);
+        $this->assertSame(false, $command->getEnvironmentVariables()['SERVER_DASHBOARD']);
+
+        $this->app['config']->set('hyde.server.dashboard.enabled', true);
+        $this->assertSame(true, $command->getEnvironmentVariables()['SERVER_DASHBOARD']);
+
+        $command = $this->getMock(['dashboard' => false]);
+        $this->assertSame(false, $command->getEnvironmentVariables()['SERVER_DASHBOARD']);
+
+        $command = $this->getMock(['dashboard' => true]);
+        $this->assertSame(true, $command->getEnvironmentVariables()['SERVER_DASHBOARD']);
+    }
+
     protected function getMock(array $options = []): ServeCommandMock
     {
         return new ServeCommandMock($options);
@@ -67,6 +106,8 @@ class ServeCommandOptionsUnitTest extends TestCase
 /**
  * @method getHostSelection
  * @method getPortSelection
+ * @method getDashboardSelection
+ * @method getEnvironmentVariables
  */
 class ServeCommandMock extends ServeCommand
 {

--- a/packages/framework/tests/Unit/ServeCommandOptionsUnitTest.php
+++ b/packages/framework/tests/Unit/ServeCommandOptionsUnitTest.php
@@ -116,6 +116,50 @@ class ServeCommandOptionsUnitTest extends UnitTestCase
         $this->assertFalse(isset($command->getEnvironmentVariables()['HYDE_PRETTY_URLS']));
     }
 
+    public function test_parseEnvironmentOption()
+    {
+        $command = $this->getMock(['foo' => 'true']);
+        $this->assertSame('enabled', $command->parseEnvironmentOption('foo'));
+
+        $command = $this->getMock(['foo' => 'false']);
+        $this->assertSame('disabled', $command->parseEnvironmentOption('foo'));
+    }
+
+    public function test_parseEnvironmentOption_withEmptyString()
+    {
+        $command = $this->getMock(['foo' => '']);
+        $this->assertSame('enabled', $command->parseEnvironmentOption('foo'));
+    }
+
+    public function test_parseEnvironmentOption_withNull()
+    {
+        $command = $this->getMock(['foo' => null]);
+        $this->assertNull($command->parseEnvironmentOption('foo'));
+    }
+
+    public function test_parseEnvironmentOption_withInvalidValue()
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('Invalid boolean value for --foo option.');
+
+        $command = $this->getMock(['foo' => 'bar']);
+        $command->parseEnvironmentOption('foo');
+    }
+
+    public function test_checkArgvForOption()
+    {
+        $serverBackup = $_SERVER;
+
+        $_SERVER['argv'] = ['--pretty-urls'];
+
+        $command = $this->getMock();
+
+        $this->assertSame('true', $command->checkArgvForOption('pretty-urls'));
+        $this->assertSame(null, $command->checkArgvForOption('dashboard'));
+
+        $_SERVER = $serverBackup;
+    }
+
     protected function getMock(array $options = []): ServeCommandMock
     {
         return new ServeCommandMock($options);
@@ -126,6 +170,8 @@ class ServeCommandOptionsUnitTest extends UnitTestCase
  * @method getHostSelection
  * @method getPortSelection
  * @method getEnvironmentVariables
+ * @method parseEnvironmentOption(string $name)
+ * @method checkArgvForOption(string $name)
  */
 class ServeCommandMock extends ServeCommand
 {

--- a/packages/realtime-compiler/bin/server.php
+++ b/packages/realtime-compiler/bin/server.php
@@ -20,7 +20,7 @@ try {
     echo '<h2>Initial exception:</h2><pre>'.print_r($exception, true).'</pre>';
     echo '<h2>Auxiliary exception:</h2><pre>'.print_r($th, true).'</pre>';
 } finally {
-    if (getenv('HYDE_RC_REQUEST_OUTPUT')) {
+    if (getenv('HYDE_SERVER_REQUEST_OUTPUT')) {
         // Write to console to emulate the standard built-in PHP server output
         $request = \Desilva\Microserve\Request::capture();
         file_put_contents('php://stderr', sprintf(

--- a/packages/realtime-compiler/src/ConsoleOutput.php
+++ b/packages/realtime-compiler/src/ConsoleOutput.php
@@ -28,17 +28,6 @@ class ConsoleOutput
     {
         $url = sprintf('%s://%s:%d', $port === 443 ? 'https' : 'http', $host, $port);
 
-        $statusOptions = [
-            'enabled' => 'green-500',
-            'disabled' => 'red-500',
-            'overridden' => 'yellow-500',
-        ];
-
-        $dashboardStatusValue = config('hyde.server.dashboard.enabled');
-        $dashboardOverridden = Arr::has($environment, 'HYDE_SERVER_DASHBOARD');
-        $dashboardStatus = $dashboardOverridden ? 'overridden' : ($dashboardStatusValue ? 'enabled' : 'disabled');
-        $dashboardStatusMessage = sprintf('<span class="text-white">Dashboard:</span> <span class="text-%s">%s</span>', $statusOptions[$dashboardStatus], $dashboardStatusValue ? 'enabled' : 'disabled');
-
         $isDashboardEnabled = (config('hyde.server.dashboard.enabled') || Arr::has($environment, 'HYDE_SERVER_DASHBOARD')) && Arr::get($environment, 'HYDE_SERVER_DASHBOARD') === 'enabled';
         $lines = Arr::whereNotNull([
             '',

--- a/packages/realtime-compiler/src/ConsoleOutput.php
+++ b/packages/realtime-compiler/src/ConsoleOutput.php
@@ -28,16 +28,15 @@ class ConsoleOutput
     {
         $url = sprintf('%s://%s:%d', $port === 443 ? 'https' : 'http', $host, $port);
 
-        $isDashboardEnabled = (config('hyde.server.dashboard.enabled') || Arr::has($environment, 'HYDE_SERVER_DASHBOARD')) && Arr::get($environment, 'HYDE_SERVER_DASHBOARD') === 'enabled';
-        $lines = Arr::whereNotNull([
+        $lines = [
             '',
             sprintf('<span class="text-blue-500">%s</span> <span class="text-gray">%s</span>', 'HydePHP Realtime Compiler', 'v'.Hyde::getInstance()->version()),
             '',
             sprintf('<span class="text-white">Listening on:</span> <a href="%s" class="text-yellow-500">%s</a>', $url, $url),
-            $isDashboardEnabled ?
+            (config('hyde.server.dashboard.enabled') || Arr::has($environment, 'HYDE_SERVER_DASHBOARD')) && Arr::get($environment, 'HYDE_SERVER_DASHBOARD') === 'enabled' ?
                 sprintf('<span class="text-white">Live dashboard:</span> <a href="%s/dashboard" class="text-yellow-500">%s/dashboard</a>', $url, $url) : null,
             '',
-        ]);
+        ];
 
         $lineLength = max(array_map('strlen', array_map('strip_tags', $lines)));
 

--- a/packages/realtime-compiler/src/ConsoleOutput.php
+++ b/packages/realtime-compiler/src/ConsoleOutput.php
@@ -39,15 +39,16 @@ class ConsoleOutput
         $dashboardStatus = $dashboardOverridden ? 'overridden' : ($dashboardStatusValue ? 'enabled' : 'disabled');
         $dashboardStatusMessage = sprintf('<span class="text-white">Dashboard:</span> <span class="text-%s">%s</span>', $statusOptions[$dashboardStatus], $dashboardStatusValue ? 'enabled' : 'disabled');
 
-        $lines = [
+        $isDashboardEnabled = (config('hyde.server.dashboard.enabled') || Arr::has($environment, 'HYDE_SERVER_DASHBOARD')) && Arr::get($environment, 'HYDE_SERVER_DASHBOARD') === 'enabled';
+        $lines = Arr::whereNotNull([
             '',
             sprintf('<span class="text-blue-500">%s</span> <span class="text-gray">%s</span>', 'HydePHP Realtime Compiler', 'v'.Hyde::getInstance()->version()),
             '',
-            sprintf('<span class="text-white">Listening on</span> <a href="%s" class="text-yellow-500">%s</a>', $url, $url),
+            sprintf('<span class="text-white">Listening on:</span> <a href="%s" class="text-yellow-500">%s</a>', $url, $url),
+            $isDashboardEnabled ?
+                sprintf('<span class="text-white">Live dashboard:</span> <a href="%s/dashboard" class="text-yellow-500">%s/dashboard</a>', $url, $url) : null,
             '',
-            $dashboardStatusMessage,
-            '',
-        ];
+        ]);
 
         $lineLength = max(array_map('strlen', array_map('strip_tags', $lines)));
 

--- a/packages/realtime-compiler/src/ConsoleOutput.php
+++ b/packages/realtime-compiler/src/ConsoleOutput.php
@@ -28,9 +28,11 @@ class ConsoleOutput
         $url = sprintf('%s://%s:%d', $port === 443 ? 'https' : 'http', $host, $port);
 
         $lines = [
+            '',
             sprintf('<span class="text-blue-500">%s</span> <span class="text-gray">%s</span>', 'HydePHP Realtime Compiler', 'v'.Hyde::getInstance()->version()),
             '',
             sprintf('<span class="text-white">Listening on</span> <a href="%s" class="text-yellow-500">%s</a>', $url, $url),
+            '',
         ];
 
         $lineLength = max(array_map('strlen', array_map('strip_tags', $lines)));
@@ -39,7 +41,7 @@ class ConsoleOutput
             return sprintf('&nbsp;│&nbsp;<span class="text-white">%s</span>%s│',
                 $line, str_repeat('&nbsp;', ($lineLength - strlen(strip_tags($line))) + 1)
             );
-        }, array_merge([''], $lines, ['']));
+        }, $lines);
 
         $topLine = sprintf('&nbsp;╭%s╮', str_repeat('─', $lineLength + 2));
         $bottomLine = sprintf('&nbsp;╰%s╯', str_repeat('─', $lineLength + 2));

--- a/packages/realtime-compiler/src/ConsoleOutput.php
+++ b/packages/realtime-compiler/src/ConsoleOutput.php
@@ -24,11 +24,11 @@ class ConsoleOutput
         $this->output = $output ?? new SymfonyOutput();
     }
 
-    public function printStartMessage(string $host, int $port, array $environment): void
+    public function printStartMessage(string $host, int $port, array $environment = []): void
     {
         $url = sprintf('%s://%s:%d', $port === 443 ? 'https' : 'http', $host, $port);
 
-        $lines = [
+        $lines = Arr::whereNotNull([
             '',
             sprintf('<span class="text-blue-500">%s</span> <span class="text-gray">%s</span>', 'HydePHP Realtime Compiler', 'v'.Hyde::getInstance()->version()),
             '',
@@ -36,7 +36,7 @@ class ConsoleOutput
             (config('hyde.server.dashboard.enabled') || Arr::has($environment, 'HYDE_SERVER_DASHBOARD')) && Arr::get($environment, 'HYDE_SERVER_DASHBOARD') === 'enabled' ?
                 sprintf('<span class="text-white">Live dashboard:</span> <a href="%s/dashboard" class="text-yellow-500">%s/dashboard</a>', $url, $url) : null,
             '',
-        ];
+        ]);
 
         $lineLength = max(array_map('strlen', array_map('strip_tags', $lines)));
 

--- a/packages/realtime-compiler/src/ConsoleOutput.php
+++ b/packages/realtime-compiler/src/ConsoleOutput.php
@@ -45,8 +45,7 @@ class ConsoleOutput
 &nbsp;│{$spacing}│<br>
 &nbsp;│{$line2}│<br>
 &nbsp;│{$spacing}│<br>
-&nbsp;╰{$lines}╯
-<br>
+&nbsp;╰{$lines}╯<br>
 </div>
 HTML);
     }

--- a/packages/realtime-compiler/src/ConsoleOutput.php
+++ b/packages/realtime-compiler/src/ConsoleOutput.php
@@ -26,28 +26,32 @@ class ConsoleOutput
     public function printStartMessage(string $host, int $port): void
     {
         $title = 'HydePHP Realtime Compiler';
-        $version = ' v'.Hyde::version();
+        $version = 'v'.Hyde::version();
 
         $url = sprintf('%s://%s:%d', $port === 443 ? 'https' : 'http', $host, $port);
 
-        $width = max(strlen("$title $version"), strlen("Listening on $url") + 1) + 1;
-        $spacing = str_repeat('&nbsp;', $width);
-        $lines = str_repeat('─', $width);
+        $lines = [
+            sprintf('<span class="text-blue-500">%s</span> <span class="text-gray">%s</span>', $title, $version),
+            '',
+            sprintf('<span class="text-white">Listening on</span> <a href="%s" class="text-yellow-500">%s</a>', $url, $url),
+        ];
 
-        $line1 = '&nbsp;'.sprintf('<span class="text-blue-500">%s</span>&nbsp;<span class="text-gray">%s</span>', $title, $version).str_repeat('&nbsp;', $width - strlen("$title $version"));
-        $line2 = '&nbsp;'.sprintf('<span class="text-white">Listening on </span>&nbsp;<a href="%s" class="text-yellow-500">%s</a>', $url, $url).str_repeat('&nbsp;', $width - strlen("Listening on $url") - 1);
-        render(<<<HTML
-<div class="text-green-500">
-<br>
-&nbsp;╭{$lines}╮<br>
-&nbsp;│{$spacing}│<br>
-&nbsp;│{$line1}│<br>
-&nbsp;│{$spacing}│<br>
-&nbsp;│{$line2}│<br>
-&nbsp;│{$spacing}│<br>
-&nbsp;╰{$lines}╯<br>
-</div>
-HTML);
+        $lineLength = max(array_map('strlen', array_map('strip_tags', $lines)));
+
+        $lines = array_map(function (string $line) use ($lineLength): string {
+            return sprintf('&nbsp;│&nbsp;<span class="text-white">%s</span>%s│',
+                $line, str_repeat('&nbsp;', ($lineLength - strlen(strip_tags($line))) + 1)
+            );
+        }, array_merge([''], $lines, ['']));
+
+        $topLine = sprintf('&nbsp;╭%s╮', str_repeat('─', $lineLength + 2));
+        $bottomLine = sprintf('&nbsp;╰%s╯', str_repeat('─', $lineLength + 2));
+
+        $lines = array_merge([$topLine], $lines, [$bottomLine]);
+
+        $body = implode('<br>', array_merge([''], $lines, ['']));
+
+        render("<div class=\"text-green-500\">$body</div>");
     }
 
     public function getFormatter(): Closure

--- a/packages/realtime-compiler/src/ConsoleOutput.php
+++ b/packages/realtime-compiler/src/ConsoleOutput.php
@@ -28,7 +28,7 @@ class ConsoleOutput
         $url = sprintf('%s://%s:%d', $port === 443 ? 'https' : 'http', $host, $port);
 
         $lines = [
-            sprintf('<span class="text-blue-500">%s</span> <span class="text-gray">%s</span>', 'HydePHP Realtime Compiler', 'v'.Hyde::version()),
+            sprintf('<span class="text-blue-500">%s</span> <span class="text-gray">%s</span>', 'HydePHP Realtime Compiler', 'v'.Hyde::getInstance()->version()),
             '',
             sprintf('<span class="text-white">Listening on</span> <a href="%s" class="text-yellow-500">%s</a>', $url, $url),
         ];

--- a/packages/realtime-compiler/src/ConsoleOutput.php
+++ b/packages/realtime-compiler/src/ConsoleOutput.php
@@ -47,9 +47,7 @@ class ConsoleOutput
         $topLine = sprintf('&nbsp;╭%s╮', str_repeat('─', $lineLength + 2));
         $bottomLine = sprintf('&nbsp;╰%s╯', str_repeat('─', $lineLength + 2));
 
-        $lines = array_merge([$topLine], $lines, [$bottomLine]);
-
-        $body = implode('<br>', array_merge([''], $lines, ['']));
+        $body = implode('<br>', array_merge([''], [$topLine], $lines, [$bottomLine], ['']));
 
         render("<div class=\"text-green-500\">$body</div>");
     }

--- a/packages/realtime-compiler/src/ConsoleOutput.php
+++ b/packages/realtime-compiler/src/ConsoleOutput.php
@@ -7,6 +7,7 @@ namespace Hyde\RealtimeCompiler;
 use Closure;
 use Hyde\Hyde;
 use Illuminate\Support\Str;
+use Illuminate\Support\Arr;
 use Illuminate\Support\Carbon;
 use Symfony\Component\Console\Output\ConsoleOutput as SymfonyOutput;
 
@@ -23,15 +24,28 @@ class ConsoleOutput
         $this->output = $output ?? new SymfonyOutput();
     }
 
-    public function printStartMessage(string $host, int $port): void
+    public function printStartMessage(string $host, int $port, array $environment): void
     {
         $url = sprintf('%s://%s:%d', $port === 443 ? 'https' : 'http', $host, $port);
+
+        $statusOptions = [
+            'enabled' => 'green-500',
+            'disabled' => 'red-500',
+            'overridden' => 'yellow-500',
+        ];
+
+        $dashboardStatusValue = config('hyde.server.dashboard.enabled');
+        $dashboardOverridden = Arr::has($environment, 'HYDE_SERVER_DASHBOARD');
+        $dashboardStatus = $dashboardOverridden ? 'overridden' : ($dashboardStatusValue ? 'enabled' : 'disabled');
+        $dashboardStatusMessage = sprintf('<span class="text-white">Dashboard:</span> <span class="text-%s">%s</span>', $statusOptions[$dashboardStatus], $dashboardStatusValue ? 'enabled' : 'disabled');
 
         $lines = [
             '',
             sprintf('<span class="text-blue-500">%s</span> <span class="text-gray">%s</span>', 'HydePHP Realtime Compiler', 'v'.Hyde::getInstance()->version()),
             '',
             sprintf('<span class="text-white">Listening on</span> <a href="%s" class="text-yellow-500">%s</a>', $url, $url),
+            '',
+            $dashboardStatusMessage,
             '',
         ];
 

--- a/packages/realtime-compiler/src/ConsoleOutput.php
+++ b/packages/realtime-compiler/src/ConsoleOutput.php
@@ -24,20 +24,9 @@ class ConsoleOutput
         $this->output = $output ?? new SymfonyOutput();
     }
 
-    public function printStartMessage(string $host, int $port, array $environment): void
+    public function printStartMessage(string $host, int $port, array $environment = []): void
     {
         $url = sprintf('%s://%s:%d', $port === 443 ? 'https' : 'http', $host, $port);
-
-        $statusOptions = [
-            'enabled' => 'green-500',
-            'disabled' => 'red-500',
-            'overridden' => 'yellow-500',
-        ];
-
-        $dashboardStatusValue = config('hyde.server.dashboard.enabled');
-        $dashboardOverridden = Arr::has($environment, 'HYDE_SERVER_DASHBOARD');
-        $dashboardStatus = $dashboardOverridden ? 'overridden' : ($dashboardStatusValue ? 'enabled' : 'disabled');
-        $dashboardStatusMessage = sprintf('<span class="text-white">Dashboard:</span> <span class="text-%s">%s</span>', $statusOptions[$dashboardStatus], $dashboardStatusValue ? 'enabled' : 'disabled');
 
         $lines = [
             '',
@@ -45,9 +34,30 @@ class ConsoleOutput
             '',
             sprintf('<span class="text-white">Listening on</span> <a href="%s" class="text-yellow-500">%s</a>', $url, $url),
             '',
-            $dashboardStatusMessage,
-            '',
         ];
+
+        if ($environment !== []) {
+            $statusOptions = [
+                'enabled' => 'green-500',
+                'disabled' => 'red-500',
+            ];
+
+            if (Arr::has($environment, 'HYDE_SERVER_DASHBOARD')) {
+                $dashboardStatus = Arr::get($environment, 'HYDE_SERVER_DASHBOARD');
+                $dashboardStatusValue = $dashboardStatus === 'enabled';
+                $dashboardStatusMessage = sprintf('<span class="text-white">Dashboard:</span> <span class="text-%s">%s</span>', $statusOptions[$dashboardStatus], $dashboardStatusValue ? 'enabled' : 'disabled');
+            }
+
+            $optionLines = Arr::whereNotNull([
+                $dashboardStatusMessage ?? null,
+            ]);
+
+            if ($optionLines !== []) {
+                $optionLines[] = '';
+            }
+
+            $lines = array_merge($lines, $optionLines);
+        }
 
         $lineLength = max(array_map('strlen', array_map('strip_tags', $lines)));
 

--- a/packages/realtime-compiler/src/ConsoleOutput.php
+++ b/packages/realtime-compiler/src/ConsoleOutput.php
@@ -25,13 +25,10 @@ class ConsoleOutput
 
     public function printStartMessage(string $host, int $port): void
     {
-        $title = 'HydePHP Realtime Compiler';
-        $version = 'v'.Hyde::version();
-
         $url = sprintf('%s://%s:%d', $port === 443 ? 'https' : 'http', $host, $port);
 
         $lines = [
-            sprintf('<span class="text-blue-500">%s</span> <span class="text-gray">%s</span>', $title, $version),
+            sprintf('<span class="text-blue-500">%s</span> <span class="text-gray">%s</span>', 'HydePHP Realtime Compiler', 'v'.Hyde::version()),
             '',
             sprintf('<span class="text-white">Listening on</span> <a href="%s" class="text-yellow-500">%s</a>', $url, $url),
         ];

--- a/packages/realtime-compiler/src/Http/DashboardController.php
+++ b/packages/realtime-compiler/src/Http/DashboardController.php
@@ -57,7 +57,7 @@ class DashboardController
         $this->title = config('hyde.name').' - Dashboard';
         $this->request = Request::capture();
 
-        if (((bool) env('HYDE_RC_REQUEST_OUTPUT', false)) === true) {
+        if (((bool) env('HYDE_SERVER_REQUEST_OUTPUT', false)) === true) {
             $this->console = new ConsoleOutput();
         }
 

--- a/packages/realtime-compiler/tests/ConsoleOutputTest.php
+++ b/packages/realtime-compiler/tests/ConsoleOutputTest.php
@@ -14,3 +14,22 @@ afterEach(function () {
 
     Styles::flush();
 });
+
+test('printStartMessage method', function () {
+    // Todo handle version dynamically
+
+    $output = new \Hyde\RealtimeCompiler\ConsoleOutput();
+    $output->printStartMessage('localhost', 8000);
+    $this->assertSame(<<<'TXT'
+
+     ╭────────────────────────────────────╮
+     │                                    │
+     │ HydePHP Realtime Compiler v1.3.3   │
+     │                                    │
+     │ Listening on http://localhost:8000 │
+     │                                    │
+     ╰────────────────────────────────────╯
+
+
+    TXT, str_replace(["\u{A0}", "\r"], [' ', ''], $this->output->fetch()));
+});

--- a/packages/realtime-compiler/tests/ConsoleOutputTest.php
+++ b/packages/realtime-compiler/tests/ConsoleOutputTest.php
@@ -6,8 +6,12 @@ use Termwind\Repositories\Styles;
 
 use function Termwind\{renderUsing};
 
+uses(\Hyde\Testing\UnitTestCase::class);
+
 beforeEach(function () {
     renderUsing($this->output = new BufferedOutput());
+
+    $this::mockConfig();
 });
 
 afterEach(function () {
@@ -31,13 +35,13 @@ test('printStartMessage method', function () {
     $output->printStartMessage('localhost', 8000);
     $this->assertSame(<<<'TXT'
 
-     ╭────────────────────────────────────╮
-     │                                    │
-     │ HydePHP Realtime Compiler v1.2.3   │
-     │                                    │
-     │ Listening on http://localhost:8000 │
-     │                                    │
-     ╰────────────────────────────────────╯
+     ╭─────────────────────────────────────╮
+     │                                     │
+     │ HydePHP Realtime Compiler v1.2.3    │
+     │                                     │
+     │ Listening on: http://localhost:8000 │
+     │                                     │
+     ╰─────────────────────────────────────╯
 
 
     TXT, str_replace(["\u{A0}", "\r"], [' ', ''], $this->output->fetch()));

--- a/packages/realtime-compiler/tests/ConsoleOutputTest.php
+++ b/packages/realtime-compiler/tests/ConsoleOutputTest.php
@@ -1,0 +1,16 @@
+<?php
+
+use Symfony\Component\Console\Output\BufferedOutput;
+use Termwind\Repositories\Styles;
+
+use function Termwind\{renderUsing};
+
+beforeEach(function () {
+    renderUsing($this->output = new BufferedOutput());
+});
+
+afterEach(function () {
+    renderUsing(null);
+
+    Styles::flush();
+});

--- a/packages/realtime-compiler/tests/ConsoleOutputTest.php
+++ b/packages/realtime-compiler/tests/ConsoleOutputTest.php
@@ -1,5 +1,6 @@
 <?php
 
+use Hyde\Foundation\HydeKernel;
 use Symfony\Component\Console\Output\BufferedOutput;
 use Termwind\Repositories\Styles;
 
@@ -13,10 +14,18 @@ afterEach(function () {
     renderUsing(null);
 
     Styles::flush();
+
+    HydeKernel::setInstance(new HydeKernel());
 });
 
 test('printStartMessage method', function () {
-    // Todo handle version dynamically
+    HydeKernel::setInstance(new class extends HydeKernel
+    {
+        public static function version(): string
+        {
+            return '1.2.3';
+        }
+    });
 
     $output = new \Hyde\RealtimeCompiler\ConsoleOutput();
     $output->printStartMessage('localhost', 8000);
@@ -24,7 +33,7 @@ test('printStartMessage method', function () {
 
      ╭────────────────────────────────────╮
      │                                    │
-     │ HydePHP Realtime Compiler v1.3.3   │
+     │ HydePHP Realtime Compiler v1.2.3   │
      │                                    │
      │ Listening on http://localhost:8000 │
      │                                    │


### PR DESCRIPTION
Adds a few new options to the `php hyde serve` command to allow some settings to be specified with command-line options. This is done by creating environment variables passed through to the Symfony process, and which are then injected into the configuration repository by our custom runtime configuration loader originally used for Yaml configuration. This makes so that the options are fully integrated into the request lifecycle. Also cleans up some adjacent code.