### PR TITLE
[2.x] Split out base navigation menu class from main menu class

### DIFF
--- a/packages/framework/src/Foundation/Providers/NavigationServiceProvider.php
+++ b/packages/framework/src/Foundation/Providers/NavigationServiceProvider.php
@@ -6,7 +6,7 @@ namespace Hyde\Foundation\Providers;
 
 use Hyde\Foundation\HydeKernel;
 use Illuminate\Support\ServiceProvider;
-use Hyde\Framework\Features\Navigation\NavigationMenu;
+use Hyde\Framework\Features\Navigation\MainNavigationMenu;
 use Hyde\Framework\Features\Navigation\NavigationManager;
 use Hyde\Framework\Features\Navigation\DocumentationSidebar;
 use Hyde\Framework\Features\Navigation\NavigationMenuGenerator;
@@ -22,7 +22,7 @@ class NavigationServiceProvider extends ServiceProvider
         $this->app->alias(NavigationManager::class, 'navigation');
 
         $this->app->make(HydeKernel::class)->booted(function () {
-            $this->app->make(NavigationManager::class)->registerMenu('main', NavigationMenuGenerator::handle(NavigationMenu::class));
+            $this->app->make(NavigationManager::class)->registerMenu('main', NavigationMenuGenerator::handle(MainNavigationMenu::class));
             $this->app->make(NavigationManager::class)->registerMenu('sidebar', NavigationMenuGenerator::handle(DocumentationSidebar::class));
         });
     }

--- a/packages/framework/src/Framework/Features/Navigation/DocumentationSidebar.php
+++ b/packages/framework/src/Framework/Features/Navigation/DocumentationSidebar.php
@@ -9,7 +9,6 @@ use Hyde\Support\Facades\Render;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Str;
 
