### PR TITLE
Legacy realtime compiler beta version reaches end of life 2023-12-31

### DIFF
--- a/packages/realtime-compiler/README.md
+++ b/packages/realtime-compiler/README.md
@@ -12,9 +12,9 @@ It thus offers no guarantees for compatibility with other versions of itself.
 
 The following table shows the supported versions of this package.
 
-| Hyde Version | Version | Supported          | Notes                   |
-|:-------------|---------|--------------------|-------------------------|
-| Release      | 3.x     | :white_check_mark: | Latest                  |
-| Beta         | 2.x     | :x:                | Security fixes only     |
-| Alpha        | 1.x LTS | :shield:           | End of Life: 2023-03-01 |
-| Alpha        | < 1.0   | :x:                | Alpha                   |
+| Hyde Version | Version | Supported          | Notes                                         |
+|:-------------|---------|--------------------|-----------------------------------------------|
+| Release      | 3.x     | :white_check_mark: | Latest                                        |
+| Beta         | 2.x     | :x:                | Security fixes only (End of Life: 2023-12-31) |
+| Alpha        | 1.x LTS | :shield:           | End of Life: 2023-03-01                       |
+| Alpha        | < 1.0   | :x:                | Alpha                                         |


### PR DESCRIPTION
This legacy beta version of the realtime compiler package has only been receiving security fixes. This PR marks the end of life for this version to the end of this year.