### PR TITLE
[2.x] Improved navigation group label generation

### DIFF
--- a/packages/framework/src/Framework/Features/Navigation/GeneratesDocumentationSidebarMenu.php
+++ b/packages/framework/src/Framework/Features/Navigation/GeneratesDocumentationSidebarMenu.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Hyde\Framework\Features\Navigation;
 
-use Hyde\Hyde;
 use Illuminate\Support\Str;
 use Hyde\Support\Models\Route;
 use Hyde\Pages\DocumentationPage;
@@ -62,7 +61,7 @@ class GeneratesDocumentationSidebarMenu
                     $groupItem = $this->items->get(Str::slug($group));
 
                     if ($groupItem === null) {
-                        $groupItem = NavItem::dropdown($this->makeTitleForGroup($group), []);
+                        $groupItem = NavItem::dropdown($group, []);
                     }
 
                     $groupItem->addChild($item);
@@ -92,13 +91,6 @@ class GeneratesDocumentationSidebarMenu
         return $this->routes->first(function (Route $route): bool {
             return filled($route->getPage()->navigationMenuGroup());
         }) !== null;
-    }
-
-    protected function makeTitleForGroup(string $group): string
-    {
-        // Todo search for other labels in the group before slugifying them
-
-        return Hyde::makeTitle($group);
     }
 
     protected function canAddRoute(Route $route): bool

--- a/packages/framework/src/Framework/Features/Navigation/GeneratesDocumentationSidebarMenu.php
+++ b/packages/framework/src/Framework/Features/Navigation/GeneratesDocumentationSidebarMenu.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Hyde\Framework\Features\Navigation;
 
 use Hyde\Hyde;
+use Illuminate\Support\Str;
 use Hyde\Support\Models\Route;
 use Hyde\Pages\DocumentationPage;
 use Illuminate\Support\Collection;
@@ -58,7 +59,7 @@ class GeneratesDocumentationSidebarMenu
                         $group = 'Other';
                     }
 
-                    $groupItem = $this->items->get($group);
+                    $groupItem = $this->items->get(Str::slug($group));
 
                     if ($groupItem === null) {
                         $groupItem = NavItem::dropdown($this->makeTitleForGroup($group), []);
@@ -66,8 +67,8 @@ class GeneratesDocumentationSidebarMenu
 
                     $groupItem->addChild($item);
 
-                    if (! $this->items->has($group)) {
-                        $this->items->put($group, $groupItem);
+                    if (! $this->items->has($groupItem->getIdentifier())) {
+                        $this->items->put($groupItem->getIdentifier(), $groupItem);
                     }
 
                     return;

--- a/packages/framework/src/Framework/Features/Navigation/NavItem.php
+++ b/packages/framework/src/Framework/Features/Navigation/NavItem.php
@@ -45,7 +45,7 @@ class NavItem implements Stringable
         }
 
         $this->destination = $destination;
-        $this->label = $this->normalizeLabel($label);
+        $this->label = $label;
         $this->priority = $priority;
         $this->group = static::normalizeGroupKey($group);
         $this->identifier = $this->makeIdentifier($label);

--- a/packages/framework/src/Framework/Features/Navigation/NavItem.php
+++ b/packages/framework/src/Framework/Features/Navigation/NavItem.php
@@ -226,6 +226,7 @@ class NavItem implements Stringable
 
     protected static function normalizeGroupLabel(?string $label): ?string
     {
+        // If there is no label, and the group is a slug, we can make a title from it
         if ($label && ($label === strtolower($label))) {
             return Hyde::makeTitle($label);
         }
@@ -242,7 +243,6 @@ class NavItem implements Stringable
             return $configLabel;
         }
 
-        // If there is no label, and the group is a slug, we can make a title from it
         return static::normalizeGroupLabel($this->group ?? $this->label);
     }
 }

--- a/packages/framework/src/Framework/Features/Navigation/NavItem.php
+++ b/packages/framework/src/Framework/Features/Navigation/NavItem.php
@@ -232,4 +232,10 @@ class NavItem implements Stringable
 
         return $config[$groupKey] ?? null;
     }
+
+    /** Find the best label for the group. */
+    protected function makeGroupLabel(): string
+    {
+        return static::normalizeGroupLabel($this->label);
+    }
 }

--- a/packages/framework/src/Framework/Features/Navigation/NavItem.php
+++ b/packages/framework/src/Framework/Features/Navigation/NavItem.php
@@ -236,6 +236,12 @@ class NavItem implements Stringable
     /** Find the best label for the group. */
     protected function makeGroupLabel(): string
     {
-        return static::normalizeGroupLabel($this->label);
+        $configLabel = Config::getNullableString('docs.sidebar_group_labels.'.Str::slug($this->identifier));
+
+        if ($configLabel) {
+            return $configLabel;
+        }
+
+        return $this->label;
     }
 }

