### PR TITLE
[2.x] Breaking: Change configuration option `docs.table_of_contents` to `docs.sidebar.table_of_contents`

### DIFF
--- a/config/docs.php
+++ b/config/docs.php
@@ -56,23 +56,24 @@ return [
             'installation',
             'getting-started',
         ],
-    ],
 
-    /*
-    |--------------------------------------------------------------------------
-    | Table of Contents Settings
-    |--------------------------------------------------------------------------
-    |
-    | The Hyde Documentation Module comes with a fancy Sidebar that, by default,
-    | has a Table of Contents included. Here, you can configure its behavior,
-    | content, look and feel. You can also disable the feature completely.
-    |
-    */
+        /*
+        |--------------------------------------------------------------------------
+        | Table of Contents Settings
+        |--------------------------------------------------------------------------
+        |
+        | The Hyde Documentation Module comes with a fancy Sidebar that, by default,
+        | has a Table of Contents included. Here, you can configure its behavior,
+        | content, look and feel. You can also disable the feature completely.
+        |
+        */
 
-    'table_of_contents' => [
-        'enabled' => true,
-        'min_heading_level' => 2,
-        'max_heading_level' => 4,
+        'table_of_contents' => [
+            'enabled' => true,
+            'min_heading_level' => 2,
+            'max_heading_level' => 4,
+        ],
+
     ],
 
     /*

--- a/docs/creating-content/documentation-pages.md
+++ b/docs/creating-content/documentation-pages.md
@@ -258,11 +258,13 @@ In the `config/docs.php` file you can configure the behaviour, content, and the 
 You can also disable the feature completely.
 
 ```php
-'table_of_contents' => [
-    'enabled' => true,
-    'min_heading_level' => 2,
-    'max_heading_level' => 4,
-    'smooth_page_scrolling' => true,
+'sidebar' => [
+    'table_of_contents' => [
+        'enabled' => true,
+        'min_heading_level' => 2,
+        'max_heading_level' => 4,
+        'smooth_page_scrolling' => true,
+    ],
 ],
 ```
 

--- a/packages/framework/config/docs.php
+++ b/packages/framework/config/docs.php
@@ -56,23 +56,24 @@ return [
             'installation',
             'getting-started',
         ],
-    ],
 
-    /*
-    |--------------------------------------------------------------------------
-    | Table of Contents Settings
-    |--------------------------------------------------------------------------
-    |
-    | The Hyde Documentation Module comes with a fancy Sidebar that, by default,
-    | has a Table of Contents included. Here, you can configure its behavior,
-    | content, look and feel. You can also disable the feature completely.
-    |
-    */
+        /*
+        |--------------------------------------------------------------------------
+        | Table of Contents Settings
+        |--------------------------------------------------------------------------
+        |
+        | The Hyde Documentation Module comes with a fancy Sidebar that, by default,
+        | has a Table of Contents included. Here, you can configure its behavior,
+        | content, look and feel. You can also disable the feature completely.
+        |
+        */
 
-    'table_of_contents' => [
-        'enabled' => true,
-        'min_heading_level' => 2,
-        'max_heading_level' => 4,
+        'table_of_contents' => [
+            'enabled' => true,
+            'min_heading_level' => 2,
+            'max_heading_level' => 4,
+        ],
+
     ],
 
     /*

--- a/packages/framework/resources/views/components/docs/sidebar-item.blade.php
+++ b/packages/framework/resources/views/components/docs/sidebar-item.blade.php
@@ -12,7 +12,7 @@
             {{ $item->getLabel() }}
         </a>
 
-        @if(config('docs.table_of_contents.enabled', true))
+        @if(config('docs.sidebar.table_of_contents.enabled', true))
             <span class="sr-only">Table of contents</span>
             {!! ($page->getTableOfContents()) !!}
         @endif

--- a/packages/framework/src/Framework/Actions/GeneratesTableOfContents.php
+++ b/packages/framework/src/Framework/Actions/GeneratesTableOfContents.php
@@ -35,8 +35,8 @@ class GeneratesTableOfContents
                 'position' => 'placeholder',
                 'placeholder' => '[[START_TOC]]',
                 'style' => 'bullet',
-                'min_heading_level' => Config::getInt('docs.table_of_contents.min_heading_level', 2),
-                'max_heading_level' => Config::getInt('docs.table_of_contents.max_heading_level', 4),
+                'min_heading_level' => Config::getInt('docs.sidebar.table_of_contents.min_heading_level', 2),
+                'max_heading_level' => Config::getInt('docs.sidebar.table_of_contents.max_heading_level', 4),
                 'normalize' => 'relative',
             ],
             'heading_permalink' => [

--- a/packages/framework/src/Pages/DocumentationPage.php
+++ b/packages/framework/src/Pages/DocumentationPage.php
@@ -51,7 +51,7 @@ class DocumentationPage extends BaseMarkdownPage
 
     public static function hasTableOfContents(): bool
     {
-        return Config::getBool('docs.table_of_contents.enabled', true);
+        return Config::getBool('docs.sidebar.table_of_contents.enabled', true);
     }
 
     /**

--- a/packages/framework/tests/Feature/MarkdownServiceTest.php
+++ b/packages/framework/tests/Feature/MarkdownServiceTest.php
@@ -192,7 +192,7 @@ class MarkdownServiceTest extends TestCase
     {
         $service = new MarkdownServiceTestClass(pageClass: DocumentationPage::class);
 
-        Config::set('docs.table_of_contents.enabled', true);
+        Config::set('docs.sidebar.table_of_contents.enabled', true);
 
         $this->assertTrue($service->canEnablePermalinks());
     }

--- a/packages/framework/tests/Unit/DocumentationPageTest.php
+++ b/packages/framework/tests/Unit/DocumentationPageTest.php
@@ -195,10 +195,10 @@ class DocumentationPageTest extends TestCase
     {
         $this->assertIsBool(DocumentationPage::hasTableOfContents());
 
-        Config::set('docs.table_of_contents.enabled', true);
+        Config::set('docs.sidebar.table_of_contents.enabled', true);
         $this->assertTrue(DocumentationPage::hasTableOfContents());
 
-        Config::set('docs.table_of_contents.enabled', false);
+        Config::set('docs.sidebar.table_of_contents.enabled', false);
         $this->assertFalse(DocumentationPage::hasTableOfContents());
     }
 


### PR DESCRIPTION
## Abstract

This changes the configuration option `docs.table_of_contents` to `docs.sidebar.table_of_contents` in order to normalize the configuration API. It targets HydePHP v2.x via https://github.com/hydephp/develop/pull/1568.

### Upgrade guide

Move the `table_of_contents` option's array in the `config/docs.php` file into the `sidebar` array in the same file.

#### Before

```php
return [
  'sidebar' => [
      // ...
  ],

  'table_of_contents' => [
    'enabled' => true,
    'min_heading_level' => 2,
    'max_heading_level' => 4,
  ],
];
```

#### After

```php
return [
  'sidebar' => [
      // ...
  
    'table_of_contents' => [
        'enabled' => true,
        'min_heading_level' => 2,
        'max_heading_level' => 4,
    ],
  ],
];
```
