### PR TITLE
Improved helper functions

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -12,6 +12,7 @@ This serves two purposes:
 ### Added
 - Added a `@head` stack to the `head.blade.php` component in https://github.com/hydephp/develop/pull/1567
 - Added a `Hyde::route()` helper to the `Hyde` facade in https://github.com/hydephp/develop/pull/1591
+- Added new global helper functions (`asset()`, `route()`, `url()`) in https://github.com/hydephp/develop/pull/1592
 
 ### Changed
 - for changes in existing functionality.

--- a/docs/digging-deeper/helpers.md
+++ b/docs/digging-deeper/helpers.md
@@ -189,7 +189,9 @@ $time->formatUsingClosure(function (int $minutes, int $seconds): string {
 
 ## Helper Functions
 
-HydePHP comes with a few helper functions to make your life easier. 
+HydePHP comes with a few helper functions to make your life easier.
+
+The most common ones are documented here, however you can also see the full list in the source code [`helpers.php`](https://github.com/hydephp/framework/blob/master/src/helpers.php) file.
 
 ### Global `hyde` function
 

--- a/docs/digging-deeper/helpers.md
+++ b/docs/digging-deeper/helpers.md
@@ -266,19 +266,6 @@ If a base URL is not set, an exception will be thrown.
 <a href="{{ url('page.html') }}">Link</a>
 ```
 
-### Namespaced functions
-
-HydePHP also comes with a functions that are under the `Hyde` namespace,
-in order to avoid conflicts with other packages and your own code.
-
-#### `\Hyde\hyde`
-
-This is an alias for the `hyde` global function.
-
-```php
-\Hyde\hyde(); // Returns the HydeKernel instance
-```
-
 ## Pagination Utility
 
 The `Pagination` class provides utilities to help you create custom pagination components.

--- a/docs/digging-deeper/helpers.md
+++ b/docs/digging-deeper/helpers.md
@@ -191,6 +191,20 @@ $time->formatUsingClosure(function (int $minutes, int $seconds): string {
 
 HydePHP comes with a few helper functions to make your life easier. 
 
+### Global `hyde` function
+
+The `hyde` function is a global helper function that returns the HydeKernel instance.
+From this, you can access the same methods as you would from the `Hyde` facade.
+
+```php
+hyde(); // Returns the HydeKernel instance
+
+hyde()->routes()) === Hyde::routes(); // true
+```
+
+It's up to you if you want to use the facade or the global function, or a mix of both.
+A benefit of using the global function is that it may have better IDE support.
+
 
 ## Pagination Utility
 

--- a/docs/digging-deeper/helpers.md
+++ b/docs/digging-deeper/helpers.md
@@ -193,7 +193,9 @@ HydePHP comes with a few helper functions to make your life easier.
 
 The most common ones are documented here, however you can also see the full list in the source code [`helpers.php`](https://github.com/hydephp/framework/blob/master/src/helpers.php) file.
 
-### Global `hyde` function
+### Global functions
+
+#### `hyde`
 
 The `hyde` function is a global helper function that returns the HydeKernel instance.
 From this, you can access the same methods as you would from the `Hyde` facade.

--- a/docs/digging-deeper/helpers.md
+++ b/docs/digging-deeper/helpers.md
@@ -210,6 +210,13 @@ A benefit of using the global function is that it may have better IDE support.
 HydePHP also comes with a functions that are under the `Hyde` namespace,
 in order to avoid conflicts with other packages and your own code.
 
+#### `\Hyde\hyde`
+
+This is an alias for the `hyde` global function.
+
+```php
+\Hyde\hyde(); // Returns the HydeKernel instance
+```
 
 ## Pagination Utility
 

--- a/docs/digging-deeper/helpers.md
+++ b/docs/digging-deeper/helpers.md
@@ -193,9 +193,7 @@ HydePHP comes with a few helper functions to make your life easier.
 
 The most common ones are documented here, however you can also see the full list in the source code [`helpers.php`](https://github.com/hydephp/framework/blob/master/src/helpers.php) file.
 
-### Global functions
-
-#### `hyde`
+### `hyde`
 
 The `hyde` function is a global helper function that returns the HydeKernel instance.
 From this, you can access the same methods as you would from the `Hyde` facade.
@@ -209,7 +207,7 @@ hyde()->routes()) === Hyde::routes(); // true
 It's up to you if you want to use the facade or the global function, or a mix of both.
 A benefit of using the global function is that it may have better IDE support.
 
-#### `asset`
+### `asset`
 
 This is an alias of the `Hyde::asset()` facade method and allows you to get a relative link or URL to an asset in the media directory. 
 
@@ -229,7 +227,7 @@ the image will be returned with a qualified absolute URL.
 <img src="{{ asset('image.png') }}" alt="My image">
 ```
 
-#### `route`
+### `route`
 
 >info Routing primer: All pages in your Hyde project are automatically tied to an internal route. You can run `php hyde route:list` to see a list of all routes and their route keys.
 
@@ -248,7 +246,7 @@ If a route does not exist, `null` will be returned. Route instances can be cast 
 <a href="{{ route('index')->getLink() }}">Home</a>
 ```
 
-#### `url`
+### `url`
 
 This is an alias of the `Hyde::url()` facade method and formats a relative link to an absolute URL using the configured base URL.
 

--- a/docs/digging-deeper/helpers.md
+++ b/docs/digging-deeper/helpers.md
@@ -205,6 +205,11 @@ hyde()->routes()) === Hyde::routes(); // true
 It's up to you if you want to use the facade or the global function, or a mix of both.
 A benefit of using the global function is that it may have better IDE support.
 
+### Namespaced functions
+
+HydePHP also comes with a functions that are under the `Hyde` namespace,
+in order to avoid conflicts with other packages and your own code.
+
 
 ## Pagination Utility
 

--- a/docs/digging-deeper/helpers.md
+++ b/docs/digging-deeper/helpers.md
@@ -209,6 +209,26 @@ hyde()->routes()) === Hyde::routes(); // true
 It's up to you if you want to use the facade or the global function, or a mix of both.
 A benefit of using the global function is that it may have better IDE support.
 
+#### `asset`
+
+This is an alias of the `Hyde::asset()` facade method and allows you to get a relative link or URL to an asset in the media directory. 
+
+```php
+asset('image.png'); // Returns a relative web link to the given image
+```
+
+Gets a relative web link to the given image stored in the `_site/media` folder.
+If the image is remote (starts with http) it will be returned as is.
+
+If `true` is passed as the second argument, and a base URL is set,
+the image will be returned with a qualified absolute URL.
+
+**Example usage:**
+
+```blade
+<img src="{{ asset('image.png') }}" alt="My image">
+```
+
 ### Namespaced functions
 
 HydePHP also comes with a functions that are under the `Hyde` namespace,

--- a/docs/digging-deeper/helpers.md
+++ b/docs/digging-deeper/helpers.md
@@ -187,6 +187,10 @@ $time->formatUsingClosure(function (int $minutes, int $seconds): string {
 }); // 1 minutes, 30 seconds
 ```
 
+## Helper Functions
+
+HydePHP comes with a few helper functions to make your life easier. 
+
 
 ## Pagination Utility
 

--- a/docs/digging-deeper/helpers.md
+++ b/docs/digging-deeper/helpers.md
@@ -229,6 +229,25 @@ the image will be returned with a qualified absolute URL.
 <img src="{{ asset('image.png') }}" alt="My image">
 ```
 
+#### `route`
+
+>info Routing primer: All pages in your Hyde project are automatically tied to an internal route. You can run `php hyde route:list` to see a list of all routes and their route keys.
+
+This is an alias of the `Hyde::route()` facade method and allows you to get a route instance by its route key.
+
+```php
+route('index'); // Returns the route instance with the given key
+```
+
+If a route does not exist, `null` will be returned. Route instances can be cast to strings to resolve a link to the page.
+
+**Example usage:**
+
+```blade
+<a href="{{ route('index') }}">Home</a>
+<a href="{{ route('index')->getLink() }}">Home</a>
+```
+
 ### Namespaced functions
 
 HydePHP also comes with a functions that are under the `Hyde` namespace,

--- a/docs/digging-deeper/helpers.md
+++ b/docs/digging-deeper/helpers.md
@@ -248,6 +248,24 @@ If a route does not exist, `null` will be returned. Route instances can be cast 
 <a href="{{ route('index')->getLink() }}">Home</a>
 ```
 
+#### `url`
+
+This is an alias of the `Hyde::url()` facade method and formats a relative link to an absolute URL using the configured base URL.
+
+```php
+url('page.html'); // Returns an absolute URL to the given page
+```
+
+[//]: # (If the given link is already an absolute URL, it will be returned as is.)
+
+If a base URL is not set, an exception will be thrown.
+
+**Example usage:**
+
+```blade
+<a href="{{ url('page.html') }}">Link</a>
+```
+
 ### Namespaced functions
 
 HydePHP also comes with a functions that are under the `Hyde` namespace,

--- a/packages/framework/src/helpers.php
+++ b/packages/framework/src/helpers.php
@@ -44,6 +44,16 @@ namespace {
             return hyde()->route($key);
         }
     }
+
+    if (! function_exists('url')) {
+        /**
+         * Get a qualified URL to the supplied path if a base URL is set.
+         */
+        function url(string $path = ''): string
+        {
+            return hyde()->url($path);
+        }
+    }
 }
 
 namespace Hyde {

--- a/packages/framework/src/helpers.php
+++ b/packages/framework/src/helpers.php
@@ -34,6 +34,16 @@ namespace {
             return hyde()->asset($name, $preferQualifiedUrl);
         }
     }
+
+    if (! function_exists('route')) {
+        /**
+         * Get a page route by its key.
+         */
+        function route(string $key): ?Hyde\Support\Models\Route
+        {
+            return hyde()->route($key);
+        }
+    }
 }
 
 namespace Hyde {

--- a/packages/framework/src/helpers.php
+++ b/packages/framework/src/helpers.php
@@ -24,6 +24,16 @@ namespace {
             return trim($string, '/\\');
         }
     }