--- a/packages/framework/src/Framework/Features/Navigation/NavItem.php
+++ b/packages/framework/src/Framework/Features/Navigation/NavItem.php
@@ -12,6 +12,9 @@ use Illuminate\Support\Str;
 use Stringable;
 use Hyde\Support\Models\ExternalRoute;
 
+use function is_string;
+use function strtolower;
+
 /**
  * Abstraction for a navigation menu item. Used by the MainNavigationMenu and DocumentationSidebar classes.
  *

--- a/packages/framework/src/Framework/Features/Navigation/NavItem.php
+++ b/packages/framework/src/Framework/Features/Navigation/NavItem.php
@@ -233,7 +233,6 @@ class NavItem implements Stringable
     /** Find the best label for the group. */
     protected function makeGroupLabel(): string
     {
-        return Config::getArray('docs.sidebar_group_labels', [])[Str::slug($this->identifier)]
-            ?? $this->label;
+        return Config::getArray('docs.sidebar_group_labels', [])[Str::slug($this->identifier)] ?? $this->label;
     }
 }

--- a/packages/framework/src/Framework/Features/Navigation/NavItem.php
+++ b/packages/framework/src/Framework/Features/Navigation/NavItem.php
@@ -196,6 +196,8 @@ class NavItem implements Stringable
      */
     public function addChild(NavItem $item): void
     {
+        // Todo: Ensure that the item has a group identifier by creating it from the label if it doesn't exist?
+
         $this->children[] = $item;
     }
 

--- a/packages/framework/src/Framework/Features/Navigation/NavItem.php
+++ b/packages/framework/src/Framework/Features/Navigation/NavItem.php
@@ -231,6 +231,11 @@ class NavItem implements Stringable
             return $configLabel;
         }
 
+        // If there is no label, and the group is a slug, we can make a title from it
+        if ($this->group === $this->label && $this->group === strtolower($this->group)) {
+            return Hyde::makeTitle($this->group);
+        }
+
         return $this->label;
     }
 }

--- a/packages/framework/src/Framework/Features/Navigation/NavItem.php
+++ b/packages/framework/src/Framework/Features/Navigation/NavItem.php
@@ -218,11 +218,7 @@ class NavItem implements Stringable
     protected static function searchForDropdownPriorityInNavigationConfig(string $groupKey): ?int
     {
         /** @var array<string, int> $config */
-        $config = Config::getArray('hyde.navigation.order', [
-            'index' => 0,
-            'posts' => 10,
-            'docs/index' => 100,
-        ]);
+        $config = Config::getArray('hyde.navigation.order', []);
 
         return $config[$groupKey] ?? null;
     }

--- a/packages/framework/src/Framework/Features/Navigation/NavItem.php
+++ b/packages/framework/src/Framework/Features/Navigation/NavItem.php
@@ -217,10 +217,7 @@ class NavItem implements Stringable
     // TODO: Consider moving all of these to a dropdown factory
     protected static function searchForDropdownPriorityInNavigationConfig(string $groupKey): ?int
     {
-        /** @var array<string, int> $config */
-        $config = Config::getArray('hyde.navigation.order', []);
-
-        return $config[$groupKey] ?? null;
+        return Config::getArray('hyde.navigation.order', [])[$groupKey] ?? null;
     }
 
     protected static function normalizeGroupLabel(string $label): string

--- a/packages/framework/src/Framework/Features/Navigation/NavItem.php
+++ b/packages/framework/src/Framework/Features/Navigation/NavItem.php
@@ -224,6 +224,15 @@ class NavItem implements Stringable
         return $config[$groupKey] ?? null;
     }
 
+    protected static function normalizeGroupLabel(?string $label): ?string
+    {
+        if ($label && ($label === strtolower($label))) {
+            return Hyde::makeTitle($label);
+        }
+
+        return $label;
+    }
+
     /** Find the best label for the group. */
     protected function makeGroupLabel(): string
     {
@@ -235,14 +244,5 @@ class NavItem implements Stringable
 
         // If there is no label, and the group is a slug, we can make a title from it
         return $this->normalizeGroupLabel($this->group ?? $this->label);
-    }
-
-    protected static function normalizeGroupLabel(?string $label): ?string
-    {
-        if ($label && ($label === strtolower($label))) {
-            return Hyde::makeTitle($label);
-        }
-
-        return $label;
     }
 }

--- a/packages/framework/src/Framework/Features/Navigation/NavItem.php
+++ b/packages/framework/src/Framework/Features/Navigation/NavItem.php
@@ -235,9 +235,9 @@ class NavItem implements Stringable
         return $this->normalizeLabel($this->group);
     }
 
