### PR TITLE
Add option to open site in the browser when starting the realtime compiler

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -13,6 +13,7 @@ This serves two purposes:
 - Adds a new fancy output for the realtime compiler serve command in https://github.com/hydephp/develop/pull/1444
 - Added support for dot notation in the Yaml configuration files in https://github.com/hydephp/develop/pull/1478
 - Added a config option to customize automatic sidebar navigation group names in https://github.com/hydephp/develop/pull/1481
+- Added a new `hyde serve --open` option to automatically open the site in the browser in https://github.com/hydephp/develop/pull/1483
 
 ### Changed
 - The `docs.sidebar.footer` config option now accepts a Markdown string to replace the default footer in https://github.com/hydephp/develop/pull/1477

--- a/packages/framework/src/Console/Commands/ServeCommand.php
+++ b/packages/framework/src/Console/Commands/ServeCommand.php
@@ -151,11 +151,11 @@ class ServeCommand extends Command
             default => null
         };
 
-        $process = Process::command(sprintf('%s http://%s:%d', $command, $this->getHostSelection(), $this->getPortSelection()))->run();
+        $process = $command ? Process::command(sprintf('%s http://%s:%d', $command, $this->getHostSelection(), $this->getPortSelection()))->run() : null;
 
-        if ($process->failed()) {
+        if (! $process || $process->failed()) {
             $this->warn('Unable to open the site preview in the browser on your system:');
-            $this->line(sprintf('  %s', str_replace("\n", "\n  ", $process->errorOutput())));
+            $this->line(sprintf('  %s', str_replace("\n", "\n  ", $process ? $process->errorOutput() : "Missing suitable 'open' binary.")));
         }
 
         $this->newLine();

--- a/packages/framework/src/Console/Commands/ServeCommand.php
+++ b/packages/framework/src/Console/Commands/ServeCommand.php
@@ -156,8 +156,7 @@ class ServeCommand extends Command
         if (! $process || $process->failed()) {
             $this->warn('Unable to open the site preview in the browser on your system:');
             $this->line(sprintf('  %s', str_replace("\n", "\n  ", $process ? $process->errorOutput() : "Missing suitable 'open' binary.")));
+            $this->newLine();
         }
-
-        $this->newLine();
     }
 }

--- a/packages/framework/src/Console/Commands/ServeCommand.php
+++ b/packages/framework/src/Console/Commands/ServeCommand.php
@@ -12,10 +12,9 @@ use InvalidArgumentException;
 use Hyde\Console\Concerns\Command;
 use Hyde\RealtimeCompiler\ConsoleOutput;
 use Illuminate\Support\Facades\Process;
-use Symfony\Component\Process\Process as SymfonyProcess;
-use Symfony\Component\Process\Exception\ProcessFailedException;
 
 use function sprintf;
