### PR TITLE
[2.x] Change default DocumentationPage group to be `null` instead of `'other'`

### DIFF
--- a/packages/framework/src/Framework/Factories/NavigationDataFactory.php
+++ b/packages/framework/src/Framework/Factories/NavigationDataFactory.php
@@ -84,7 +84,7 @@ class NavigationDataFactory extends Concerns\PageDataFactory implements Navigati
             return $this->getSubdirectoryName();
         }
 
-        return $this->searchForGroupInFrontMatter() ?? null;
+        return $this->searchForGroupInFrontMatter();
     }
 
     protected function makeHidden(): bool

--- a/packages/framework/src/Framework/Factories/NavigationDataFactory.php
+++ b/packages/framework/src/Framework/Factories/NavigationDataFactory.php
@@ -210,7 +210,7 @@ class NavigationDataFactory extends Concerns\PageDataFactory implements Navigati
 
     private function defaultGroup(): ?string
     {
-        return $this->isInstanceOf(DocumentationPage::class) ? null : null;
+        return null;
     }
 
     private function pageIsInSubdirectory(): bool

--- a/packages/framework/src/Framework/Factories/NavigationDataFactory.php
+++ b/packages/framework/src/Framework/Factories/NavigationDataFactory.php
@@ -84,7 +84,7 @@ class NavigationDataFactory extends Concerns\PageDataFactory implements Navigati
             return $this->getSubdirectoryName();
         }
 
-        return $this->searchForGroupInFrontMatter() ?? $this->defaultGroup();
+        return $this->searchForGroupInFrontMatter() ?? null;
     }
 
     protected function makeHidden(): bool
@@ -206,11 +206,6 @@ class NavigationDataFactory extends Concerns\PageDataFactory implements Navigati
     {
         return $this->getSubdirectoryConfiguration() === 'dropdown'
             || $this->isInstanceOf(DocumentationPage::class);
-    }
-
-    private function defaultGroup(): ?string
-    {
-        return null;
     }
 
     private function pageIsInSubdirectory(): bool

--- a/packages/framework/src/Framework/Factories/NavigationDataFactory.php
+++ b/packages/framework/src/Framework/Factories/NavigationDataFactory.php
@@ -211,7 +211,7 @@ class NavigationDataFactory extends Concerns\PageDataFactory implements Navigati
     private function defaultGroup(): ?string
     {
         // TODO: It would be better if this was null in all cases, considering 'other' is used a a sort of confusing pseudo-null
-        return $this->isInstanceOf(DocumentationPage::class) ? 'other' : null;
+        return $this->isInstanceOf(DocumentationPage::class) ? null : null;
     }
 
     private function pageIsInSubdirectory(): bool

--- a/packages/framework/src/Framework/Factories/NavigationDataFactory.php
+++ b/packages/framework/src/Framework/Factories/NavigationDataFactory.php
@@ -210,7 +210,6 @@ class NavigationDataFactory extends Concerns\PageDataFactory implements Navigati
 
     private function defaultGroup(): ?string
     {
-        // TODO: It would be better if this was null in all cases, considering 'other' is used a a sort of confusing pseudo-null
         return $this->isInstanceOf(DocumentationPage::class) ? null : null;
     }
 

--- a/packages/framework/src/Framework/Features/Navigation/DocumentationSidebar.php
+++ b/packages/framework/src/Framework/Features/Navigation/DocumentationSidebar.php
@@ -81,9 +81,9 @@ class DocumentationSidebar
      *
      * @todo Get title from instance
      */
-    public function makeGroupTitle(string $group): string
+    public function makeGroupTitle(?string $group): string
     {
-        return Config::getNullableString("docs.sidebar_group_labels.$group") ?? Hyde::makeTitle($group);
+        return Config::getNullableString("docs.sidebar_group_labels.$group") ?? Hyde::makeTitle($group ?? 'Other');
     }
 
     private function isPageIndexPage(): bool

