### PR TITLE
Deprecate `BuildService::transferMediaAssets()`

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -28,7 +28,7 @@ This serves two purposes:
 - HydeFront: Changed `<code>` styling to display as inline instead of inline-block in https://github.com/hydephp/develop/pull/1525
 
 ### Deprecated
-- for soon-to-be removed features.
+- Deprecated the `BuildService::transferMediaAssets()` method in https://github.com/hydephp/develop/pull/1533, as it will be moved into a build task in v2.0.
 
 ### Removed
 - for now removed features.

--- a/packages/framework/src/Framework/Services/BuildService.php
+++ b/packages/framework/src/Framework/Services/BuildService.php
@@ -48,6 +48,7 @@ class BuildService
         });
     }
 
+    /** @deprecated This method will be replaced by a build task in v2.0 */
     public function transferMediaAssets(): void
     {
         $this->needsDirectory(Hyde::siteMediaPath());


### PR DESCRIPTION
This method will be replaced by a build task in v2.0. See https://github.com/hydephp/develop/pull/1536

Drafting until implementation is made for the v2 branch, at which point the release notes for this branch will be updated.