### PR TITLE
[2.x] Support setting sidebar labels and visibility in docs config

### DIFF
--- a/packages/framework/src/Framework/Factories/NavigationDataFactory.php
+++ b/packages/framework/src/Framework/Factories/NavigationDataFactory.php
@@ -136,7 +136,7 @@ class NavigationDataFactory extends Concerns\PageDataFactory implements Navigati
     {
         $config = Config::getArray('docs.sidebar.exclude', ['404']);
 
-        return in_array($this->routeKey, $config) || in_array($this->identifier, $config);
+        return in_array($this->routeKey, $config) || in_array($this->identifier, $config) || $this->isPageHiddenInNavigationConfiguration();
     }
 
     private function isNonDocumentationPageInHiddenSubdirectory(): bool

--- a/packages/framework/src/Framework/Factories/NavigationDataFactory.php
+++ b/packages/framework/src/Framework/Factories/NavigationDataFactory.php
@@ -73,7 +73,7 @@ class NavigationDataFactory extends Concerns\PageDataFactory implements Navigati
     protected function makeLabel(): ?string
     {
         return $this->searchForLabelInFrontMatter()
-            ?? $this->searchForLabelInConfig()
+            ?? $this->searchForLabelInConfigs()
             ?? $this->getMatter('title')
             ?? $this->title;
     }
@@ -139,7 +139,14 @@ class NavigationDataFactory extends Concerns\PageDataFactory implements Navigati
             ?? $this->getMatter('navigation.order');
     }
 
-    private function searchForLabelInConfig(): ?string
+    private function searchForLabelInConfigs(): ?string
+    {
+        return $this->isInstanceOf(DocumentationPage::class)
+            ? $this->searchForLabelInSidebarConfig()
+            : $this->searchForLabelInNavigationConfig();
+    }
+
+    private function searchForLabelInNavigationConfig(): ?string
     {
         /** @var array<string, string> $config */
         $config = Config::getArray('hyde.navigation.labels', [
@@ -148,6 +155,16 @@ class NavigationDataFactory extends Concerns\PageDataFactory implements Navigati
         ]);
 
         return $config[$this->routeKey] ?? null;
+    }
+
+    private function searchForLabelInSidebarConfig(): ?string
+    {
+        /** @var array<string>|array<string, string> $config */
+        $config = Config::getArray('docs.sidebar.labels', [
+            DocumentationPage::homeRouteName() => 'Docs',
+        ]);
+
+        return $config[$this->routeKey] ?? $config[$this->identifier] ?? null;
     }
 
     private function searchForPriorityInConfigs(): ?int

--- a/packages/framework/src/Framework/Factories/NavigationDataFactory.php
+++ b/packages/framework/src/Framework/Factories/NavigationDataFactory.php
@@ -136,7 +136,11 @@ class NavigationDataFactory extends Concerns\PageDataFactory implements Navigati
     {
         $config = Config::getArray('docs.sidebar.exclude', ['404']);
 
-        return in_array($this->routeKey, $config) || in_array($this->identifier, $config) || $this->isPageHiddenInNavigationConfiguration();
+        return
+            // Check if the page is hidden from the sidebar by route key or identifier.
+            (in_array($this->routeKey, $config) || in_array($this->identifier, $config))
+            // Check if the page is hidden from the main navigation by its route key.
+            || $this->isPageHiddenInNavigationConfiguration();
     }
 
     private function isNonDocumentationPageInHiddenSubdirectory(): bool

--- a/packages/framework/src/Framework/Factories/NavigationDataFactory.php
+++ b/packages/framework/src/Framework/Factories/NavigationDataFactory.php
@@ -91,7 +91,7 @@ class NavigationDataFactory extends Concerns\PageDataFactory implements Navigati
     {
         return $this->isInstanceOf(MarkdownPost::class)
             || $this->searchForHiddenInFrontMatter()
-            || $this->isPageHiddenInNavigationConfiguration()
+            || $this->searchForHiddenInConfigs()
             || $this->isNonDocumentationPageInHiddenSubdirectory();
     }
 
@@ -120,9 +120,23 @@ class NavigationDataFactory extends Concerns\PageDataFactory implements Navigati
             ?? $this->invert($this->getMatter('navigation.visible'));
     }
 
+    private function searchForHiddenInConfigs(): ?bool
+    {
+        return $this->isInstanceOf(DocumentationPage::class)
+            ? $this->isPageHiddenInSidebarConfiguration()
+            : $this->isPageHiddenInNavigationConfiguration();
+    }
+
     private function isPageHiddenInNavigationConfiguration(): ?bool
     {
         return in_array($this->routeKey, Config::getArray('hyde.navigation.exclude', ['404']));
+    }
+
+    private function isPageHiddenInSidebarConfiguration(): ?bool
+    {
+        $config = Config::getArray('docs.sidebar.exclude', ['404']);
+
+        return in_array($this->routeKey, $config) || in_array($this->identifier, $config);
     }
 
     private function isNonDocumentationPageInHiddenSubdirectory(): bool

