### PR TITLE
Make heading permalink hashes hidden when not hovered

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -24,6 +24,7 @@ This serves two purposes:
 
 ### Fixed
 - Fixed icons not being considered as images by dashboard viewer in https://github.com/hydephp/develop/pull/1512
+- HydeFront: Fixed bug where heading permalink buttons were included in text represented output in https://github.com/hydephp/develop/pull/1519
 
 ### Security
 - in case of vulnerabilities.

--- a/packages/hydefront/sass/docs/heading-permalinks.scss
+++ b/packages/hydefront/sass/docs/heading-permalinks.scss
@@ -13,12 +13,14 @@
 
 			.heading-permalink {
 				opacity: 0;
+				visibility: hidden;
 				margin-left: 0.25rem;
 				transition: opacity 0.3s ease;
 				padding: 0 0.25rem;
 				scroll-margin: 1rem;
 				&:hover, &:focus {
 					opacity: 1;
+					visibility: visible;
 					filter: unset;
 				}
 			}


### PR DESCRIPTION
Should fix a bug where crawlers like Google Bot thinks this is a part of the heading, leading to it being visible in search results.

![image](https://github.com/hydephp/develop/assets/95144705/34aa1d13-4d0f-41b2-9ded-ccf867e24da5)

Adding `display: hidden` would likely solve this, but that breaks the transition. Using visibility modifiers should work the same, but retain the existing visual behaviour.

![image](https://github.com/hydephp/develop/assets/95144705/5ee9867e-e0f3-49db-af3e-eefe6ef41617)
