### PR TITLE
Add sitemap fallback to use relative links when missing a site url

### DIFF
--- a/packages/framework/src/Framework/Features/XmlGenerators/SitemapGenerator.php
+++ b/packages/framework/src/Framework/Features/XmlGenerators/SitemapGenerator.php
@@ -22,6 +22,7 @@ use function filemtime;
 use function in_array;
 use function date;
 use function time;
+use function str_starts_with;
 
 /**
  * @see https://www.sitemaps.org/protocol.html
@@ -109,7 +110,7 @@ class SitemapGenerator extends BaseXmlGenerator
     {
         $baseUrl = Config::getNullableString('hyde.url');
 
-        $canUseQualifiedUrl = filled($baseUrl);
+        $canUseQualifiedUrl = filled($baseUrl) && ! str_starts_with($baseUrl, 'http://localhost');
 
         if ($canUseQualifiedUrl) {
             return Hyde::url($route->getOutputPath());

--- a/packages/framework/src/Framework/Features/XmlGenerators/SitemapGenerator.php
+++ b/packages/framework/src/Framework/Features/XmlGenerators/SitemapGenerator.php
@@ -57,7 +57,7 @@ class SitemapGenerator extends BaseXmlGenerator
     {
         $urlItem = $this->xmlElement->addChild('url');
 
-        $this->addChild($urlItem, 'loc', Hyde::url($route->getOutputPath()));
+        $this->addChild($urlItem, 'loc', $this->resolveRouteLink($route));
         $this->addChild($urlItem, 'lastmod', $this->getLastModDate($route->getSourcePath()));
         $this->addChild($urlItem, 'changefreq', 'daily');
 
@@ -102,5 +102,10 @@ class SitemapGenerator extends BaseXmlGenerator
     protected function getFormattedProcessingTime(): string
     {
         return (string) $this->getExecutionTimeInMs();
+    }
+
+    protected function resolveRouteLink(Route $route): string
+    {
+        return Hyde::url($route->getOutputPath());
     }
 }

--- a/packages/framework/src/Framework/Features/XmlGenerators/SitemapGenerator.php
+++ b/packages/framework/src/Framework/Features/XmlGenerators/SitemapGenerator.php
@@ -17,6 +17,7 @@ use Hyde\Pages\DocumentationPage;
 use Hyde\Foundation\Facades\Routes;
 use Hyde\Framework\Concerns\TracksExecutionTime;
 
+use function filled;
 use function filemtime;
 use function in_array;
 use function date;
@@ -106,6 +107,14 @@ class SitemapGenerator extends BaseXmlGenerator
 
     protected function resolveRouteLink(Route $route): string
     {
-        return Hyde::url($route->getOutputPath());
+        $baseUrl = Config::getNullableString('hyde.url');
+
+        $canUseQualifiedUrl = filled($baseUrl);
+
+        if ($canUseQualifiedUrl) {
+            return Hyde::url($route->getOutputPath());
+        }
+
+        return $route->getLink();
     }
 }

--- a/packages/framework/tests/Feature/Services/SitemapServiceTest.php
+++ b/packages/framework/tests/Feature/Services/SitemapServiceTest.php
@@ -158,4 +158,15 @@ class SitemapServiceTest extends TestCase
         copy(Hyde::vendorPath('resources/views/homepages/welcome.blade.php'), Hyde::path('_pages/index.blade.php'));
         copy(Hyde::vendorPath('resources/views/pages/404.blade.php'), Hyde::path('_pages/404.blade.php'));
     }
+
+    public function testLinksFallbackToRelativeLinksWhenASiteUrlIsNotSet()
+    {
+        config(['hyde.url' => null]);
+
+        $service = new SitemapGenerator();
+        $service->generate();
+
+        $this->assertEquals('404.html', $service->getXmlElement()->url[0]->loc);
+        $this->assertEquals('index.html', $service->getXmlElement()->url[1]->loc);
+    }
 }

--- a/packages/framework/tests/Feature/Services/SitemapServiceTest.php
+++ b/packages/framework/tests/Feature/Services/SitemapServiceTest.php
@@ -169,4 +169,15 @@ class SitemapServiceTest extends TestCase
         $this->assertEquals('404.html', $service->getXmlElement()->url[0]->loc);
         $this->assertEquals('index.html', $service->getXmlElement()->url[1]->loc);
     }
+
+    public function testLinksFallbackToRelativeLinksWhenSiteUrlIsLocalhost()
+    {
+        config(['hyde.url' => 'http://localhost']);
+
+        $service = new SitemapGenerator();
+        $service->generate();
+
+        $this->assertEquals('404.html', $service->getXmlElement()->url[0]->loc);
+        $this->assertEquals('index.html', $service->getXmlElement()->url[1]->loc);
+    }
 }


### PR DESCRIPTION
## Abstract

This PR makes so that when a site URL is null, or for localhost, we use relative links instead of absolute links using the fallback URL of `http://localhost`.

This change was especially complicated as there are many conflicting factors to consider here. Most noted in https://github.com/hydephp/develop/issues/1469.

I eventually landed on this as I think it's the least bad decision. Relative URLs are technically not allowed by the sitemap spec, but considering that the alternative (and current implementation) is to use localhost which will _never_ resolve, I think it's more reasonable to use relative links that will _hopefully_ resolve.

While localhost URLs are valid when building locally, this is one of the drawbacks of this route, as Hyde does not know if a build is for testing or production as that would add a lot of complexity without much value (an early design decision that it makes little sense to have different static site versions for local/prod)

### Impact

Due to this change, when a site URL is not set to a custom value, instead of the following XML which is syntactically valid according to the spec, but which will never resolve when deployed:

```xml
<?xml version="1.0" encoding="UTF-8"?>
<urlset
	xmlns="https://www.sitemaps.org/schemas/sitemap/0.9" generator="HydePHP 1.3.4" processing_time_ms="0.33092498779297">
	<url>
		<loc>http://localhost/404.html</loc>
		<lastmod>2023-11-27T15:18:49+00:00</lastmod>
		<changefreq>daily</changefreq>
		<priority>0.5</priority>
	</url>
	<url>
		<loc>http://localhost/index.html</loc>
		<lastmod>2023-11-27T15:18:49+00:00</lastmod>
		<changefreq>daily</changefreq>
		<priority>1</priority>
	</url>
</urlset>
```

Instead, the output will now be as follows, which is technically not adhering to the spec, but crawlers should still be able to figure it out.

```xml
<?xml version="1.0" encoding="UTF-8"?>
<urlset
	xmlns="https://www.sitemaps.org/schemas/sitemap/0.9" generator="HydePHP 1.3.4" processing_time_ms="0.3211498260498">
	<url>
		<loc>404.html</loc>
		<lastmod>2023-11-27T15:18:49+00:00</lastmod>
		<changefreq>daily</changefreq>
		<priority>0.5</priority>
	</url>
	<url>
		<loc>index.html</loc>
		<lastmod>2023-11-27T15:18:49+00:00</lastmod>
		<changefreq>daily</changefreq>
		<priority>1</priority>
	</url>
</urlset>
```

### Considerations

I, for now, decided against adding a build warning, for now, as that would likely spam the console and not be relevant and could overwhelm the console for new users making their first build.

Since the docs currently just specify that a site URL is needed to be specified to use sitemaps, they don't need to be updated.