### PR TITLE
Shorten path printed to console when using dashboard to create a page

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -13,7 +13,7 @@ This serves two purposes:
 - for new features.
 
 ### Changed
-- for changes in existing functionality.
+- Shortened the path printed to console when using dashboard to create a page in https://github.com/hydephp/develop/pull/1492
 
 ### Deprecated
 - for soon-to-be removed features.

--- a/packages/realtime-compiler/src/Http/DashboardController.php
+++ b/packages/realtime-compiler/src/Http/DashboardController.php
@@ -357,7 +357,7 @@ class DashboardController extends BaseController
             $this->abort($exception->getCode(), $exception->getMessage());
         }
 
-        $this->writeToConsole(sprintf("Created file '%s'", $path), 'dashboard@createPage');
+        $this->writeToConsole(sprintf("Created file '%s'", Hyde::pathToRelative($path)), 'dashboard@createPage');
 
         $this->flash('justCreatedPage', RouteKey::fromPage($pageClass, $pageClass::pathToIdentifier($path))->get());
         $this->setJsonResponse(201, "Created file '$path'!");

--- a/packages/realtime-compiler/src/Http/DashboardController.php
+++ b/packages/realtime-compiler/src/Http/DashboardController.php
@@ -357,7 +357,7 @@ class DashboardController extends BaseController
             $this->abort($exception->getCode(), $exception->getMessage());
         }
 
-        $this->writeToConsole("Created file '$path'", 'dashboard@createPage');
+        $this->writeToConsole(sprintf("Created file '%s'", $path), 'dashboard@createPage');
 
         $this->flash('justCreatedPage', RouteKey::fromPage($pageClass, $pageClass::pathToIdentifier($path))->get());
         $this->setJsonResponse(201, "Created file '$path'!");


### PR DESCRIPTION
Uses just the relative path, instead of the absolute one, partly because having the qualifier adds nothing since Hyde always only modifies files in the project, and partly to make it shorter to fit smaller consoles.