### PR TITLE
Add documentation index page to the sidebar when it's the only page

### DIFF
--- a/packages/framework/src/Framework/Features/Navigation/DocumentationSidebar.php
+++ b/packages/framework/src/Framework/Features/Navigation/DocumentationSidebar.php
@@ -25,7 +25,7 @@ class DocumentationSidebar extends BaseNavigationMenu
 
         // If there are no pages other than the index page, we add it to the sidebar so that it's not empty
         if ($this->items->count() === 0 && DocumentationPage::home() !== null) {
-            $this->items->push(NavItem::fromRoute(DocumentationPage::home()));
+            $this->items->push(NavItem::fromRoute(DocumentationPage::home(), group: 'other'));
         }
     }
 

--- a/packages/framework/src/Framework/Features/Navigation/DocumentationSidebar.php
+++ b/packages/framework/src/Framework/Features/Navigation/DocumentationSidebar.php
@@ -22,6 +22,11 @@ class DocumentationSidebar extends BaseNavigationMenu
                 $this->items->put($route->getRouteKey(), NavItem::fromRoute($route));
             }
         });
+
+        // If there are no pages other than the index page, we add it to the sidebar so that it's not empty
+        if ($this->items->count() === 0 && DocumentationPage::home() !== null) {
+            $this->items->push(NavItem::fromRoute(DocumentationPage::home()));
+        }
     }
 
     public function hasGroups(): bool

--- a/packages/framework/tests/Feature/Services/DocumentationSidebarTest.php
+++ b/packages/framework/tests/Feature/Services/DocumentationSidebarTest.php
@@ -376,6 +376,31 @@ class DocumentationSidebarTest extends TestCase
         $this->assertFalse(DocumentationSidebar::create()->isGroupActive('foo'));
     }
 
+    public function test_index_page_added_to_sidebar_when_it_is_the_only_page()
+    {
+        Filesystem::touch('_docs/index.md');
+        $sidebar = DocumentationSidebar::create();
+
+        $this->assertCount(1, $sidebar->items);
+        $this->assertEquals(
+            collect([NavItem::fromRoute(Routes::get('docs/index'))]),
+            $sidebar->items
+        );
+    }
+
+    public function test_index_page_not_added_to_sidebar_when_other_pages_exist()
+    {
+        $this->createTestFiles(1);
+        Filesystem::touch('_docs/index.md');
+        $sidebar = DocumentationSidebar::create();
+
+        $this->assertCount(1, $sidebar->items);
+        $this->assertEquals(
+            collect([NavItem::fromRoute(Routes::get('docs/test-0'))]),
+            $sidebar->items
+        );
+    }
+
     protected function createTestFiles(int $count = 5): void
     {
         for ($i = 0; $i < $count; $i++) {


### PR DESCRIPTION
## Abstract

Automatically include the index page in the documentation sidebar when it is the only page present. This ensures the sidebar is not empty for a single-page documentation site, providing a more user-friendly experience.

### Comparison

#### Before

![localhost_8080_docs_index html(1280x720) (1)](https://github.com/hydephp/develop/assets/95144705/e91d0702-4598-483f-8ea5-d03015444de0)

#### After

![localhost_8080_docs_index html(1280x720)](https://github.com/hydephp/develop/assets/95144705/06efb134-519c-47da-9dd3-f000552b8e03)
