### PR TITLE
Add media extensions option to default config

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -20,7 +20,7 @@ This serves two purposes:
 2. At release time, you can move the Unreleased section changes into a new release version section.
 
 ### Added
-- for new features.
+- Added the existing `media_extensions` option to the `hyde` configuration file in https://github.com/hydephp/develop/pull/1531
 
 ### Changed
 - Renamed local template variable `$document` to `$article` to better match the usage in https://github.com/hydephp/develop/pull/1506

--- a/config/hyde.php
+++ b/config/hyde.php
@@ -446,6 +446,10 @@ return [
     |
     */
 
+    // Change the file extensions to be considered as media files and are copied to the output directory.
+    // If you want to add more extensions, add it to the empty merge array, or just override the entire array.
+    'media_extensions' => array_merge([], \Hyde\Support\Filesystem\MediaFile::EXTENSIONS),
+
     // The list of directories that are considered to be safe to empty upon site build.
     // If the site output directory is set to a directory that is not in this list,
     // the build command will prompt for confirmation before emptying it.

--- a/packages/framework/config/hyde.php
+++ b/packages/framework/config/hyde.php
@@ -446,9 +446,8 @@ return [
     |
     */
 
-    // Change the file extensions to be considered as media files.
-    // If you want to add more extensions, use the merge array.
-    // If you want to replace them, override the entire array.
+    // Change the file extensions to be considered as media files and are copied to the output directory.
+    // If you want to add more extensions, add it to the empty merge array, or just override the entire array.
     'media_extensions' => array_merge([], \Hyde\Support\Filesystem\MediaFile::EXTENSIONS),
 
     // The list of directories that are considered to be safe to empty upon site build.

--- a/packages/framework/config/hyde.php
+++ b/packages/framework/config/hyde.php
@@ -446,6 +446,11 @@ return [
     |
     */
 
+    // Change the file extensions to be considered as media files.
+    // If you want to add more extensions, use the merge array.
+    // If you want to replace them, override the entire array.
+    'media_extensions' => array_merge([], \Hyde\Support\Filesystem\MediaFile::EXTENSIONS),
+
     // The list of directories that are considered to be safe to empty upon site build.
     // If the site output directory is set to a directory that is not in this list,
     // the build command will prompt for confirmation before emptying it.


### PR DESCRIPTION
Since I've gotten a few people wondering about changing the extensions, I figure we should include it in the default config. See https://github.com/hydephp/develop/pull/105 for the PR that implemented this "hidden" option.