### PR TITLE
Update configuration option for the documentation sidebar footer to allow custom Markdown to be specified

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -13,7 +13,7 @@ This serves two purposes:
 - Adds a new fancy output for the realtime compiler serve command in https://github.com/hydephp/develop/pull/1444
 
 ### Changed
-- for changes in existing functionality.
+- The `docs.sidebar.footer` config option now accepts a Markdown string to replace the default footer in https://github.com/hydephp/develop/pull/1477
 
 ### Deprecated
 - for soon-to-be removed features.

--- a/config/docs.php
+++ b/config/docs.php
@@ -30,7 +30,8 @@ return [
         // When using a grouped sidebar, should the groups be collapsible?
         'collapsible' => true,
 
-        // Should the sidebar footer be shown?
+        // Should the sidebar footer be shown? You can also set this to a string
+        // of Markdown to show in the footer. Set to `false` to disable.
         'footer' => true,
     ],
 

--- a/docs/creating-content/documentation-pages.md
+++ b/docs/creating-content/documentation-pages.md
@@ -140,6 +140,20 @@ The feature is enabled automatically when one or more of your documentation page
 in the front matter. This will then switch to a slightly more compact sidebar layout with pages sorted into categories.
 Any pages without the group front matter will get put in the "Other" group.
 
+### Sidebar footer customization
+
+The sidebar footer contains, by default, a link to your site homepage. You can change this in the `config/docs.php` file.
+
+```php
+// filepath: config/docs.php
+
+'sidebar' => [
+    'footer' => 'My **Markdown** Footer Text',
+],
+```
+
+You can also set the option to `false` to disable it entirely.
+
 #### Using Front Matter
 
 To enable sidebar grouping, you can add the following front matter to your documentation pages:

--- a/packages/framework/config/docs.php
+++ b/packages/framework/config/docs.php
@@ -30,7 +30,8 @@ return [
         // When using a grouped sidebar, should the groups be collapsible?
         'collapsible' => true,
 
-        // Should the sidebar footer be shown?
+        // Should the sidebar footer be shown? You can also set this to a string
+        // of Markdown to show in the footer. Set to `false` to disable.
         'footer' => true,
     ],
 

--- a/packages/framework/resources/views/components/docs/sidebar-footer-text.blade.php
+++ b/packages/framework/resources/views/components/docs/sidebar-footer-text.blade.php
@@ -1,7 +1,3 @@
 <p>
-    @if(config('docs.sidebar.footer_text', true))
-        {{ Hyde::markdown(config('docs.sidebar.footer_text')) }}
-    @else
-        <a href="{{ Hyde::relativeLink('index.html') }}">Back to home page</a>
-    @endif
+    <a href="{{ Hyde::relativeLink('index.html') }}">Back to home page</a>
 </p>

--- a/packages/framework/resources/views/components/docs/sidebar-footer-text.blade.php
+++ b/packages/framework/resources/views/components/docs/sidebar-footer-text.blade.php
@@ -1,3 +1,7 @@
 <p>
-    <a href="{{ Hyde::relativeLink('index.html') }}">Back to home page</a>
+    @if(config('docs.sidebar.footer_text', true))
+        {{ Hyde::markdown(config('docs.sidebar.footer_text')) }}
+    @else
+        <a href="{{ Hyde::relativeLink('index.html') }}">Back to home page</a>
+    @endif
 </p>

--- a/packages/framework/resources/views/components/docs/sidebar-footer-text.blade.php
+++ b/packages/framework/resources/views/components/docs/sidebar-footer-text.blade.php
@@ -1,3 +1,7 @@
 <p>
-    <a href="{{ Hyde::relativeLink('index.html') }}">Back to home page</a>
+    @if(is_bool(config('docs.sidebar.footer', true)))
+        <a href="{{ Hyde::relativeLink('index.html') }}">Back to home page</a>
+    @else
+        {{ Hyde::markdown(config('docs.sidebar.footer')) }}
+    @endif
 </p>

--- a/packages/framework/resources/views/components/docs/sidebar.blade.php
+++ b/packages/framework/resources/views/components/docs/sidebar.blade.php
@@ -7,7 +7,7 @@
             'sidebar' => \Hyde\Framework\Features\Navigation\DocumentationSidebar::create(),
         ])
     </nav>
-    @if(config('docs.sidebar.footer', true))
+    @if(config('docs.sidebar.footer', true) !== false)
         <footer id="sidebar-footer" class="h-16 p-4 w-full bottom-0 left-0 text-center leading-8">
             @include('hyde::components.docs.sidebar-footer-text')
         </footer>

--- a/packages/framework/tests/Feature/SidebarViewTest.php
+++ b/packages/framework/tests/Feature/SidebarViewTest.php
@@ -65,6 +65,17 @@ class SidebarViewTest extends TestCase
         $this->assertViewWasNotRendered(view('hyde::components.docs.sidebar-footer-text'));
     }
 
+    public function testBaseSidebarWithCustomFooterText()
+    {
+        config(['docs.sidebar.footer' => 'My **Markdown** Footer Text']);
+
+        $this->renderComponent(view('hyde::components.docs.sidebar'))
+            ->assertSeeHtml('<footer id="sidebar-footer"')
+            ->assertSeeHtml('<p>My <strong>Markdown</strong> Footer Text</p>')
+            ->assertDontSee('Back to home page')
+            ->allGood();
+    }
+
     public function testBaseSidebarCustomHeaderBrand()
     {
         config(['docs.sidebar.header' => 'My Custom Header']);


### PR DESCRIPTION
Fixes https://github.com/hydephp/develop/issues/1474 by checking if the existing `docs.sidebar.footer` option is a string, and if so it replaces the default "Back to home" link  with that content. Like before, if the option is `false` the footer is not rendered at all.