### PR TITLE
Update NavItem class to support deferring route resolves

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -11,10 +11,12 @@ This serves two purposes:
 
 ### Added
 - Added a new `\Hyde\Framework\Actions\PreBuildTasks\TransferMediaAssets` build task handle media assets transfers for site builds.
+- Added a new `NavItem::getLink()` method contain the previous `NavItem::getDestination()` logic, to return the link URL.
 
 ### Changed
 - Changed how the documentation search is generated, to be an `InMemoryPage` instead of a post-build task.
 - Media asset files are now copied using the new build task instead of the deprecated `BuildService::transferMediaAssets()` method.
+- The `NavItem::getDestination()` method now returns its `Route` instance if that is the destination type.
 
 ### Deprecated
 - for soon-to-be removed features.
@@ -53,6 +55,11 @@ want to adapt your code to interact with the new `InMemoryPage`, which is genera
 For more information, see https://github.com/hydephp/develop/pull/1498.
 
 ## Low impact
+
+### Navigation item changes
+
+The `NavItem::getDestination()` method now returns its `Route` instance if that is the destination type.
+If you want to retain the previous state where a string is always returned, you can use the new `NavItem::getLink()` method instead.
 
 ### New documentation search implementation
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -58,8 +58,11 @@ For more information, see https://github.com/hydephp/develop/pull/1498.
 
 ### Navigation item changes
 
-The `NavItem::getDestination()` method now returns its `Route` instance if that is the destination type.
-If you want to retain the previous state where a string is always returned, you can use the new `NavItem::getLink()` method instead.
+The `NavItem::getDestination()` method now returns its `Route` instance if that is the destination type. This allows for deferring the route evaluation.
+
+If you have previously used this method directly and expected a string to be returned, you may need to adapt your code to handle the new return type.
+
+If you want to retain the previous state where a string is always returned, you can use the new `NavItem::getLink()` method instead, which will resolve the route immediately.
 
 ### New documentation search implementation
 

--- a/packages/framework/src/Framework/Features/Navigation/NavItem.php
+++ b/packages/framework/src/Framework/Features/Navigation/NavItem.php
@@ -75,7 +75,7 @@ class NavItem implements Stringable
      */
     public function __toString(): string
     {
-        return $this->destination;
+        return (string) $this->destination;
     }
 
     /**

--- a/packages/framework/src/Framework/Features/Navigation/NavItem.php
+++ b/packages/framework/src/Framework/Features/Navigation/NavItem.php
@@ -82,9 +82,9 @@ class NavItem implements Stringable
      * Get the destination link of the navigation item.
      *
      * If the navigation item is an external link, this will return the link as is,
-     * if it's for a route, a resolved relative link will be returned.
+     * if it's for a route, the route instance will be returned.
      */
-    public function getDestination(): string
+    public function getDestination(): Route|string
     {
         return $this->destination;
     }

