### PR TITLE
Update live edit feature to protect against overwriting modified content

### DIFF
--- a/packages/realtime-compiler/resources/live-edit.blade.php
+++ b/packages/realtime-compiler/resources/live-edit.blade.php
@@ -21,6 +21,7 @@
                 </header>
                 <input type="hidden" name="_token" value="{{ $csrfToken }}">
                 <input type="hidden" name="page" value="{{ $page->getSourcePath() }}">
+                <input type="hidden" name="currentContentHash" value="{{ hash_file('sha256', $page->getSourcePath()) }}">
                 <label for="live-editor" class="sr-only">Edit page contents</label>
                 <textarea name="markdown" id="live-editor" cols="30" rows="20" class="rounded-lg bg-gray-200 dark:bg-gray-800">{{ $markdown }}</textarea>
             </form>

--- a/packages/realtime-compiler/resources/live-edit.blade.php
+++ b/packages/realtime-compiler/resources/live-edit.blade.php
@@ -21,7 +21,7 @@
                 </header>
                 <input type="hidden" name="_token" value="{{ $csrfToken }}">
                 <input type="hidden" name="page" value="{{ $page->getSourcePath() }}">
-                <input type="hidden" name="currentContentHash" value="{{ hash_file('sha256', $page->getSourcePath()) }}">
+                <input type="hidden" name="currentContentHash" value="{{ hash('sha256', $page->markdown()->body()) }}">
                 <label for="live-editor" class="sr-only">Edit page contents</label>
                 <textarea name="markdown" id="live-editor" cols="30" rows="20" class="rounded-lg bg-gray-200 dark:bg-gray-800">{{ $markdown }}</textarea>
             </form>

--- a/packages/realtime-compiler/resources/live-edit.js
+++ b/packages/realtime-compiler/resources/live-edit.js
@@ -75,6 +75,14 @@ function initLiveEdit() {
             if (response.ok) {
                 window.location.reload();
             } else {
+                if (response.status === 409) {
+                    if (confirm('This page has been modified in another window. Do you want to overwrite the changes?')) {
+                        document.getElementById('liveEditForm').insertAdjacentHTML('beforeend', '<input type="hidden" name="force" value="true">');
+                        document.getElementById('liveEditForm').submit();
+                    }
+                    return;
+                }
+
                 alert(`Error saving content: ${response.status} ${response.statusText}\n${JSON.parse(await response.text()).error ?? 'Unknown error'}`);
             }
         });

--- a/packages/realtime-compiler/resources/live-edit.js
+++ b/packages/realtime-compiler/resources/live-edit.js
@@ -51,6 +51,8 @@ function initLiveEdit() {
             showEditor();
 
             document.getElementById('liveEditCancel').addEventListener('click', hideEditor);
+
+            document.getElementById('liveEditForm').addEventListener('submit', handleFormSubmit);
         }
 
         if (hasEditorBeenSetUp()) {
@@ -58,6 +60,24 @@ function initLiveEdit() {
         } else {
             setupEditor();
         }
+    }
+
+    function handleFormSubmit(event) {
+        event.preventDefault();
+
+        fetch('/_hyde/live-edit', {
+            method: "POST",
+            body: new FormData(event.target),
+            headers: new Headers({
+                "Accept": "application/json",
+            }),
+        }).then(async response => {
+            if (response.ok) {
+                window.location.reload();
+            } else {
+                alert(`Error saving content: ${response.status} ${response.statusText}\n${JSON.parse(await response.text()).error ?? 'Unknown error'}`);
+            }
+        });
     }
 
     function handleShortcut(event) {

--- a/packages/realtime-compiler/src/Http/LiveEditController.php
+++ b/packages/realtime-compiler/src/Http/LiveEditController.php
@@ -41,11 +41,17 @@ class LiveEditController extends BaseController
     {
         $pagePath = $this->request->data['page'] ?? $this->abort(400, 'Must provide page path');
         $content = $this->request->data['markdown'] ?? $this->abort(400, 'Must provide content');
+        $currentContentHash = $this->request->data['currentContentHash'] ?? $this->abort(400, 'Must provide content hash');
+        $force = $this->request->data['force'] ?? false;
 
         $page = Hyde::pages()->getPage($pagePath);
 
         if (! $page instanceof BaseMarkdownPage) {
             $this->abort(400, 'Page is not a markdown page');
+        }
+
+        if (! $force && hash_file('sha256', $page->getSourcePath()) !== $currentContentHash) {
+            $this->abort(409, 'Content has changed in another window');
         }
 
         $page->markdown = new Markdown($content);

--- a/packages/realtime-compiler/src/Http/LiveEditController.php
+++ b/packages/realtime-compiler/src/Http/LiveEditController.php
@@ -50,7 +50,7 @@ class LiveEditController extends BaseController
             $this->abort(400, 'Page is not a markdown page');
         }
 
-        if (! $force && hash_file('sha256', $page->getSourcePath()) !== $currentContentHash) {
+        if (! $force && hash('sha256', $page->markdown()->body()) !== $currentContentHash) {
             $this->abort(409, 'Content has changed in another window');
         }
 


### PR DESCRIPTION
Updates the live edit feature to protect against overwriting content modified in other tabs/editors. This works by restoring the JavaScript form handler together with a hidden input for the source file hash as it is on the page load. The backend returns a 409 response when the supplied content hash does not match the current one. The frontend then catches the 409 response, prints a JavaScript alert to ask the user if they want to overwrite the page, if they select yes, then the request is send again with a force parameter.