-    protected function normalizeLabel(string $label): ?string
+    protected function normalizeLabel(?string $label): ?string
     {
-        if ($label === strtolower($label)) {
+        if ($label && ($label === strtolower($label))) {
             return Hyde::makeTitle($label);
         }
 

--- a/packages/framework/src/Framework/Features/Navigation/NavItem.php
+++ b/packages/framework/src/Framework/Features/Navigation/NavItem.php
@@ -98,7 +98,7 @@ class NavItem implements Stringable
     public static function dropdown(string $label, array $items, ?int $priority = null): static
     {
         // TODO resolve label from config here instead of view
-        return new static('', $label, $priority ?? static::searchForDropdownPriorityInNavigationConfig($label) ?? 999, null, $items);
+        return new static('', $label, $priority ?? static::searchForDropdownPriorityInNavigationConfig($label) ?? 999, $label, $items);
     }
 
     /**

--- a/packages/framework/src/Framework/Features/Navigation/NavItem.php
+++ b/packages/framework/src/Framework/Features/Navigation/NavItem.php
@@ -130,6 +130,10 @@ class NavItem implements Stringable
      */
     public function getLabel(): string
     {
+        if ($this->hasChildren()) {
+            return $this->makeGroupLabel();
+        }
+
         return $this->label;
     }
 

--- a/packages/framework/src/Framework/Features/Navigation/NavItem.php
+++ b/packages/framework/src/Framework/Features/Navigation/NavItem.php
@@ -243,6 +243,6 @@ class NavItem implements Stringable
         }
 
         // If there is no label, and the group is a slug, we can make a title from it
-        return $this->normalizeGroupLabel($this->group ?? $this->label);
+        return static::normalizeGroupLabel($this->group ?? $this->label);
     }
 }

--- a/packages/framework/src/Framework/Features/Navigation/NavItem.php
+++ b/packages/framework/src/Framework/Features/Navigation/NavItem.php
@@ -98,7 +98,7 @@ class NavItem implements Stringable
     public static function dropdown(string $label, array $items, ?int $priority = null): static
     {
         // TODO resolve label from config here instead of view
-        return new static('', $label, $priority ?? static::searchForDropdownPriorityInNavigationConfig($label) ?? 999, $label, $items);
+        return new static('', static::normalizeLabel($label), $priority ?? static::searchForDropdownPriorityInNavigationConfig($label) ?? 999, $label, $items);
     }
 
     /**
@@ -237,7 +237,7 @@ class NavItem implements Stringable
         return $this->normalizeLabel($this->group ?? $this->label);
     }
 
-    protected function normalizeLabel(?string $label): ?string
+    protected static function normalizeLabel(?string $label): ?string
     {
         if ($label && ($label === strtolower($label))) {
             return Hyde::makeTitle($label);

--- a/packages/framework/src/Framework/Features/Navigation/NavItem.php
+++ b/packages/framework/src/Framework/Features/Navigation/NavItem.php
@@ -233,7 +233,7 @@ class NavItem implements Stringable
     /** Find the best label for the group. */
     protected function makeGroupLabel(): string
     {
-        return Config::getNullableString('docs.sidebar_group_labels.'.Str::slug($this->identifier))
+        return Config::getArray('docs.sidebar_group_labels', [])[Str::slug($this->identifier)]
             ?? $this->label;
     }
 }

