### PR TITLE
Improve portability of the realtime compiler

### DIFF
--- a/packages/realtime-compiler/bin/server.php
+++ b/packages/realtime-compiler/bin/server.php
@@ -4,7 +4,7 @@ try {
     define('BASE_PATH', realpath(getcwd()));
     define('HYDE_START', microtime(true));
 
-    require_once BASE_PATH.'/vendor/autoload.php';
+    require getenv('HYDE_AUTOLOAD_PATH') ?: BASE_PATH.'/vendor/autoload.php';
 
     try {
         $app = \Desilva\Microserve\Microserve::boot(\Hyde\RealtimeCompiler\Http\HttpKernel::class);

--- a/packages/realtime-compiler/src/Concerns/InteractsWithLaravel.php
+++ b/packages/realtime-compiler/src/Concerns/InteractsWithLaravel.php
@@ -18,7 +18,7 @@ trait InteractsWithLaravel
 
     protected function createApplication(): void
     {
-        $this->laravel = require BASE_PATH.'/app/bootstrap.php';
+        $this->laravel = require getenv('HYDE_BOOTSTRAP_PATH') ?: (BASE_PATH.'/app/bootstrap.php');
     }
 
     protected function bootApplication(): void


### PR DESCRIPTION
Improves the portability of the realtime compiler to better support running through the standalone executable.

Pulls changes from https://github.com/hydephp/realtime-compiler/pull/20