### PR TITLE
[2.x] Remove duplicate navigation item filtering

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -18,6 +18,7 @@ This serves two purposes:
 - Changed how the documentation search is generated, to be an `InMemoryPage` instead of a post-build task.
 - Media asset files are now copied using the new build task instead of the deprecated `BuildService::transferMediaAssets()` method.
 - Minor: The documentation article component now supports disabling the semantic rendering using a falsy value in https://github.com/hydephp/develop/pull/1566
+- Navigation menu items are now no longer filtered by duplicates (meaning two items with the same label can now exist in the same menu) in https://github.com/hydephp/develop/pull/1573
 - Breaking: The `NavItem` class now always stores the destination as a `Route` instance.
 - Breaking: The `NavItem::getDestination()` method now returns its `Route` instance.
 

--- a/packages/framework/src/Framework/Features/Navigation/GeneratesDocumentationSidebarMenu.php
+++ b/packages/framework/src/Framework/Features/Navigation/GeneratesDocumentationSidebarMenu.php
@@ -34,7 +34,6 @@ class GeneratesDocumentationSidebarMenu
 
         $menu->generate();
         $menu->sortByPriority();
-        $menu->removeDuplicateItems();
 
         return new DocumentationSidebar($menu->items);
     }
@@ -84,14 +83,6 @@ class GeneratesDocumentationSidebarMenu
     protected function canAddRoute(Route $route): bool
     {
         return $route->getPage()->showInNavigation() && ! $route->is(DocumentationPage::homeRouteName());
-    }
-
-    protected function removeDuplicateItems(): void
-    {
-        $this->items = $this->items->unique(function (NavItem $item): string {
-            // Filter using a combination of the group and identifier to allow duplicate labels in different groups
-            return $item->getGroup().$item->identifier;
-        });
     }
 
     protected function sortByPriority(): void

--- a/packages/framework/src/Framework/Features/Navigation/GeneratesMainNavigationMenu.php
+++ b/packages/framework/src/Framework/Features/Navigation/GeneratesMainNavigationMenu.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Hyde\Framework\Features\Navigation;
 
 use Hyde\Facades\Config;
-use Illuminate\Support\Str;
 use Hyde\Support\Models\Route;
 use Hyde\Pages\DocumentationPage;
 use Illuminate\Support\Collection;
@@ -36,7 +35,6 @@ class GeneratesMainNavigationMenu
 
         $menu->generate();
         $menu->sortByPriority();
-        $menu->removeDuplicateItems();
 
         return new NavigationMenu($menu->items);
     }
@@ -92,14 +90,6 @@ class GeneratesMainNavigationMenu
     protected function useSubdirectoriesAsDropdowns(): bool
     {
         return Config::getString('hyde.navigation.subdirectories', 'hidden') === 'dropdown';
-    }
-
-    protected function removeDuplicateItems(): void
-    {
-        $this->items = $this->items->unique(function (NavItem $item): string {
-            // Filter using a combination of the group and label to allow duplicate labels in different groups
-            return $item->getGroup().Str::slug($item->getLabel());
-        });
     }
 
     protected function sortByPriority(): void

--- a/packages/framework/tests/Feature/AutomaticNavigationConfigurationsTest.php
+++ b/packages/framework/tests/Feature/AutomaticNavigationConfigurationsTest.php
@@ -457,28 +457,29 @@ class AutomaticNavigationConfigurationsTest extends TestCase
         ]);
     }
 
