### PR TITLE
Refactor media asset transferring to a build task

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -71,7 +71,7 @@ according to the information below in case you wrote custom code that interacted
   you would now need to do that in the kernel page collection due to the search pages being generated earlier in the lifecycle.
   https://github.com/hydephp/develop/commit/82dc71f4a0e7b6be7a9f8d822fbebe39d2289ced
 
-### Media asset transfers
+### Media asset transfer implementation changes
 
 The internals of how media asset files are copied during the build process have been changed. For most users, this change
 has no impact. However, if you have previously extended this method, or called it directly from your custom code,

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -10,16 +10,18 @@ This serves two purposes:
 2. At release time, you can move the Unreleased section changes into a new release version section.
 
 ### Added
-- for new features.
+- Added a new `\Hyde\Framework\Actions\PreBuildTasks\TransferMediaAssets` build task handle media assets transfers for site builds.
 
 ### Changed
 - Changed how the documentation search is generated, to be an `InMemoryPage` instead of a post-build task.
+- Media asset files are now copied using the new build task instead of the deprecated `BuildService::transferMediaAssets()` method.
 
 ### Deprecated
 - for soon-to-be removed features.
 
 ### Removed
 - Breaking: Removed the build task `\Hyde\Framework\Actions\PostBuildTasks\GenerateSearch` (see upgrade guide below)
+- Breaking: Removed the deprecated `\Hyde\Framework\Services\BuildService::transferMediaAssets()` method (see upgrade guide below)
 
 ### Fixed
 - for any bug fixes.
@@ -68,3 +70,17 @@ according to the information below in case you wrote custom code that interacted
 - In the highly unlikely event your site customizes any of the search pages by replacing them in the kernel route collection,
   you would now need to do that in the kernel page collection due to the search pages being generated earlier in the lifecycle.
   https://github.com/hydephp/develop/commit/82dc71f4a0e7b6be7a9f8d822fbebe39d2289ced
+
+### Media asset transfers
+
+The internals of how media asset files are copied during the build process have been changed. For most users, this change
+has no impact. However, if you have previously extended this method, or called it directly from your custom code,
+you will need to adapt your code to use the new `TransferMediaAssets` build task.
+
+For example, if you triggered the media transfer with a build service method call, use the new build task instead:
+
+```php
+(new BuildService)->transferMediaAssets();
+
+(new TransferMediaAssets())->run();
+```

--- a/packages/framework/src/Console/Commands/BuildSiteCommand.php
+++ b/packages/framework/src/Console/Commands/BuildSiteCommand.php
@@ -50,8 +50,6 @@ class BuildSiteCommand extends Command
 
         $this->runPreBuildActions();
 
-        $this->service->transferMediaAssets();
-
         $this->service->compileStaticPages();
 
         $this->runPostBuildActions();

--- a/packages/framework/src/Console/Commands/RebuildPageCommand.php
+++ b/packages/framework/src/Console/Commands/RebuildPageCommand.php
@@ -9,7 +9,7 @@ use Hyde\Console\Concerns\Command;
 use Hyde\Foundation\Facades\Pages;
 use Hyde\Framework\Actions\StaticPageBuilder;
 use Hyde\Framework\Features\BuildTasks\BuildTask;
-use Hyde\Framework\Services\BuildService;
+use Hyde\Framework\Actions\PreBuildTasks\TransferMediaAssets;
 use Hyde\Hyde;
 use Hyde\Pages\BladePage;
 use Hyde\Pages\DocumentationPage;
