### PR TITLE
Remove old smooth page scrolling config entry from documentation

### DIFF
--- a/docs/creating-content/documentation-pages.md
+++ b/docs/creating-content/documentation-pages.md
@@ -260,7 +260,6 @@ You can also disable the feature completely.
     'enabled' => true,
     'min_heading_level' => 2,
     'max_heading_level' => 4,
-    'smooth_page_scrolling' => true,
 ],
 ```
 


### PR DESCRIPTION
I can't find any other references to this option in the codebase or on GitHub code search, so I'm assuming it's some kind of legacy layover. Since it's not supported, this removes it from the docs.

    'smooth_page_scrolling' => true, // Removed this from the table of contents example
