### PR TITLE
Internal: Update monorepo documentation previews to use the new server

### DIFF
--- a/.github/workflows/deploy-documentation-preview.yml
+++ b/.github/workflows/deploy-documentation-preview.yml
@@ -100,7 +100,7 @@ jobs:
 
       - name: Sign the artifact
         run: |
-          echo ${{ secrets.CI_PREVIEW_SIGNING_RSA_PRIVATE_KEY }} > private.pem
+          echo '${{ secrets.CI_PREVIEW_SIGNING_RSA_PRIVATE_KEY }}' > private.pem
           openssl dgst -sha256 -sign private.pem -out signature.bin site.zip
           unlink private.pem
 

--- a/.github/workflows/deploy-documentation-preview.yml
+++ b/.github/workflows/deploy-documentation-preview.yml
@@ -22,9 +22,10 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
-      - uses: shivammathur/setup-php@v2
-        with:
-          php-version: "8.1"
+# Disabled as it should not be necessary, and it takes a long time to run
+#      - uses: shivammathur/setup-php@v2
+#        with:
+#          php-version: "8.1"
 
       - name: Cache Composer packages
         id: composer-cache

--- a/.github/workflows/deploy-documentation-preview.yml
+++ b/.github/workflows/deploy-documentation-preview.yml
@@ -50,7 +50,7 @@ jobs:
       - name: Update configuration files
         run: |
           echo "output_directories:" >> hyde.yml
-          echo "  Hyde\Pages\DocumentationPage: dev-docs-preview" >> hyde.yml
+          echo "  Hyde\Pages\DocumentationPage: ''" >> hyde.yml
           sed -i "s/'header' => env('SITE_NAME', 'HydePHP').' Docs'/'header' => 'PR #${{ github.event.pull_request.number }} - Docs'/g" config/docs.php
 
       - name: Remove published article component

--- a/.github/workflows/deploy-documentation-preview.yml
+++ b/.github/workflows/deploy-documentation-preview.yml
@@ -99,7 +99,10 @@ jobs:
         run: zip -r site.zip _site
 
       - name: Sign the artifact
-        run: openssl dgst -sha256 -sign ${{ secrets.CI_PREVIEW_SIGNING_RSA_PRIVATE_KEY }} -out signature.bin site.zip
+        run: |
+          echo ${{ secrets.CI_PREVIEW_SIGNING_RSA_PRIVATE_KEY }} > private.pem
+          openssl dgst -sha256 -sign private.pem -out signature.bin site.zip
+          unlink private.pem
 
       - name: Upload the artifact
         run: |

--- a/.github/workflows/deploy-documentation-preview.yml
+++ b/.github/workflows/deploy-documentation-preview.yml
@@ -113,10 +113,10 @@ jobs:
             artifact="site.zip"
           
             curl -X POST \
-              -H 'Content-Type: multipart/form-data' \
+              -H "Content-Type: multipart/form-data" \
               -H "Authorization: Bearer $bearerToken" \
-              -F 'repository=$repository' \
-              -F 'pullRequest=$pullRequest' \
-              -F 'artifact=@$artifact' \
-              -F 'signature=$signature' \
+              -F "repository=$repository" \
+              -F "pullRequest=$pullRequest" \
+              -F "artifact=@$artifact" \
+              -F "signature=$signature" \
               https://ci.hydephp.com/api/deployment-previews

--- a/.github/workflows/deploy-documentation-preview.yml
+++ b/.github/workflows/deploy-documentation-preview.yml
@@ -87,7 +87,7 @@ jobs:
       - name: Configure environment variables
         run: |
           echo 'SITE_NAME="HydePHP Documentation Preview"' >> .env
-          echo 'SITE_URL="https://hydephp.github.io/develop/pr-${{ github.event.pull_request.number }}/dev-docs-preview"' >> .env
+          echo 'SITE_URL="https://ci.hydephp.com/previews/develop/${{ github.event.pull_request.number }}"' >> .env
 
       - name: Move documentation files
         run: rm -rf _docs && mv -f docs _docs

--- a/.github/workflows/deploy-documentation-preview.yml
+++ b/.github/workflows/deploy-documentation-preview.yml
@@ -94,3 +94,26 @@ jobs:
 
       - name: Compile the static site
         run: php hyde build
+
+      - name: Package the static site
+        run: zip -r site.zip _site
+
+      - name: Sign the artifact
+        run: openssl dgst -sha256 -sign ${{ secrets.CI_PREVIEW_SIGNING_RSA_PRIVATE_KEY }} -out signature.bin site.zip
+
+      - name: Upload the artifact
+        run: |
+            repository="develop"
+            bearerToken="${{ secrets.CI_SERVER_TOKEN }}"
+            pullRequest="${{ github.event.pull_request.number }}"
+            signature=$(openssl base64 -in signature.bin)
+            artifact="site.zip"
+          
+            curl -X POST \
+              -H 'Content-Type: multipart/form-data' \
+              -H "Authorization: Bearer $bearerToken" \
+              -F 'repository=$repository \
+              -F 'pullRequest=$pullRequest' \
+              -F 'artifact=@$artifact' \
+              -F 'signature=$signature' \
+              https://ci.hydephp.com/api/deployment-previews