--- a/packages/framework/src/Framework/Features/Navigation/NavItem.php
+++ b/packages/framework/src/Framework/Features/Navigation/NavItem.php
@@ -98,7 +98,7 @@ class NavItem implements Stringable
     public static function dropdown(string $label, array $items, ?int $priority = null): static
     {
         // TODO resolve label from config here instead of view
-        return new static('', static::normalizeLabel($label), $priority ?? static::searchForDropdownPriorityInNavigationConfig($label) ?? 999, $label, $items);
+        return new static('', static::normalizeGroupLabel($label), $priority ?? static::searchForDropdownPriorityInNavigationConfig($label) ?? 999, $label, $items);
     }
 
     /**
@@ -234,10 +234,10 @@ class NavItem implements Stringable
         }
 
         // If there is no label, and the group is a slug, we can make a title from it
-        return $this->normalizeLabel($this->group ?? $this->label);
+        return $this->normalizeGroupLabel($this->group ?? $this->label);
     }
 
-    protected static function normalizeLabel(?string $label): ?string
+    protected static function normalizeGroupLabel(?string $label): ?string
     {
         if ($label && ($label === strtolower($label))) {
             return Hyde::makeTitle($label);

--- a/packages/framework/src/Framework/Features/Navigation/NavItem.php
+++ b/packages/framework/src/Framework/Features/Navigation/NavItem.php
@@ -234,7 +234,7 @@ class NavItem implements Stringable
         }
 
         // If there is no label, and the group is a slug, we can make a title from it
-        return $this->normalizeLabel($this->group);
+        return $this->normalizeLabel($this->group ?? $this->label);
     }
 
     protected function normalizeLabel(?string $label): ?string

--- a/packages/framework/src/Framework/Features/Navigation/NavItem.php
+++ b/packages/framework/src/Framework/Features/Navigation/NavItem.php
@@ -98,7 +98,7 @@ class NavItem implements Stringable
     public static function dropdown(string $label, array $items, ?int $priority = null): static
     {
         // TODO resolve label from config here instead of view
-        return new static('', static::normalizeGroupLabel($label), $priority ?? static::searchForDropdownPriorityInNavigationConfig($label) ?? 999, null, $items);
+        return new static('', $label, $priority ?? static::searchForDropdownPriorityInNavigationConfig($label) ?? 999, null, $items);
     }
 
     /**
@@ -207,17 +207,6 @@ class NavItem implements Stringable
     protected static function makeIdentifier(string $label): string
     {
         return Str::slug($label); // Todo: If it's a dropdown based on a subdirectory, we should use the subdirectory as the identifier
-    }
-
-    protected static function normalizeGroupLabel(string $label): string
-    {
-        $configLabel = Config::getNullableString('docs.sidebar_group_labels.'.Str::slug($label));
-
-        if ($configLabel) {
-            return $configLabel;
-        }
-
-        return $label;
     }
 
     // TODO: Consider moving all of these to a dropdown factory

--- a/packages/framework/src/Framework/Features/Navigation/NavItem.php
+++ b/packages/framework/src/Framework/Features/Navigation/NavItem.php
@@ -240,12 +240,7 @@ class NavItem implements Stringable
     /** Find the best label for the group. */
     protected function makeGroupLabel(): string
     {
-        $configLabel = Config::getNullableString('docs.sidebar_group_labels.'.Str::slug($this->identifier));
-
-        if ($configLabel) {
-            return $configLabel;
-        }
-
-        return static::normalizeGroupLabel($this->group ?? $this->label);
+        return Config::getNullableString('docs.sidebar_group_labels.'.Str::slug($this->identifier))
+            ?? static::normalizeGroupLabel($this->group ?? $this->label);
     }
 }

--- a/packages/framework/src/Framework/Features/Navigation/NavItem.php
+++ b/packages/framework/src/Framework/Features/Navigation/NavItem.php
@@ -241,6 +241,6 @@ class NavItem implements Stringable
     protected function makeGroupLabel(): string
     {
         return Config::getNullableString('docs.sidebar_group_labels.'.Str::slug($this->identifier))
-            ?? static::normalizeGroupLabel($this->group ?? $this->label);
+            ?? $this->label;
     }
 }

--- a/packages/framework/src/Framework/Features/Navigation/NavItem.php
+++ b/packages/framework/src/Framework/Features/Navigation/NavItem.php
@@ -227,10 +227,10 @@ class NavItem implements Stringable
         return $config[$groupKey] ?? null;
     }
 
-    protected static function normalizeGroupLabel(?string $label): ?string
+    protected static function normalizeGroupLabel(string $label): string
     {
         // If there is no label, and the group is a slug, we can make a title from it
-        if ($label && ($label === strtolower($label))) {
+        if ($label === strtolower($label)) {
             return Hyde::makeTitle($label);
         }
 

--- a/packages/framework/src/Framework/Features/Navigation/NavItem.php
+++ b/packages/framework/src/Framework/Features/Navigation/NavItem.php
@@ -232,10 +232,15 @@ class NavItem implements Stringable
         }
 
         // If there is no label, and the group is a slug, we can make a title from it
-        if ($this->group === $this->label && $this->group === strtolower($this->group)) {
-            return Hyde::makeTitle($this->group);
+        return $this->normalizeLabel($this->group);
+    }
+
+    protected function normalizeLabel(string $label): ?string
+    {
+        if ($label === strtolower($label)) {
+            return Hyde::makeTitle($label);
         }
 
-        return $this->label;
+        return $label;
     }
 }

--- a/packages/framework/src/Framework/Features/Navigation/NavItem.php
+++ b/packages/framework/src/Framework/Features/Navigation/NavItem.php
@@ -45,7 +45,7 @@ class NavItem implements Stringable
         }
 
         $this->destination = $destination;
-        $this->label = $label;
+        $this->label = $this->normalizeLabel($label);
         $this->priority = $priority;
         $this->group = static::normalizeGroupKey($group);
         $this->identifier = $this->makeIdentifier($label);

