### PR TITLE
Add `Includes::html()` helper

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -21,6 +21,7 @@ This serves two purposes:
 
 ### Added
 - Added the existing `media_extensions` option to the `hyde` configuration file in https://github.com/hydephp/develop/pull/1531
+- Added an `html` helper to the `Includes` facade in https://github.com/hydephp/develop/pull/1552
 
 ### Changed
 - Renamed local template variable `$document` to `$article` to better match the usage in https://github.com/hydephp/develop/pull/1506

--- a/docs/digging-deeper/helpers.md
+++ b/docs/digging-deeper/helpers.md
@@ -80,6 +80,20 @@ Includes::blade('banner.blade.php');
 Includes::blade('banner', 'Default content');
 ```
 
+### HTML Includes
+
+Gets the raw HTML of a partial file in the includes directory. Supplying the file extension is optional.
+
+```php
+use Hyde\Support\Includes;
+
+Includes::html('footer');
+Includes::html('footer.html');
+
+// With default value if the file does not exist
+Includes::html('footer', 'Default content');
+```
+
 ### Directory Structure Example
 
 Here is an example of the directory structure for includes:

--- a/packages/framework/src/Support/Includes.php
+++ b/packages/framework/src/Support/Includes.php
@@ -61,6 +61,24 @@ class Includes
     }
 
     /**
+     * Get the HTML contents of a partial file in the includes directory.
+     *
+     * @param  string  $filename  The name of the partial file, with or without the extension.
+     * @param  string|null  $default  The default value to return if the partial is not found.
+     * @return string|null The raw contents of the partial file, or the default value if not found.
+     */
+    public static function html(string $filename, ?string $default = null): ?string
+    {
+        $path = static::path(basename($filename, '.html').'.html');
+
+        if (! file_exists($path)) {
+            return $default === null ? null : $default;
+        }
+
+        return file_get_contents($path);
+    }
+
+    /**
      * Get the rendered Markdown of a partial file in the includes directory.
      *
      * @param  string  $filename  The name of the partial file, with or without the extension.

--- a/packages/framework/tests/Feature/IncludesFacadeTest.php
+++ b/packages/framework/tests/Feature/IncludesFacadeTest.php
@@ -53,6 +53,27 @@ class IncludesFacadeTest extends TestCase
         $this->assertEquals('default', Includes::get('foo.txt', 'default'));
     }
 
+    public function test_html_returns_rendered_partial()
+    {
+        $expected = '<h1>foo bar</h1>';
+        file_put_contents(Hyde::path('resources/includes/foo.html'), '<h1>foo bar</h1>');
+        $this->assertEquals($expected, Includes::html('foo.html'));
+        Filesystem::unlink('resources/includes/foo.html');
+    }
+
+    public function test_html_returns_efault_value_when_not_found()
+    {
+        $this->assertNull(Includes::html('foo.html'));
+        $this->assertEquals('<h1>default</h1>', Includes::html('foo.html', '<h1>default</h1>'));
+    }
+
+    public function test_html_with_and_without_extension()
+    {
+        file_put_contents(Hyde::path('resources/includes/foo.html'), '# foo bar');
+        $this->assertEquals(Includes::html('foo.html'), Includes::html('foo'));
+        Filesystem::unlink('resources/includes/foo.html');
+    }
+
     public function test_markdown_returns_rendered_partial()
     {
         $expected = "<h1>foo bar</h1>\n";


### PR DESCRIPTION
Adds a new helper to the `Includes` facad: to include raw HTML contents. 