@@ -37,7 +37,7 @@ class RebuildPageCommand extends Command
     public function handle(): int
     {
         if ($this->argument('path') === Hyde::getMediaDirectory()) {
-            (new BuildService($this->getOutput()))->transferMediaAssets();
+            return (new TransferMediaAssets())->run($this->output);
 
             $this->info('All done!');
 

--- a/packages/framework/src/Framework/Actions/PreBuildTasks/TransferMediaAssets.php
+++ b/packages/framework/src/Framework/Actions/PreBuildTasks/TransferMediaAssets.php
@@ -8,5 +8,5 @@ use Hyde\Framework\Features\BuildTasks\PreBuildTask;
 
 class TransferMediaAssets extends PreBuildTask
 {
-    //
+    protected static string $message = 'Transferring Media Assets';
 }

--- a/packages/framework/src/Framework/Actions/PreBuildTasks/TransferMediaAssets.php
+++ b/packages/framework/src/Framework/Actions/PreBuildTasks/TransferMediaAssets.php
@@ -4,9 +4,25 @@ declare(strict_types=1);
 
 namespace Hyde\Framework\Actions\PreBuildTasks;
 
+use Hyde\Hyde;
+use Hyde\Support\Filesystem\MediaFile;
 use Hyde\Framework\Features\BuildTasks\PreBuildTask;
+use Hyde\Framework\Concerns\InteractsWithDirectories;
 
 class TransferMediaAssets extends PreBuildTask
 {
     protected static string $message = 'Transferring Media Assets';
+
+    use InteractsWithDirectories;
+
+    public function handle(): void
+    {
+        $this->needsDirectory(Hyde::siteMediaPath());
+
+        $this->withProgressBar(MediaFile::files(), function (string $identifier): void {
+            $sitePath = Hyde::siteMediaPath($identifier);
+            $this->needsParentDirectory($sitePath);
+            copy(Hyde::mediaPath($identifier), $sitePath);
+        });
+    }
 }

--- a/packages/framework/src/Framework/Actions/PreBuildTasks/TransferMediaAssets.php
+++ b/packages/framework/src/Framework/Actions/PreBuildTasks/TransferMediaAssets.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Hyde\Framework\Actions\PreBuildTasks;
+
+use Hyde\Framework\Features\BuildTasks\PreBuildTask;
+
+class TransferMediaAssets extends PreBuildTask
+{
+    //
+}

--- a/packages/framework/src/Framework/Actions/PreBuildTasks/TransferMediaAssets.php
+++ b/packages/framework/src/Framework/Actions/PreBuildTasks/TransferMediaAssets.php
@@ -19,6 +19,8 @@ class TransferMediaAssets extends PreBuildTask
     {
         $this->needsDirectory(Hyde::siteMediaPath());
 
+        $this->newLine();
+
         $this->withProgressBar(MediaFile::files(), function (string $identifier): void {
             $sitePath = Hyde::siteMediaPath($identifier);
             $this->needsParentDirectory($sitePath);

--- a/packages/framework/src/Framework/Actions/PreBuildTasks/TransferMediaAssets.php
+++ b/packages/framework/src/Framework/Actions/PreBuildTasks/TransferMediaAssets.php
@@ -26,6 +26,8 @@ class TransferMediaAssets extends PreBuildTask
             $this->needsParentDirectory($sitePath);
             copy(Hyde::mediaPath($identifier), $sitePath);
         });
+
+        $this->newLine();
     }
 
     public function printFinishMessage(): void

--- a/packages/framework/src/Framework/Actions/PreBuildTasks/TransferMediaAssets.php
+++ b/packages/framework/src/Framework/Actions/PreBuildTasks/TransferMediaAssets.php
@@ -25,4 +25,9 @@ class TransferMediaAssets extends PreBuildTask
             copy(Hyde::mediaPath($identifier), $sitePath);
         });
     }
+
+    public function printFinishMessage(): void
+    {
+        // We don't need a finish message for this task.
+    }
 }

--- a/packages/framework/src/Framework/Services/BuildService.php
+++ b/packages/framework/src/Framework/Services/BuildService.php
@@ -8,9 +8,7 @@ use Hyde\Hyde;
 use Hyde\Foundation\Facades\Routes;
 use Hyde\Foundation\Kernel\RouteCollection;
 use Hyde\Framework\Actions\StaticPageBuilder;
-use Hyde\Framework\Concerns\InteractsWithDirectories;
 use Hyde\Pages\Concerns\HydePage;
-use Hyde\Support\Filesystem\MediaFile;
 use Hyde\Support\Models\Route;
 use Illuminate\Console\Concerns\InteractsWithIO;
 use Illuminate\Console\OutputStyle;
@@ -18,7 +16,6 @@ use Illuminate\Console\OutputStyle;
 use function class_basename;
 use function preg_replace;
 use function collect;
