### PR TITLE
Add realtime compiler dashboard CSRF protection

### DIFF
--- a/packages/realtime-compiler/resources/dashboard.blade.php
+++ b/packages/realtime-compiler/resources/dashboard.blade.php
@@ -4,6 +4,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
+    <meta name="csrf-token" content="{{ $csrfToken }}">
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-T3c6CoIi6uLrA9TneNEoa7RxnatzjcDSCmG1MXxSR1GAsXEV/Dwwykc2MPK8M2HN" crossorigin="anonymous">
     <title>{{ $title }}</title>
     <base target="_parent">
@@ -64,6 +65,7 @@
                         <h2 class="h5 mb-0">Site Pages & Routes</h2>
                         @if($dashboard->isInteractive())
                             <form class="buttonActionForm" action="" method="POST">
+                                <input type="hidden" name="_token" value="{{ $csrfToken }}">
                                 <input type="hidden" name="action" value="openInExplorer">
                                 <button type="submit" class="btn btn-outline-primary btn-sm" title="Open project in system file explorer">Open folder</button>
                             </form>
@@ -136,6 +138,7 @@
                                             <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
                                         </div>
                                         <form id="createPageForm" action="" method="POST">
+                                            <input type="hidden" name="_token" value="{{ $csrfToken }}">
                                             <input type="hidden" name="action" value="createPage">
 
                                             <div class="modal-body">
@@ -242,6 +245,7 @@
                                     <div class="d-flex justify-content-end">
                                         @if($dashboard->isInteractive())
                                             <form class="buttonActionForm" action="" method="POST">
+                                                <input type="hidden" name="_token" value="{{ $csrfToken }}">
                                                 <input type="hidden" name="action" value="openPageInEditor">
                                                 <input type="hidden" name="routeKey" value="{{ $route->getRouteKey() }}">
                                                 <button type="submit" class="btn btn-outline-primary btn-sm me-2" title="Open in system default application">Edit</button>
@@ -302,6 +306,7 @@
                                                     @if($dashboard->isInteractive())
                                                         <div class="w-auto ps-0">
                                                             <form class="buttonActionForm" action="" method="POST">
+                                                                <input type="hidden" name="_token" value="{{ $csrfToken }}">
                                                                 <input type="hidden" name="action" value="openMediaFileInEditor">
                                                                 <input type="hidden" name="identifier" value="{{ $mediaFile->getIdentifier() }}">
                                                                 <button type="submit" class="btn btn-link btn-sm py-0" title="Open this image in the system editor">Edit</button>

--- a/packages/realtime-compiler/src/Http/BaseController.php
+++ b/packages/realtime-compiler/src/Http/BaseController.php
@@ -20,8 +20,6 @@ abstract class BaseController
     protected bool $withConsoleOutput = false;
     protected bool $withSession = false;
 
-    protected static bool $sessionStarted = false;
-
     abstract public function handle(): Response;
 
     public function __construct(?Request $request = null)
@@ -32,17 +30,8 @@ abstract class BaseController
             $this->console = new ConsoleOutput();
         }
 
-        if ($this->withSession && ! self::$sessionStarted) {
+        if ($this->withSession) {
             session_start();
-            self::$sessionStarted = true;
-        }
-    }
-
-    public function __destruct()
-    {
-        if ($this->withSession && self::$sessionStarted) {
-            session_write_close();
-            self::$sessionStarted = false;
         }
     }
 

--- a/packages/realtime-compiler/src/Http/BaseController.php
+++ b/packages/realtime-compiler/src/Http/BaseController.php
@@ -55,6 +55,13 @@ abstract class BaseController
         };
     }
 
