### PR TITLE
Refactor unit test to replace complex mock with inlined build loop

### DIFF
--- a/packages/framework/tests/Unit/RelativeLinksAcrossPagesRetainsIntegrityTest.php
+++ b/packages/framework/tests/Unit/RelativeLinksAcrossPagesRetainsIntegrityTest.php
@@ -5,12 +5,10 @@ declare(strict_types=1);
 namespace Hyde\Framework\Testing\Unit;
 
 use Hyde\Facades\Filesystem;
+use Hyde\Support\Models\Route;
+use Hyde\Foundation\Facades\Routes;
+use Hyde\Framework\Actions\StaticPageBuilder;
 use Hyde\Framework\Actions\CreatesNewMarkdownPostFile;
-use Hyde\Framework\Services\BuildService;
-use Illuminate\Console\OutputStyle;
-use Mockery;
-use Symfony\Component\Console\Formatter\OutputFormatterInterface;
-use Symfony\Component\Console\Helper\ProgressBar;
 
 use function config;
 
@@ -70,30 +68,9 @@ class RelativeLinksAcrossPagesRetainsIntegrityTest extends TestCase
 
     public function testRelativeLinksAcrossPagesRetainsIntegrity()
     {
-        $service = new BuildService(Mockery::mock(OutputStyle::class, [
-            'getFormatter' => Mockery::mock(OutputFormatterInterface::class, [
-                'hasStyle' => false,
-                'setStyle' => null,
-            ]),
-            'createProgressBar' => new ProgressBar(Mockery::mock(OutputStyle::class, [
-                'isDecorated' => false,
-                'getVerbosity' => 0,
-                'write' => null,
-                'getFormatter' => Mockery::mock(OutputFormatterInterface::class, [
-                    'hasStyle' => false,
-                    'setStyle' => null,
-                    'isDecorated' => false,
-                    'setDecorated' => null,
-                    'format' => null,
-                ]),
-            ])),
-            'writeln' => null,
-            'newLine' => null,
-            'write' => null,
-        ]));
-
-        $service->transferMediaAssets();
-        $service->compileStaticPages();
+        Routes::getRoutes()->each(function (Route $route): void {
+            StaticPageBuilder::handle($route->getPage());
+        });
 
         $this->assertSee('root', [
             '<link rel="stylesheet" href="media/app.css">',


### PR DESCRIPTION
We don't need a complex service mock when all we want to do is to run the build loop