-use function copy;
 
 /**
  * Moves logic from the build command to a service.
@@ -30,7 +27,6 @@ use function copy;
 class BuildService
 {
     use InteractsWithIO;
-    use InteractsWithDirectories;
 
     protected RouteCollection $router;
 
@@ -50,16 +46,7 @@ class BuildService
 
     public function transferMediaAssets(): void
     {
-        $this->needsDirectory(Hyde::siteMediaPath());
-
-        $this->comment('Transferring Media Assets...');
-        $this->withProgressBar(MediaFile::files(), function (string $identifier): void {
-            $sitePath = Hyde::siteMediaPath($identifier);
-            $this->needsParentDirectory($sitePath);
-            copy(Hyde::mediaPath($identifier), $sitePath);
-        });
-
-        $this->newLine(2);
+        //
     }
 
     /**

--- a/packages/framework/src/Framework/Services/BuildService.php
+++ b/packages/framework/src/Framework/Services/BuildService.php
@@ -44,11 +44,6 @@ class BuildService
         });
     }
 
-    public function transferMediaAssets(): void
-    {
-        //
-    }
-
     /**
      * @param  class-string<\Hyde\Pages\Concerns\HydePage>  $pageClass
      */

--- a/packages/framework/src/Framework/Services/BuildTaskService.php
+++ b/packages/framework/src/Framework/Services/BuildTaskService.php
@@ -133,7 +133,7 @@ class BuildTaskService
     private function registerFrameworkTasks(): void
     {
         $this->registerIf(CleanSiteDirectory::class, $this->canCleanSiteDirectory());
-        $this->registerTask(TransferMediaAssets::class);
+        $this->registerIf(TransferMediaAssets::class, $this->canTransferMediaAssets());
         $this->registerIf(GenerateBuildManifest::class, $this->canGenerateManifest());
         $this->registerIf(GenerateSitemap::class, $this->canGenerateSitemap());
         $this->registerIf(GenerateRssFeed::class, $this->canGenerateFeed());
@@ -142,6 +142,11 @@ class BuildTaskService
     private function canCleanSiteDirectory(): bool
     {
         return Config::getBool('hyde.empty_output_directory', true);
+    }
+
+    private function canTransferMediaAssets(): bool
+    {
+        return Config::getBool('hyde.transfer_media_assets', true);
     }
 
     private function canGenerateManifest(): bool

--- a/packages/framework/src/Framework/Services/BuildTaskService.php
+++ b/packages/framework/src/Framework/Services/BuildTaskService.php
@@ -13,6 +13,7 @@ use Hyde\Framework\Features\BuildTasks\PostBuildTask;
 use Hyde\Framework\Actions\PreBuildTasks\CleanSiteDirectory;
 use Hyde\Framework\Actions\PostBuildTasks\GenerateRssFeed;
 use Hyde\Framework\Actions\PostBuildTasks\GenerateSitemap;
+use Hyde\Framework\Actions\PreBuildTasks\TransferMediaAssets;
 use Hyde\Framework\Actions\PostBuildTasks\GenerateBuildManifest;
 use Illuminate\Console\OutputStyle;
 use Illuminate\Support\Str;
@@ -132,6 +133,7 @@ class BuildTaskService
     private function registerFrameworkTasks(): void
     {
         $this->registerIf(CleanSiteDirectory::class, $this->canCleanSiteDirectory());
+        $this->registerTask(TransferMediaAssets::class);
         $this->registerIf(GenerateBuildManifest::class, $this->canGenerateManifest());
         $this->registerIf(GenerateSitemap::class, $this->canGenerateSitemap());
         $this->registerIf(GenerateRssFeed::class, $this->canGenerateFeed());

--- a/packages/framework/tests/Unit/BuildTaskServiceUnitTest.php
+++ b/packages/framework/tests/Unit/BuildTaskServiceUnitTest.php
@@ -6,7 +6,6 @@ namespace Hyde\Framework\Testing\Unit;
 
 use Hyde\Foundation\HydeKernel;
 use Hyde\Foundation\Kernel\Filesystem;
-use Hyde\Framework\Actions\PreBuildTasks\TransferMediaAssets;
 use Hyde\Framework\Actions\PostBuildTasks\GenerateBuildManifest;
 use Hyde\Framework\Actions\PostBuildTasks\GenerateRssFeed;
 use Hyde\Framework\Actions\PostBuildTasks\GenerateSitemap as FrameworkGenerateSitemap;
@@ -51,75 +50,49 @@ class BuildTaskServiceUnitTest extends UnitTestCase
 
     public function testGetTasks()
     {
-        $this->assertSame([
-            TransferMediaAssets::class,
-        ], $this->service->getRegisteredTasks());
+        $this->assertSame([], $this->service->getRegisteredTasks());
     }
 
     public function testGetTasksWithTaskRegisteredInConfig()
     {
-        self::mockConfig(array_merge(config()->all(), ['hyde.build_tasks' => [
-            TransferMediaAssets::class,
-            TestBuildTask::class
-        ]]));
-        $this->assertSame([
-            TransferMediaAssets::class,
-            TestBuildTask::class
-        ], $this->createService()->getRegisteredTasks());
+        self::mockConfig(array_merge(config()->all(), ['hyde.build_tasks' => [TestBuildTask::class]]));
+        $this->assertSame([TestBuildTask::class], $this->createService()->getRegisteredTasks());
     }
 
     public function testRegisterTask()
     {
         $this->service->registerTask(TestBuildTask::class);
-        $this->assertSame([
-            TransferMediaAssets::class,
-            TestBuildTask::class
-        ], $this->service->getRegisteredTasks());
+        $this->assertSame([TestBuildTask::class], $this->service->getRegisteredTasks());
     }
 
     public function testRegisterPreBuildTask()
     {
         $this->service->registerTask(TestPreBuildTask::class);
-        $this->assertSame([
-            TransferMediaAssets::class,
-            TestPreBuildTask::class
-        ], $this->service->getRegisteredTasks());
+        $this->assertSame([TestPreBuildTask::class], $this->service->getRegisteredTasks());
     }
 
     public function testRegisterPostBuildTask()
     {
         $this->service->registerTask(TestPostBuildTask::class);
-        $this->assertSame([
-            TransferMediaAssets::class,
-            TestPostBuildTask::class
-        ], $this->service->getRegisteredTasks());
+        $this->assertSame([TestPostBuildTask::class], $this->service->getRegisteredTasks());
     }
 
     public function testRegisterInstantiatedTask()
     {
         $this->service->registerTask(new TestBuildTask());
-        $this->assertSame([
-            TransferMediaAssets::class,
-            TestBuildTask::class
-        ], $this->service->getRegisteredTasks());
+        $this->assertSame([TestBuildTask::class], $this->service->getRegisteredTasks());
     }
 
     public function testRegisterInstantiatedPreBuildTask()
     {
         $this->service->registerTask(new TestPreBuildTask());
-        $this->assertSame([
-            TransferMediaAssets::class,
-            TestPreBuildTask::class
-        ], $this->service->getRegisteredTasks());
+        $this->assertSame([TestPreBuildTask::class], $this->service->getRegisteredTasks());
     }
 
     public function testRegisterInstantiatedPostBuildTask()
     {
         $this->service->registerTask(new TestPostBuildTask());
-        $this->assertSame([
-            TransferMediaAssets::class,
-            TestPostBuildTask::class
-        ], $this->service->getRegisteredTasks());
+        $this->assertSame([TestPostBuildTask::class], $this->service->getRegisteredTasks());
     }
 
     public function testRegisterTaskWithInvalidClassTypeThrowsException()
@@ -145,34 +118,22 @@ class BuildTaskServiceUnitTest extends UnitTestCase
         $this->service->registerTask(TestBuildTask::class);
         $this->service->registerTask(TestBuildTask::class);
 
-        $this->assertSame([
-            TransferMediaAssets::class,
-            TestBuildTask::class
-        ], $this->service->getRegisteredTasks());
+        $this->assertSame([TestBuildTask::class], $this->service->getRegisteredTasks());
     }
 
     public function testRegisterTaskWithTaskAlreadyRegisteredInConfig()
     {
-        self::mockConfig(array_merge(config()->all(), ['hyde.build_tasks' => [
-            TransferMediaAssets::class,
-            TestBuildTask::class
-        ]]));
+        self::mockConfig(array_merge(config()->all(), ['hyde.build_tasks' => [TestBuildTask::class]]));
         $this->createService();
 
         $this->service->registerTask(TestBuildTask::class);
-        $this->assertSame([
-            TransferMediaAssets::class,
-            TestBuildTask::class
-        ], $this->service->getRegisteredTasks());
+        $this->assertSame([TestBuildTask::class], $this->service->getRegisteredTasks());
     }
 
     public function testCanRegisterFrameworkTasks()
     {
         $this->service->registerTask(FrameworkGenerateSitemap::class);
-        $this->assertSame([
-            TransferMediaAssets::class,
-            FrameworkGenerateSitemap::class
-        ], $this->service->getRegisteredTasks());
+        $this->assertSame([FrameworkGenerateSitemap::class], $this->service->getRegisteredTasks());
     }
 
     public function testCanOverloadFrameworkTasks()
@@ -180,10 +141,7 @@ class BuildTaskServiceUnitTest extends UnitTestCase
         $this->service->registerTask(FrameworkGenerateSitemap::class);
         $this->service->registerTask(GenerateSitemap::class);
 
-        $this->assertSame([
-            TransferMediaAssets::class,
-            GenerateSitemap::class
-        ], $this->service->getRegisteredTasks());
+        $this->assertSame([GenerateSitemap::class], $this->service->getRegisteredTasks());
     }
 
     public function testSetOutputWithNull()

