### PR TITLE
Add a live edit feature to the realtime compiler

### DIFF
--- a/config/hyde.php
+++ b/config/hyde.php
@@ -419,7 +419,7 @@ return [
         'save_preview' => true,
 
         // Should the live edit feature be enabled?
-        'live_edit' => true,
+        'live_edit' => env('SERVER_LIVE_EDIT', true),
 
         // Configure the realtime compiler dashboard
         'dashboard' => [

--- a/packages/framework/config/hyde.php
+++ b/packages/framework/config/hyde.php
@@ -419,7 +419,7 @@ return [
         'save_preview' => true,
 
         // Should the live edit feature be enabled?
-        'live_edit' => true,
+        'live_edit' => env('SERVER_LIVE_EDIT', true),
 
         // Configure the realtime compiler dashboard
         'dashboard' => [

--- a/packages/realtime-compiler/resources/live-edit.blade.php
+++ b/packages/realtime-compiler/resources/live-edit.blade.php
@@ -20,7 +20,7 @@
                     </menu>
                 </header>
                 <label for="live-editor" class="sr-only">Edit page contents</label>
-                <textarea name="markdown" id="live-editor" cols="30" rows="20"></textarea>
+                <textarea name="markdown" id="live-editor" cols="30" rows="20">{{ $markdown }}</textarea>
             </form>
         </section>
     </template>

--- a/packages/realtime-compiler/resources/live-edit.blade.php
+++ b/packages/realtime-compiler/resources/live-edit.blade.php
@@ -6,7 +6,7 @@
     @endphp
     <style>{!! $styles !!}</style>
     <template id="live-edit-template">
-        <section id="live-edit-container">
+        <section id="live-edit-container" style="margin-top: {{ $page instanceof \Hyde\Pages\DocumentationPage ? '1rem' : '-1rem'}};">
             <form id="liveEditForm" action="/_hyde/live-edit" method="POST">
                 <header class="prose dark:prose-invert">
                     <h2>Live Editor</h2>

--- a/packages/realtime-compiler/resources/live-edit.blade.php
+++ b/packages/realtime-compiler/resources/live-edit.blade.php
@@ -25,9 +25,5 @@
         </section>
     </template>
     <script>{!! $scripts !!}</script>
-    <script>
-        const markdown = {{ Illuminate\Support\Js::from($markdown) }};
-        const sourcePath = {{ Illuminate\Support\Js::from($page->getSourcePath()) }};
-        initLiveEdit(markdown, sourcePath)
-</script>
+    <script>initLiveEdit()</script>
 </div>

--- a/packages/realtime-compiler/resources/live-edit.blade.php
+++ b/packages/realtime-compiler/resources/live-edit.blade.php
@@ -8,8 +8,8 @@
     <template id="live-edit-template">
         <section id="live-edit-container" style="margin-top: {{ $page instanceof \Hyde\Pages\DocumentationPage ? '1rem' : '-1rem'}};">
             <form id="liveEditForm" action="/_hyde/live-edit" method="POST">
-                <header class="prose dark:prose-invert">
-                    <h2>Live Editor</h2>
+                <header class="prose dark:prose-invert mb-3">
+                    <h2 class="mb-0">Live Editor</h2>
                     <menu>
                         <button id="liveEditCancel" type="button">
                             Cancel

--- a/packages/realtime-compiler/resources/live-edit.blade.php
+++ b/packages/realtime-compiler/resources/live-edit.blade.php
@@ -20,9 +20,9 @@
                     </menu>
                 </header>
                 <input type="hidden" name="_token" value="{{ $csrfToken }}">
-                <input type="hidden" name="pagePath" value="{{ $page->getSourcePath() }}">
+                <input type="hidden" name="page" value="{{ $page->getSourcePath() }}">
                 <label for="live-editor" class="sr-only">Edit page contents</label>
-                <textarea name="contentInput" id="live-editor" cols="30" rows="20" class="rounded-lg bg-gray-200 dark:bg-gray-800">{{ $markdown }}</textarea>
+                <textarea name="markdown" id="live-editor" cols="30" rows="20" class="rounded-lg bg-gray-200 dark:bg-gray-800">{{ $markdown }}</textarea>
             </form>
         </section>
     </template>

--- a/packages/realtime-compiler/resources/live-edit.blade.php
+++ b/packages/realtime-compiler/resources/live-edit.blade.php
@@ -3,9 +3,6 @@
     @php
         /** @var \Hyde\Pages\Concerns\BaseMarkdownPage $page */
         $markdown = $page->markdown()->body();
-
-        $markdownLines = substr_count($markdown, "\n");
-        $rows = max(8, $markdownLines < 32 ? $markdownLines + 2 : 32)
     @endphp
     <style>{!! $styles !!}</style>
     <template id="live-edit-template">
@@ -25,7 +22,7 @@
                 <input type="hidden" name="_token" value="{{ $csrfToken }}">
                 <input type="hidden" name="pagePath" value="{{ $page->getSourcePath() }}">
                 <label for="live-editor" class="sr-only">Edit page contents</label>
-                <textarea name="contentInput" id="live-editor" cols="30" rows="{{ $rows }}">{{ $markdown }}</textarea>
+                <textarea name="contentInput" id="live-editor" cols="30" rows="20">{{ $markdown }}</textarea>
             </form>
         </section>
     </template>

--- a/packages/realtime-compiler/resources/live-edit.blade.php
+++ b/packages/realtime-compiler/resources/live-edit.blade.php
@@ -3,6 +3,9 @@
     @php
         /** @var \Hyde\Pages\Concerns\BaseMarkdownPage $page */
         $markdown = $page->markdown()->body();
+
+        $markdownLines = substr_count($markdown, "\n");
+        $rows = max(8, $markdownLines < 32 ? $markdownLines + 2 : 32)
     @endphp
     <style>{!! $styles !!}</style>
     <template id="live-edit-template">
@@ -22,7 +25,7 @@
                 <input type="hidden" name="_token" value="{{ $csrfToken }}">
                 <input type="hidden" name="pagePath" value="{{ $page->getSourcePath() }}">
                 <label for="live-editor" class="sr-only">Edit page contents</label>
-                <textarea name="contentInput" id="live-editor" cols="30" rows="20">{{ $markdown }}</textarea>
+                <textarea name="contentInput" id="live-editor" cols="30" rows="{{ $rows }}">{{ $markdown }}</textarea>
             </form>
         </section>
     </template>

--- a/packages/realtime-compiler/resources/live-edit.blade.php
+++ b/packages/realtime-compiler/resources/live-edit.blade.php
@@ -1,0 +1,33 @@
+<div id="__realtime-compiler-live-edit-insert">
+    <!-- The live editor insert is not saved to your static site -->
+    @php
+        /** @var \Hyde\Pages\Concerns\BaseMarkdownPage $page */
+        $markdown = $page->markdown()->body();
+    @endphp
+    <style>{!! $styles !!}</style>
+    <template id="live-edit-template">
+        <section id="live-edit-container")>
+            <form action="/_hyde/live-edit" method="POST">
+                <header id="liveEditHeader">
+                    <h2>Live Editor</h2>
+                    <menu id="liveEditFormActions">
+                        <button id="liveEditCancel" type="button">
+                            Cancel
+                        </button>
+                        <button id="liveEditSubmit" type="submit">
+                            Save
+                        </button>
+                    </menu>
+                </header>
+                <label for="live-editor" class="sr-only">Edit page contents</label>
+                <textarea name="markdown" id="live-editor" cols="30" rows="20"></textarea>
+            </form>
+        </section>
+    </template>
+    <script>{!! $scripts !!}</script>
+    <script>
+        const markdown = {{ Illuminate\Support\Js::from($markdown) }};
+        const sourcePath = {{ Illuminate\Support\Js::from($page->getSourcePath()) }};
+        initLiveEdit(markdown, sourcePath)
+</script>
+</div>

--- a/packages/realtime-compiler/resources/live-edit.blade.php
+++ b/packages/realtime-compiler/resources/live-edit.blade.php
@@ -8,7 +8,7 @@
     <template id="live-edit-template">
         <section id="live-edit-container">
             <form id="liveEditForm" action="/_hyde/live-edit" method="POST">
-                <header id="liveEditHeader">
+                <header id="liveEditHeader" class="prose dark:prose-invert">
                     <h2>Live Editor</h2>
                     <menu id="liveEditFormActions">
                         <button id="liveEditCancel" type="button">

--- a/packages/realtime-compiler/resources/live-edit.blade.php
+++ b/packages/realtime-compiler/resources/live-edit.blade.php
@@ -19,6 +19,7 @@
                         </button>
                     </menu>
                 </header>
+                <input type="hidden" name="_token" value="{{ $csrfToken }}">
                 <label for="live-editor" class="sr-only">Edit page contents</label>
                 <textarea name="markdown" id="live-editor" cols="30" rows="20">{{ $markdown }}</textarea>
             </form>

--- a/packages/realtime-compiler/resources/live-edit.blade.php
+++ b/packages/realtime-compiler/resources/live-edit.blade.php
@@ -20,6 +20,7 @@
                     </menu>
                 </header>
                 <input type="hidden" name="_token" value="{{ $csrfToken }}">
+                <input type="hidden" name="pagePath" value="{{ $page->getSourcePath() }}">
                 <label for="live-editor" class="sr-only">Edit page contents</label>
                 <textarea name="markdown" id="live-editor" cols="30" rows="20">{{ $markdown }}</textarea>
             </form>

--- a/packages/realtime-compiler/resources/live-edit.blade.php
+++ b/packages/realtime-compiler/resources/live-edit.blade.php
@@ -6,9 +6,7 @@
     @endphp
     <style>{!! $styles !!}</style>
     <template id="live-edit-template">
-        <section id="live-edit-container" @class([
-                'page-type-'.\Illuminate\Support\Str::kebab(class_basename($page::class)),
-            ])>
+        <section id="live-edit-container">
             <form id="liveEditForm" action="/_hyde/live-edit" method="POST">
                 <header id="liveEditHeader">
                     <h2>Live Editor</h2>

--- a/packages/realtime-compiler/resources/live-edit.blade.php
+++ b/packages/realtime-compiler/resources/live-edit.blade.php
@@ -8,9 +8,9 @@
     <template id="live-edit-template">
         <section id="live-edit-container">
             <form id="liveEditForm" action="/_hyde/live-edit" method="POST">
-                <header id="liveEditHeader" class="prose dark:prose-invert">
+                <header class="prose dark:prose-invert">
                     <h2>Live Editor</h2>
-                    <menu id="liveEditFormActions">
+                    <menu>
                         <button id="liveEditCancel" type="button">
                             Cancel
                         </button>

--- a/packages/realtime-compiler/resources/live-edit.blade.php
+++ b/packages/realtime-compiler/resources/live-edit.blade.php
@@ -6,7 +6,7 @@
     @endphp
     <style>{!! $styles !!}</style>
     <template id="live-edit-template">
-        <section id="live-edit-container")>
+        <section id="live-edit-container">
             <form id="liveEditForm" action="/_hyde/live-edit" method="POST">
                 <header id="liveEditHeader">
                     <h2>Live Editor</h2>

--- a/packages/realtime-compiler/resources/live-edit.blade.php
+++ b/packages/realtime-compiler/resources/live-edit.blade.php
@@ -23,6 +23,13 @@
                 <input type="hidden" name="page" value="{{ $page->getSourcePath() }}">
                 <label for="live-editor" class="sr-only">Edit page contents</label>
                 <textarea name="markdown" id="live-editor" cols="30" rows="20" class="rounded-lg bg-gray-200 dark:bg-gray-800">{{ $markdown }}</textarea>
+                <footer class="prose dark:prose-invert">
+                    <small>
+                        <a id="#liveEditSettingsButton" role="button" href="javascript:liveEditSettings();">
+                            Editor preferences
+                        </a>
+                    </small>
+                </footer>
             </form>
         </section>
     </template>

--- a/packages/realtime-compiler/resources/live-edit.blade.php
+++ b/packages/realtime-compiler/resources/live-edit.blade.php
@@ -22,7 +22,7 @@
                 <input type="hidden" name="_token" value="{{ $csrfToken }}">
                 <input type="hidden" name="pagePath" value="{{ $page->getSourcePath() }}">
                 <label for="live-editor" class="sr-only">Edit page contents</label>
-                <textarea name="markdown" id="live-editor" cols="30" rows="20">{{ $markdown }}</textarea>
+                <textarea name="contentInput" id="live-editor" cols="30" rows="20">{{ $markdown }}</textarea>
             </form>
         </section>
     </template>

--- a/packages/realtime-compiler/resources/live-edit.blade.php
+++ b/packages/realtime-compiler/resources/live-edit.blade.php
@@ -7,7 +7,7 @@
     <style>{!! $styles !!}</style>
     <template id="live-edit-template">
         <section id="live-edit-container")>
-            <form action="/_hyde/live-edit" method="POST">
+            <form id="liveEditForm" action="/_hyde/live-edit" method="POST">
                 <header id="liveEditHeader">
                     <h2>Live Editor</h2>
                     <menu id="liveEditFormActions">

--- a/packages/realtime-compiler/resources/live-edit.blade.php
+++ b/packages/realtime-compiler/resources/live-edit.blade.php
@@ -22,7 +22,7 @@
                 <input type="hidden" name="_token" value="{{ $csrfToken }}">
                 <input type="hidden" name="pagePath" value="{{ $page->getSourcePath() }}">
                 <label for="live-editor" class="sr-only">Edit page contents</label>
-                <textarea name="contentInput" id="live-editor" cols="30" rows="20">{{ $markdown }}</textarea>
+                <textarea name="contentInput" id="live-editor" cols="30" rows="20" class="rounded-lg bg-gray-200 dark:bg-gray-800">{{ $markdown }}</textarea>
             </form>
         </section>
     </template>

--- a/packages/realtime-compiler/resources/live-edit.blade.php
+++ b/packages/realtime-compiler/resources/live-edit.blade.php
@@ -23,13 +23,6 @@
                 <input type="hidden" name="page" value="{{ $page->getSourcePath() }}">
                 <label for="live-editor" class="sr-only">Edit page contents</label>
                 <textarea name="markdown" id="live-editor" cols="30" rows="20" class="rounded-lg bg-gray-200 dark:bg-gray-800">{{ $markdown }}</textarea>
-                <footer class="prose dark:prose-invert">
-                    <small>
-                        <a id="#liveEditSettingsButton" role="button" href="javascript:liveEditSettings();">
-                            Editor preferences
-                        </a>
-                    </small>
-                </footer>
             </form>
         </section>
     </template>

--- a/packages/realtime-compiler/resources/live-edit.blade.php
+++ b/packages/realtime-compiler/resources/live-edit.blade.php
@@ -6,7 +6,9 @@
     @endphp
     <style>{!! $styles !!}</style>
     <template id="live-edit-template">
-        <section id="live-edit-container">
+        <section id="live-edit-container" @class([
+                'page-type-'.\Illuminate\Support\Str::kebab(class_basename($page::class)),
+            ])>
             <form id="liveEditForm" action="/_hyde/live-edit" method="POST">
                 <header id="liveEditHeader">
                     <h2>Live Editor</h2>

--- a/packages/realtime-compiler/resources/live-edit.css
+++ b/packages/realtime-compiler/resources/live-edit.css
@@ -1,0 +1,63 @@
+#live-editor {
+    width: 100%;
+    height: 100%;
+    min-height: 300px;
+    border: none;
+    outline: none;
+    font-family: 'Source Code Pro', monospace;
+    padding: 1rem;
+    white-space: pre-line;
+}
+
+#live-editor:focus {
+    outline: 2px solid transparent;
+    outline-offset: 2px;
+    box-shadow: 0 0 0 0 rgba(255, 255, 255, 0), 0 0 0 calc(1px + 0px) rgba(37, 99, 235, 1), 0 0 #0000;
+    border-color: #2563eb;
+}
+
+#live-edit-container header {
+    width: 100%;
+    max-width: 100%;
+    display: flex;
+    flex-direction: row;
+    align-items: center;
+    justify-content: space-between;
+}
+
+#live-edit-container menu button {
+    padding: 0.25rem 0.5rem;
+    border-radius: 0.375rem;
+    font-weight: 500;
+    font-size: 0.75rem;
+    line-height: 1.25rem;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+    cursor: pointer;
+    transition: background-color 0.2s ease-in-out, border-color 0.2s ease-in-out, color 0.2s ease-in-out;
+}
+
+#liveEditCancel {
+    background-color: #e5e7eb;
+    border-color: #e5e7eb;
+    color: #1f2937;
+    margin-right: 0.35rem;
+}
+
+#liveEditCancel:hover {
+    background-color: #d1d5db;
+    border-color: #d1d5db;
+    color: #1f2937;
+}
+
+#liveEditSubmit {
+    background-color: #2563eb;
+    border-color: #2563eb;
+    color: #fff;
+}
+
+#liveEditSubmit:hover {
+    background-color: #1d4ed8;
+    border-color: #1d4ed8;
+    color: #fff;
+}

