### PR TITLE
[2.x] Replace navigation item group normalization juggling with looser comparison 

### DIFF
--- a/packages/framework/src/Framework/Features/Navigation/GeneratesDocumentationSidebarMenu.php
+++ b/packages/framework/src/Framework/Features/Navigation/GeneratesDocumentationSidebarMenu.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Hyde\Framework\Features\Navigation;
 
 use Hyde\Hyde;
+use Illuminate\Support\Str;
 use Hyde\Support\Models\Route;
 use Hyde\Pages\DocumentationPage;
 use Illuminate\Support\Collection;
@@ -58,7 +59,7 @@ class GeneratesDocumentationSidebarMenu
                         $group = 'Other';
                     }
 
-                    $groupItem = $this->items->get($group);
+                    $groupItem = $this->items->get(Str::slug($group));
 
                     if ($groupItem === null) {
                         $groupItem = NavItem::dropdown($this->makeTitleForGroup($group), []);
@@ -66,8 +67,8 @@ class GeneratesDocumentationSidebarMenu
 
                     $groupItem->addChild($item);
 
-                    if (! $this->items->has($group)) {
-                        $this->items->put($group, $groupItem);
+                    if (! $this->items->has(Str::slug($group))) {
+                        $this->items->put(Str::slug($group), $groupItem);
                     }
 
                     return;

--- a/packages/framework/src/Framework/Features/Navigation/GeneratesDocumentationSidebarMenu.php
+++ b/packages/framework/src/Framework/Features/Navigation/GeneratesDocumentationSidebarMenu.php
@@ -96,9 +96,12 @@ class GeneratesDocumentationSidebarMenu
 
     protected function makeTitleForGroup(string $group): string
     {
-        // Todo search for other labels in the group before slugifying them
+        // If the label is not formatted, we format it here
+        if ($group === strtolower($group)) {
+            return Hyde::makeTitle($group);
+        }
 
-        return Hyde::makeTitle($group);
+        return $group;
     }
 
     protected function canAddRoute(Route $route): bool

--- a/packages/framework/src/Framework/Features/Navigation/NavItem.php
+++ b/packages/framework/src/Framework/Features/Navigation/NavItem.php
@@ -197,7 +197,17 @@ class NavItem implements Stringable
 
     protected static function normalizeGroupKey(?string $group): ?string
     {
-        return $group ? Str::slug($group) : null;
+        // If there is no group, we return null
+        if (! $group) {
+            return null;
+        }
+
+        // If the label is not formatted, we format it here
+        if ($group === strtolower($group)) {
+            return Hyde::makeTitle($group);
+        }
+
+        return $group;
     }
 
     protected static function makeIdentifier(string $label): string

--- a/packages/framework/tests/Feature/AutomaticNavigationConfigurationsTest.php
+++ b/packages/framework/tests/Feature/AutomaticNavigationConfigurationsTest.php
@@ -203,9 +203,9 @@ class AutomaticNavigationConfigurationsTest extends TestCase
         // TODO: For new v2 system, this should insert a root item with the group name and the children as the pages
 
         $this->assertMenuEquals([
-            ['label' => 'Foo', 'group' => 'group-1'],
-            ['label' => 'Bar', 'group' => 'group-1'],
-            ['label' => 'Baz', 'group' => 'group-1'],
+            ['label' => 'Foo', 'group' => 'Group 1'],
+            ['label' => 'Bar', 'group' => 'Group 1'],
+            ['label' => 'Baz', 'group' => 'Group 1'],
         ], [
             new MarkdownPage('foo', ['navigation.group' => 'Group 1']),
             new MarkdownPage('bar', ['navigation.group' => 'Group 1']),
@@ -218,9 +218,9 @@ class AutomaticNavigationConfigurationsTest extends TestCase
         // TODO: For new v2 system, this should insert a root item with the group name and the children as the pages
 
         $this->assertMenuEquals([
-            ['label' => 'Foo', 'group' => 'group-1'],
-            ['label' => 'Bar', 'group' => 'group-1'],
-            ['label' => 'Baz', 'group' => 'group-1'],
+            ['label' => 'Foo', 'group' => 'Group 1'],
+            ['label' => 'Bar', 'group' => 'Group 1'],
+            ['label' => 'Baz', 'group' => 'Group 1'],
         ], [
             new MarkdownPage('foo', ['navigation.category' => 'Group 1']),
             new MarkdownPage('bar', ['navigation.category' => 'Group 1']),
@@ -290,7 +290,7 @@ class AutomaticNavigationConfigurationsTest extends TestCase
     {
         // Since the main key in the navigation schema is 'group', that takes precedence over its 'category' alias
 
-        $this->assertMenuEquals(array_fill(0, 3, ['group' => 'group-1']), [
+        $this->assertMenuEquals(array_fill(0, 3, ['group' => 'Group 1']), [
             new MarkdownPage('foo', ['navigation.group' => 'Group 1', 'navigation.category' => 'Group 2']),
             new MarkdownPage('bar', ['navigation.group' => 'Group 1', 'navigation.category' => 'Group 2']),
             new MarkdownPage('baz', ['navigation.group' => 'Group 1', 'navigation.category' => 'Group 2']),
@@ -483,8 +483,8 @@ class AutomaticNavigationConfigurationsTest extends TestCase
     public function testMainNavigationMenuItemsWithSameLabelButDifferentGroupsAreNotFiltered()
     {
         $this->assertMenuEquals([
-            ['label' => 'Foo', 'group' => 'group-1'],
-            ['label' => 'Foo', 'group' => 'group-2'],
+            ['label' => 'Foo', 'group' => 'Group 1'],
+            ['label' => 'Foo', 'group' => 'Group 2'],
         ], [
             new MarkdownPage('foo', ['navigation.label' => 'Foo', 'navigation.group' => 'Group 1']),
             new MarkdownPage('bar', ['navigation.label' => 'Foo', 'navigation.group' => 'Group 2']),
@@ -496,9 +496,8 @@ class AutomaticNavigationConfigurationsTest extends TestCase
         config(['hyde.navigation.subdirectories' => 'dropdown']);
 
         $this->assertMenuEquals([
-            // Todo: Should use proper group name
-            ['label' => 'group-1', 'children' => ['Foo']],
-            ['label' => 'group-2', 'children' => ['Foo']],
+            ['label' => 'Group 1', 'children' => ['Foo']],
+            ['label' => 'Group 2', 'children' => ['Foo']],
         ], [
             new MarkdownPage('one/foo', ['navigation.group' => 'Group 1']),
             new MarkdownPage('two/foo', ['navigation.group' => 'Group 2']),
@@ -980,8 +979,6 @@ class AutomaticNavigationConfigurationsTest extends TestCase
 
     public function testSidebarLabelsRetainBestFormatting()
     {
-        $this->markTestSkipped('Not yet implemented');
-
         $this->assertSidebarEquals(['GitHub'], [
             new DocumentationPage('foo', ['navigation.group' => 'GitHub']),
             new DocumentationPage('bar', ['navigation.group' => 'github']),

--- a/packages/framework/tests/Unit/NavItemTest.php
+++ b/packages/framework/tests/Unit/NavItemTest.php
@@ -345,8 +345,8 @@ class NavItemTest extends UnitTestCase
 
     public function testGroupKeysAreNormalized()
     {
-        $item = new NavItem(new Route(new MarkdownPage()), 'Test', 500, 'Foo Bar');
-        $this->assertSame('foo-bar', $item->getGroup());
+        $this->assertSame('Foo Bar', (new NavItem(new Route(new MarkdownPage()), 'Test', 500, 'Foo Bar'))->getGroup());
+        $this->assertSame('Foo Bar', (new NavItem(new Route(new MarkdownPage()), 'Test', 500, 'foo-bar'))->getGroup());
     }
 
     public function testIdentifier()


### PR DESCRIPTION
This targets v2.x via https://github.com/hydephp/develop/pull/1568

The reason we slugified the label is to have a looser comparison, considering "Foo" and "foo" the same for navigation groups. But messing with the title then makes it harder to format it back. By instead slugifying at comparison time, we bypass this problem. It also has the "side effect" of having more cases where the title is accurate, hence why some tests needed updating.

This is obviously susceptible to race conditions, but there is only so much we can do if the user is not consistent with their group naming. It also kinda makes the internal state "ugly" but since it reduces complexity and improves accuracy I think it's worth it.