--- a/packages/framework/tests/Unit/BuildTaskServiceUnitTest.php
+++ b/packages/framework/tests/Unit/BuildTaskServiceUnitTest.php
@@ -6,6 +6,7 @@ namespace Hyde\Framework\Testing\Unit;
 
 use Hyde\Foundation\HydeKernel;
 use Hyde\Foundation\Kernel\Filesystem;
+use Hyde\Framework\Actions\PreBuildTasks\TransferMediaAssets;
 use Hyde\Framework\Actions\PostBuildTasks\GenerateBuildManifest;
 use Hyde\Framework\Actions\PostBuildTasks\GenerateRssFeed;
 use Hyde\Framework\Actions\PostBuildTasks\GenerateSitemap as FrameworkGenerateSitemap;
@@ -50,49 +51,75 @@ class BuildTaskServiceUnitTest extends UnitTestCase
 
     public function testGetTasks()
     {
-        $this->assertSame([], $this->service->getRegisteredTasks());
+        $this->assertSame([
+            TransferMediaAssets::class,
+        ], $this->service->getRegisteredTasks());
     }
 
     public function testGetTasksWithTaskRegisteredInConfig()
     {
-        self::mockConfig(array_merge(config()->all(), ['hyde.build_tasks' => [TestBuildTask::class]]));
-        $this->assertSame([TestBuildTask::class], $this->createService()->getRegisteredTasks());
+        self::mockConfig(array_merge(config()->all(), ['hyde.build_tasks' => [
+            TransferMediaAssets::class,
+            TestBuildTask::class
+        ]]));
+        $this->assertSame([
+            TransferMediaAssets::class,
+            TestBuildTask::class
+        ], $this->createService()->getRegisteredTasks());
     }
 
     public function testRegisterTask()
     {
         $this->service->registerTask(TestBuildTask::class);
-        $this->assertSame([TestBuildTask::class], $this->service->getRegisteredTasks());
+        $this->assertSame([
+            TransferMediaAssets::class,
+            TestBuildTask::class
+        ], $this->service->getRegisteredTasks());
     }
 
     public function testRegisterPreBuildTask()
     {
         $this->service->registerTask(TestPreBuildTask::class);
-        $this->assertSame([TestPreBuildTask::class], $this->service->getRegisteredTasks());
+        $this->assertSame([
+            TransferMediaAssets::class,
+            TestPreBuildTask::class
+        ], $this->service->getRegisteredTasks());
     }
 
     public function testRegisterPostBuildTask()
     {
         $this->service->registerTask(TestPostBuildTask::class);
-        $this->assertSame([TestPostBuildTask::class], $this->service->getRegisteredTasks());
+        $this->assertSame([
+            TransferMediaAssets::class,
+            TestPostBuildTask::class
+        ], $this->service->getRegisteredTasks());
     }
 
     public function testRegisterInstantiatedTask()
     {
         $this->service->registerTask(new TestBuildTask());
-        $this->assertSame([TestBuildTask::class], $this->service->getRegisteredTasks());
+        $this->assertSame([
+            TransferMediaAssets::class,
+            TestBuildTask::class
+        ], $this->service->getRegisteredTasks());
     }
 
     public function testRegisterInstantiatedPreBuildTask()
     {
         $this->service->registerTask(new TestPreBuildTask());
-        $this->assertSame([TestPreBuildTask::class], $this->service->getRegisteredTasks());
+        $this->assertSame([
+            TransferMediaAssets::class,
+            TestPreBuildTask::class
+        ], $this->service->getRegisteredTasks());
     }
 
     public function testRegisterInstantiatedPostBuildTask()
     {
         $this->service->registerTask(new TestPostBuildTask());
-        $this->assertSame([TestPostBuildTask::class], $this->service->getRegisteredTasks());
+        $this->assertSame([
+            TransferMediaAssets::class,
+            TestPostBuildTask::class
+        ], $this->service->getRegisteredTasks());
     }
 
     public function testRegisterTaskWithInvalidClassTypeThrowsException()
