### PR TITLE
Add a `@head` stack to the `head.blade.php` component

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -10,7 +10,7 @@ This serves two purposes:
 2. At release time, you can move the Unreleased section changes into a new release version section.
 
 ### Added
-- for new features.
+- Added a `@head` stack to the `head.blade.php` component in https://github.com/hydephp/develop/pull/1567
 
 ### Changed
 - for changes in existing functionality.

--- a/packages/framework/resources/views/layouts/head.blade.php
+++ b/packages/framework/resources/views/layouts/head.blade.php
@@ -18,6 +18,9 @@
     <script>if (localStorage.getItem('color-theme') === 'dark' || (!('color-theme' in localStorage) && window.matchMedia('(prefers-color-scheme: dark)').matches)) { document.documentElement.classList.add('dark'); document.getElementById('meta-color-scheme').setAttribute('content', 'dark');} else { document.documentElement.classList.remove('dark') } </script>
 @endif
 
+{{-- Add any extra code to include before the closing <head> tag --}}
+@stack('head')
+
 {{-- If the user has defined any custom head tags, render them here --}}
 {!! config('hyde.head') !!}
 {!! Includes::html('head') !!}


### PR DESCRIPTION
Adds a `@head` stack to the `head.blade.php` component. My original plan was to move the existing meta stack, but this makes more sense and is more compatible. It allows code to be pushed to just before the end of the `head` component, just like in the scripts component.