### PR TITLE
RFC: Allow the Blade view to be set using front matter for Markdown pages

### DIFF
--- a/packages/framework/src/Pages/MarkdownPage.php
+++ b/packages/framework/src/Pages/MarkdownPage.php
@@ -19,4 +19,9 @@ class MarkdownPage extends BaseMarkdownPage
     public static string $sourceDirectory = '_pages';
     public static string $outputDirectory = '';
     public static string $template = 'hyde::layouts/page';
+
+    public function getBladeView(): string
+    {
+        return $this->matter->get('extends') ?? parent::getBladeView();
+    }
 }


### PR DESCRIPTION
## Abstract

### Summary

This proposal adds a front matter option for Markdown pages to allow a custom Blade template to be used.

### Usage

```markdown
---
extends: my-custom-layout
---

# Markdown content here

Lorem Ipsum Dolor Sit Amet.
```

### Implementation

Implementation is simple by adding the following method override to the `MarkdownPage` class.

This makes the change fully backwards compatible as it null coalesces to the default behaviour.

```php
public function getBladeView(): string
{
    return $this->matter->get('extends') ?? parent::getBladeView();
}
```

### Alternate implementations

I initially went with `extends` as the front matter key, as that matches the Blade syntax. I also see that Jigsaw uses extends. However Jekyll uses `layout`. We could also support both, same as we support both group and category for navigation data.

### My thoughts on the matter

Something like this was considered when originally creating HydePHP as I did not find it necessary, and it risks adding complexity without value. Additionally, for most sites this is not needed as the various page types have different views that get automatically configured, and an override could make things less obvious.

Furthermore, the general use of HydePHP means that it's okay that most Markdown-based pages look the same in terms of layout. However, I realize now that I think it could be useful for Markdown pages for sites with a lot of Markdown page content to have this option.

And considering how surprisingly light this implementation is codewise it comes down to the following: Is this a design pattern we want to encourage? And if the answer is no, is that reason enough not to implement this? Even if something is discouraged we can still have the option for users do things the way they want. For some people this might fit their workflow. And since it's opt-in and doesn't add any unnecessary boilerplate for those who are happy with the defaults I think this feature could be useful.

I always like to get user feedback, hence why I drafted this as an RFC, paired with a [Twitter poll](https://twitter.com/CodeWithCaen/status/1753090055705407905). In addition to knowing if users are for or against this, I would also love to get feedback on the front matter property name issue mentioned above: if we should use `extends` or `layout`.

### Voting

Please vote with an emoji on this post:
- Yes: 👍
- No: 👎
- Undecided: 😕

Or vote via the [Twitter poll](https://twitter.com/CodeWithCaen/status/1753090055705407905).

Please also leave feedback in the comments!