--- a/packages/realtime-compiler/resources/live-edit.js
+++ b/packages/realtime-compiler/resources/live-edit.js
@@ -11,8 +11,12 @@ function initLiveEdit() {
     }
 
     function switchToEditor() {
+        function getLiveEditor() {
+            return document.querySelector('#live-edit-container');
+        }
+
         function hasEditorBeenSetUp() {
-            return document.querySelector('#live-edit-container') === null;
+            return getLiveEditor() === null;
         }
 
         function setupEditor() {

--- a/packages/realtime-compiler/resources/live-edit.js
+++ b/packages/realtime-compiler/resources/live-edit.js
@@ -28,9 +28,7 @@ function initLiveEdit() {
 
             showEditor();
 
-            document.getElementById('liveEditCancel').addEventListener('click', function () {
-                hideEditor();
-            });
+            document.getElementById('liveEditCancel').addEventListener('click', hideEditor);
         }
 
         function showEditor() {

--- a/packages/realtime-compiler/resources/live-edit.js
+++ b/packages/realtime-compiler/resources/live-edit.js
@@ -26,6 +26,9 @@ function initLiveEdit() {
             article.parentNode.insertBefore(editor, article.nextSibling);
             editor = getLiveEditor();
 
+            // Apply CSS classes from article to editor to match layout
+            editor.classList.add(...article.classList);
+
             showEditor();
 
             document.getElementById('liveEditCancel').addEventListener('click', hideEditor);

--- a/packages/realtime-compiler/resources/live-edit.js
+++ b/packages/realtime-compiler/resources/live-edit.js
@@ -21,8 +21,8 @@ function initLiveEdit() {
 
         function setupEditor() {
             const template = document.getElementById('live-edit-template');
-            const editor = document.importNode(template.content, true);
             const article = getArticle();
+            const editor = document.importNode(template.content, true);
 
             article.parentNode.insertBefore(editor, article.nextSibling);
 

--- a/packages/realtime-compiler/resources/live-edit.js
+++ b/packages/realtime-compiler/resources/live-edit.js
@@ -84,7 +84,46 @@ function initLiveEdit() {
         });
     }
 
+    function handleShortcut(event) {
+        let isEditorHidden = getLiveEditor() === null || getLiveEditor().style.display === 'none';
+        let isEditorVisible = getLiveEditor() !== null && getLiveEditor().style.display !== 'none';
+
+        if (event.ctrlKey && event.key === 'e') {
+            event.preventDefault();
+
+            if (isEditorHidden) {
+                switchToEditor();
+            } else {
+                hideEditor();
+            }
+        }
+
+        if (event.ctrlKey && event.key === 's') {
+            if (isEditorVisible) {
+                event.preventDefault();
+
+                document.getElementById('liveEditSubmit').click();
+            }
+        }
+
+        if (event.key === 'Escape') {
+            if (isEditorVisible) {
+                event.preventDefault();
+
+                hideEditor();
+            }
+        }
+    }
+
+    function shortcutsEnabled() {
+        return true; // Todo: Add option to disable all keyboard shortcuts
+    }
+
     const article = getArticle();
 
     article.addEventListener('dblclick', switchToEditor);
+
+    if (shortcutsEnabled()) {
+        document.addEventListener('keydown', handleShortcut);
+    }
 }

--- a/packages/realtime-compiler/resources/live-edit.js
+++ b/packages/realtime-compiler/resources/live-edit.js
@@ -25,7 +25,8 @@ function initLiveEdit() {
             const article = getArticle();
 
             article.parentNode.insertBefore(editor, article.nextSibling);
-            article.style.display = 'none';
+
+            showEditor();
         }
 
         function showEditor() {

--- a/packages/realtime-compiler/resources/live-edit.js
+++ b/packages/realtime-compiler/resources/live-edit.js
@@ -20,7 +20,12 @@ function initLiveEdit() {
         }
 
         function setupEditor() {
-            //
+            const template = document.getElementById('live-edit-template');
+            const editor = document.importNode(template.content, true);
+            const article = getArticle();
+
+            article.parentNode.insertBefore(editor, article.nextSibling);
+            article.style.display = 'none';
         }
 
         function showEditor() {

--- a/packages/realtime-compiler/resources/live-edit.js
+++ b/packages/realtime-compiler/resources/live-edit.js
@@ -1,3 +1,14 @@
 function initLiveEdit() {
-    //
+    function getArticle() {
+        let article = document.querySelector('#content > article');
+
+        if (article === null) {
+            // If no article element is found the user may have a custom template, so we cannot know which element to edit.
+            throw new Error('No article element found, cannot live edit. If you are using a custom template, please make sure to include an article element in the #content container.');
+        }
+
+        return article;
+    }
+
+    const article = getArticle();
 }

--- a/packages/realtime-compiler/resources/live-edit.js
+++ b/packages/realtime-compiler/resources/live-edit.js
@@ -51,10 +51,6 @@ function initLiveEdit() {
             showEditor();
 
             document.getElementById('liveEditCancel').addEventListener('click', hideEditor);
-
-            document.getElementById('liveEditForm').addEventListener('submit', function(event) {
-                handleFormSubmit(event, editor);
-            });
         }
 
         if (hasEditorBeenSetUp()) {
@@ -62,26 +58,6 @@ function initLiveEdit() {
         } else {
             setupEditor();
         }
-    }
-
-    // Todo: By adding a return redirect we could do this part without JavaScript,
-    //       but then we might need client-side validation, nullifying the value.
-    function handleFormSubmit(event, editor) {
-        event.preventDefault();
-
-        fetch('/_hyde/live-edit', {
-            method: "POST",
-            body: new FormData(event.target),
-            headers: new Headers({
-                "Accept": "application/json",
-            }),
-        }).then(async response => {
-            if (response.ok) {
-                window.location.reload();
-            } else {
-                alert(`Error saving content: ${response.status} ${response.statusText}\n${JSON.parse(await response.text()).error ?? 'Unknown error'}`);
-            }
-        });
     }
 
     function handleShortcut(event) {

--- a/packages/realtime-compiler/resources/live-edit.js
+++ b/packages/realtime-compiler/resources/live-edit.js
@@ -10,10 +10,29 @@ function initLiveEdit() {
         return article;
     }
 
+    function getLiveEditor() {
+        return document.querySelector('#live-edit-container');
+    }
+
+    function showEditor() {
+        article.style.display = 'none';
+        getLiveEditor().style.display = '';
+        focusOnTextarea();
+    }
+
+    function hideEditor() {
+        article.style.display = '';
+        getLiveEditor().style.display = 'none';
+    }
+
+    function focusOnTextarea() {
+        const textarea = getLiveEditor().querySelector('textarea');
+
+        textarea.selectionStart = textarea.value.length;
+        textarea.focus();
+    }
+
     function switchToEditor() {
-        function getLiveEditor() {
-            return document.querySelector('#live-edit-container');
-        }
 
         function hasEditorBeenSetUp() {
             return getLiveEditor() !== null;
@@ -36,24 +55,6 @@ function initLiveEdit() {
             document.getElementById('liveEditForm').addEventListener('submit', function(event) {
                 handleFormSubmit(event, editor);
             });
-        }
-
-        function showEditor() {
-            article.style.display = 'none';
-            getLiveEditor().style.display = '';
-            focusOnTextarea();
-        }
-
-        function hideEditor() {
-            article.style.display = '';
-            getLiveEditor().style.display = 'none';
-        }
-
-        function focusOnTextarea() {
-            const textarea = getLiveEditor().querySelector('textarea');
-
-            textarea.selectionStart = textarea.value.length;
-            textarea.focus();
         }
 
         if (hasEditorBeenSetUp()) {

--- a/packages/realtime-compiler/resources/live-edit.js
+++ b/packages/realtime-compiler/resources/live-edit.js
@@ -27,6 +27,10 @@ function initLiveEdit() {
             article.parentNode.insertBefore(editor, article.nextSibling);
 
             showEditor();
+
+            document.getElementById('liveEditCancel').addEventListener('click', function () {
+                hideEditor();
+            });
         }
 
         function showEditor() {

--- a/packages/realtime-compiler/resources/live-edit.js
+++ b/packages/realtime-compiler/resources/live-edit.js
@@ -61,7 +61,21 @@ function initLiveEdit() {
     }
 
     function handleFormSubmit(event, editor) {
-        //
+        event.preventDefault();
+
+        fetch('/_hyde/live-edit', {
+            method: "POST",
+            body: new FormData(event.target),
+            headers: new Headers({
+                "Accept": "application/json",
+            }),
+        }).then(async response => {
+            if (response.ok) {
+                window.location.reload();
+            } else {
+                alert(`Error saving content: ${response.status} ${response.statusText}\n${JSON.parse(await response.text()).error ?? 'Unknown error'}`);
+            }
+        });
     }
 
     const article = getArticle();

--- a/packages/realtime-compiler/resources/live-edit.js
+++ b/packages/realtime-compiler/resources/live-edit.js
@@ -60,6 +60,8 @@ function initLiveEdit() {
         }
     }
 
+    // Todo: By adding a return redirect we could do this part without JavaScript,
+    //       but then we might need client-side validation, nullifying the value.
     function handleFormSubmit(event, editor) {
         event.preventDefault();
 

--- a/packages/realtime-compiler/resources/live-edit.js
+++ b/packages/realtime-compiler/resources/live-edit.js
@@ -1,0 +1,3 @@
+function initLiveEdit() {
+    //
+}

--- a/packages/realtime-compiler/resources/live-edit.js
+++ b/packages/realtime-compiler/resources/live-edit.js
@@ -29,7 +29,8 @@ function initLiveEdit() {
         }
 
         function showEditor() {
-            //
+            article.style.display = 'none';
+            getLiveEditor().style.display = '';
         }
 
         if (hasEditorBeenSetUp()) {

--- a/packages/realtime-compiler/resources/live-edit.js
+++ b/packages/realtime-compiler/resources/live-edit.js
@@ -16,7 +16,7 @@ function initLiveEdit() {
         }
 
         function hasEditorBeenSetUp() {
-            return getLiveEditor() === null;
+            return getLiveEditor() !== null;
         }
 
         function setupEditor() {

--- a/packages/realtime-compiler/resources/live-edit.js
+++ b/packages/realtime-compiler/resources/live-edit.js
@@ -23,10 +23,10 @@ function initLiveEdit() {
             //
         }
 
-        if (! hasEditorBeenSetUp()) {
-            setupEditor();
-        } else {
+        if (hasEditorBeenSetUp()) {
             showEditor();
+        } else {
+            setupEditor();
         }
     }
 

--- a/packages/realtime-compiler/resources/live-edit.js
+++ b/packages/realtime-compiler/resources/live-edit.js
@@ -22,9 +22,9 @@ function initLiveEdit() {
         function setupEditor() {
             const template = document.getElementById('live-edit-template');
             const article = getArticle();
-            const editor = document.importNode(template.content, true);
-
+            let editor = document.importNode(template.content, true);
             article.parentNode.insertBefore(editor, article.nextSibling);
+            editor = getLiveEditor();
 
             showEditor();
 

--- a/packages/realtime-compiler/resources/live-edit.js
+++ b/packages/realtime-compiler/resources/live-edit.js
@@ -116,7 +116,7 @@ function initLiveEdit() {
     }
 
     function shortcutsEnabled() {
-        return true; // Todo: Add option to disable all keyboard shortcuts
+        return localStorage.getItem('hydephp.live-edit.shortcuts') !== 'false';
     }
 
     const article = getArticle();

--- a/packages/realtime-compiler/resources/live-edit.js
+++ b/packages/realtime-compiler/resources/live-edit.js
@@ -11,7 +11,23 @@ function initLiveEdit() {
     }
 
     function switchToEditor() {
-        // TODO
+        function hasEditorBeenSetUp() {
+            return document.querySelector('#live-edit-container') === null;
+        }
+
+        function setupEditor() {
+            //
+        }
+
+        function showEditor() {
+            //
+        }
+
+        if (! hasEditorBeenSetUp()) {
+            setupEditor();
+        } else {
+            showEditor();
+        }
     }
 
     const article = getArticle();

--- a/packages/realtime-compiler/resources/live-edit.js
+++ b/packages/realtime-compiler/resources/live-edit.js
@@ -29,6 +29,10 @@ function initLiveEdit() {
             showEditor();
 
             document.getElementById('liveEditCancel').addEventListener('click', hideEditor);
+
+            document.getElementById('liveEditForm').addEventListener('submit', function(event) {
+                handleFormSubmit(event, editor);
+            });
         }
 
         function showEditor() {
@@ -54,6 +58,10 @@ function initLiveEdit() {
         } else {
             setupEditor();
         }
+    }
+
+    function handleFormSubmit(event, editor) {
+        //
     }
 
     const article = getArticle();

--- a/packages/realtime-compiler/resources/live-edit.js
+++ b/packages/realtime-compiler/resources/live-edit.js
@@ -34,6 +34,11 @@ function initLiveEdit() {
             getLiveEditor().style.display = '';
         }
 
+        function hideEditor() {
+            article.style.display = '';
+            getLiveEditor().style.display = 'none';
+        }
+
         if (hasEditorBeenSetUp()) {
             showEditor();
         } else {

--- a/packages/realtime-compiler/resources/live-edit.js
+++ b/packages/realtime-compiler/resources/live-edit.js
@@ -34,11 +34,19 @@ function initLiveEdit() {
         function showEditor() {
             article.style.display = 'none';
             getLiveEditor().style.display = '';
+            focusOnTextarea();
         }
 
         function hideEditor() {
             article.style.display = '';
             getLiveEditor().style.display = 'none';
+        }
+
+        function focusOnTextarea() {
+            const textarea = getLiveEditor().querySelector('textarea');
+
+            textarea.selectionStart = textarea.value.length;
+            textarea.focus();
         }
 
         if (hasEditorBeenSetUp()) {

--- a/packages/realtime-compiler/resources/live-edit.js
+++ b/packages/realtime-compiler/resources/live-edit.js
@@ -10,5 +10,11 @@ function initLiveEdit() {
         return article;
     }
 
+    function switchToEditor() {
+        // TODO
+    }
+
     const article = getArticle();
+
+    article.addEventListener('dblclick', switchToEditor);
 }

--- a/packages/realtime-compiler/src/ConsoleOutput.php
+++ b/packages/realtime-compiler/src/ConsoleOutput.php
@@ -64,7 +64,7 @@ class ConsoleOutput
     /** @experimental */
     public function printMessage(string $message, string $context): void
     {
-        $this->output->writeln(sprintf('%s [%s]', $message, $context));
+        $this->output->writeln(sprintf('%s ::context=[%s]', $message, $context));
     }
 
     protected function handleOutput(string $buffer): void
@@ -92,8 +92,8 @@ class ConsoleOutput
         if (str_ends_with(trim($line), 'Accepted') || str_ends_with(trim($line), 'Closing')) {
             return $this->verbose ? $this->formatRequestStatusLine($line) : null;
         }
-        if (str_contains($line, '[dashboard@')) {
-            return $this->formatDashboardContextLine($line);
+        if (str_contains($line, '::context=')) {
+            return $this->formatContextLine($line);
         }
 
         return $this->formatLine($line, Carbon::now());
@@ -126,10 +126,10 @@ class ConsoleOutput
         return $this->formatLine(sprintf('%s %s', $address, $status), $this->parseDate($line));
     }
 
-    protected function formatDashboardContextLine(string $line): string
+    protected function formatContextLine(string $line): string
     {
-        $message = trim(Str::before($line, '[dashboard@'));
-        $context = trim(trim(Str::after($line, $message)), '[]');
+        $message = trim(Str::before($line, '::context='), '[]');
+        $context = Str::between($line, '::context=[', ']');
         $success = str_contains($message, 'Created') || str_contains($message, 'Updated');
 
         return $this->formatLine($message, Carbon::now(), $success ? 'green-500' : 'blue-500', $context);

--- a/packages/realtime-compiler/src/Http/LiveEditController.php
+++ b/packages/realtime-compiler/src/Http/LiveEditController.php
@@ -48,6 +48,8 @@ class LiveEditController extends BaseController
         $page->markdown = new Markdown($content);
         $page->save();
 
+        $this->writeToConsole("Updated file '$pagePath'", 'hyde@live-edit');
+
         return new JsonResponse(200, 'OK', [
             'message' => 'Page saved successfully.',
         ]);

--- a/packages/realtime-compiler/src/Http/LiveEditController.php
+++ b/packages/realtime-compiler/src/Http/LiveEditController.php
@@ -36,8 +36,8 @@ class LiveEditController extends BaseController
 
     protected function handleRequest(): JsonResponse
     {
-        $pagePath = $this->request->data['pagePath'] ?? $this->abort(400, 'Must provide page path');
-        $content = $this->request->data['contentInput'] ?? $this->abort(400, 'Must provide content');
+        $pagePath = $this->request->data['page'] ?? $this->abort(400, 'Must provide page path');
+        $content = $this->request->data['markdown'] ?? $this->abort(400, 'Must provide content');
 
         $page = Hyde::pages()->getPage($pagePath);
 

--- a/packages/realtime-compiler/src/Http/LiveEditController.php
+++ b/packages/realtime-compiler/src/Http/LiveEditController.php
@@ -47,7 +47,9 @@ class LiveEditController extends BaseController
         $page->markdown = new Markdown($content);
         $page->save();
 
-        //
+        return new JsonResponse(200, 'OK', [
+            'message' => 'Page saved successfully.',
+        ]);
     }
 
     public static function enabled(): bool

--- a/packages/realtime-compiler/src/Http/LiveEditController.php
+++ b/packages/realtime-compiler/src/Http/LiveEditController.php
@@ -4,7 +4,8 @@ declare(strict_types=1);
 
 namespace Hyde\RealtimeCompiler\Http;
 
-use Desilva\Microserve\Response;
+use Desilva\Microserve\JsonResponse;
+use Symfony\Component\HttpKernel\Exception\HttpException;
 
 /**
  * @internal This class is not intended to be edited outside the Hyde Realtime Compiler.
@@ -14,9 +15,24 @@ class LiveEditController extends BaseController
     protected bool $withConsoleOutput = true;
     protected bool $withSession = true;
 
-    public function handle(): Response
+    public function handle(): JsonResponse
     {
-        $this->authorizePostRequest();
+        try {
+            $this->authorizePostRequest();
+
+            return $this->handleRequest();
+        } catch (HttpException $exception) {
+            if ($this->expectsJson()) {
+                return $this->sendJsonErrorResponse($exception->getStatusCode(), $exception->getMessage());
+            }
+
+            throw $exception;
+        }
+    }
+
+    protected function handleRequest(): JsonResponse
+    {
+        //
     }
 
     public static function enabled(): bool

--- a/packages/realtime-compiler/src/Http/LiveEditController.php
+++ b/packages/realtime-compiler/src/Http/LiveEditController.php
@@ -60,6 +60,8 @@ class LiveEditController extends BaseController
 
     public static function injectLiveEditScript(string $html): string
     {
+        session_start();
+
         return str_replace('</body>', sprintf('%s</body>', Blade::render(file_get_contents(__DIR__.'/../../resources/live-edit.blade.php'), [
             'styles' => file_get_contents(__DIR__.'/../../resources/live-edit.css'),
             'scripts' => file_get_contents(__DIR__.'/../../resources/live-edit.js'),

--- a/packages/realtime-compiler/src/Http/LiveEditController.php
+++ b/packages/realtime-compiler/src/Http/LiveEditController.php
@@ -7,6 +7,7 @@ namespace Hyde\RealtimeCompiler\Http;
 use Hyde\Hyde;
 use Hyde\Markdown\Models\Markdown;
 use Desilva\Microserve\JsonResponse;
+use Illuminate\Support\Facades\Blade;
 use Hyde\Pages\Concerns\BaseMarkdownPage;
 use Symfony\Component\HttpKernel\Exception\HttpException;
 
@@ -55,5 +56,14 @@ class LiveEditController extends BaseController
     public static function enabled(): bool
     {
         return config('hyde.server.live_edit', true);
+    }
+
+    public static function injectLiveEditScript(string $html): string
+    {
+        return str_replace('</body>', sprintf('%s</body>', Blade::render(file_get_contents(__DIR__.'/../../resources/live-edit.blade.php'), [
+            'styles' => file_get_contents(__DIR__.'/../../resources/live-edit.css'),
+            'scripts' => file_get_contents(__DIR__.'/../../resources/live-edit.js'),
+            'csrfToken' => self::generateCSRFToken(),
+        ])), $html);
     }
 }

--- a/packages/realtime-compiler/src/Http/LiveEditController.php
+++ b/packages/realtime-compiler/src/Http/LiveEditController.php
@@ -63,7 +63,7 @@ class LiveEditController extends BaseController
 
     protected function redirectToPage(Route $route): HtmlResponse
     {
-        $redirectPage = new Redirect($this->request->path, "../" . $route);
+        $redirectPage = new Redirect($this->request->path, "../$route");
         Hyde::shareViewData($redirectPage);
 
         return (new HtmlResponse(303, 'Redirect', [

--- a/packages/realtime-compiler/src/Http/LiveEditController.php
+++ b/packages/realtime-compiler/src/Http/LiveEditController.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Hyde\RealtimeCompiler\Http;
 
 use Hyde\Hyde;
+use Hyde\Markdown\Models\Markdown;
 use Desilva\Microserve\JsonResponse;
 use Hyde\Pages\Concerns\BaseMarkdownPage;
 use Symfony\Component\HttpKernel\Exception\HttpException;
@@ -42,6 +43,9 @@ class LiveEditController extends BaseController
         if (! $page instanceof BaseMarkdownPage) {
             $this->abort(400, 'Page is not a markdown page');
         }
+
+        $page->markdown = new Markdown($content);
+        $page->save();
 
         //
     }

--- a/packages/realtime-compiler/src/Http/LiveEditController.php
+++ b/packages/realtime-compiler/src/Http/LiveEditController.php
@@ -4,7 +4,9 @@ declare(strict_types=1);
 
 namespace Hyde\RealtimeCompiler\Http;
 
+use Hyde\Hyde;
 use Desilva\Microserve\JsonResponse;
+use Hyde\Pages\Concerns\BaseMarkdownPage;
 use Symfony\Component\HttpKernel\Exception\HttpException;
 
 /**
@@ -34,6 +36,12 @@ class LiveEditController extends BaseController
     {
         $pagePath = $this->request->data['pagePath'] ?? $this->abort(400, 'Must provide page path');
         $content = $this->request->data['contentInput'] ?? $this->abort(400, 'Must provide content');
+
+        $page = Hyde::pages()->getPage($pagePath);
+
+        if (! $page instanceof BaseMarkdownPage) {
+            $this->abort(400, 'Page is not a markdown page');
+        }
 
         //
     }

--- a/packages/realtime-compiler/src/Http/LiveEditController.php
+++ b/packages/realtime-compiler/src/Http/LiveEditController.php
@@ -66,7 +66,7 @@ class LiveEditController extends BaseController
         $redirectPage = new Redirect($this->request->path, "../$route");
         Hyde::shareViewData($redirectPage);
 
-        return (new HtmlResponse(303, 'Redirect', [
+        return (new HtmlResponse(303, 'See Other', [
             'body' => $redirectPage->compile(),
         ]))->withHeaders([
             'Location' => $route,

--- a/packages/realtime-compiler/src/Http/LiveEditController.php
+++ b/packages/realtime-compiler/src/Http/LiveEditController.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Hyde\RealtimeCompiler\Http;
 
 use Hyde\Hyde;
+use Hyde\Support\Models\Route;
 use Hyde\Support\Models\Redirect;
 use Hyde\Markdown\Models\Markdown;
 use Illuminate\Support\Facades\Blade;
@@ -41,14 +42,7 @@ class LiveEditController extends BaseController
 
         $this->writeToConsole("Updated file '$pagePath'", 'hyde@live-edit');
 
-        $redirectPage = new Redirect($this->request->path, "../".$page->getRoute());
-        Hyde::shareViewData($redirectPage);
-
-        return (new HtmlResponse(303, 'Redirect', [
-            'body' => $redirectPage->compile(),
-        ]))->withHeaders( [
-            'Location' => $page->getRoute(),
-        ]);
+        return $this->redirectToPage($page->getRoute());
     }
 
     public static function enabled(): bool
@@ -65,5 +59,17 @@ class LiveEditController extends BaseController
             'scripts' => file_get_contents(__DIR__.'/../../resources/live-edit.js'),
             'csrfToken' => self::generateCSRFToken(),
         ])), $html);
+    }
+
+    protected function redirectToPage(Route $route): HtmlResponse
+    {
+        $redirectPage = new Redirect($this->request->path, "../" . $route);
+        Hyde::shareViewData($redirectPage);
+
+        return (new HtmlResponse(303, 'Redirect', [
+            'body' => $redirectPage->compile(),
+        ]))->withHeaders([
+            'Location' => $route,
+        ]);
     }
 }

--- a/packages/realtime-compiler/src/Http/LiveEditController.php
+++ b/packages/realtime-compiler/src/Http/LiveEditController.php
@@ -32,6 +32,9 @@ class LiveEditController extends BaseController
 
     protected function handleRequest(): JsonResponse
     {
+        $pagePath = $this->request->data['pagePath'] ?? $this->abort(400, 'Must provide page path');
+        $content = $this->request->data['contentInput'] ?? $this->abort(400, 'Must provide content');
+
         //
     }
 

--- a/packages/realtime-compiler/src/Routing/PageRouter.php
+++ b/packages/realtime-compiler/src/Routing/PageRouter.php
@@ -5,6 +5,7 @@ namespace Hyde\RealtimeCompiler\Routing;
 use Desilva\Microserve\Request;
 use Desilva\Microserve\Response;
 use Hyde\Foundation\Facades\Routes;
+use Hyde\Pages\Concerns\BaseMarkdownPage;
 use Hyde\Framework\Actions\StaticPageBuilder;
 use Hyde\RealtimeCompiler\Http\LiveEditController;
 use Hyde\Framework\Features\Documentation\DocumentationSearchPage;
@@ -73,6 +74,10 @@ class PageRouter
             Hyde::shareViewData($page);
 
             $contents = $page->compile();
+        }
+
+        if ($page instanceof BaseMarkdownPage && LiveEditController::enabled()) {
+            $contents = LiveEditController::injectLiveEditScript($contents);
         }
 
         return $contents;

--- a/packages/realtime-compiler/tests/RealtimeCompilerTest.php
+++ b/packages/realtime-compiler/tests/RealtimeCompilerTest.php
@@ -17,6 +17,10 @@ if (BASE_PATH === false || ! file_exists(BASE_PATH.'/hyde')) {
 
 ob_start();
 
+beforeEach(function () {
+    putenv('SERVER_LIVE_EDIT=false');
+});
+
 test('handle routes index page', function () {
     putenv('SERVER_DASHBOARD=false');
     mockRoute('');


### PR DESCRIPTION

### Live edit
#### Usage
The live edit feature allows you to quickly edit Markdown-based pages (posts, docs, and pages) directly in the browser.
To enter the live editor, simply double-click on the article you want to edit, and it will be replaced with a text editor.
When you're done, click the save button to save the changes to the page's source file.
#### Shortcuts
The live editor supports the following keyboard shortcuts:
- `Ctrl + E` - Enter/Exit editor
- `Ctrl + S` - Save changes
- `esc` - Exit editor if active
#### Configuration
The live editor can be disabled in the `config/hyde.php` file.
The live editor plugin code will not be saved to your static site.
```php
// filepath config/hyde.php
'server' => [
    'live_edit' => env('SERVER_LIVE_EDIT', true),
],
```