### PR TITLE
Remove inline block display from inline code elements

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -15,6 +15,7 @@ This serves two purposes:
 ### Changed
 - Renamed local template variable `$document` to `$article` to better match the usage in https://github.com/hydephp/develop/pull/1506
 - Updated semantic documentation article component to support existing variables in https://github.com/hydephp/develop/pull/1506
+- HydeFront: Changed `<code>` styling to display as inline instead of inline-block in https://github.com/hydephp/develop/pull/1525
 
 ### Deprecated
 - for soon-to-be removed features.
@@ -25,6 +26,7 @@ This serves two purposes:
 ### Fixed
 - Fixed icons not being considered as images by dashboard viewer in https://github.com/hydephp/develop/pull/1512
 - HydeFront: Fixed bug where heading permalink buttons were included in text represented output in https://github.com/hydephp/develop/pull/1519
+- HydeFront: Fix visual overflow bug in inline code blocks within blockquotes https://github.com/hydephp/hydefront/issues/65 in https://github.com/hydephp/develop/pull/1525
 
 ### Security
 - in case of vulnerabilities.

--- a/packages/hydefront/sass/markdown/codeblocks.scss
+++ b/packages/hydefront/sass/markdown/codeblocks.scss
@@ -3,7 +3,6 @@
 code {
 	max-width: 80vw;
 	overflow-x: auto;
-	display: inline-block;
 	vertical-align: top;
 	word-break: break-all;
 }


### PR DESCRIPTION
Removes the HydeFront style specified to make `inline code` tags render as `inline-block`, instead letting them be the default `inline` display.

This fixes the visual overflow bug in https://github.com/hydephp/hydefront/issues/65, and improves line height compatibility as the code background now fits to the text instead of taking up the full line height. This also desirably removes the extra background above the text.