### PR TITLE
Clean up and normalize class description comments

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -14,6 +14,7 @@ This serves two purposes:
 
 ### Changed
 - Shortened the path printed to console when using the dashboard to create a page in https://github.com/hydephp/develop/pull/1492
+- Code cleanup and style improvements in https://github.com/hydephp/develop/pull/1501 and https://github.com/hydephp/develop/pull/1502
 
 ### Deprecated
 - for soon-to-be removed features.

--- a/packages/framework/src/Console/Commands/BuildRssFeedCommand.php
+++ b/packages/framework/src/Console/Commands/BuildRssFeedCommand.php
@@ -8,7 +8,7 @@ use Hyde\Framework\Actions\PostBuildTasks\GenerateRssFeed;
 use LaravelZero\Framework\Commands\Command;
 
 /**
- * Hyde command to run the build process for the RSS feed.
+ * Run the build process for the RSS feed.
  */
 class BuildRssFeedCommand extends Command
 {

--- a/packages/framework/src/Console/Commands/BuildSearchCommand.php
+++ b/packages/framework/src/Console/Commands/BuildSearchCommand.php
@@ -8,7 +8,7 @@ use Hyde\Framework\Actions\PostBuildTasks\GenerateSearch;
 use LaravelZero\Framework\Commands\Command;
 
 /**
- * Hyde command to run the build process for the documentation search index.
+ * Run the build process for the documentation search index.
  */
 class BuildSearchCommand extends Command
 {

--- a/packages/framework/src/Console/Commands/BuildSiteCommand.php
+++ b/packages/framework/src/Console/Commands/BuildSiteCommand.php
@@ -20,7 +20,7 @@ use function sprintf;
 use function app;
 
 /**
- * Run the Build Process.
+ * Run the static site build process.
  */
 class BuildSiteCommand extends Command
 {

--- a/packages/framework/src/Console/Commands/BuildSiteCommand.php
+++ b/packages/framework/src/Console/Commands/BuildSiteCommand.php
@@ -20,7 +20,7 @@ use function sprintf;
 use function app;
 
 /**
- * Hyde command to run the Build Process.
+ * Run the Build Process.
  */
 class BuildSiteCommand extends Command
 {

--- a/packages/framework/src/Console/Commands/BuildSiteCommand.php
+++ b/packages/framework/src/Console/Commands/BuildSiteCommand.php
@@ -20,7 +20,7 @@ use function sprintf;
 use function app;
 
 /**
- * Hyde Command to run the Build Process.
+ * Hyde command to run the Build Process.
  */
 class BuildSiteCommand extends Command
 {

--- a/packages/framework/src/Console/Commands/BuildSitemapCommand.php
+++ b/packages/framework/src/Console/Commands/BuildSitemapCommand.php
@@ -8,7 +8,7 @@ use Hyde\Framework\Actions\PostBuildTasks\GenerateSitemap;
 use LaravelZero\Framework\Commands\Command;
 
 /**
- * Hyde command to run the build process for the sitemap.
+ * Run the build process for the sitemap.
  */
 class BuildSitemapCommand extends Command
 {

--- a/packages/framework/src/Console/Commands/ChangeSourceDirectoryCommand.php
+++ b/packages/framework/src/Console/Commands/ChangeSourceDirectoryCommand.php
@@ -21,6 +21,9 @@ use function str_replace;
 use function basename;
 use function realpath;
 
+/**
+ * Change the source directory for your project.
+ */
 class ChangeSourceDirectoryCommand extends Command
 {
     /** @var string */

--- a/packages/framework/src/Console/Commands/DebugCommand.php
+++ b/packages/framework/src/Console/Commands/DebugCommand.php
@@ -14,7 +14,7 @@ use function realpath;
 use function app;
 
 /**
- * Hyde command to print debug information.
+ * Print debug information.
  */
 class DebugCommand extends Command
 {

--- a/packages/framework/src/Console/Commands/DebugCommand.php
+++ b/packages/framework/src/Console/Commands/DebugCommand.php
@@ -14,7 +14,7 @@ use function realpath;
 use function app;
 
 /**
- * Hyde Command to print debug information.
+ * Hyde command to print debug information.
  */
 class DebugCommand extends Command
 {

--- a/packages/framework/src/Console/Commands/MakePageCommand.php
+++ b/packages/framework/src/Console/Commands/MakePageCommand.php
@@ -15,7 +15,7 @@ use function strtolower;
 use function ucfirst;
 
 /**
- * Hyde Command to scaffold a new Markdown or Blade page file.
+ * Hyde command to scaffold a new Markdown or Blade page file.
  */
 class MakePageCommand extends Command
 {

--- a/packages/framework/src/Console/Commands/MakePageCommand.php
+++ b/packages/framework/src/Console/Commands/MakePageCommand.php
@@ -15,7 +15,7 @@ use function strtolower;
 use function ucfirst;
 
 /**
- * Hyde command to scaffold a new Markdown or Blade page file.
+ * Scaffold a new Markdown or Blade page file.
  */
 class MakePageCommand extends Command
 {

--- a/packages/framework/src/Console/Commands/MakePostCommand.php
+++ b/packages/framework/src/Console/Commands/MakePostCommand.php
@@ -12,7 +12,7 @@ use function sprintf;
 use function ucwords;
 
 /**
- * Hyde command to scaffold a new Markdown Post.
+ * Scaffold a new Markdown Post.
  */
 class MakePostCommand extends Command
 {

--- a/packages/framework/src/Console/Commands/MakePostCommand.php
+++ b/packages/framework/src/Console/Commands/MakePostCommand.php
@@ -12,7 +12,7 @@ use function sprintf;
 use function ucwords;
 
 /**
- * Hyde Command to scaffold a new Markdown Post.
+ * Hyde command to scaffold a new Markdown Post.
  */
 class MakePostCommand extends Command
 {

--- a/packages/framework/src/Console/Commands/MakePostCommand.php
+++ b/packages/framework/src/Console/Commands/MakePostCommand.php
@@ -12,7 +12,7 @@ use function sprintf;
 use function ucwords;
 
 /**
- * Scaffold a new Markdown Post.
+ * Scaffold a new Markdown blog post file.
  */
 class MakePostCommand extends Command
 {

--- a/packages/framework/src/Console/Commands/PackageDiscoverCommand.php
+++ b/packages/framework/src/Console/Commands/PackageDiscoverCommand.php
@@ -8,6 +8,9 @@ use Hyde\Hyde;
 use Illuminate\Foundation\Console\PackageDiscoverCommand as BaseCommand;
 use Illuminate\Foundation\PackageManifest;
 
+/**
+ * Extended package discovery command to use the custom manifest path.
+ */
 class PackageDiscoverCommand extends BaseCommand
 {
     /** @var true */

--- a/packages/framework/src/Console/Commands/PublishConfigsCommand.php
+++ b/packages/framework/src/Console/Commands/PublishConfigsCommand.php
@@ -12,7 +12,7 @@ use function array_search;
 use function sprintf;
 
 /**
- * Publish the Hyde Config Files.
+ * Publish the Hyde config files.
  */
 class PublishConfigsCommand extends Command
 {

--- a/packages/framework/src/Console/Commands/PublishHomepageCommand.php
+++ b/packages/framework/src/Console/Commands/PublishHomepageCommand.php
@@ -18,7 +18,7 @@ use function str_replace;
 use function strstr;
 
 /**
- * Publish one of the default homepages.
+ * Publish one of the default homepages to index.blade.php.
  */
 class PublishHomepageCommand extends Command
 {

--- a/packages/framework/src/Console/Commands/RebuildPageCommand.php
+++ b/packages/framework/src/Console/Commands/RebuildPageCommand.php
@@ -24,7 +24,7 @@ use function str_replace;
 use function unslash;
 
 /**
- * Hyde command to build a single static site file.
+ * Build a single static site file.
  */
 class RebuildPageCommand extends Command
 {

--- a/packages/framework/src/Console/Commands/RebuildPageCommand.php
+++ b/packages/framework/src/Console/Commands/RebuildPageCommand.php
@@ -24,7 +24,7 @@ use function str_replace;
 use function unslash;
 
 /**
- * Hyde Command to build a single static site file.
+ * Hyde command to build a single static site file.
  */
 class RebuildPageCommand extends Command
 {

--- a/packages/framework/src/Console/Commands/RouteListCommand.php
+++ b/packages/framework/src/Console/Commands/RouteListCommand.php
@@ -15,7 +15,7 @@ use function file_exists;
 use function sprintf;
 
 /**
- * Hyde command to display the list of site routes.
+ * Display the list of site routes.
  */
 class RouteListCommand extends Command
 {

--- a/packages/framework/src/Console/Commands/ValidateCommand.php
+++ b/packages/framework/src/Console/Commands/ValidateCommand.php
@@ -13,6 +13,9 @@ use function microtime;
 use function sprintf;
 use function sizeof;
 
+/**
+ * Run a series of tests to validate your setup and help you optimize your site.
+ */
 class ValidateCommand extends Command
 {
     use TracksExecutionTime;

--- a/packages/framework/src/Foundation/Kernel/RouteCollection.php
+++ b/packages/framework/src/Foundation/Kernel/RouteCollection.php
@@ -10,7 +10,8 @@ use Hyde\Pages\Concerns\HydePage;
 use Hyde\Support\Models\Route;
 
 /**
- * The RouteCollection contains all the routes, making it the Pseudo-Router for Hyde.
+ * The RouteCollection contains all the page routes, making it the pseudo-router for Hyde,
+ * as it maps each page to the eventual URL that will be used to access it once built.
  *
  * @template T of \Hyde\Support\Models\Route
  *

--- a/packages/framework/src/Framework/Actions/StaticPageBuilder.php
+++ b/packages/framework/src/Framework/Actions/StaticPageBuilder.php
@@ -10,7 +10,7 @@ use Hyde\Framework\Concerns\InteractsWithDirectories;
 use Hyde\Pages\Concerns\HydePage;
 
 /**
- * Converts a Page Model into a static HTML page.
+ * Converts a Hyde page object into a static HTML page.
  */
 class StaticPageBuilder
 {

--- a/packages/framework/src/Framework/Concerns/InteractsWithFrontMatter.php
+++ b/packages/framework/src/Framework/Concerns/InteractsWithFrontMatter.php
@@ -11,7 +11,7 @@ use function array_merge;
 use function blank;
 
 /**
- * Adds methods to a class to allow it to fluently interact with the front matter.
+ * Adds methods to a class to allow it to fluently interact with its front matter.
  */
 trait InteractsWithFrontMatter
 {

--- a/packages/framework/src/Framework/Features/Blogging/Models/PostAuthor.php
+++ b/packages/framework/src/Framework/Features/Blogging/Models/PostAuthor.php
@@ -13,7 +13,7 @@ use function strtolower;
 use function is_string;
 
 /**
- * The Post Author model object.
+ * Object representation of a post author for the site.
  */
 class PostAuthor implements Stringable
 {

--- a/packages/publications/src/Commands/MakePublicationCommand.php
+++ b/packages/publications/src/Commands/MakePublicationCommand.php
@@ -25,7 +25,7 @@ use function in_array;
 use function str_starts_with;
 
 /**
- * Hyde Command to create a new publication for a given publication type.
+ * Hyde command to create a new publication for a given publication type.
  *
  * @see \Hyde\Publications\Actions\CreatesNewPublicationPage
  * @see \Hyde\Publications\Testing\Feature\MakePublicationCommandTest

--- a/packages/publications/src/Commands/MakePublicationTypeCommand.php
+++ b/packages/publications/src/Commands/MakePublicationTypeCommand.php
@@ -24,7 +24,7 @@ use function array_keys;
 use function strtolower;
 
 /**
- * Hyde Command to create a new publication type.
+ * Hyde command to create a new publication type.
  *
  * @see \Hyde\Publications\Actions\CreatesNewPublicationType
  * @see \Hyde\Publications\Testing\Feature\MakePublicationTypeCommandTest

--- a/packages/publications/src/Commands/SeedPublicationCommand.php
+++ b/packages/publications/src/Commands/SeedPublicationCommand.php
@@ -16,7 +16,7 @@ use function round;
 use function sprintf;
 
 /**
- * Hyde Command to seed publication files for a publication type.
+ * Hyde command to seed publication files for a publication type.
  *
  * @see \Hyde\Publications\Actions\SeedsPublicationFiles
  * @see \Hyde\Publications\Testing\Feature\SeedPublicationCommandTest

--- a/packages/publications/src/Commands/ValidatePublicationTypesCommand.php
+++ b/packages/publications/src/Commands/ValidatePublicationTypesCommand.php
@@ -23,7 +23,7 @@ use function round;
 use function sprintf;
 
 /**
- * Hyde Command to validate all publication schema file..
+ * Hyde command to validate all publication schema file..
  *
  * @see \Hyde\Publications\Testing\Feature\ValidatePublicationTypesCommandTest
  *

--- a/packages/publications/src/Commands/ValidatePublicationsCommand.php
+++ b/packages/publications/src/Commands/ValidatePublicationsCommand.php
@@ -34,7 +34,7 @@ use function strlen;
 use function substr_count;
 
 /**
- * Hyde Command to validate one or all publications.
+ * Hyde command to validate one or all publications.
  *
  * @see \Hyde\Publications\Testing\Feature\ValidatePublicationsCommandTest
  *


### PR DESCRIPTION
Made this crude script to help, posting here in case of me wanting it in the future again.

```php
<?php

// Create a list of all class descriptions (the first line in a PHPDoc) in the Framework package.

require_once __DIR__.'/../vendor/autoload.php';

$files = (new \Illuminate\Filesystem\Filesystem())->allFiles(__DIR__.'/../packages/framework/src');

$html = '';


foreach ($files as $file) {
    $source = file_get_contents($file->getPathname());
    // If file is not a class, skip it.
    if (!str_contains($source, 'class ')) {
        continue;
    }

    $reflection = new ReflectionClass('Hyde\\'.str_replace('/', '\\', substr($file->getPathname(), strlen(__DIR__.'/../packages/framework/src/'), -4)));

    $doc = $reflection->getDocComment();
    if (empty($doc)) {
        $commentText = '<span style="color: red">Missing PHPDoc</span>';
    } else {
        $commentText = trim(str_replace(['*', '/', '@experimental', '@internal', '@property', '@mixin', '@see'], '', getFirstLine($doc) ?: $doc)) ?: '<span style="color: red">Empty PHPDoc</span>';
    }

    $html .= sprintf('<tr><td><a href="%s">%s</a></td><td>%s</td></tr>'."\n", $file->getPathname(), $reflection->getName(), $commentText);
}

$html = "<table><tbody>{$html}</tbody>";
file_put_contents(__DIR__.'/framework-classes.html', $html);
echo $html;

function getFirstLine(string $doc): string
{
    $lines = explode("\n", $doc);
    return $lines[1] ?? '';
}
```