@@ -118,22 +145,34 @@ class BuildTaskServiceUnitTest extends UnitTestCase
         $this->service->registerTask(TestBuildTask::class);
         $this->service->registerTask(TestBuildTask::class);
 
-        $this->assertSame([TestBuildTask::class], $this->service->getRegisteredTasks());
+        $this->assertSame([
+            TransferMediaAssets::class,
+            TestBuildTask::class
+        ], $this->service->getRegisteredTasks());
     }
 
     public function testRegisterTaskWithTaskAlreadyRegisteredInConfig()
     {
-        self::mockConfig(array_merge(config()->all(), ['hyde.build_tasks' => [TestBuildTask::class]]));
+        self::mockConfig(array_merge(config()->all(), ['hyde.build_tasks' => [
+            TransferMediaAssets::class,
+            TestBuildTask::class
+        ]]));
         $this->createService();
 
         $this->service->registerTask(TestBuildTask::class);
-        $this->assertSame([TestBuildTask::class], $this->service->getRegisteredTasks());
+        $this->assertSame([
+            TransferMediaAssets::class,
+            TestBuildTask::class
+        ], $this->service->getRegisteredTasks());
     }
 
     public function testCanRegisterFrameworkTasks()
     {
         $this->service->registerTask(FrameworkGenerateSitemap::class);
-        $this->assertSame([FrameworkGenerateSitemap::class], $this->service->getRegisteredTasks());
+        $this->assertSame([
+            TransferMediaAssets::class,
+            FrameworkGenerateSitemap::class
+        ], $this->service->getRegisteredTasks());
     }
 
     public function testCanOverloadFrameworkTasks()
