### PR TITLE
Update Markdown to plaintext formatter to trim whitespace

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -28,6 +28,7 @@ This serves two purposes:
 ### Changed
 - Renamed local template variable `$document` to `$article` to better match the usage in https://github.com/hydephp/develop/pull/1506
 - Updated semantic documentation article component to support existing variables in https://github.com/hydephp/develop/pull/1506
+- Updated the Markdown to plain text converter to trim whitespace in https://github.com/hydephp/develop/pull/1561
 - HydeFront: Changed `<code>` styling to display as inline instead of inline-block in https://github.com/hydephp/develop/pull/1525
 - Realtime Compiler: Add strict type declarations in https://github.com/hydephp/develop/pull/1555
 - Internal: Renamed snake case test methods to camel case in https://github.com/hydephp/develop/pull/1556

--- a/packages/framework/src/Framework/Actions/ConvertsMarkdownToPlainText.php
+++ b/packages/framework/src/Framework/Actions/ConvertsMarkdownToPlainText.php
@@ -93,6 +93,7 @@ class ConvertsMarkdownToPlainText
         foreach ($lines as $line => $contents) {
             $contents = $this->removeTables($contents);
             $contents = $this->removeBlockquotes($contents);
+            $contents = $this->trimWhitespace($contents);
 
             $lines[$line] = $contents;
         }
@@ -126,5 +127,17 @@ class ConvertsMarkdownToPlainText
         }
 
         return $contents;
+    }
+
+    protected function trimWhitespace(string $contents): string
+    {
+        // If it is a list, don't trim the whitespace
+        $firstCharacter = substr(trim($contents), 0, 1);
+
+        if ($firstCharacter === '-' || $firstCharacter === '*' || $firstCharacter === '+' || is_numeric($firstCharacter)) {
+            return $contents;
+        }
+
+        return trim($contents);
     }
 }

--- a/packages/framework/tests/Feature/Actions/ConvertsMarkdownToPlainTextTest.php
+++ b/packages/framework/tests/Feature/Actions/ConvertsMarkdownToPlainTextTest.php
@@ -259,11 +259,11 @@ class ConvertsMarkdownToPlainTextTest extends TestCase
     public function testItRemovesCodeBlocks()
     {
         $markdown = <<<'MD'
-            <p>Hello World</p>
+        <p>Hello World</p>
         MD;
 
         $text = <<<'TXT'
-            Hello World
+        Hello World
         TXT;
 
         $this->assertSame($text, $this->convert($markdown));
@@ -367,9 +367,9 @@ class ConvertsMarkdownToPlainTextTest extends TestCase
         $text = <<<'TXT'
         This word is bold. This word is italic.
 
-            
-                &copy; My Company
-            
+        
+        &copy; My Company
+        
 
         Hello World
         TXT;
@@ -482,6 +482,23 @@ class ConvertsMarkdownToPlainTextTest extends TestCase
 
         Header    Title
         Paragraph Text
+        TXT;
+
+        $this->assertSame($text, $this->convert($markdown));
+    }
+
+    public function testItTrimsIndentation()
+    {
+        $markdown = <<<'MD'
+        foo
+            bar
+                baz
+        MD;
+
+        $text = <<<'TXT'
+        foo
+        bar
+        baz
         TXT;
 
         $this->assertSame($text, $this->convert($markdown));


### PR DESCRIPTION
This is especially helpful if there are HTML tags that we stripped