--- a/packages/framework/tests/Feature/AutomaticNavigationConfigurationsTest.php
+++ b/packages/framework/tests/Feature/AutomaticNavigationConfigurationsTest.php
@@ -448,8 +448,7 @@ class AutomaticNavigationConfigurationsTest extends TestCase
         config(['hyde.navigation.subdirectories' => 'dropdown']);
 
         $this->assertMenuEquals([
-            ['label' => 'about', 'children' => ['Foo', 'Bar', 'Baz']],
-            // TODO: Label should be About
+            ['label' => 'About', 'children' => ['Foo', 'Bar', 'Baz']],
         ], [
             new MarkdownPage('about/foo'),
             new MarkdownPage('about/bar'),
@@ -496,9 +495,8 @@ class AutomaticNavigationConfigurationsTest extends TestCase
         config(['hyde.navigation.subdirectories' => 'dropdown']);
 
         $this->assertMenuEquals([
-            // Todo: Should use proper group name
-            ['label' => 'group-1', 'children' => ['Foo']],
-            ['label' => 'group-2', 'children' => ['Foo']],
+            ['label' => 'Group 1', 'children' => ['Foo']],
+            ['label' => 'Group 2', 'children' => ['Foo']],
         ], [
             new MarkdownPage('one/foo', ['navigation.group' => 'Group 1']),
             new MarkdownPage('two/foo', ['navigation.group' => 'Group 2']),
@@ -510,9 +508,8 @@ class AutomaticNavigationConfigurationsTest extends TestCase
         config(['hyde.navigation.subdirectories' => 'dropdown']);
 
         $this->assertMenuEquals([
-            // Todo: Should use proper group name
-            ['label' => 'one', 'children' => ['Foo']],
-            ['label' => 'two', 'children' => ['Foo']],
+            ['label' => 'One', 'children' => ['Foo']],
+            ['label' => 'Two', 'children' => ['Foo']],
         ], [
             new MarkdownPage('one/foo'),
             new MarkdownPage('two/foo'),

--- a/packages/framework/tests/Feature/AutomaticNavigationConfigurationsTest.php
+++ b/packages/framework/tests/Feature/AutomaticNavigationConfigurationsTest.php
@@ -1042,6 +1042,8 @@ class AutomaticNavigationConfigurationsTest extends TestCase
 
     public function testMainMenuNavigationItemCasing()
     {
+        // These labels are based on the page titles, which are made from the file names, so we try to format them
+
         $this->assertMenuEquals(['Hello World'], [new MarkdownPage('Hello World')]);
         $this->assertMenuEquals(['Hello World'], [new MarkdownPage('hello-world')]);
         $this->assertMenuEquals(['Hello World'], [new MarkdownPage('hello world')]);
@@ -1049,14 +1051,22 @@ class AutomaticNavigationConfigurationsTest extends TestCase
 
     public function testMainMenuNavigationItemCasingUsingFrontMatter()
     {
+        // If the user explicitly sets the label, we should respect that and assume it's already formatted correctly
+
+        $this->assertMenuEquals(['Hello World'], [new MarkdownPage('foo', ['title' => 'Hello World'])]);
+        $this->assertMenuEquals(['hello-world'], [new MarkdownPage('foo', ['title' => 'hello-world'])]);
+        $this->assertMenuEquals(['hello world'], [new MarkdownPage('foo', ['title' => 'hello world'])]);
+
         $this->assertMenuEquals(['Hello World'], [new MarkdownPage('foo', ['navigation.label' => 'Hello World'])]);
-        $this->assertMenuEquals(['Hello World'], [new MarkdownPage('foo', ['navigation.label' => 'hello-world'])]);
-        $this->assertMenuEquals(['Hello World'], [new MarkdownPage('foo', ['navigation.label' => 'hello world'])]);
+        $this->assertMenuEquals(['hello-world'], [new MarkdownPage('foo', ['navigation.label' => 'hello-world'])]);
+        $this->assertMenuEquals(['hello world'], [new MarkdownPage('foo', ['navigation.label' => 'hello world'])]);
     }
 
     public function testMainMenuNavigationGroupCasing()
     {
         config(['hyde.navigation.subdirectories' => 'dropdown']);
+
+        // When using subdirectory groupings, we try to format them the same way as the page titles
 
         $this->assertMenuEquals(['Hello World'], [new MarkdownPage('Hello World/foo')]);
         $this->assertMenuEquals(['Hello World'], [new MarkdownPage('hello-world/foo')]);
@@ -1067,6 +1077,8 @@ class AutomaticNavigationConfigurationsTest extends TestCase
     {
         config(['hyde.navigation.subdirectories' => 'dropdown']); // TODO This should NOT be necessary when using front matter
 
+        // If the user explicitly sets the group, we should respect that and assume it's already formatted correctly
+
         $this->assertMenuEquals(['Hello World'], [new MarkdownPage('foo', ['navigation.group' => 'Hello World'])]);
         $this->assertMenuEquals(['Hello World'], [new MarkdownPage('foo', ['navigation.group' => 'hello-world'])]);
         $this->assertMenuEquals(['Hello World'], [new MarkdownPage('foo', ['navigation.group' => 'hello world'])]);
@@ -1074,6 +1086,8 @@ class AutomaticNavigationConfigurationsTest extends TestCase
 
     public function testSidebarItemCasing()
     {
+        // These labels are based on the page titles, which are made from the file names, so we try to format them
+
         $this->assertSidebarEquals(['Hello World'], [new DocumentationPage('Hello World')]);
         $this->assertSidebarEquals(['Hello World'], [new DocumentationPage('hello-world')]);
         $this->assertSidebarEquals(['Hello World'], [new DocumentationPage('hello world')]);
@@ -1081,13 +1095,21 @@ class AutomaticNavigationConfigurationsTest extends TestCase
 
     public function testSidebarItemCasingUsingFrontMatter()
     {
+        // If the user explicitly sets the label, we should respect that and assume it's already formatted correctly
+
+        $this->assertSidebarEquals(['Hello World'], [new DocumentationPage('foo', ['title' => 'Hello World'])]);
+        $this->assertSidebarEquals(['hello-world'], [new DocumentationPage('foo', ['title' => 'hello-world'])]);
+        $this->assertSidebarEquals(['hello world'], [new DocumentationPage('foo', ['title' => 'hello world'])]);
+
         $this->assertSidebarEquals(['Hello World'], [new DocumentationPage('foo', ['navigation.label' => 'Hello World'])]);
-        $this->assertSidebarEquals(['Hello World'], [new DocumentationPage('foo', ['navigation.label' => 'hello-world'])]);
-        $this->assertSidebarEquals(['Hello World'], [new DocumentationPage('foo', ['navigation.label' => 'hello world'])]);
+        $this->assertSidebarEquals(['hello-world'], [new DocumentationPage('foo', ['navigation.label' => 'hello-world'])]);
+        $this->assertSidebarEquals(['hello world'], [new DocumentationPage('foo', ['navigation.label' => 'hello world'])]);
     }
 
     public function testSidebarGroupCasing()
     {
+        // When using subdirectory groupings, we try to format them the same way as the page titles
+
         $this->assertSidebarEquals(['Hello World'], [new DocumentationPage('Hello World/foo')]);
         $this->assertSidebarEquals(['Hello World'], [new DocumentationPage('hello-world/foo')]);
         $this->assertSidebarEquals(['Hello World'], [new DocumentationPage('hello world/foo')]);
@@ -1095,6 +1117,8 @@ class AutomaticNavigationConfigurationsTest extends TestCase
 
     public function testSidebarGroupCasingUsingFrontMatter()
     {
+        // If the user explicitly sets the group, we should respect that and assume it's already formatted correctly
+
         $this->assertSidebarEquals(['Hello World'], [new DocumentationPage('foo', ['navigation.group' => 'Hello World'])]);
         $this->assertSidebarEquals(['Hello World'], [new DocumentationPage('foo', ['navigation.group' => 'hello-world'])]);
         $this->assertSidebarEquals(['Hello World'], [new DocumentationPage('foo', ['navigation.group' => 'hello world'])]);

--- a/packages/framework/tests/Feature/AutomaticNavigationConfigurationsTest.php
+++ b/packages/framework/tests/Feature/AutomaticNavigationConfigurationsTest.php
@@ -472,7 +472,7 @@ class AutomaticNavigationConfigurationsTest extends TestCase
             new MarkdownPage('FOO'),
         ]);
 
-        $this->assertMenuEquals(['Foo', 'Foo', 'FOO'], [
+        $this->assertMenuEquals(['foo', 'Foo', 'FOO'], [
             new MarkdownPage('foo', ['navigation.label' => 'foo']),
             new MarkdownPage('bar', ['navigation.label' => 'Foo']),
             new MarkdownPage('baz', ['navigation.label' => 'FOO']),
@@ -890,7 +890,7 @@ class AutomaticNavigationConfigurationsTest extends TestCase
             new DocumentationPage('FOO'),
         ]);
 
-        $this->assertSidebarEquals(['Foo', 'Foo', 'FOO'], [
+        $this->assertSidebarEquals(['foo', 'Foo', 'FOO'], [
             new DocumentationPage('foo', ['navigation.label' => 'foo']),
             new DocumentationPage('bar', ['navigation.label' => 'Foo']),
             new DocumentationPage('baz', ['navigation.label' => 'FOO']),

--- a/packages/framework/tests/Feature/AutomaticNavigationConfigurationsTest.php
+++ b/packages/framework/tests/Feature/AutomaticNavigationConfigurationsTest.php
@@ -986,6 +986,11 @@ class AutomaticNavigationConfigurationsTest extends TestCase
             new DocumentationPage('foo', ['navigation.group' => 'GitHub']),
             new DocumentationPage('bar', ['navigation.group' => 'github']),
         ]);
+
+        $this->assertSidebarEquals(['GitHub'], [
+            new DocumentationPage('foo', ['navigation.group' => 'github']),
+            new DocumentationPage('bar', ['navigation.group' => 'GitHub']),
+        ]);
     }
 
     public function testSidebarLabelsCanBeSetInConfig()

--- a/packages/framework/tests/Feature/AutomaticNavigationConfigurationsTest.php
+++ b/packages/framework/tests/Feature/AutomaticNavigationConfigurationsTest.php
@@ -1038,6 +1038,68 @@ class AutomaticNavigationConfigurationsTest extends TestCase
         ]);
     }
 
+    // Label casing tests
+
+    public function testMainMenuNavigationItemCasing()
+    {
+        $this->assertMenuEquals(['Hello World'], [new MarkdownPage('Hello World')]);
+        $this->assertMenuEquals(['Hello World'], [new MarkdownPage('hello-world')]);
+        $this->assertMenuEquals(['Hello World'], [new MarkdownPage('hello world')]);
+    }
+
+    public function testMainMenuNavigationItemCasingUsingFrontMatter()
+    {
+        $this->assertMenuEquals(['Hello World'], [new MarkdownPage('foo', ['navigation.label' => 'Hello World'])]);
+        $this->assertMenuEquals(['Hello World'], [new MarkdownPage('foo', ['navigation.label' => 'hello-world'])]);
+        $this->assertMenuEquals(['Hello World'], [new MarkdownPage('foo', ['navigation.label' => 'hello world'])]);
+    }
+
+    public function testMainMenuNavigationGroupCasing()
+    {
+        config(['hyde.navigation.subdirectories' => 'dropdown']);
+
+        $this->assertMenuEquals(['Hello World'], [new MarkdownPage('Hello World/foo')]);
+        $this->assertMenuEquals(['Hello World'], [new MarkdownPage('hello-world/foo')]);
+        $this->assertMenuEquals(['Hello World'], [new MarkdownPage('hello world/foo')]);
+    }
+
+    public function testMainMenuNavigationGroupCasingUsingFrontMatter()
+    {
+        config(['hyde.navigation.subdirectories' => 'dropdown']); // TODO This should NOT be necessary when using front matter
+
+        $this->assertMenuEquals(['Hello World'], [new MarkdownPage('foo', ['navigation.group' => 'Hello World'])]);
+        $this->assertMenuEquals(['Hello World'], [new MarkdownPage('foo', ['navigation.group' => 'hello-world'])]);
+        $this->assertMenuEquals(['Hello World'], [new MarkdownPage('foo', ['navigation.group' => 'hello world'])]);
+    }
+
+    public function testSidebarItemCasing()
+    {
+        $this->assertSidebarEquals(['Hello World'], [new DocumentationPage('Hello World')]);
+        $this->assertSidebarEquals(['Hello World'], [new DocumentationPage('hello-world')]);
+        $this->assertSidebarEquals(['Hello World'], [new DocumentationPage('hello world')]);
+    }
+
+    public function testSidebarItemCasingUsingFrontMatter()
+    {
+        $this->assertSidebarEquals(['Hello World'], [new DocumentationPage('foo', ['navigation.label' => 'Hello World'])]);
+        $this->assertSidebarEquals(['Hello World'], [new DocumentationPage('foo', ['navigation.label' => 'hello-world'])]);
+        $this->assertSidebarEquals(['Hello World'], [new DocumentationPage('foo', ['navigation.label' => 'hello world'])]);
+    }
+
+    public function testSidebarGroupCasing()
+    {
+        $this->assertSidebarEquals(['Hello World'], [new DocumentationPage('Hello World/foo')]);
+        $this->assertSidebarEquals(['Hello World'], [new DocumentationPage('hello-world/foo')]);
+        $this->assertSidebarEquals(['Hello World'], [new DocumentationPage('hello world/foo')]);
+    }
+
+    public function testSidebarGroupCasingUsingFrontMatter()
+    {
+        $this->assertSidebarEquals(['Hello World'], [new DocumentationPage('foo', ['navigation.group' => 'Hello World'])]);
+        $this->assertSidebarEquals(['Hello World'], [new DocumentationPage('foo', ['navigation.group' => 'hello-world'])]);
+        $this->assertSidebarEquals(['Hello World'], [new DocumentationPage('foo', ['navigation.group' => 'hello world'])]);
+    }
+
     // Testing helpers
 
     protected function assertSidebarEquals(array $expected, array $menuPages): void

--- a/packages/framework/tests/Feature/AutomaticNavigationConfigurationsTest.php
+++ b/packages/framework/tests/Feature/AutomaticNavigationConfigurationsTest.php
@@ -472,7 +472,7 @@ class AutomaticNavigationConfigurationsTest extends TestCase
             new MarkdownPage('FOO'),
         ]);
 
-        $this->assertMenuEquals(['foo', 'Foo', 'FOO'], [
+        $this->assertMenuEquals(['Foo', 'Foo', 'FOO'], [
             new MarkdownPage('foo', ['navigation.label' => 'foo']),
             new MarkdownPage('bar', ['navigation.label' => 'Foo']),
             new MarkdownPage('baz', ['navigation.label' => 'FOO']),
@@ -890,7 +890,7 @@ class AutomaticNavigationConfigurationsTest extends TestCase
             new DocumentationPage('FOO'),
         ]);
 
-        $this->assertSidebarEquals(['foo', 'Foo', 'FOO'], [
+        $this->assertSidebarEquals(['Foo', 'Foo', 'FOO'], [
             new DocumentationPage('foo', ['navigation.label' => 'foo']),
             new DocumentationPage('bar', ['navigation.label' => 'Foo']),
             new DocumentationPage('baz', ['navigation.label' => 'FOO']),

--- a/packages/framework/tests/Unit/NavItemTest.php
+++ b/packages/framework/tests/Unit/NavItemTest.php
@@ -186,7 +186,7 @@ class NavItemTest extends UnitTestCase
         $item = NavItem::forLink('foo', 'bar');
 
         $this->assertEquals(new ExternalRoute('foo'), $item->getDestination());
-        $this->assertSame('bar', $item->getLabel());
+        $this->assertSame('Bar', $item->getLabel());
         $this->assertSame(500, $item->getPriority());
     }
 
@@ -201,7 +201,7 @@ class NavItemTest extends UnitTestCase
         $item = NavItem::forRoute($route, 'foo');
 
         $this->assertSame($route, $item->getDestination());
-        $this->assertSame('foo', $item->getLabel());
+        $this->assertSame('Foo', $item->getLabel());
         $this->assertSame(999, $item->getPriority());
     }
 
@@ -211,7 +211,7 @@ class NavItemTest extends UnitTestCase
         $item = NavItem::forRoute($route, 'foo');
 
         $this->assertSame($route, $item->getDestination());
-        $this->assertSame('foo', $item->getLabel());
+        $this->assertSame('Foo', $item->getLabel());
         $this->assertSame(0, $item->getPriority());
     }
 
@@ -265,7 +265,7 @@ class NavItemTest extends UnitTestCase
     {
         $item = NavItem::dropdown('foo', []);
 
-        $this->assertSame('foo', $item->getLabel());
+        $this->assertSame('Foo', $item->getLabel());
         $this->assertSame([], $item->getChildren());
         $this->assertSame(999, $item->getPriority());
     }

--- a/packages/framework/tests/Unit/NavItemTest.php
+++ b/packages/framework/tests/Unit/NavItemTest.php
@@ -265,7 +265,7 @@ class NavItemTest extends UnitTestCase
     {
         $item = NavItem::dropdown('foo', []);
 
-        $this->assertSame('foo', $item->getLabel());
+        $this->assertSame('Foo', $item->getLabel());
         $this->assertSame([], $item->getChildren());
         $this->assertSame(999, $item->getPriority());
     }

--- a/packages/framework/tests/Unit/NavItemTest.php
+++ b/packages/framework/tests/Unit/NavItemTest.php
@@ -186,7 +186,7 @@ class NavItemTest extends UnitTestCase
         $item = NavItem::forLink('foo', 'bar');
 
         $this->assertEquals(new ExternalRoute('foo'), $item->getDestination());
-        $this->assertSame('Bar', $item->getLabel());
+        $this->assertSame('bar', $item->getLabel());
         $this->assertSame(500, $item->getPriority());
     }
 
@@ -201,7 +201,7 @@ class NavItemTest extends UnitTestCase
         $item = NavItem::forRoute($route, 'foo');
 
         $this->assertSame($route, $item->getDestination());
-        $this->assertSame('Foo', $item->getLabel());
+        $this->assertSame('foo', $item->getLabel());
         $this->assertSame(999, $item->getPriority());
     }
 
@@ -211,7 +211,7 @@ class NavItemTest extends UnitTestCase
         $item = NavItem::forRoute($route, 'foo');
 
         $this->assertSame($route, $item->getDestination());
-        $this->assertSame('Foo', $item->getLabel());
+        $this->assertSame('foo', $item->getLabel());
         $this->assertSame(0, $item->getPriority());
     }
 
@@ -265,7 +265,7 @@ class NavItemTest extends UnitTestCase
     {
         $item = NavItem::dropdown('foo', []);
 
-        $this->assertSame('Foo', $item->getLabel());
+        $this->assertSame('foo', $item->getLabel());
         $this->assertSame([], $item->getChildren());
         $this->assertSame(999, $item->getPriority());
     }


### PR DESCRIPTION
This targets v2.x via https://github.com/hydephp/develop/pull/1568 and picks up the idea behind https://github.com/hydephp/develop/pull/1575

This PR makes improvements to how navigation group labels are generated

<s>This PR makes improvements to how navigation item labels are generated. The biggest change which could be breaking is that all labels are now formatted. So if you create a navigation item with the label "foo" it will now be normalized to "Foo". This may be opinionated, but considering that we do the same for page titles, why should this be different?</s>