@@ -141,7 +180,10 @@ class BuildTaskServiceUnitTest extends UnitTestCase
         $this->service->registerTask(FrameworkGenerateSitemap::class);
         $this->service->registerTask(GenerateSitemap::class);
 
-        $this->assertSame([GenerateSitemap::class], $this->service->getRegisteredTasks());
+        $this->assertSame([
+            TransferMediaAssets::class,
+            GenerateSitemap::class
+        ], $this->service->getRegisteredTasks());
     }
 
     public function testSetOutputWithNull()

--- a/packages/framework/tests/Unit/BuildTaskServiceUnitTest.php
+++ b/packages/framework/tests/Unit/BuildTaskServiceUnitTest.php
@@ -39,6 +39,7 @@ class BuildTaskServiceUnitTest extends UnitTestCase
         self::mockConfig(['hyde' => [
             'empty_output_directory' => false,
             'generate_build_manifest' => false,
+            'transfer_media_assets' => false,
         ]]);
         $this->createService();
     }

--- a/packages/framework/tests/Unit/RelativeLinksAcrossPagesRetainsIntegrityTest.php
+++ b/packages/framework/tests/Unit/RelativeLinksAcrossPagesRetainsIntegrityTest.php
@@ -9,6 +9,7 @@ use Hyde\Framework\Actions\CreatesNewMarkdownPostFile;
 use Hyde\Framework\Services\BuildService;
 use Illuminate\Console\OutputStyle;
 use Mockery;
+use Hyde\Framework\Actions\PreBuildTasks\TransferMediaAssets;
 use Symfony\Component\Console\Formatter\OutputFormatterInterface;
 use Symfony\Component\Console\Helper\ProgressBar;
 
@@ -92,7 +93,7 @@ class RelativeLinksAcrossPagesRetainsIntegrityTest extends TestCase
             'write' => null,
         ]));
 
-        $service->transferMediaAssets();
+        (new TransferMediaAssets())->run();
         $service->compileStaticPages();
 
         $this->assertSee('root', [


### PR DESCRIPTION
### Visual regression check

Changes have been visually tested to ensure console output state is not changed.

<details>
<summary>Click to show</summary>

### Before change
![image](https://github.com/hydephp/develop/assets/95144705/928f4d85-8952-4c6d-9d62-ba4810ca36db)

### After change
![image](https://github.com/hydephp/develop/assets/95144705/52abadcc-dde4-4d45-a06c-b528a823616d)

### Diff

![diffchecker-output](https://github.com/hydephp/develop/assets/95144705/4f57c9fb-b3d3-44b5-8929-49572f0c112d)

</details>