--- a/packages/framework/src/Framework/Features/Navigation/DocumentationSidebar.php
+++ b/packages/framework/src/Framework/Features/Navigation/DocumentationSidebar.php
@@ -66,6 +66,10 @@ class DocumentationSidebar
      */
     public function isGroupActive(?string $group): bool
     {
+        if ($group === null) {
+            return false;
+        }
+
         $groupMatchesCurrentPageGroup = Str::slug(Render::getPage()->navigationMenuGroup()) === $group;
         $currentPageIsIndexPageAndShouldBeActive = $this->isPageIndexPage() && $this->shouldIndexPageBeActive($group);
 

--- a/packages/framework/src/Framework/Features/Navigation/DocumentationSidebar.php
+++ b/packages/framework/src/Framework/Features/Navigation/DocumentationSidebar.php
@@ -45,7 +45,7 @@ class DocumentationSidebar
     /** @return array<string> */
     public function getGroups(): array
     {
-        return $this->items->map(function (NavItem $item): string {
+        return $this->items->map(function (NavItem $item): ?string {
             return $item->getGroup();
         })->unique()->toArray();
     }

--- a/packages/framework/src/Framework/Features/Navigation/DocumentationSidebar.php
+++ b/packages/framework/src/Framework/Features/Navigation/DocumentationSidebar.php
@@ -64,7 +64,7 @@ class DocumentationSidebar
      *
      * For index pages, this will also return true for the first group in the menu, unless the index page has a specific group set.
      */
-    public function isGroupActive(string $group): bool
+    public function isGroupActive(?string $group): bool
     {
         $groupMatchesCurrentPageGroup = Str::slug(Render::getPage()->navigationMenuGroup()) === $group;
         $currentPageIsIndexPageAndShouldBeActive = $this->isPageIndexPage() && $this->shouldIndexPageBeActive($group);

--- a/packages/framework/src/Framework/Features/Navigation/DocumentationSidebar.php
+++ b/packages/framework/src/Framework/Features/Navigation/DocumentationSidebar.php
@@ -39,7 +39,7 @@ class DocumentationSidebar
 
     public function hasGroups(): bool
     {
-        return (count($this->getGroups()) >= 1) && ($this->getGroups() !== ['other']);
+        return (count($this->getGroups()) >= 1) && ($this->getGroups() !== [null]);
     }
 
     /** @return array<string> */
@@ -89,7 +89,7 @@ class DocumentationSidebar
 
     private function shouldIndexPageBeActive(string $group): bool
     {
-        $indexPageHasNoSetGroup = Render::getPage()->navigationMenuGroup() === 'other';
+        $indexPageHasNoSetGroup = Render::getPage()->navigationMenuGroup() === null;
         $groupIsTheFirstOneInSidebar = $group === collect($this->getGroups())->first();
 
         return $indexPageHasNoSetGroup && $groupIsTheFirstOneInSidebar;

--- a/packages/framework/src/Framework/Features/Navigation/GeneratesDocumentationSidebarMenu.php
+++ b/packages/framework/src/Framework/Features/Navigation/GeneratesDocumentationSidebarMenu.php
@@ -48,7 +48,7 @@ class GeneratesDocumentationSidebarMenu
 
         // If there are no pages other than the index page, we add it to the sidebar so that it's not empty
         if ($this->items->count() === 0 && DocumentationPage::home() !== null) {
-            $this->items->push(NavItem::fromRoute(DocumentationPage::home(), group: 'other'));
+            $this->items->push(NavItem::fromRoute(DocumentationPage::home(), group: null));
         }
     }
 

--- a/packages/framework/tests/Feature/HydePageTest.php
+++ b/packages/framework/tests/Feature/HydePageTest.php
@@ -239,7 +239,7 @@ class HydePageTest extends TestCase
         $this->assertNull((new MarkdownPage())->navigationMenuGroup());
         $this->assertNull((new MarkdownPost())->navigationMenuGroup());
         $this->assertNull((new HtmlPage())->navigationMenuGroup());
-        $this->assertSame(null, (new DocumentationPage())->navigationMenuGroup());
+        $this->assertNull((new DocumentationPage())->navigationMenuGroup());
         $this->assertSame('foo', DocumentationPage::make(matter: ['navigation' => ['group' => 'foo']])->navigationMenuGroup());
     }
 

--- a/packages/framework/tests/Feature/HydePageTest.php
+++ b/packages/framework/tests/Feature/HydePageTest.php
@@ -239,7 +239,7 @@ class HydePageTest extends TestCase
         $this->assertNull((new MarkdownPage())->navigationMenuGroup());
         $this->assertNull((new MarkdownPost())->navigationMenuGroup());
         $this->assertNull((new HtmlPage())->navigationMenuGroup());
-        $this->assertSame('other', (new DocumentationPage())->navigationMenuGroup());
+        $this->assertSame(null, (new DocumentationPage())->navigationMenuGroup());
         $this->assertSame('foo', DocumentationPage::make(matter: ['navigation' => ['group' => 'foo']])->navigationMenuGroup());
     }
 

--- a/packages/framework/tests/Unit/HydePageSerializableUnitTest.php
+++ b/packages/framework/tests/Unit/HydePageSerializableUnitTest.php
@@ -347,7 +347,7 @@ class HydePageSerializableUnitTest extends UnitTestCase
                     "label": "",
                     "priority": 999,
                     "hidden": false,
-                    "group": "other"
+                    "group": null
                 },
                 "title": ""
             }

--- a/packages/framework/tests/Unit/Pages/DocumentationPageUnitTest.php
+++ b/packages/framework/tests/Unit/Pages/DocumentationPageUnitTest.php
@@ -98,7 +98,7 @@ class DocumentationPageUnitTest extends BaseMarkdownPageUnitTest
 
     public function testNavigationMenuGroup()
     {
-        $this->assertSame('other', (new DocumentationPage('foo'))->navigationMenuGroup());
+        $this->assertSame(null, (new DocumentationPage('foo'))->navigationMenuGroup());
     }
 
     public function testNavigationMenuGroupWithData()


### PR DESCRIPTION
It's kinda weird that we've been using `'other'` as a sort of pseudo-null state. It only makes sense for the group to be other when there are other groups, so that should be handled in the frontend Blade, thus we instead now null coalesce to `'Other'` when creating the group title.

This is breaking and targets V2 (specifically https://github.com/hydephp/develop/pull/1568)