--- a/.github/workflows/deploy-documentation-preview.yml
+++ b/.github/workflows/deploy-documentation-preview.yml
@@ -112,7 +112,7 @@ jobs:
             signature="$(openssl base64 -in signature.bin)"
             artifact="site.zip"
           
-            curl -X POST \
+            curl -X POST --fail-with-body \
               -H "Content-Type: multipart/form-data" \
               -H "Authorization: Bearer $bearerToken" \
               -F "repository=$repository" \

--- a/.github/workflows/deploy-documentation-preview.yml
+++ b/.github/workflows/deploy-documentation-preview.yml
@@ -115,7 +115,7 @@ jobs:
             curl -X POST \
               -H 'Content-Type: multipart/form-data' \
               -H "Authorization: Bearer $bearerToken" \
-              -F 'repository=$repository \
+              -F 'repository=$repository' \
               -F 'pullRequest=$pullRequest' \
               -F 'artifact=@$artifact' \
               -F 'signature=$signature' \

--- a/.github/workflows/deploy-documentation-preview.yml
+++ b/.github/workflows/deploy-documentation-preview.yml
@@ -5,6 +5,7 @@ on:
     branches: [ "master" ]
     paths:
       - 'docs/**'
+      - '.github/workflows/deploy-documentation-preview.yml'
 
 jobs:
 

--- a/.github/workflows/deploy-documentation-preview.yml
+++ b/.github/workflows/deploy-documentation-preview.yml
@@ -109,7 +109,7 @@ jobs:
             repository="develop"
             bearerToken="${{ secrets.CI_SERVER_TOKEN }}"
             pullRequest="${{ github.event.pull_request.number }}"
-            signature=$(openssl base64 -in signature.bin)
+            signature="$(openssl base64 -in signature.bin)"
             artifact="site.zip"
           
             curl -X POST \

--- a/.github/workflows/deploy-documentation-preview.yml
+++ b/.github/workflows/deploy-documentation-preview.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
 
-  build-documentation-preview:
+  build-and-deploy-documentation-preview:
     # We could add a check to only rerun if docs have changed since last run on the PR
     # But this would require a state storage, and the current version is good enough.
     if: "! contains(github.event.pull_request.labels.*.name, 'pause-pages')"

--- a/.github/workflows/deploy-documentation-preview.yml
+++ b/.github/workflows/deploy-documentation-preview.yml
@@ -15,7 +15,7 @@ jobs:
 
     environment:
       name: pr-documentation-${{ github.event.pull_request.number }}
-      url: https://hydephp.github.io/develop/pr-${{ github.event.pull_request.number }}/dev-docs-preview
+      url: https://ci.hydephp.com/previews/develop/${{ github.event.pull_request.number }}
 
     runs-on: ubuntu-latest
 

--- a/.github/workflows/deploy-documentation-preview.yml
+++ b/.github/workflows/deploy-documentation-preview.yml
@@ -100,33 +100,3 @@ jobs:
         with:
           name: 'preview-docs'
           path: '_site/dev-docs-preview'
-
-
-  upload-generated-site:
-
-    runs-on: ubuntu-latest
-    needs:
-      - build-documentation-preview
-
-    steps:
-      - uses: actions/checkout@v3
-        with:
-          ref: 'gh-pages'
-
-      - name: Reset output directories
-        run: |
-          rm -rf pr-${{ github.event.pull_request.number }}/dev-docs-preview
-          mkdir -p pr-${{ github.event.pull_request.number }}/dev-docs-preview
-
-      - name: Download documentation artifact
-        uses: actions/download-artifact@v3
-        with:
-          name: preview-docs
-          path: pr-${{ github.event.pull_request.number }}/dev-docs-preview
-
-      - name: Commit changes
-        uses: EndBug/add-and-commit@v9
-        with:
-          pull: 'origin gh-pages'
-          add: 'pr-${{ github.event.pull_request.number }}/dev-docs-preview'
-          message: 'Upload documentation preview for PR ${{ github.event.pull_request.number }}'

--- a/.github/workflows/deploy-documentation-preview.yml
+++ b/.github/workflows/deploy-documentation-preview.yml
@@ -94,9 +94,3 @@ jobs:
 
       - name: Compile the static site
         run: php hyde build
-
-      - name: Upload artifacts
-        uses: actions/upload-artifact@v1
-        with:
-          name: 'preview-docs'
-          path: '_site/dev-docs-preview'


### PR DESCRIPTION
Moves to a faster deployment server than GitHub Pages. Paired with using the runner PHP, and the fact that deployments are instant, we now get previews live in about 10 seconds, instead of a minute, massively reducing the friction of deployment previews. 