--- a/packages/framework/src/Framework/Features/Navigation/NavItem.php
+++ b/packages/framework/src/Framework/Features/Navigation/NavItem.php
@@ -20,7 +20,7 @@ use Stringable;
  */
 class NavItem implements Stringable
 {
-    public readonly string $destination;
+    public readonly Route|string $destination;
     public readonly string $label;
     public readonly int $priority;
     public readonly ?string $group;

--- a/packages/framework/src/Framework/Features/Navigation/NavItem.php
+++ b/packages/framework/src/Framework/Features/Navigation/NavItem.php
@@ -120,7 +120,7 @@ class NavItem implements Stringable
      */
     public function isCurrent(): bool
     {
-        return Hyde::currentRoute()->getLink() === $this->destination;
+        return Hyde::currentRoute()->getLink() === (string) $this->destination;
     }
 
     protected static function getRouteGroup(Route $route): ?string

--- a/packages/framework/src/Framework/Features/Navigation/NavItem.php
+++ b/packages/framework/src/Framework/Features/Navigation/NavItem.php
@@ -79,7 +79,7 @@ class NavItem implements Stringable
     }
 
     /**
-     * Get the destination link of the navigation item.
+     * Get the destination of the navigation item.
      *
      * If the navigation item is an external link, this will return the link as is,
      * if it's for a route, the route instance will be returned.
@@ -87,6 +87,17 @@ class NavItem implements Stringable
     public function getDestination(): Route|string
     {
         return $this->destination;
+    }
+
+    /**
+     * Get the destination link of the navigation item.
+     *
+     * If the navigation item is an external link, this will return the link as is,
+     * if it's for a route, the route's resolved link will be returned.
+     */
+    public function getLink(): string
+    {
+        return (string) $this->destination;
     }
 
     /**

--- a/packages/framework/src/Framework/Features/Navigation/NavItem.php
+++ b/packages/framework/src/Framework/Features/Navigation/NavItem.php
@@ -30,7 +30,7 @@ class NavItem implements Stringable
      */
     public function __construct(Route|string $destination, string $label, int $priority = 500, ?string $group = null)
     {
-        $this->destination = (string) $destination;
+        $this->destination = $destination;
         $this->label = $label;
         $this->priority = $priority;
         $this->group = $group;

--- a/packages/framework/src/Framework/Features/Navigation/NavItem.php
+++ b/packages/framework/src/Framework/Features/Navigation/NavItem.php
@@ -42,7 +42,7 @@ class NavItem implements Stringable
     public static function fromRoute(Route $route, ?string $label = null, ?int $priority = null, ?string $group = null): static
     {
         return new static(
-            $route->getLink(),
+            $route,
             $label ?? $route->getPage()->navigationMenuLabel(),
             $priority ?? $route->getPage()->navigationMenuPriority(),
             $group ?? static::getRouteGroup($route),

--- a/packages/framework/tests/Unit/NavItemTest.php
+++ b/packages/framework/tests/Unit/NavItemTest.php
@@ -43,13 +43,21 @@ class NavItemTest extends UnitTestCase
         $route = new Route(new MarkdownPage());
         $item = new NavItem($route, 'Test', 500);
 
-        $this->assertSame($route->getLink(), $item->destination);
+        $this->assertSame($route, $item->destination);
     }
 
     public function testGetDestination()
     {
+        $route = new Route(new MarkdownPage());
+        $item = new NavItem($route, 'Test', 500);
+
+        $this->assertSame($route, $item->getDestination());
+    }
+
+    public function testGetLink()
+    {
         $navItem = new NavItem(new Route(new InMemoryPage('foo')), 'Page', 500);
-        $this->assertSame('foo.html', $navItem->getDestination());
+        $this->assertSame('foo.html', $navItem->getLink());
     }
 
     public function testGetLabel()
@@ -75,7 +83,7 @@ class NavItemTest extends UnitTestCase
         $route = new Route(new MarkdownPage());
         $item = NavItem::fromRoute($route);
 
-        $this->assertSame($route->getLink(), $item->destination);
+        $this->assertSame($route, $item->destination);
     }
 
     public function test__toString()
@@ -104,7 +112,7 @@ class NavItemTest extends UnitTestCase
         $route = Routes::get('404');
         $item = NavItem::forRoute($route, 'foo');
 
-        $this->assertSame($route->getLink(), $item->destination);
+        $this->assertSame($route, $item->destination);
         $this->assertSame('foo', $item->label);
         $this->assertSame(999, $item->priority);
     }
@@ -114,7 +122,7 @@ class NavItemTest extends UnitTestCase
         $route = Routes::get('index');
         $item = NavItem::forRoute($route, 'foo');
 
-        $this->assertSame($route->getLink(), $item->destination);
+        $this->assertSame($route, $item->destination);
         $this->assertSame('foo', $item->label);
         $this->assertSame(0, $item->priority);
     }


### PR DESCRIPTION
Part of https://github.com/hydephp/develop/pull/1538 and allows for deferring the route link evaluation instead of forcing it at construction time. This has the side effect that the destination method now may return a route object instead of string. This targets v2.