--- a/packages/framework/tests/Feature/AutomaticNavigationConfigurationsTest.php
+++ b/packages/framework/tests/Feature/AutomaticNavigationConfigurationsTest.php
@@ -847,8 +847,6 @@ class AutomaticNavigationConfigurationsTest extends TestCase
 
     public function testSidebarWithConfigLabels()
     {
-        $this->markTestSkipped('Not supported (yet?)');
-
         config(['docs.sidebar.labels' => ['foo' => 'First', 'bar' => 'Second', 'baz' => 'Third']]);
 
         $this->assertSidebarEquals(['First', 'Second', 'Third'], [

--- a/packages/framework/tests/Feature/AutomaticNavigationConfigurationsTest.php
+++ b/packages/framework/tests/Feature/AutomaticNavigationConfigurationsTest.php
@@ -869,8 +869,6 @@ class AutomaticNavigationConfigurationsTest extends TestCase
 
     public function testSidebarWithConfigHidden()
     {
-        $this->markTestSkipped('Not supported (yet?)');
-
         config(['docs.sidebar.exclude' => ['foo', 'bar', 'baz']]);
 
         $this->assertSidebarEquals([], [

--- a/packages/framework/tests/Unit/NavigationDataFactoryUnitTest.php
+++ b/packages/framework/tests/Unit/NavigationDataFactoryUnitTest.php
@@ -146,6 +146,53 @@ class NavigationDataFactoryUnitTest extends UnitTestCase
         $this->assertSame(502, $factory->makePriority());
     }
 
+    public function testSearchForLabelInNavigationConfigForMarkdownPage()
+    {
+        self::mockConfig([
+            'hyde.navigation.labels' => [
+                'foo' => 'Foo Label',
+                'bar' => 'Bar Label',
+            ],
+        ]);
+
+        $factory = new NavigationConfigTestClass($this->makeCoreDataObject(routeKey: 'foo'));
+        $this->assertSame('Foo Label', $factory->makeLabel());
+
+        $factory = new NavigationConfigTestClass($this->makeCoreDataObject(routeKey: 'bar'));
+        $this->assertSame('Bar Label', $factory->makeLabel());
+    }
+
+    public function testSearchForLabelInSidebarConfigForDocumentationPage()
+    {
+        self::mockConfig([
+            'docs.sidebar.labels' => [
+                'foo' => 'Documentation Foo Label',
+                'bar' => 'Documentation Bar Label',
+            ],
+        ]);
+
+        $factory = new NavigationConfigTestClass($this->makeCoreDataObject(routeKey: 'foo', pageClass: DocumentationPage::class));
+        $this->assertSame('Documentation Foo Label', $factory->makeLabel());
+
+        $factory = new NavigationConfigTestClass($this->makeCoreDataObject(routeKey: 'bar', pageClass: DocumentationPage::class));
+        $this->assertSame('Documentation Bar Label', $factory->makeLabel());
+    }
+
+    public function testLabelFallbackToTitleIfNotDefinedInConfig()
+    {
+        self::mockConfig([
+            'hyde.navigation.labels' => [],
+            'docs.sidebar.labels' => [],
+        ]);
+
+        // Assuming the title fallback is correctly set in front matter or title property
+        $frontMatter = new FrontMatter(['title' => 'Fallback Title']);
+        $coreDataObject = new CoreDataObject($frontMatter, new Markdown(), MarkdownPage::class, '', '', '', 'undefinedKey');
+
+        $factory = new NavigationConfigTestClass($coreDataObject);
+        $this->assertSame('Fallback Title', $factory->makeLabel());
+    }
+
     protected function makeCoreDataObject(string $identifier = '', string $routeKey = '', string $pageClass = MarkdownPage::class): CoreDataObject
     {
         return new CoreDataObject(new FrontMatter(), new Markdown(), $pageClass, $identifier, '', '', $routeKey);
@@ -162,5 +209,10 @@ class NavigationConfigTestClass extends NavigationDataFactory
     public function makePriority(): int
     {
         return parent::makePriority();
+    }
+
+    public function makeLabel(): ?string
+    {
+        return parent::makeLabel();
     }
 }


### PR DESCRIPTION
Further normalizes the configuration API. Targets https://github.com/hydephp/develop/pull/1568