### PR TITLE
Improve the semantic documentation article Blade view

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -13,7 +13,8 @@ This serves two purposes:
 - for new features.
 
 ### Changed
-- for changes in existing functionality.
+- Renamed local template variable `$document` to `$article` to better match the usage in https://github.com/hydephp/develop/pull/1506
+- Updated semantic documentation article component to support existing variables in https://github.com/hydephp/develop/pull/1506
 
 ### Deprecated
 - for soon-to-be removed features.

--- a/packages/framework/resources/views/components/docs/documentation-article.blade.php
+++ b/packages/framework/resources/views/components/docs/documentation-article.blade.php
@@ -1,5 +1,5 @@
 @php
-    $article = \Hyde\Framework\Features\Documentation\SemanticDocumentationArticle::make($page);
+    $article ??= \Hyde\Framework\Features\Documentation\SemanticDocumentationArticle::make($page);
 @endphp
 
 <article id="document" itemscope itemtype="https://schema.org/Article" @class([

--- a/packages/framework/resources/views/components/docs/documentation-article.blade.php
+++ b/packages/framework/resources/views/components/docs/documentation-article.blade.php
@@ -1,20 +1,20 @@
 @php
-    $document = \Hyde\Framework\Features\Documentation\SemanticDocumentationArticle::make($page);
+    $article = \Hyde\Framework\Features\Documentation\SemanticDocumentationArticle::make($page);
 @endphp
 
 <article id="document" itemscope itemtype="https://schema.org/Article" @class([
         'mx-auto lg:ml-8 max-w-3xl p-12 md:px-16 max-w-[1000px] min-h-[calc(100vh_-_4rem)]',
         config('markdown.prose_classes', 'prose dark:prose-invert'),
-        'torchlight-enabled' => $document->hasTorchlight()])>
+        'torchlight-enabled' => $article->hasTorchlight()])>
     @yield('content')
 
     <header id="document-header" class="flex items-center flex-wrap justify-between prose-h1:mb-3">
-        {{ $document->renderHeader() }}
+        {{ $article->renderHeader() }}
     </header>
     <section id="document-main-content" itemprop="articleBody">
-        {{ $document->renderBody() }}
+        {{ $article->renderBody() }}
     </section>
     <footer id="document-footer" class="flex items-center flex-wrap mt-8 prose-p:my-3 justify-between text-[90%]">
-        {{ $document->renderFooter() }}
+        {{ $article->renderFooter() }}
     </footer>
 </article>

--- a/packages/framework/tests/Feature/Services/HydeSmartDocsTest.php
+++ b/packages/framework/tests/Feature/Services/HydeSmartDocsTest.php
@@ -198,6 +198,28 @@ class HydeSmartDocsTest extends TestCase
         $this->assertStringContainsString('<p>Hello world.</p>', $rendered);
     }
 
+    public function test_the_documentation_article_view_with_existing_variable()
+    {
+        $rendered = view('hyde::components.docs.documentation-article', [
+            'page' => $page = $this->makePage(),
+            'article' => new class($page) extends SemanticDocumentationArticle
+            {
+                public function __construct(DocumentationPage $page)
+                {
+                    parent::__construct($page);
+                }
+
+                public function renderHeader(): HtmlString
+                {
+                    return new HtmlString('<h1>Custom Header</h1>');
+                }
+            },
+        ])->render();
+
+        $this->assertStringContainsString('<h1>Custom Header</h1>', $rendered);
+        $this->assertStringContainsString('<p>Hello world.</p>', $rendered);
+    }
+
     protected function makeArticle(string $sourceFileContents = "# Foo\n\nHello world."): SemanticDocumentationArticle
     {
         $this->file('_docs/foo.md', $sourceFileContents);


### PR DESCRIPTION
### Changes

#### Renames the local template variable `$document` to `$article` to better match the usage
- This also makes it more inline with the `$article` used by blog posts.

#### Updates documentation article component to support existing variables
- Allows for them to be passed from a model class, for example.