### PR TITLE
Normalize console command descriptions

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -14,7 +14,7 @@ This serves two purposes:
 
 ### Changed
 - Shortened the path printed to console when using the dashboard to create a page in https://github.com/hydephp/develop/pull/1492
-- Code cleanup and style improvements in https://github.com/hydephp/develop/pull/1501 and https://github.com/hydephp/develop/pull/1502
+- Code cleanup and style improvements in https://github.com/hydephp/develop/pull/1501, https://github.com/hydephp/develop/pull/1502, and https://github.com/hydephp/develop/pull/1503.
 
 ### Deprecated
 - for soon-to-be removed features.

--- a/packages/framework/src/Console/Commands/ChangeSourceDirectoryCommand.php
+++ b/packages/framework/src/Console/Commands/ChangeSourceDirectoryCommand.php
@@ -30,7 +30,7 @@ class ChangeSourceDirectoryCommand extends Command
     protected $signature = 'change:sourceDirectory {name : The new source directory name }';
 
     /** @var string */
-    protected $description = 'Change the source directory for your project.';
+    protected $description = 'Change the source directory for your project';
 
     protected $hidden = true;
 

--- a/packages/framework/src/Console/Commands/DebugCommand.php
+++ b/packages/framework/src/Console/Commands/DebugCommand.php
@@ -22,7 +22,7 @@ class DebugCommand extends Command
     protected $signature = 'debug';
 
     /** @var string */
-    protected $description = 'Print debug info';
+    protected $description = 'Print debug information';
 
     public function __construct()
     {

--- a/packages/framework/src/Console/Commands/PublishHomepageCommand.php
+++ b/packages/framework/src/Console/Commands/PublishHomepageCommand.php
@@ -29,7 +29,7 @@ class PublishHomepageCommand extends Command
                                 {--force : Overwrite any existing files}';
 
     /** @var string */
-    protected $description = 'Publish one of the default homepages to index.blade.php.';
+    protected $description = 'Publish one of the default homepages to index.blade.php';
 
     /** @var array<string, array{name: string, description: string, group: string}> */
     protected array $options = [

--- a/packages/framework/src/Console/Commands/PublishViewsCommand.php
+++ b/packages/framework/src/Console/Commands/PublishViewsCommand.php
@@ -20,23 +20,23 @@ class PublishViewsCommand extends Command
     protected $signature = 'publish:views {category? : The category to publish}';
 
     /** @var string */
-    protected $description = 'Publish the hyde components for customization. Note that existing files will be overwritten.';
+    protected $description = 'Publish the hyde components for customization. Note that existing files will be overwritten';
 
     /** @var array<string, array<string, string>> */
     protected array $options = [
         'layouts' => [
             'name' => 'Blade Layouts',
-            'description' => 'Shared layout views, such as the app layout, navigation menu, and Markdown page templates.',
+            'description' => 'Shared layout views, such as the app layout, navigation menu, and Markdown page templates',
             'group' => 'hyde-layouts',
         ],
         'components' => [
             'name' => 'Blade Components',
-            'description' => 'More or less self contained components, extracted for customizability and DRY code.',
+            'description' => 'More or less self contained components, extracted for customizability and DRY code',
             'group' => 'hyde-components',
         ],
         'page-404' => [
             'name' => '404 Page',
-            'description' => 'A beautiful 404 error page by the Laravel Collective.',
+            'description' => 'A beautiful 404 error page by the Laravel Collective',
             'group' => 'hyde-page-404',
         ],
     ];

--- a/packages/framework/src/Console/Commands/RouteListCommand.php
+++ b/packages/framework/src/Console/Commands/RouteListCommand.php
@@ -23,7 +23,7 @@ class RouteListCommand extends Command
     protected $signature = 'route:list';
 
     /** @var string */
-    protected $description = 'Display all registered routes';
+    protected $description = 'Display all the registered routes';
 
     public function handle(): int
     {

--- a/packages/framework/src/Console/Commands/RouteListCommand.php
+++ b/packages/framework/src/Console/Commands/RouteListCommand.php
@@ -23,7 +23,7 @@ class RouteListCommand extends Command
     protected $signature = 'route:list';
 
     /** @var string */
-    protected $description = 'Display all registered routes.';
+    protected $description = 'Display all registered routes';
 
     public function handle(): int
     {

--- a/packages/framework/src/Console/Commands/ServeCommand.php
+++ b/packages/framework/src/Console/Commands/ServeCommand.php
@@ -36,7 +36,7 @@ class ServeCommand extends Command
     ';
 
     /** @var string */
-    protected $description = 'Start the realtime compiler server.';
+    protected $description = 'Start the realtime compiler server';
 
     protected ConsoleOutput $console;
 

--- a/packages/framework/src/Console/Commands/ValidateCommand.php
+++ b/packages/framework/src/Console/Commands/ValidateCommand.php
@@ -24,10 +24,10 @@ class ValidateCommand extends Command
     protected $signature = 'validate';
 
     /** @var string */
-    protected $description = 'Test and validate your project to optimize your site.';
+    protected $description = 'Test and validate your project to optimize your site';
 
     /** @var string */
-    protected $help = 'Run a series of tests to validate your setup and help you optimize your site.';
+    protected $help = 'Run a series of tests to validate your setup and help you optimize your site';
 
     protected ValidationService $service;
 


### PR DESCRIPTION
Crude script to get a good overview of all of these

```php
<?php

// Create a list of all console command descriptions in the Framework package.

require_once __DIR__.'/../vendor/autoload.php';

$html = '';

$classes = (new \Illuminate\Filesystem\Filesystem())->allFiles(__DIR__.'/../packages/framework/src/Console/Commands');

foreach ($classes as $class) {
    $source = file_get_contents($class->getPathname());
    $description = 'No description found';
    foreach (explode("\n", $source) as $line) {
        if (str_contains($line, 'protected $description')) {
            $description = trim(str_replace(['protected $description = ', ';', "'"], '', $line));
            break;
        }
    }
    $name = str_replace('.php', '', $class->getFilename());
    $path = str_replace('\\', '/', substr($class->getPathname(), strlen(__DIR__.'/../packages/framework/src/')));
    $html .= sprintf('<tr><td><a href="%s">%s</a></td><td>%s</td></tr>'."\n", $path, $name, $description);
}


$html = "<table><tbody>{$html}</tbody></table>";
file_put_contents(__DIR__.'/framework-console-commands.html', $html);
echo $html;

```