### PR TITLE
[2.x] Add conditional semantic documentation article rendering

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -15,6 +15,7 @@ This serves two purposes:
 ### Changed
 - Changed how the documentation search is generated, to be an `InMemoryPage` instead of a post-build task.
 - Media asset files are now copied using the new build task instead of the deprecated `BuildService::transferMediaAssets()` method.
+- Minor: The documentation article component now supports disabling the semantic rendering using a falsy value in https://github.com/hydephp/develop/pull/1566
 
 ### Deprecated
 - for soon-to-be removed features.

--- a/packages/framework/resources/views/components/docs/documentation-article.blade.php
+++ b/packages/framework/resources/views/components/docs/documentation-article.blade.php
@@ -5,16 +5,18 @@
 <article id="document" itemscope itemtype="https://schema.org/Article" @class([
         'mx-auto lg:ml-8 max-w-3xl p-12 md:px-16 max-w-[1000px] min-h-[calc(100vh_-_4rem)]',
         config('markdown.prose_classes', 'prose dark:prose-invert'),
-        'torchlight-enabled' => $article->hasTorchlight()])>
+        'torchlight-enabled' => $article && $article->hasTorchlight()])>
     @yield('content')
 
-    <header id="document-header" class="flex items-center flex-wrap justify-between prose-h1:mb-3">
-        {{ $article->renderHeader() }}
-    </header>
-    <section id="document-main-content" itemprop="articleBody">
-        {{ $article->renderBody() }}
-    </section>
-    <footer id="document-footer" class="flex items-center flex-wrap mt-8 prose-p:my-3 justify-between text-[90%]">
-        {{ $article->renderFooter() }}
-    </footer>
+    @if ($article)
+        <header id="document-header" class="flex items-center flex-wrap justify-between prose-h1:mb-3">
+            {{ $article->renderHeader() }}
+        </header>
+        <section id="document-main-content" itemprop="articleBody">
+            {{ $article->renderBody() }}
+        </section>
+        <footer id="document-footer" class="flex items-center flex-wrap mt-8 prose-p:my-3 justify-between text-[90%]">
+            {{ $article->renderFooter() }}
+        </footer>
+    @endif
 </article>

--- a/packages/framework/src/Framework/Features/Documentation/DocumentationSearchPage.php
+++ b/packages/framework/src/Framework/Features/Documentation/DocumentationSearchPage.php
@@ -39,7 +39,7 @@ class DocumentationSearchPage extends InMemoryPage
         parent::__construct(static::routeKey(), [
             'title' => 'Search',
             'navigation' => ['hidden' => true],
-            'article' => $this->makeArticle(),
+            'article' => false,
         ], view: 'hyde::pages.documentation-search');
     }
 

--- a/packages/framework/src/Framework/Features/Documentation/DocumentationSearchPage.php
+++ b/packages/framework/src/Framework/Features/Documentation/DocumentationSearchPage.php
@@ -59,10 +59,4 @@ class DocumentationSearchPage extends InMemoryPage
         // we need to check the page collection directly, instead of the route collection.
         return Hyde::pages()->first(fn (HydePage $file): bool => $file->getRouteKey() === static::routeKey()) !== null;
     }
-
-    /** @experimental Fixes type issue {@see https://github.com/hydephp/develop/commit/37f7046251b8c0514b8d8ef821de4ef3d35bbac8#commitcomment-135026537} */
-    protected function makeArticle(): SemanticDocumentationArticle
-    {
-        return SemanticDocumentationArticle::make(new DocumentationPage());
-    }
 }

--- a/packages/framework/tests/Feature/DocumentationSearchPageTest.php
+++ b/packages/framework/tests/Feature/DocumentationSearchPageTest.php
@@ -76,4 +76,34 @@ class DocumentationSearchPageTest extends TestCase
         DocumentationPage::setOutputDirectory('');
         $this->assertSame('search', DocumentationSearchPage::routeKey());
     }
+
+    public function testCanRenderSearchPage()
+    {
+        $page = new DocumentationSearchPage();
+
+        Hyde::shareViewData($page);
+        $this->assertStringContainsString('<h1>Search the documentation site</h1>', $page->compile());
+    }
+
+    public function testRenderedSearchPageUsesDocumentationPageLayout()
+    {
+        $page = new DocumentationSearchPage();
+
+        Hyde::shareViewData($page);
+        $html = $page->compile();
+
+        $this->assertStringContainsString('<body id="hyde-docs"', $html);
+    }
+
+    public function testRenderedSearchPageDoesNotUseSemanticDocumentationMarkup()
+    {
+        $page = new DocumentationSearchPage();
+
+        Hyde::shareViewData($page);
+        $html = $page->compile();
+
+        $this->assertStringNotContainsString('<header id="document-header"', $html);
+        $this->assertStringNotContainsString('<section id="document-main-content"', $html);
+        $this->assertStringNotContainsString('<footer id="document-footer"', $html);
+    }
 }


### PR DESCRIPTION
This is the most elegant solution I have been able to come up with for reusing the base documentation layout for search pages.

Before this change, the following empty HTML is added to the full page search page:

```html
<header id="document-header" class="flex items-center flex-wrap justify-between prose-h1:mb-3">

</header>
<section id="document-main-content" itemprop="articleBody">

</section>
<footer id="document-footer" class="flex items-center flex-wrap mt-8 prose-p:my-3 justify-between text-[90%]">

</footer>
```

This is of course not very semantic. But now, we can set the article to false, and this won't render.