-    public function testMainNavigationMenuItemsWithTheSameLabelAreFiltered()
+    public function testMainNavigationMenuItemsWithTheSameLabelAreNotFilteredForDuplicates()
     {
+        // Since the route key is the same, only one route is actually added
         $this->assertMenuEquals(['Foo'], [
             new MarkdownPage('foo'),
             new MarkdownPage('foo'),
         ]);
 
-        $this->assertMenuEquals(['Foo'], [
+        $this->assertMenuEquals(['Foo', 'Foo'], [
             new MarkdownPage('foo', ['navigation.label' => 'Foo']),
             new MarkdownPage('bar', ['navigation.label' => 'Foo']),
         ]);
     }
 
-    public function testMainNavigationMenuItemsWithTheSameLabelAreFilteredCaseInsensitive()
+    public function testMainNavigationMenuItemsWithTheSameLabelAreNotFilteredForDuplicatesRegardlessOfCase()
     {
-        $this->assertMenuEquals(['Foo'], [
+        $this->assertMenuEquals(['Foo', 'Foo', 'FOO'], [
             new MarkdownPage('foo'),
             new MarkdownPage('Foo'),
             new MarkdownPage('FOO'),
         ]);
 
-        $this->assertMenuEquals(['foo'], [
+        $this->assertMenuEquals(['foo', 'Foo', 'FOO'], [
             new MarkdownPage('foo', ['navigation.label' => 'foo']),
             new MarkdownPage('bar', ['navigation.label' => 'Foo']),
             new MarkdownPage('baz', ['navigation.label' => 'FOO']),

--- a/packages/framework/tests/Feature/AutomaticNavigationConfigurationsTest.php
+++ b/packages/framework/tests/Feature/AutomaticNavigationConfigurationsTest.php
@@ -883,28 +883,29 @@ class AutomaticNavigationConfigurationsTest extends TestCase
         }
     }
 
-    public function testSidebarItemsWithTheSameLabelAreFiltered()
+    public function testSidebarItemsWithTheSameLabelAreNotFiltered()
     {
+        // Since the route key is the same, only one route is actually added
         $this->assertSidebarEquals(['Foo'], [
             new DocumentationPage('foo'),
             new DocumentationPage('foo'),
         ]);
 
-        $this->assertSidebarEquals(['Foo'], [
+        $this->assertSidebarEquals(['Foo', 'Foo'], [
             new DocumentationPage('foo', ['navigation.label' => 'Foo']),
             new DocumentationPage('bar', ['navigation.label' => 'Foo']),
         ]);
     }
 
-    public function testSidebarItemsWithTheSameLabelAreFilteredCaseInsensitive()
+    public function testSidebarItemsWithTheSameLabelAreNotFilteredForDuplicatesRegardlessOfCase()
     {
-        $this->assertSidebarEquals(['Foo'], [
+        $this->assertSidebarEquals(['Foo', 'Foo', 'FOO'], [
             new DocumentationPage('foo'),
             new DocumentationPage('Foo'),
             new DocumentationPage('FOO'),
         ]);
 
-        $this->assertSidebarEquals(['foo'], [
+        $this->assertSidebarEquals(['foo', 'Foo', 'FOO'], [
             new DocumentationPage('foo', ['navigation.label' => 'foo']),
             new DocumentationPage('bar', ['navigation.label' => 'Foo']),
             new DocumentationPage('baz', ['navigation.label' => 'FOO']),

--- a/packages/framework/tests/Feature/AutomaticNavigationConfigurationsTest.php
+++ b/packages/framework/tests/Feature/AutomaticNavigationConfigurationsTest.php
@@ -459,12 +459,6 @@ class AutomaticNavigationConfigurationsTest extends TestCase
 
     public function testMainNavigationMenuItemsWithTheSameLabelAreNotFilteredForDuplicates()
     {
-        // Since the route key is the same, only one route is actually added
-        $this->assertMenuEquals(['Foo'], [
-            new MarkdownPage('foo'),
-            new MarkdownPage('foo'),
-        ]);
-
         $this->assertMenuEquals(['Foo', 'Foo'], [
             new MarkdownPage('foo', ['navigation.label' => 'Foo']),
             new MarkdownPage('bar', ['navigation.label' => 'Foo']),
@@ -885,12 +879,6 @@ class AutomaticNavigationConfigurationsTest extends TestCase
 
     public function testSidebarItemsWithTheSameLabelAreNotFiltered()
     {
-        // Since the route key is the same, only one route is actually added
-        $this->assertSidebarEquals(['Foo'], [
-            new DocumentationPage('foo'),
-            new DocumentationPage('foo'),
-        ]);
-
         $this->assertSidebarEquals(['Foo', 'Foo'], [
             new DocumentationPage('foo', ['navigation.label' => 'Foo']),
             new DocumentationPage('bar', ['navigation.label' => 'Foo']),

--- a/packages/framework/tests/Feature/NavigationMenuTest.php
+++ b/packages/framework/tests/Feature/NavigationMenuTest.php
@@ -119,7 +119,7 @@ class NavigationMenuTest extends TestCase
         $this->assertEquals($expected, $menu->getItems());
     }
 
-    public function testDuplicatesAreRemovedWhenAddingInConfig()
+    public function testDuplicatesAreNotRemovedWhenAddingInConfig()
     {
         config(['hyde.navigation.custom' => [
             NavItem::forLink('foo', 'foo'),
@@ -131,13 +131,14 @@ class NavigationMenuTest extends TestCase
         $expected = collect([
             NavItem::fromRoute(Routes::get('index')),
             NavItem::forLink('foo', 'foo'),
+            NavItem::forLink('foo', 'foo'),
         ]);
 
         $this->assertCount(count($expected), $menu->getItems());
         $this->assertEquals($expected, $menu->getItems());
     }
 
-    public function testDuplicatesAreRemovedWhenAddingInConfigRegardlessOfDestination()
+    public function testDuplicatesAreNotRemovedWhenAddingInConfigRegardlessOfDestination()
     {
         config(['hyde.navigation.custom' => [
             NavItem::forLink('foo', 'foo'),
@@ -149,6 +150,7 @@ class NavigationMenuTest extends TestCase
         $expected = collect([
             NavItem::fromRoute(Routes::get('index')),
             NavItem::forLink('foo', 'foo'),
+            NavItem::forLink('bar', 'foo'),
         ]);
 
         $this->assertCount(count($expected), $menu->getItems());
@@ -166,6 +168,7 @@ class NavigationMenuTest extends TestCase
         $expected = collect([
             NavItem::fromRoute(Routes::get('index')),
             NavItem::forLink('bar', 'Foo'),
+            NavItem::fromRoute(Routes::get('foo')),
         ]);
 
         $this->assertCount(count($expected), $menu->getItems());

--- a/packages/framework/tests/Feature/Services/DocumentationSidebarTest.php
+++ b/packages/framework/tests/Feature/Services/DocumentationSidebarTest.php
@@ -372,16 +372,19 @@ class DocumentationSidebarTest extends TestCase
         );
     }
 
-    public function testDuplicateLabelsWithinTheSameGroupIsRemoved()
+    public function testDuplicateLabelsWithinTheSameGroupAreNotRemoved()
     {
         $this->makePage('foo', ['navigation.group' => 'foo', 'navigation.label' => 'Foo']);
         $this->makePage('bar', ['navigation.group' => 'foo', 'navigation.label' => 'Foo']);
 
         $sidebar = DocumentationSidebar::create();
-        $this->assertCount(1, $sidebar->getItems());
+        $this->assertCount(2, $sidebar->getItems());
 
         $this->assertEquals(
-            collect([NavItem::fromRoute(Routes::get('docs/bar'), priority: 999)]),
+            collect([
+                NavItem::fromRoute(Routes::get('docs/bar'), priority: 999),
+                NavItem::fromRoute(Routes::get('docs/foo'), priority: 999),
+            ]),
             $sidebar->getItems()
         );
     }


### PR DESCRIPTION
This targets HydePHP v2.x via https://github.com/hydephp/develop/pull/1568

> I realized something, do we actually want to remove duplicate items? What's really the point of that? If two pages have the same label the user might be doing something wrong, so should we try to obscure that by hiding one of them? Better to have visibility so the user can find the issue and manually hide the page they don't want,

_Originally posted by @caendesilva in https://github.com/hydephp/develop/issues/1568#issuecomment-1952387747_
            