### PR TITLE
Fix icons not being considered as images by dashboard viewer

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -23,7 +23,7 @@ This serves two purposes:
 - for now removed features.
 
 ### Fixed
-- for any bug fixes.
+- Fixed icons not being considered images by dashboard viewer in 
 
 ### Security
 - in case of vulnerabilities.

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -23,7 +23,7 @@ This serves two purposes:
 - for now removed features.
 
 ### Fixed
-- Fixed icons not being considered images by dashboard viewer in 
+- Fixed icons not being considered as images by dashboard viewer in https://github.com/hydephp/develop/pull/1512
 
 ### Security
 - in case of vulnerabilities.

--- a/packages/realtime-compiler/resources/dashboard.blade.php
+++ b/packages/realtime-compiler/resources/dashboard.blade.php
@@ -292,7 +292,7 @@
                             @foreach(\Hyde\Support\Filesystem\MediaFile::all() as $mediaFile)
                                 <div class="col-lg-4 p-2 d-flex flex-grow-1">
                                     <figure class="card w-100 p-2 mb-0">
-                                        @if(in_array($mediaFile->getExtension(), ['svg', 'png', 'jpg', 'jpeg', 'gif']))
+                                        @if(in_array($mediaFile->getExtension(), ['svg', 'png', 'jpg', 'jpeg', 'gif', 'ico']))
                                             <img loading="lazy" src="media/{{ $mediaFile->getIdentifier() }}" alt="{{ $mediaFile->getName() }}" class="object-fit-cover w-100 rounded-2" style="height: 240px;">
                                         @else
                                             <code style="height: 240px; overflow: hidden; -webkit-mask-image: linear-gradient(180deg, white 60%, transparent);" role="presentation">


### PR DESCRIPTION
Realtime compiler dashboard bugfix, where `.ico` files had their binary data printed instead of being previewed.