### PR TITLE
Improve support for running HydePHP through the Phar archive

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -22,7 +22,7 @@ This serves two purposes:
 - for now removed features.
 
 ### Fixed
-- for any bug fixes.
+- Improved support for running HydePHP through the Phar archive in https://github.com/hydephp/develop/pull/1491
 
 ### Security
 - in case of vulnerabilities.

--- a/packages/framework/src/Foundation/Kernel/Filesystem.php
+++ b/packages/framework/src/Foundation/Kernel/Filesystem.php
@@ -56,6 +56,10 @@ class Filesystem
             return $this->getBasePath();
         }
 
+        if (str_starts_with($path, 'phar://')) {
+            return $path;
+        }
+
         $path = unslash($this->pathToRelative($path));
 
         return path_join($this->getBasePath(), $path);

--- a/packages/framework/src/Foundation/PharSupport.php
+++ b/packages/framework/src/Foundation/PharSupport.php
@@ -6,7 +6,6 @@ namespace Hyde\Foundation;
 
 use Hyde\Hyde;
 use Phar;
-use BadMethodCallException;
 
 use function dirname;
 use function is_dir;
@@ -47,10 +46,6 @@ class PharSupport
 
     public static function vendorPath(string $path = '', string $package = 'framework'): string
     {
-        if ($package !== 'framework') {
-            throw new BadMethodCallException('Cannot use vendorPath() outside of the framework package when running from a Phar archive.');
-        }
-
-        return rtrim(str_replace('/', DIRECTORY_SEPARATOR, rtrim(dirname(__DIR__, 2).'/'.$path, '/\\')), '/\\');
+        return rtrim(str_replace('/', DIRECTORY_SEPARATOR, rtrim(dirname(__DIR__, 3).'/'.$package.'/'.$path, '/\\')), '/\\');
     }
 }

--- a/packages/framework/tests/Feature/Foundation/FilesystemTest.php
+++ b/packages/framework/tests/Feature/Foundation/FilesystemTest.php
@@ -115,6 +115,11 @@ class FilesystemTest extends UnitTestCase
         $this->assertSame($this->filesystem->path('foo'), $this->filesystem->path($this->filesystem->path('foo/')));
     }
 
+    public function testPathMethodDoesNotModifyPharPaths()
+    {
+        $this->assertSame('phar://foo', $this->filesystem->path('phar://foo'));
+    }
+
     public function testHydePathMethodExists()
     {
         $this->assertTrue(method_exists(HydeKernel::class, 'path'));

--- a/packages/framework/tests/Feature/PharSupportTest.php
+++ b/packages/framework/tests/Feature/PharSupportTest.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Hyde\Framework\Testing\Feature;
 
-use BadMethodCallException;
 use Hyde\Foundation\PharSupport;
 use Hyde\Hyde;
 use Hyde\Testing\TestCase;
@@ -63,16 +62,6 @@ class PharSupportTest extends TestCase
         PharSupport::mock('hasVendorDirectory', false);
 
         $this->assertEquals($this->replaceSlashes(Hyde::path("{$this->getBaseVendorPath()}/framework/file.php")), Hyde::vendorPath('file.php'));
-    }
-
-    public function test_vendor_path_can_run_in_phar_with_package_argument_but_throws()
-    {
-        PharSupport::mock('running', true);
-        PharSupport::mock('hasVendorDirectory', false);
-
-        $this->expectException(BadMethodCallException::class);
-
-        Hyde::vendorPath(package: 'realtime-compiler');
     }
 
     protected function getBaseVendorPath(): string

--- a/packages/realtime-compiler/src/Http/DashboardController.php
+++ b/packages/realtime-compiler/src/Http/DashboardController.php
@@ -13,6 +13,7 @@ use Hyde\Pages\MarkdownPage;
 use Hyde\Pages\MarkdownPost;
 use Desilva\Microserve\Request;
 use Desilva\Microserve\Response;
+use Hyde\Foundation\PharSupport;
 use Hyde\Pages\Concerns\HydePage;
 use Hyde\Pages\DocumentationPage;
 use Hyde\Support\Models\RouteKey;
@@ -261,7 +262,11 @@ class DashboardController extends BaseController
 
     public function getScripts(): string
     {
-        return file_get_contents(__DIR__.'/../../resources/dashboard.js');
+        if (PharSupport::running()) {
+            return file_get_contents('phar://hyde.phar/vendor/hyde/realtime-compiler/resources/dashboard.js');
+        }
+
+        return file_get_contents(Hyde::vendorPath('resources/dashboard.js', 'realtime-compiler'));
     }
 
     public function getFlash(string $key, $default = null): ?string


### PR DESCRIPTION
## Changes

These will fix https://github.com/hydephp/cli/issues/49, as well as other probable compatibility issues in that repo.

### Update PharSupport vendor path method to support more packages

Removes the requirement that the vendor package is `framework` and updates the resolver to handle other Hyde packages.

### Update path helper to not format Phar paths
This should resolve a lot of the issues we're having with the standalone, due to Phar paths being formatted like `'H:\monorepo/phar://foo'`, when they should be unchanged (`'phar://foo'`)

### Update dashboard to load scripts from Phar

Update dashboard to inject scripts directly from archive when running in Phar