+    protected function authorizePostRequest(): void
+    {
+        if ($this->shouldUnsafeRequestBeBlocked()) {
+            throw new HttpException(403, "Refusing to serve request from address {$_SERVER['REMOTE_ADDR']} (must be on localhost)");
+        }
+    }
+
     protected function shouldUnsafeRequestBeBlocked(): bool
     {
         // As the dashboard is not password-protected, and it can make changes to the file system,

--- a/packages/realtime-compiler/src/Http/BaseController.php
+++ b/packages/realtime-compiler/src/Http/BaseController.php
@@ -110,11 +110,7 @@ abstract class BaseController
 
     protected function validateCSRFToken(?string $suppliedToken): bool
     {
-        if ($suppliedToken === null) {
-            return false;
-        }
-
-        return ! empty($_SESSION['csrf_token']) && hash_equals($_SESSION['csrf_token'], $suppliedToken);
+        return $suppliedToken !== null && ! empty($_SESSION['csrf_token']) && hash_equals($_SESSION['csrf_token'], $suppliedToken);
     }
 
     protected function expireCSRFToken(): void

--- a/packages/realtime-compiler/src/Http/BaseController.php
+++ b/packages/realtime-compiler/src/Http/BaseController.php
@@ -57,12 +57,12 @@ abstract class BaseController
 
     protected function authorizePostRequest(): void
     {
-        if ($this->shouldUnsafeRequestBeBlocked()) {
+        if (! $this->isRequestMadeFromLocalhost()) {
             throw new HttpException(403, "Refusing to serve request from address {$_SERVER['REMOTE_ADDR']} (must be on localhost)");
         }
     }
 
-    protected function shouldUnsafeRequestBeBlocked(): bool
+    protected function isRequestMadeFromLocalhost(): bool
     {
         // As the dashboard is not password-protected, and it can make changes to the file system,
         // we block any requests that are not coming from the host machine. While we are clear
@@ -72,7 +72,7 @@ abstract class BaseController
         $requestIp = $_SERVER['REMOTE_ADDR'];
         $allowedIps = ['::1', '127.0.0.1', 'localhost'];
 
-        return ! in_array($requestIp, $allowedIps, true);
+        return in_array($requestIp, $allowedIps, true);
     }
 
     protected function writeToConsole(string $message, string $context = 'dashboard'): void

--- a/packages/realtime-compiler/src/Http/BaseController.php
+++ b/packages/realtime-compiler/src/Http/BaseController.php
@@ -110,7 +110,11 @@ abstract class BaseController
 
     protected function validateCSRFToken(?string $suppliedToken): bool
     {
-        return $suppliedToken !== null && ! empty($_SESSION['csrf_token']) && hash_equals($_SESSION['csrf_token'], $suppliedToken);
+        if ($suppliedToken === null) {
+            return false;
+        }
+
+        return ! empty($_SESSION['csrf_token']) && hash_equals($_SESSION['csrf_token'], $suppliedToken);
     }
 
     protected function expireCSRFToken(): void

--- a/packages/realtime-compiler/src/Http/BaseController.php
+++ b/packages/realtime-compiler/src/Http/BaseController.php
@@ -4,10 +4,74 @@ declare(strict_types=1);
 
 namespace Hyde\RealtimeCompiler\Http;
 
+use Desilva\Microserve\Request;
+use Desilva\Microserve\Response;
+use Desilva\Microserve\JsonResponse;
+use Hyde\RealtimeCompiler\ConsoleOutput;
+use Symfony\Component\HttpKernel\Exception\HttpException;
+
 /**
  * @internal This class is not intended to be edited outside the Hyde Realtime Compiler.
  */
 abstract class BaseController
 {
-    //
+    protected Request $request;
+    protected ConsoleOutput $console;
+    protected bool $withConsoleOutput = true;
+
+    abstract public function handle(): Response;
+
+    public function __construct()
+    {
+        $this->request = Request::capture();
+
+        if ($this->withConsoleOutput && ((bool) env('HYDE_SERVER_REQUEST_OUTPUT', false)) === true) {
+            $this->console = new ConsoleOutput();
+        }
+    }
+
+    protected function sendJsonErrorResponse(int $statusCode, string $message): JsonResponse
+    {
+        return new JsonResponse($statusCode, $this->matchStatusCode($statusCode), [
+            'error' => $message,
+        ]);
+    }
+
+    protected function abort(int $code, string $message): never
+    {
+        throw new HttpException($code, $message);
+    }
+
+    protected function matchStatusCode(int $statusCode): string
+    {
+        return match ($statusCode) {
+            200 => 'OK',
+            201 => 'Created',
+            400 => 'Bad Request',
+            403 => 'Forbidden',
+            404 => 'Not Found',
+            409 => 'Conflict',
+            default => 'Internal Server Error',
+        };
+    }
+
+    protected function shouldUnsafeRequestBeBlocked(): bool
+    {
+        // As the dashboard is not password-protected, and it can make changes to the file system,
+        // we block any requests that are not coming from the host machine. While we are clear
+        // in the documentation that the realtime compiler should only be used for local
+        // development, we still want to be extra careful in case someone forgets.
+
+        $requestIp = $_SERVER['REMOTE_ADDR'];
+        $allowedIps = ['::1', '127.0.0.1', 'localhost'];
+
+        return ! in_array($requestIp, $allowedIps, true);
+    }
+
+    protected function writeToConsole(string $message, string $context = 'dashboard'): void
+    {
+        if (isset($this->console)) {
+            $this->console->printMessage($message, $context);
+        }
+    }
 }

--- a/packages/realtime-compiler/src/Http/BaseController.php
+++ b/packages/realtime-compiler/src/Http/BaseController.php
@@ -97,11 +97,11 @@ abstract class BaseController
 
     protected function validateCSRFToken(?string $suppliedToken): bool
     {
-        if ($suppliedToken === null) {
+        if ($suppliedToken === null || empty($_SESSION['csrf_token'])) {
             return false;
         }
 
-        return ! empty($_SESSION['csrf_token']) && hash_equals($_SESSION['csrf_token'], $suppliedToken);
+        return hash_equals($_SESSION['csrf_token'], $suppliedToken);
     }
 
     protected function writeToConsole(string $message, string $context = 'dashboard'): void

--- a/packages/realtime-compiler/src/Http/BaseController.php
+++ b/packages/realtime-compiler/src/Http/BaseController.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Hyde\RealtimeCompiler\Http;
+
+/**
+ * @internal This class is not intended to be edited outside the Hyde Realtime Compiler.
+ */
+abstract class BaseController
+{
+    //
+}

--- a/packages/realtime-compiler/src/Http/BaseController.php
+++ b/packages/realtime-compiler/src/Http/BaseController.php
@@ -18,6 +18,9 @@ abstract class BaseController
     protected Request $request;
     protected ConsoleOutput $console;
     protected bool $withConsoleOutput = false;
+    protected bool $withSession = false;
+
+    protected static bool $sessionStarted = false;
 
     abstract public function handle(): Response;
 
@@ -27,6 +30,19 @@ abstract class BaseController
 
         if ($this->withConsoleOutput && ((bool) env('HYDE_SERVER_REQUEST_OUTPUT', false)) === true) {
             $this->console = new ConsoleOutput();
+        }
+
+        if ($this->withSession && ! self::$sessionStarted) {
+            session_start();
+            self::$sessionStarted = true;
+        }
+    }
+
+    public function __destruct()
+    {
+        if ($this->withSession && self::$sessionStarted) {
+            session_write_close();
+            self::$sessionStarted = false;
         }
     }
 

--- a/packages/realtime-compiler/src/Http/BaseController.php
+++ b/packages/realtime-compiler/src/Http/BaseController.php
@@ -21,9 +21,9 @@ abstract class BaseController
 
     abstract public function handle(): Response;
 
-    public function __construct()
+    public function __construct(?Request $request = null)
     {
-        $this->request = Request::capture();
+        $this->request = $request ?? Request::capture();
 
         if ($this->withConsoleOutput && ((bool) env('HYDE_SERVER_REQUEST_OUTPUT', false)) === true) {
             $this->console = new ConsoleOutput();

--- a/packages/realtime-compiler/src/Http/BaseController.php
+++ b/packages/realtime-compiler/src/Http/BaseController.php
@@ -17,7 +17,7 @@ abstract class BaseController
 {
     protected Request $request;
     protected ConsoleOutput $console;
-    protected bool $withConsoleOutput = true;
+    protected bool $withConsoleOutput = false;
 
     abstract public function handle(): Response;
 

--- a/packages/realtime-compiler/src/Http/BaseController.php
+++ b/packages/realtime-compiler/src/Http/BaseController.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Hyde\RealtimeCompiler\Http;
 
-use BadMethodCallException;
 use Desilva\Microserve\Request;
 use Desilva\Microserve\Response;
 use Desilva\Microserve\JsonResponse;
@@ -102,10 +101,6 @@ abstract class BaseController
 
     protected function generateCSRFToken(): string
     {
-        if (session_status() !== PHP_SESSION_ACTIVE) {
-            throw new BadMethodCallException('Session not started');
-        }
-
         if (empty($_SESSION['csrf_token'])) {
             $_SESSION['csrf_token'] = bin2hex(random_bytes(32));
         }
@@ -115,10 +110,6 @@ abstract class BaseController
 
     protected function validateCSRFToken(?string $suppliedToken): bool
     {
-        if (session_status() !== PHP_SESSION_ACTIVE) {
-            throw new BadMethodCallException('Session not started');
-        }
-
         if ($suppliedToken === null) {
             return false;
         }
@@ -128,10 +119,6 @@ abstract class BaseController
 
     protected function expireCSRFToken(): void
     {
-        if (session_status() !== PHP_SESSION_ACTIVE) {
-            throw new BadMethodCallException('Session not started');
-        }
-
         unset($_SESSION['csrf_token']);
     }
 

--- a/packages/realtime-compiler/src/Http/BaseController.php
+++ b/packages/realtime-compiler/src/Http/BaseController.php
@@ -80,8 +80,6 @@ abstract class BaseController
         if ($this->withSession) {
             if (! $this->validateCSRFToken($this->request->get('_token'))) {
                 throw new HttpException(403, 'Invalid CSRF token');
-            } else {
-                $this->expireCSRFToken();
             }
         }
     }
@@ -115,11 +113,6 @@ abstract class BaseController
         }
 
         return ! empty($_SESSION['csrf_token']) && hash_equals($_SESSION['csrf_token'], $suppliedToken);
-    }
-
-    protected function expireCSRFToken(): void
-    {
-        unset($_SESSION['csrf_token']);
     }
 
     protected function writeToConsole(string $message, string $context = 'dashboard'): void

--- a/packages/realtime-compiler/src/Http/DashboardController.php
+++ b/packages/realtime-compiler/src/Http/DashboardController.php
@@ -33,7 +33,7 @@ use Symfony\Component\HttpKernel\Exception\HttpException;
 /**
  * @internal This class is not intended to be edited outside the Hyde Realtime Compiler.
  */
-class DashboardController
+class DashboardController extends BaseController
 {
     public string $title;
 

--- a/packages/realtime-compiler/src/Http/DashboardController.php
+++ b/packages/realtime-compiler/src/Http/DashboardController.php
@@ -93,7 +93,7 @@ class DashboardController extends BaseController
     protected function show(): string
     {
         return AnonymousViewCompiler::handle(__DIR__.'/../../resources/dashboard.blade.php', array_merge(
-            (array) $this, ['dashboard' => $this, 'request' => $this->request],
+            (array) $this, ['dashboard' => $this, 'request' => $this->request, 'csrfToken' => $this->generateCSRFToken()],
         ));
     }
 

--- a/packages/realtime-compiler/src/Http/DashboardController.php
+++ b/packages/realtime-compiler/src/Http/DashboardController.php
@@ -71,11 +71,8 @@ class DashboardController extends BaseController
                 return $this->sendJsonErrorResponse(403, 'Enable `server.editor` in `config/hyde.php` to use interactive dashboard features.');
             }
 
-            if ($this->shouldUnsafeRequestBeBlocked()) {
-                return $this->sendJsonErrorResponse(403, "Refusing to serve request from address {$_SERVER['REMOTE_ADDR']} (must be on localhost)");
-            }
-
             try {
+                $this->authorizePostRequest();
                 return $this->handlePostRequest();
             } catch (HttpException $exception) {
                 if (! $this->isAsync) {

--- a/packages/realtime-compiler/src/Http/DashboardController.php
+++ b/packages/realtime-compiler/src/Http/DashboardController.php
@@ -37,6 +37,7 @@ class DashboardController extends BaseController
     public string $title;
 
     protected bool $withConsoleOutput = true;
+    protected bool $withSession = true;
 
     protected JsonResponse $response;
 

--- a/packages/realtime-compiler/src/Http/DashboardController.php
+++ b/packages/realtime-compiler/src/Http/DashboardController.php
@@ -11,6 +11,7 @@ use Illuminate\Support\Str;
 use Illuminate\Support\Arr;
 use Hyde\Pages\MarkdownPage;
 use Hyde\Pages\MarkdownPost;
+use Desilva\Microserve\Request;
 use Desilva\Microserve\Response;
 use Hyde\Pages\Concerns\HydePage;
 use Hyde\Pages\DocumentationPage;
@@ -50,9 +51,9 @@ class DashboardController extends BaseController
         'The dashboard update your project files. You can disable this by setting `server.dashboard.interactive` to `false` in `config/hyde.php`.',
     ];
 
-    public function __construct()
+    public function __construct(?Request $request = null)
     {
-        parent::__construct();
+        parent::__construct($request);
 
         $this->title = config('hyde.name').' - Dashboard';
 

--- a/packages/realtime-compiler/src/Routing/PageRouter.php
+++ b/packages/realtime-compiler/src/Routing/PageRouter.php
@@ -33,7 +33,7 @@ class PageRouter
     protected function handlePageRequest(): Response
     {
         if ($this->request->path === '/dashboard' && DashboardController::enabled()) {
-            return (new DashboardController())->handle();
+            return (new DashboardController($this->request))->handle();
         }
 
         return new HtmlResponse(200, 'OK', [


### PR DESCRIPTION
While we make it clear that the realtime compiler is only intended to be used for local development (as it uses the built in PHP server, which is not designed for public use, as per the manual), since it does allow access to the file system I felt it responsible to at least add some CSRF protection to the dashboard forms. Also extracts a base class while I'm at it.

I ran benchmarks, and adding the session has a negligible performance impact of about `2.5` seconds for `10 000` requests, and that's only for the dashboard page.