-/** @deprecated Use the new NavigationMenu class instead */
 class DocumentationSidebar extends NavigationMenu
 {
     /** @var \Illuminate\Support\Collection<string, \Hyde\Framework\Features\Navigation\NavItem> */

--- a/packages/framework/src/Framework/Features/Navigation/DocumentationSidebar.php
+++ b/packages/framework/src/Framework/Features/Navigation/DocumentationSidebar.php
@@ -15,12 +15,6 @@ class DocumentationSidebar extends NavigationMenu
     /** @var \Illuminate\Support\Collection<string, \Hyde\Framework\Features\Navigation\NavItem> */
     protected Collection $items;
 
-    /** @deprecated Will be moved to an action */
-    public static function create(): static
-    {
-        return NavigationMenuGenerator::handle(DocumentationSidebar::class);
-    }
-
     public function hasGroups(): bool
     {
         return $this->getItems()->contains(fn (NavItem $item): bool => $item->hasChildren());

--- a/packages/framework/src/Framework/Features/Navigation/MainNavigationMenu.php
+++ b/packages/framework/src/Framework/Features/Navigation/MainNavigationMenu.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Hyde\Framework\Features\Navigation;
+
+class MainNavigationMenu extends NavigationMenu
+{
+    //
+}

--- a/packages/framework/src/Framework/Features/Navigation/NavigationMenu.php
+++ b/packages/framework/src/Framework/Features/Navigation/NavigationMenu.php
@@ -15,7 +15,7 @@ use Illuminate\Contracts\Support\Arrayable;
  * @example `$menu = app('navigation')->getMenu('main');` for the main navigation menu.
  * @example `$menu = app('navigation')->getMenu('sidebar');` for the documentation sidebar.
  */
-class NavigationMenu
+abstract class NavigationMenu
 {
     /** @var \Illuminate\Support\Collection<\Hyde\Framework\Features\Navigation\NavItem> */
     protected Collection $items;

--- a/packages/framework/src/Framework/Features/Navigation/NavigationMenuGenerator.php
+++ b/packages/framework/src/Framework/Features/Navigation/NavigationMenuGenerator.php
@@ -39,7 +39,7 @@ class NavigationMenuGenerator
     /** @param class-string<\Hyde\Framework\Features\Navigation\NavigationMenu> $menuType */
     protected function __construct(string $menuType)
     {
-        assert(in_array($menuType, [NavigationMenu::class, DocumentationSidebar::class]));
+        assert(in_array($menuType, [MainNavigationMenu::class, DocumentationSidebar::class]));
 
         $this->menuType = $menuType;
 
@@ -55,7 +55,7 @@ class NavigationMenuGenerator
     }
 
     /** @param class-string<\Hyde\Framework\Features\Navigation\NavigationMenu> $menuType */
-    public static function handle(string $menuType): NavigationMenu|DocumentationSidebar
+    public static function handle(string $menuType): MainNavigationMenu|DocumentationSidebar
     {
         $menu = new static($menuType);
 

--- a/packages/framework/tests/Feature/AutomaticNavigationConfigurationsTest.php
+++ b/packages/framework/tests/Feature/AutomaticNavigationConfigurationsTest.php
@@ -18,7 +18,7 @@ use Hyde\Support\Models\Redirect;
 use Illuminate\Support\Collection;
 use Hyde\Foundation\Kernel\RouteCollection;
 use Hyde\Framework\Features\Navigation\NavItem;
-use Hyde\Framework\Features\Navigation\NavigationMenu;
+use Hyde\Framework\Features\Navigation\MainNavigationMenu;
 use Hyde\Framework\Features\Navigation\DocumentationSidebar;
 use Hyde\Framework\Features\Navigation\NavigationMenuGenerator;
 
@@ -28,7 +28,7 @@ use Hyde\Framework\Features\Navigation\NavigationMenuGenerator;
  * @covers \Hyde\Framework\Factories\NavigationDataFactory
  * @covers \Hyde\Framework\Features\Navigation\NavigationMenuGenerator
  * @covers \Hyde\Framework\Features\Navigation\DocumentationSidebar
- * @covers \Hyde\Framework\Features\Navigation\NavigationMenu
+ * @covers \Hyde\Framework\Features\Navigation\MainNavigationMenu
  * @covers \Hyde\Framework\Features\Navigation\NavItem
  */
 class AutomaticNavigationConfigurationsTest extends TestCase
@@ -1298,7 +1298,7 @@ class AssertableNavigationMenu
     {
         $this->items = $sidebar
             ? NavigationMenuGenerator::handle(DocumentationSidebar::class)->getItems()
-            : NavigationMenuGenerator::handle(NavigationMenu::class)->getItems();
+            : NavigationMenuGenerator::handle(MainNavigationMenu::class)->getItems();
 
         $this->test = $test;
     }

--- a/packages/framework/tests/Feature/NavigationManagerTest.php
+++ b/packages/framework/tests/Feature/NavigationManagerTest.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace Hyde\Framework\Testing\Feature;
 
 use Hyde\Framework\Features\Navigation\NavigationManager;
-use Hyde\Framework\Features\Navigation\NavigationMenu;
+use Hyde\Framework\Features\Navigation\MainNavigationMenu;
 use Hyde\Testing\TestCase;
 
 /**
@@ -17,7 +17,7 @@ class NavigationManagerTest extends TestCase
     {
         $manager = new NavigationManager();
 
-        $menu = $this->createMock(NavigationMenu::class);
+        $menu = $this->createMock(MainNavigationMenu::class);
         $manager->registerMenu('foo', $menu);
 
         $reflection = new \ReflectionClass($manager);
@@ -33,7 +33,7 @@ class NavigationManagerTest extends TestCase
     {
         $manager = new NavigationManager();
 
-        $menu = $this->createMock(NavigationMenu::class);
+        $menu = $this->createMock(MainNavigationMenu::class);
         $manager->registerMenu('foo', $menu);
 
         $retrievedMenu = $manager->getMenu('foo');

--- a/packages/framework/tests/Feature/NavigationMenuTest.php
+++ b/packages/framework/tests/Feature/NavigationMenuTest.php
@@ -7,7 +7,7 @@ namespace Hyde\Framework\Testing\Feature;
 use Hyde\Support\Models\Route;
 use Hyde\Foundation\Facades\Routes;
 use Hyde\Support\Models\ExternalRoute;
-use Hyde\Framework\Features\Navigation\NavigationMenu;
+use Hyde\Framework\Features\Navigation\MainNavigationMenu;
 use Hyde\Framework\Features\Navigation\NavItem;
 use Hyde\Pages\MarkdownPage;
 use Hyde\Testing\TestCase;
@@ -15,7 +15,7 @@ use Illuminate\Support\Collection;
 use Hyde\Framework\Features\Navigation\NavigationMenuGenerator;
 
 /**
- * @covers \Hyde\Framework\Features\Navigation\NavigationMenu
+ * @covers \Hyde\Framework\Features\Navigation\MainNavigationMenu
  * @covers \Hyde\Framework\Features\Navigation\NavigationMenuGenerator
  *
  * @see \Hyde\Framework\Testing\Unit\NavigationMenuUnitTest
@@ -24,7 +24,7 @@ class NavigationMenuTest extends TestCase
 {
     public function testConstructor()
     {
-        $this->assertInstanceOf(NavigationMenu::class, $this->createNavigationMenu());
+        $this->assertInstanceOf(MainNavigationMenu::class, $this->createNavigationMenu());
     }
 
     public function testGenerateMethodCreatesCollectionOfNavItems()
@@ -269,8 +269,8 @@ class NavigationMenuTest extends TestCase
         $this->assertSame('Foo', $navigation->getItems()->last()->getLabel());
     }
 
-    protected function createNavigationMenu(): NavigationMenu
+    protected function createNavigationMenu(): MainNavigationMenu
     {
-        return NavigationMenuGenerator::handle(NavigationMenu::class);
+        return NavigationMenuGenerator::handle(MainNavigationMenu::class);
     }
 }

--- a/packages/framework/tests/Feature/Services/DocumentationSidebarTest.php
+++ b/packages/framework/tests/Feature/Services/DocumentationSidebarTest.php
@@ -15,6 +15,7 @@ use Hyde\Support\Facades\Render;
 use Hyde\Testing\TestCase;
 use Illuminate\Support\Facades\Config;
 use Illuminate\Support\Facades\File;
+use Hyde\Framework\Features\Navigation\NavigationMenuGenerator;
 
 /**
  * @covers \Hyde\Framework\Features\Navigation\DocumentationSidebar
@@ -41,7 +42,7 @@ class DocumentationSidebarTest extends TestCase
 
     public function testSidebarCanBeCreated()
     {
-        $sidebar = DocumentationSidebar::create();
+        $sidebar = NavigationMenuGenerator::handle(DocumentationSidebar::class);
 
         $this->assertInstanceOf(DocumentationSidebar::class, $sidebar);
     }
@@ -50,7 +51,7 @@ class DocumentationSidebarTest extends TestCase
     {
         $this->createTestFiles();
 
-        $sidebar = DocumentationSidebar::create();
+        $sidebar = NavigationMenuGenerator::handle(DocumentationSidebar::class);
 
         $this->assertCount(5, $sidebar->getItems());
     }
@@ -60,7 +61,7 @@ class DocumentationSidebarTest extends TestCase
         $this->createTestFiles();
         Filesystem::touch('_docs/index.md');
 
-        $sidebar = DocumentationSidebar::create();
+        $sidebar = NavigationMenuGenerator::handle(DocumentationSidebar::class);
         $this->assertCount(5, $sidebar->getItems());
     }
 
@@ -69,7 +70,7 @@ class DocumentationSidebarTest extends TestCase
         $this->createTestFiles();
         File::put(Hyde::path('_docs/test.md'), "---\nnavigation:\n    hidden: true\n---\n\n# Foo");
 
-        $sidebar = DocumentationSidebar::create();
+        $sidebar = NavigationMenuGenerator::handle(DocumentationSidebar::class);
         $this->assertCount(5, $sidebar->getItems());
     }
 
@@ -86,7 +87,7 @@ class DocumentationSidebarTest extends TestCase
                 NavItem::fromRoute(Routes::get('docs/b'), priority: 999),
                 NavItem::fromRoute(Routes::get('docs/c'), priority: 999),
             ]),
-            DocumentationSidebar::create()->getItems()
+            NavigationMenuGenerator::handle(DocumentationSidebar::class)->getItems()
         );
     }
 
@@ -107,7 +108,7 @@ class DocumentationSidebarTest extends TestCase
                 NavItem::fromRoute(Routes::get('docs/b'), priority: 250 + 251),
                 NavItem::fromRoute(Routes::get('docs/a'), priority: 250 + 252),
             ]),
-            DocumentationSidebar::create()->getItems()
+            NavigationMenuGenerator::handle(DocumentationSidebar::class)->getItems()
         );
     }
 
@@ -115,7 +116,7 @@ class DocumentationSidebarTest extends TestCase
     {
         $this->makePage('foo', ['navigation.priority' => 25]);
 
-        $this->assertEquals(25, DocumentationSidebar::create()->getItems()->first()->getPriority());
+        $this->assertEquals(25, NavigationMenuGenerator::handle(DocumentationSidebar::class)->getItems()->first()->getPriority());
     }
 
     public function testSidebarItemPrioritySetInConfigOverridesFrontMatter()
@@ -124,7 +125,7 @@ class DocumentationSidebarTest extends TestCase
 
         Config::set('docs.sidebar_order', ['foo']);
 
-        $this->assertEquals(25, DocumentationSidebar::create()->getItems()->first()->getPriority());
+        $this->assertEquals(25, NavigationMenuGenerator::handle(DocumentationSidebar::class)->getItems()->first()->getPriority());
     }
 
     public function testSidebarPrioritiesCanBeSetInBothFrontMatterAndConfig()
@@ -146,26 +147,26 @@ class DocumentationSidebarTest extends TestCase
                 NavItem::fromRoute(Routes::get('docs/second'), priority: 250 + 252),
                 NavItem::fromRoute(Routes::get('docs/third'), priority: 250 + 300),
             ]),
-            DocumentationSidebar::create()->getItems()
+            NavigationMenuGenerator::handle(DocumentationSidebar::class)->getItems()
         );
     }
 
     public function testGroupCanBeSetInFrontMatter()
     {
         $this->makePage('foo', ['navigation.group' => 'bar']);
-        $this->assertEquals('bar', collect(DocumentationSidebar::create()->getItems()->first()->getChildren())->first()->getGroup());
+        $this->assertEquals('bar', collect(NavigationMenuGenerator::handle(DocumentationSidebar::class)->getItems()->first()->getChildren())->first()->getGroup());
     }
 
     public function testHasGroupsReturnsFalseWhenThereAreNoGroups()
     {
-        $this->assertFalse(DocumentationSidebar::create()->hasGroups());
+        $this->assertFalse(NavigationMenuGenerator::handle(DocumentationSidebar::class)->hasGroups());
     }
 
     public function testHasGroupsReturnsTrueWhenThereAreGroups()
     {
         $this->makePage('foo', ['navigation.group' => 'bar']);
 
-        $this->assertTrue(DocumentationSidebar::create()->hasGroups());
+        $this->assertTrue(NavigationMenuGenerator::handle(DocumentationSidebar::class)->hasGroups());
     }
 
     public function testHasGroupsReturnsTrueWhenThereAreMultipleGroups()
@@ -173,7 +174,7 @@ class DocumentationSidebarTest extends TestCase
         $this->makePage('foo', ['navigation.group' => 'bar']);
         $this->makePage('bar', ['navigation.group' => 'baz']);
 
-        $this->assertTrue(DocumentationSidebar::create()->hasGroups());
+        $this->assertTrue(NavigationMenuGenerator::handle(DocumentationSidebar::class)->hasGroups());
     }
 
     public function testHasGroupsReturnsTrueWhenThereAreMultipleGroupsMixedWithDefaults()
@@ -182,7 +183,7 @@ class DocumentationSidebarTest extends TestCase
         $this->makePage('bar', ['navigation.group' => 'baz']);
         $this->makePage('baz');
 
-        $this->assertTrue(DocumentationSidebar::create()->hasGroups());
+        $this->assertTrue(NavigationMenuGenerator::handle(DocumentationSidebar::class)->hasGroups());
     }
 
     public function testGetItemsInGroupDoesNotIncludeDocsIndex()
@@ -192,26 +193,26 @@ class DocumentationSidebarTest extends TestCase
 
         $this->assertEquals(
             collect([NavItem::fromRoute(Routes::get('docs/foo'), priority: 999)]),
-            DocumentationSidebar::create()->getItems()
+            NavigationMenuGenerator::handle(DocumentationSidebar::class)->getItems()
         );
     }
 
     public function testIsGroupActiveReturnsFalseWhenSuppliedGroupIsNotActive()
     {
         Render::setPage(new DocumentationPage(matter: ['navigation.group' => 'foo']));
-        $this->assertFalse(DocumentationSidebar::create()->isGroupActive('bar'));
+        $this->assertFalse(NavigationMenuGenerator::handle(DocumentationSidebar::class)->isGroupActive('bar'));
     }
 
     public function testIsGroupActiveReturnsTrueWhenSuppliedGroupIsActive()
     {
         Render::setPage(new DocumentationPage(matter: ['navigation.group' => 'foo']));
-        $this->assertTrue(DocumentationSidebar::create()->isGroupActive('foo'));
+        $this->assertTrue(NavigationMenuGenerator::handle(DocumentationSidebar::class)->isGroupActive('foo'));
     }
 
     public function testIsGroupActiveReturnsTrueForDifferingCasing()
     {
         Render::setPage(new DocumentationPage(matter: ['navigation.group' => 'Foo Bar']));
-        $this->assertTrue(DocumentationSidebar::create()->isGroupActive('foo-bar'));
+        $this->assertTrue(NavigationMenuGenerator::handle(DocumentationSidebar::class)->isGroupActive('foo-bar'));
     }
 
     public function testIsGroupActiveReturnsTrueFirstGroupOfIndexPage()
@@ -222,9 +223,9 @@ class DocumentationSidebarTest extends TestCase
         $this->makePage('baz', ['navigation.group' => 'baz']);
 
         Render::setPage(DocumentationPage::get('index'));
-        $this->assertTrue(DocumentationSidebar::create()->isGroupActive('bar'));
-        $this->assertFalse(DocumentationSidebar::create()->isGroupActive('foo'));
-        $this->assertFalse(DocumentationSidebar::create()->isGroupActive('baz'));
+        $this->assertTrue(NavigationMenuGenerator::handle(DocumentationSidebar::class)->isGroupActive('bar'));
+        $this->assertFalse(NavigationMenuGenerator::handle(DocumentationSidebar::class)->isGroupActive('foo'));
+        $this->assertFalse(NavigationMenuGenerator::handle(DocumentationSidebar::class)->isGroupActive('baz'));
     }
 
     public function testIsGroupActiveReturnsTrueFirstSortedGroupOfIndexPage()
@@ -235,9 +236,9 @@ class DocumentationSidebarTest extends TestCase
         $this->makePage('baz', ['navigation.group' => 'baz', 'navigation.priority' => 3]);
 
         Render::setPage(DocumentationPage::get('index'));
-        $this->assertTrue(DocumentationSidebar::create()->isGroupActive('foo'));
-        $this->assertFalse(DocumentationSidebar::create()->isGroupActive('bar'));
-        $this->assertFalse(DocumentationSidebar::create()->isGroupActive('baz'));
+        $this->assertTrue(NavigationMenuGenerator::handle(DocumentationSidebar::class)->isGroupActive('foo'));
+        $this->assertFalse(NavigationMenuGenerator::handle(DocumentationSidebar::class)->isGroupActive('bar'));
+        $this->assertFalse(NavigationMenuGenerator::handle(DocumentationSidebar::class)->isGroupActive('baz'));
     }
 
     public function testAutomaticIndexPageGroupExpansionRespectsCustomNavigationMenuSettings()
@@ -248,9 +249,9 @@ class DocumentationSidebarTest extends TestCase
         $this->makePage('baz', ['navigation.group' => 'baz', 'navigation.priority' => 3]);
 
         Render::setPage(DocumentationPage::get('index'));
-        $this->assertFalse(DocumentationSidebar::create()->isGroupActive('foo'));
-        $this->assertFalse(DocumentationSidebar::create()->isGroupActive('bar'));
-        $this->assertTrue(DocumentationSidebar::create()->isGroupActive('baz'));
+        $this->assertFalse(NavigationMenuGenerator::handle(DocumentationSidebar::class)->isGroupActive('foo'));
+        $this->assertFalse(NavigationMenuGenerator::handle(DocumentationSidebar::class)->isGroupActive('bar'));
+        $this->assertTrue(NavigationMenuGenerator::handle(DocumentationSidebar::class)->isGroupActive('baz'));
     }
 
     public function testCanHaveMultipleGroupedPagesWithTheSameNameLabels()
@@ -258,7 +259,7 @@ class DocumentationSidebarTest extends TestCase
         $this->makePage('foo', ['navigation.group' => 'foo', 'navigation.label' => 'Foo']);
         $this->makePage('bar', ['navigation.group' => 'bar', 'navigation.label' => 'Foo']);
 
-        $sidebar = DocumentationSidebar::create();
+        $sidebar = NavigationMenuGenerator::handle(DocumentationSidebar::class);
         $this->assertCount(2, $sidebar->getItems());
 
         $this->assertEquals(
@@ -279,7 +280,7 @@ class DocumentationSidebarTest extends TestCase
         $this->makePage('foo', ['navigation.group' => 'foo', 'navigation.label' => 'Foo']);
         $this->makePage('bar', ['navigation.group' => 'foo', 'navigation.label' => 'Foo']);
 
-        $sidebar = DocumentationSidebar::create();
+        $sidebar = NavigationMenuGenerator::handle(DocumentationSidebar::class);
         $this->assertCount(1, $sidebar->getItems());
 
         $this->assertEquals(
@@ -298,13 +299,13 @@ class DocumentationSidebarTest extends TestCase
         $this->makePage('index');
 
         Render::setPage(DocumentationPage::get('index'));
-        $this->assertFalse(DocumentationSidebar::create()->isGroupActive('foo'));
+        $this->assertFalse(NavigationMenuGenerator::handle(DocumentationSidebar::class)->isGroupActive('foo'));
     }
 
     public function testIndexPageAddedToSidebarWhenItIsTheOnlyPage()
     {
         Filesystem::touch('_docs/index.md');
-        $sidebar = DocumentationSidebar::create();
+        $sidebar = NavigationMenuGenerator::handle(DocumentationSidebar::class);
 
         $this->assertCount(1, $sidebar->getItems());
         $this->assertEquals(
@@ -317,7 +318,7 @@ class DocumentationSidebarTest extends TestCase
     {
         $this->createTestFiles(1);
         Filesystem::touch('_docs/index.md');
-        $sidebar = DocumentationSidebar::create();
+        $sidebar = NavigationMenuGenerator::handle(DocumentationSidebar::class);
 
         $this->assertCount(1, $sidebar->getItems());
         $this->assertEquals(

--- a/packages/framework/tests/Feature/SidebarViewTest.php
+++ b/packages/framework/tests/Feature/SidebarViewTest.php
@@ -11,6 +11,7 @@ use Hyde\Hyde;
 use Hyde\Testing\TestCase;
 use Illuminate\Contracts\View\View;
 use Throwable;
+use Hyde\Framework\Features\Navigation\NavigationMenuGenerator;
 
 use function config;
 use function file_put_contents;
@@ -49,7 +50,7 @@ class SidebarViewTest extends TestCase
             ->allGood();
 
         $this->assertViewWasRendered(view('hyde::components.docs.sidebar-items', [
-            'sidebar' => DocumentationSidebar::create(),
+            'sidebar' => NavigationMenuGenerator::handle(DocumentationSidebar::class),
         ]));
 
         $this->assertViewWasRendered(view('hyde::components.docs.sidebar-brand'));
@@ -102,7 +103,7 @@ class SidebarViewTest extends TestCase
             ->allGood();
 
         $this->assertViewWasRendered(view('hyde::components.docs.sidebar-items', [
-            'sidebar' => DocumentationSidebar::create(),
+            'sidebar' => NavigationMenuGenerator::handle(DocumentationSidebar::class),
         ]));
     }
 
@@ -130,7 +131,7 @@ class SidebarViewTest extends TestCase
             ->allGood();
 
         $this->assertViewWasRendered(view('hyde::components.docs.sidebar-items', [
-            'sidebar' => DocumentationSidebar::create(),
+            'sidebar' => NavigationMenuGenerator::handle(DocumentationSidebar::class),
             'grouped' => true,
         ]));
 
@@ -162,7 +163,7 @@ class SidebarViewTest extends TestCase
             ->allGood();
 
         $this->assertViewWasRendered(view('hyde::components.docs.sidebar-items', [
-            'sidebar' => DocumentationSidebar::create(),
+            'sidebar' => NavigationMenuGenerator::handle(DocumentationSidebar::class),
             'grouped' => true,
         ]));
 
@@ -187,7 +188,7 @@ class SidebarViewTest extends TestCase
             ->allGood();
 
         $this->assertViewWasRendered(view('hyde::components.docs.sidebar-items', [
-            'sidebar' => DocumentationSidebar::create(),
+            'sidebar' => NavigationMenuGenerator::handle(DocumentationSidebar::class),
             'grouped' => true,
         ]));
 

--- a/packages/framework/tests/Unit/NavigationMenuUnitTest.php
+++ b/packages/framework/tests/Unit/NavigationMenuUnitTest.php
@@ -8,10 +8,10 @@ use Hyde\Testing\UnitTestCase;
 use Illuminate\Support\Collection;
 use Hyde\Support\Models\ExternalRoute;
 use Hyde\Framework\Features\Navigation\NavItem;
-use Hyde\Framework\Features\Navigation\NavigationMenu;
+use Hyde\Framework\Features\Navigation\MainNavigationMenu;
 
 /**
- * @covers \Hyde\Framework\Features\Navigation\NavigationMenu
+ * @covers \Hyde\Framework\Features\Navigation\MainNavigationMenu
  *
  * @see \Hyde\Framework\Testing\Feature\NavigationMenuTest
  */
@@ -19,56 +19,56 @@ class NavigationMenuUnitTest extends UnitTestCase
 {
     public function testCanConstruct()
     {
-        $this->assertInstanceOf(NavigationMenu::class, new NavigationMenu());
+        $this->assertInstanceOf(MainNavigationMenu::class, new MainNavigationMenu());
     }
 
     public function testCanConstructWithItemsArray()
     {
-        $this->assertInstanceOf(NavigationMenu::class, new NavigationMenu($this->getItems()));
+        $this->assertInstanceOf(MainNavigationMenu::class, new MainNavigationMenu($this->getItems()));
     }
 
     public function testCanConstructWithItemsArrayable()
     {
-        $this->assertInstanceOf(NavigationMenu::class, new NavigationMenu(collect($this->getItems())));
+        $this->assertInstanceOf(MainNavigationMenu::class, new MainNavigationMenu(collect($this->getItems())));
     }
 
     public function testGetItemsReturnsCollection()
     {
-        $this->assertInstanceOf(Collection::class, (new NavigationMenu())->getItems());
+        $this->assertInstanceOf(Collection::class, (new MainNavigationMenu())->getItems());
     }
 
     public function testGetItemsReturnsCollectionWhenSuppliedArray()
     {
-        $this->assertInstanceOf(Collection::class, (new NavigationMenu($this->getItems()))->getItems());
+        $this->assertInstanceOf(Collection::class, (new MainNavigationMenu($this->getItems()))->getItems());
     }
 
     public function testGetItemsReturnsCollectionWhenSuppliedArrayable()
     {
-        $this->assertInstanceOf(Collection::class, (new NavigationMenu(collect($this->getItems())))->getItems());
+        $this->assertInstanceOf(Collection::class, (new MainNavigationMenu(collect($this->getItems())))->getItems());
     }
 
     public function testGetItemsReturnsItems()
     {
         $items = $this->getItems();
 
-        $this->assertSame($items, (new NavigationMenu($items))->getItems()->all());
+        $this->assertSame($items, (new MainNavigationMenu($items))->getItems()->all());
     }
 
     public function testGetItemsReturnsItemsWhenSuppliedArrayable()
     {
         $items = $this->getItems();
 
-        $this->assertSame($items, (new NavigationMenu(collect($items)))->getItems()->all());
+        $this->assertSame($items, (new MainNavigationMenu(collect($items)))->getItems()->all());
     }
 
     public function testGetItemsReturnsEmptyArrayWhenNoItems()
     {
-        $this->assertSame([], (new NavigationMenu())->getItems()->all());
+        $this->assertSame([], (new MainNavigationMenu())->getItems()->all());
     }
 
     public function testCanAddItems()
     {
-        $menu = new NavigationMenu();
+        $menu = new MainNavigationMenu();
         $item = new NavItem(new ExternalRoute('/'), 'Home');
 
         $menu->add($item);
@@ -79,7 +79,7 @@ class NavigationMenuUnitTest extends UnitTestCase
 
     public function testItemsAreInTheOrderTheyWereAddedWhenThereAreNoCustomPriorities()
     {
-        $menu = new NavigationMenu();
+        $menu = new MainNavigationMenu();
         $item1 = new NavItem(new ExternalRoute('/'), 'Home');
         $item2 = new NavItem(new ExternalRoute('/about'), 'About');
         $item3 = new NavItem(new ExternalRoute('/contact'), 'Contact');
@@ -93,7 +93,7 @@ class NavigationMenuUnitTest extends UnitTestCase
 
     public function testItemsAreSortedByPriority()
     {
-        $menu = new NavigationMenu();
+        $menu = new MainNavigationMenu();
         $item1 = new NavItem(new ExternalRoute('/'), 'Home', 100);
         $item2 = new NavItem(new ExternalRoute('/about'), 'About', 200);
         $item3 = new NavItem(new ExternalRoute('/contact'), 'Contact', 300);

--- a/packages/framework/tests/Unit/Views/NavigationBrandViewTest.php
+++ b/packages/framework/tests/Unit/Views/NavigationBrandViewTest.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Hyde\Framework\Testing\Unit\Views;
 
-use Hyde\Framework\Features\Navigation\NavigationMenu;
+use Hyde\Framework\Features\Navigation\MainNavigationMenu;
 use Hyde\Testing\TestCase;
 
 /**
@@ -22,7 +22,7 @@ class NavigationBrandViewTest extends TestCase
     protected function render(): string
     {
         return view('hyde::components.navigation.navigation-brand', [
-            'navigation' => new NavigationMenu(),
+            'navigation' => new MainNavigationMenu(),
         ])->render();
     }
 


### PR DESCRIPTION
Targets v2.x via https://github.com/hydephp/develop/pull/1568

See https://github.com/hydephp/develop/pull/1568#pullrequestreview-1895565140