+use function str_replace;
 use function class_exists;
 
 /**
@@ -152,13 +151,13 @@ class ServeCommand extends Command
             default => null
         };
 
-        try {
-            SymfonyProcess::fromShellCommandline(sprintf('%s http://%s:%d', $command, $this->getHostSelection(), $this->getPortSelection()))->mustRun();
-        } catch (ProcessFailedException $exception) {
-            $this->warn("Unable to open the site preview in the browser on your system.\n");
-            if ($this->output->isVerbose()) {
-                $this->line($exception->getMessage());
-            }
+        $process = Process::command(sprintf('%s http://%s:%d', $command, $this->getHostSelection(), $this->getPortSelection()))->run();
+
+        if ($process->failed()) {
+            $this->warn('Unable to open the site preview in the browser on your system:');
+            $this->line(sprintf('  %s', str_replace("\n", "\n  ", $process->errorOutput())));
         }
+
+        $this->newLine();
     }
 }

--- a/packages/framework/tests/Unit/ServeCommandOptionsUnitTest.php
+++ b/packages/framework/tests/Unit/ServeCommandOptionsUnitTest.php
@@ -4,8 +4,13 @@ declare(strict_types=1);
 
 namespace Hyde\Framework\Testing\Unit;
 
+use Mockery;
 use Hyde\Testing\UnitTestCase;
+use Illuminate\Console\OutputStyle;
 use Hyde\Console\Commands\ServeCommand;
+use Illuminate\Support\Facades\Process;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Formatter\OutputFormatterInterface;
 
 /**
  * @covers \Hyde\Console\Commands\ServeCommand
@@ -196,6 +201,60 @@ class ServeCommandOptionsUnitTest extends UnitTestCase
         $_SERVER = $serverBackup;
     }
 
+    public function testWithOpenArgument()
+    {
+        $output = $this->createMock(OutputStyle::class);
+        $output->expects($this->never())->method('writeln');
+
+        $command = $this->getMock(['--open' => true]);
+        $command->setOutput($output);
+
+        $binary = match (PHP_OS_FAMILY) {
+            'Darwin' => 'open',
+            'Windows' => 'start',
+            default => 'xdg-open',
+        };
+
+        Process::shouldReceive('command')->once()->with("$binary http://localhost:8080")->andReturnSelf();
+        Process::shouldReceive('run')->once()->andReturnSelf();
+        Process::shouldReceive('failed')->once()->andReturn(false);
+
+        $command->openInBrowser();
+    }
+
+    public function testWithOpenArgumentThatFails()
+    {
+        $output = Mockery::mock(OutputStyle::class);
+        $output->shouldReceive('getFormatter')->andReturn($this->createMock(OutputFormatterInterface::class));
+
+        $warning = '<warning>Unable to open the site preview in the browser on your system:</warning>';
+        $context = '  Missing suitable \'open\' binary.';
+
+        $output->shouldReceive('writeln')->once()->with($warning, OutputInterface::VERBOSITY_NORMAL);
+        $output->shouldReceive('writeln')->once()->with($context, OutputInterface::VERBOSITY_NORMAL);
+        $output->shouldReceive('newLine')->once();
+
+        $command = $this->getMock(['--open' => true]);
+        $command->setOutput($output);
+
+        $binary = match (PHP_OS_FAMILY) {
+            'Darwin' => 'open',
+            'Windows' => 'start',
+            default => 'xdg-open',
+        };
+
+        Process::shouldReceive('command')->once()->with("$binary http://localhost:8080")->andReturnSelf();
+        Process::shouldReceive('run')->once()->andReturnSelf();
+        Process::shouldReceive('failed')->once()->andReturn(true);
+        Process::shouldReceive('errorOutput')->once()->andReturn("Missing suitable 'open' binary.");
+
+        $command->openInBrowser();
+
+        Mockery::close();
+
+        $this->assertTrue(true);
+    }
+
     protected function getMock(array $options = []): ServeCommandMock
     {
         return new ServeCommandMock($options);
@@ -208,6 +267,7 @@ class ServeCommandOptionsUnitTest extends UnitTestCase
  * @method getEnvironmentVariables
  * @method parseEnvironmentOption(string $name)
  * @method checkArgvForOption(string $name)
+ * @method openInBrowser()
  */
 class ServeCommandMock extends ServeCommand
 {

--- a/packages/framework/tests/Unit/ServeCommandOptionsUnitTest.php
+++ b/packages/framework/tests/Unit/ServeCommandOptionsUnitTest.php
@@ -6,6 +6,7 @@ namespace Hyde\Framework\Testing\Unit;
 
 use Mockery;
 use Hyde\Testing\UnitTestCase;
+use Hyde\Foundation\HydeKernel;
 use Illuminate\Console\OutputStyle;
 use Hyde\Console\Commands\ServeCommand;
 use Illuminate\Support\Facades\Process;
@@ -203,6 +204,37 @@ class ServeCommandOptionsUnitTest extends UnitTestCase
 
     public function testWithOpenArgument()
     {
+        HydeKernel::setInstance(new HydeKernel());
+
+        $command = new class(['open' => true]) extends ServeCommandMock
+        {
+            public bool $openInBrowserCalled = false;
+
+            // Void unrelated methods
+            protected function configureOutput(): void
+            {
+            }
+
+            protected function printStartMessage(): void
+            {
+            }
+
+            protected function runServerProcess(string $command): void
+            {
+            }
+
+            protected function openInBrowser(): void
+            {
+                $this->openInBrowserCalled = true;
+            }
+        };
+
+        $command->safeHandle();
+        $this->assertTrue($command->openInBrowserCalled);
+    }
+
+    public function test_openInBrowser()
+    {
         $output = $this->createMock(OutputStyle::class);
         $output->expects($this->never())->method('writeln');
 
@@ -222,7 +254,7 @@ class ServeCommandOptionsUnitTest extends UnitTestCase
         $command->openInBrowser();
     }
 
-    public function testWithOpenArgumentThatFails()
+    public function test_openInBrowserThatFails()
     {
         $output = Mockery::mock(OutputStyle::class);
         $output->shouldReceive('getFormatter')->andReturn($this->createMock(OutputFormatterInterface::class));


### PR DESCRIPTION

![image](https://github.com/hydephp/develop/assets/95144705/a0402344-527d-4bfc-8877-7f5f6ad9db17)


```bash
php hyde serve --open
```