+
+    if (! function_exists('asset')) {
+        /**
+         * Get a relative link or URL to an asset in the media directory.
+         */
+        function asset(string $name, bool $preferQualifiedUrl = false): string
+        {
+            return hyde()->asset($name, $preferQualifiedUrl);
+        }
+    }
 }
 
 namespace Hyde {

--- a/packages/framework/src/helpers.php
+++ b/packages/framework/src/helpers.php
@@ -25,33 +25,37 @@ namespace {
         }
     }
 
-    if (! function_exists('asset')) {
-        /**
-         * Get a relative link or URL to an asset in the media directory.
-         */
-        function asset(string $name, bool $preferQualifiedUrl = false): string
-        {
-            return hyde()->asset($name, $preferQualifiedUrl);
+    if (defined('HYDE_COMPATIBILITY_MODE') && HYDE_COMPATIBILITY_MODE === true) {
+        // Don't declare these functions when running in compatibility mode.
+    } else {
+        if (! function_exists('asset')) {
+            /**
+             * Get a relative link or URL to an asset in the media directory.
+             */
+            function asset(string $name, bool $preferQualifiedUrl = false): string
+            {
+                return hyde()->asset($name, $preferQualifiedUrl);
+            }
         }
-    }
 
-    if (! function_exists('route')) {
-        /**
-         * Get a page route by its key.
-         */
-        function route(string $key): ?Hyde\Support\Models\Route
-        {
-            return hyde()->route($key);
+        if (! function_exists('route')) {
+            /**
+             * Get a page route by its key.
+             */
+            function route(string $key): ?Hyde\Support\Models\Route
+            {
+                return hyde()->route($key);
+            }
         }
-    }
 
-    if (! function_exists('url')) {
-        /**
-         * Get a qualified URL to the supplied path if a base URL is set.
-         */
-        function url(string $path = ''): string
-        {
-            return hyde()->url($path);
+        if (! function_exists('url')) {
+            /**
+             * Get a qualified URL to the supplied path if a base URL is set.
+             */
+            function url(string $path = ''): string
+            {
+                return hyde()->url($path);
+            }
         }
     }
 }

--- a/packages/framework/tests/Feature/HelpersTest.php
+++ b/packages/framework/tests/Feature/HelpersTest.php
@@ -137,6 +137,36 @@ class HelpersTest extends TestCase
         $this->assertNull(route('nonexistent'));
     }
 
+    /** @covers ::url */
+    public function testUrlFunction()
+    {
+        $this->assertSame(Hyde::url('foo'), url('foo'));
+    }
+
+    /** @covers ::url */
+    public function testUrlFunctionWithBaseUrl()
+    {
+        $this->app['config']->set(['hyde.url' => 'http://localhost']);
+        $this->assertSame('http://localhost/foo', url('foo'));
+    }
+
+    /** @covers ::url */
+    public function testUrlFunctionWithoutBaseUrl()
+    {
+        $this->app['config']->set(['hyde.url' => null]);
+        $this->expectException(\Hyde\Framework\Exceptions\BaseUrlNotSetException::class);
+        $this->assertNull(url('foo'));
+    }
+
+    /** @covers ::url */
+    public function testUrlFunctionWithAlreadyQualifiedUrl()
+    {
+        $this->markTestSkipped('The url function does not check if the URL is already qualified.');
+
+        $this->assertSame('https://example.com/foo', url('https://example.com/foo'));
+        $this->assertSame('http://localhost/foo', url('http://localhost/foo'));
+    }
+
     /** @covers ::\Hyde\hyde */
     public function testHydeFunctionExistsInHydeNamespace()
     {

--- a/packages/framework/tests/Feature/HelpersTest.php
+++ b/packages/framework/tests/Feature/HelpersTest.php
@@ -10,6 +10,7 @@ use Hyde\Foundation\HydeKernel;
 use Hyde\Hyde;
 use Hyde\Testing\TestCase;
 use Symfony\Component\Yaml\Yaml;
+use Hyde\Support\Facades\Render;
 
 /**
  * Covers the helpers in helpers.php.
@@ -62,6 +63,58 @@ class HelpersTest extends TestCase
         foreach ($tests as $test) {
             $this->assertSame('foo/bar', unslash($test));
         }
+    }
+
+    /** @covers ::asset */
+    public function testAssetFunction()
+    {
+        $this->assertSame(Hyde::asset('foo'), asset('foo'));
+        $this->assertSame('media/foo', asset('foo'));
+    }
+
+    /** @covers ::asset */
+    public function testAssetFunctionWithQualifiedUrl()
+    {
+        $this->assertSame(Hyde::asset('foo', true), asset('foo', true));
+        $this->assertSame('http://localhost/media/foo', asset('foo', true));
+    }
+
+    /** @covers ::asset */
+    public function testAssetFunctionWithExternalUrl()
+    {
+        $this->assertSame('https://example.com/foo', asset('https://example.com/foo'));
+        $this->assertSame('https://example.com/foo', asset('https://example.com/foo', true));
+    }
+
+    /** @covers ::asset */
+    public function testAssetFunctionWithQualifiedUrlAndNoBaseUrl()
+    {
+        $this->app['config']->set(['hyde.url' => null]);
+        $this->assertSame('media/foo', asset('foo', true));
+    }
+
+    /** @covers ::asset */
+    public function testAssetFunctionFromNestedPage()
+    {
+        Render::shouldReceive('getRouteKey')->andReturn('foo/bar');
+
+        $this->assertSame('../media/foo', asset('foo'));
+    }
+
+    /** @covers ::asset */
+    public function testAssetFunctionFromDeeplyNestedPage()
+    {
+        Render::shouldReceive('getRouteKey')->andReturn('foo/bar/baz');
+
+        $this->assertSame('../../media/foo', asset('foo'));
+    }
+
+    /** @covers ::asset */
+    public function testAssetFunctionWithCustomMediaDirectory()
+    {
+        Hyde::setMediaDirectory('custom');
+
+        $this->assertSame('custom/foo', asset('foo'));
     }
 
     /** @covers ::\Hyde\hyde */

--- a/packages/framework/tests/Feature/HelpersTest.php
+++ b/packages/framework/tests/Feature/HelpersTest.php
@@ -11,6 +11,7 @@ use Hyde\Hyde;
 use Hyde\Testing\TestCase;
 use Symfony\Component\Yaml\Yaml;
 use Hyde\Support\Facades\Render;
+use Hyde\Foundation\Facades\Routes;
 
 /**
  * Covers the helpers in helpers.php.
@@ -115,6 +116,25 @@ class HelpersTest extends TestCase
         Hyde::setMediaDirectory('custom');
 
         $this->assertSame('custom/foo', asset('foo'));
+    }
+
+    /** @covers ::route */
+    public function testRouteFunction()
+    {
+        $this->assertNotNull(Hyde::route('index'));
+        $this->assertSame(Routes::get('index'), route('index'));
+    }
+
+    /** @covers ::route */
+    public function testRouteFunctionWithInvalidRoute()
+    {
+        $this->assertNull(route('foo'));
+    }
+
+    /** @covers ::route */
+    public function testRouteFunctionReturnsNullForNonExistentRoute()
+    {
+        $this->assertNull(route('nonexistent'));
     }
 
     /** @covers ::\Hyde\hyde */


### PR DESCRIPTION
Adds helper function documentation and adds a few new global helper functions:

- Add a global `asset()` helper function
- Add a global `route()` helper function
- Add a global `url()` helper function

Design notes:

I debated weather these functions should be global or under the Hyde function namespace. I think making them global is the best. For the majority of users, this will be the most convenient, and for a small subset of users where there are conflicts (such as including Hyde in a Laravel application (which is not "officially" supported)), we can add a constant to disable these functions in case of function registration race conditions. TLDR: I think the small conflict risk is worth the major convenience of global functions. 

Compatibility mode:

To disable the new global functions, define a constant called `HYDE_COMPATIBILITY_MODE` and set it to `true`, and the new functions will not be registered. The constant should be defined early on, for example in a bootstrap file. 