### PR TITLE
[2.x] Massively simplify sidebar footer text handling

### DIFF
--- a/packages/framework/resources/views/components/docs/sidebar-footer-text.blade.php
+++ b/packages/framework/resources/views/components/docs/sidebar-footer-text.blade.php
@@ -1,7 +1,1 @@
-<p>
-    @if(is_bool($sidebar->getFooter())))
-        <a href="{{ Hyde::relativeLink('index.html') }}">Back to home page</a>
-    @else
-        {{ Hyde::markdown($sidebar->getFooter()) }}
-    @endif
-</p>
+{{ Hyde::markdown($sidebar->getFooter()) }}

--- a/packages/framework/src/Framework/Features/Navigation/DocumentationSidebar.php
+++ b/packages/framework/src/Framework/Features/Navigation/DocumentationSidebar.php
@@ -28,17 +28,17 @@ class DocumentationSidebar extends NavigationMenu
         parent::__construct($items);
     }
 
-    public function getFooter(): bool|string
+    public function getFooter(): ?string
     {
-        return Config::get('docs.sidebar.footer', true);
-    }
-
-    public function getFooterText(): ?string
-    {
-        $option = Config::get('docs.sidebar.footer', true);
+        $option = Config::get('docs.sidebar.footer', '[Back to home page](../)');
 
         if (is_string($option)) {
             return $option;
+        }
+
+        if ($option === true) {
+            /** @deprecated Backwards compatibility */
+            return '[Back to home page](../)';
         }
 
         return null;
@@ -46,11 +46,7 @@ class DocumentationSidebar extends NavigationMenu
 
     public function hasFooter(): bool
     {
-        if (is_string(Config::get('docs.sidebar.footer', true))) {
-            return true;
-        }
-
-        return Config::getBool('docs.sidebar.footer', true);
+        return $this->getFooter() !== null;
     }
 
     public function isCollapsible(): bool

--- a/packages/framework/tests/Feature/SidebarViewTest.php
+++ b/packages/framework/tests/Feature/SidebarViewTest.php
@@ -37,7 +37,7 @@ class SidebarViewTest extends TestCase
             ->assertSeeHtml('<ul id="sidebar-items" role="list"')
             ->assertSeeHtml('<nav id="sidebar-navigation"')
             ->assertSeeHtml('<footer id="sidebar-footer"')
-            ->assertSeeHtml('<a href="index.html">Back to home page</a>')
+            ->assertSeeHtml('<a href="../">Back to home page</a>')
             ->assertSeeHtml('<span class="sr-only">Toggle dark theme</span>')
             ->assertDontSee('<a href="docs/index.html">')
             ->assertDontSee('<li class="sidebar-item')
@@ -53,9 +53,10 @@ class SidebarViewTest extends TestCase
     {
         config(['docs.sidebar.footer' => false]);
 
-        $this->renderComponent(view('hyde::components.docs.sidebar'));
-
-        $this->assertViewWasNotRendered(view('hyde::components.docs.sidebar-footer-text'));
+        $this->renderComponent(view('hyde::components.docs.sidebar'))
+            ->assertDontSee('<footer id="sidebar-footer"')
+            ->assertDontSee('Back to home page')
+            ->allGood();
     }
 
     public function testBaseSidebarWithCustomFooterText()

--- a/packages/framework/tests/Feature/Views/SidebarFooterTextViewTest.php
+++ b/packages/framework/tests/Feature/Views/SidebarFooterTextViewTest.php
@@ -17,7 +17,7 @@ class SidebarFooterTextViewTest extends TestCase
     {
         $view = $this->test(view('hyde::components.docs.sidebar-footer-text', $this->withSidebar()));
 
-        $view->assertSeeHtml('<a href="index.html">Back to home page</a>');
+        $view->assertSeeHtml('<a href="../">Back to home page</a>');
     }
 
     public function testSidebarFooterTextViewWhenConfigOptionIsTrue()
@@ -26,7 +26,7 @@ class SidebarFooterTextViewTest extends TestCase
 
         $view = $this->test(view('hyde::components.docs.sidebar-footer-text', $this->withSidebar()));
 
-        $view->assertSeeHtml('<a href="index.html">Back to home page</a>');
+        $view->assertSeeHtml('<a href="../">Back to home page</a>');
     }
 
     public function testSidebarFooterTextViewWhenConfigOptionIsMarkdownString()
@@ -36,13 +36,6 @@ class SidebarFooterTextViewTest extends TestCase
         $view = $this->test(view('hyde::components.docs.sidebar-footer-text', $this->withSidebar()));
 
         $view->assertSeeText('Your Markdown String Here');
-    }
-
-    public function testSidebarFooterTextViewWhenConfigOptionIsFalse()
-    {
-        // This state is handled earlier in the component by the sidebar component so we don't need to test it here.
-
-        $this->assertTrue(true);
     }
 
     protected function withSidebar(): array

--- a/packages/framework/tests/Unit/DocumentationSidebarUnitTest.php
+++ b/packages/framework/tests/Unit/DocumentationSidebarUnitTest.php
@@ -122,11 +122,11 @@ class DocumentationSidebarUnitTest extends UnitTestCase
         $this->assertSame($instance, DocumentationSidebar::get());
     }
 
-    public function testGetFooterReturnsTrueByDefault()
+    public function testGetFooterReturnsBackLinkByDefault()
     {
         self::mockConfig();
 
-        $this->assertTrue((new DocumentationSidebar())->getFooter());
+        $this->assertSame('[Back to home page](../)', (new DocumentationSidebar())->getFooter());
     }
 
     public function testGetFooterReturnsStringWhenConfigIsString()
@@ -136,39 +136,18 @@ class DocumentationSidebarUnitTest extends UnitTestCase
         $this->assertSame('Some footer content', (new DocumentationSidebar())->getFooter());
     }
 
-    public function testGetFooterReturnsTrueWhenConfigIsTrue()
+    public function testGetFooterReturnsBackLinkWhenConfigIsTrue()
     {
         self::mockConfig(['docs.sidebar.footer' => true]);
 
-        $this->assertTrue((new DocumentationSidebar())->getFooter());
+        $this->assertSame('[Back to home page](../)', (new DocumentationSidebar())->getFooter());
     }
 
-    public function testGetFooterReturnsFalseWhenConfigIsFalse()
+    public function testGetFooterReturnsNullWhenConfigIsFalse()
     {
         self::mockConfig(['docs.sidebar.footer' => false]);
 
-        $this->assertFalse((new DocumentationSidebar())->getFooter());
-    }
-
-    public function testGetFooterTextReturnsStringWhenConfigIsString()
-    {
-        self::mockConfig(['docs.sidebar.footer' => 'Some footer content']);
-
-        $this->assertSame('Some footer content', (new DocumentationSidebar())->getFooterText());
-    }
-
-    public function testGetFooterTextReturnsNullWhenConfigIsTrue()
-    {
-        self::mockConfig(['docs.sidebar.footer' => true]);
-
-        $this->assertNull((new DocumentationSidebar())->getFooterText());
-    }
-
-    public function testGetFooterTextReturnsNullWhenConfigIsFalse()
-    {
-        self::mockConfig(['docs.sidebar.footer' => false]);
-
-        $this->assertNull((new DocumentationSidebar())->getFooterText());
+        $this->assertNull((new DocumentationSidebar())->getFooter());
     }
 
     public function testIsCollapsibleReturnsTrueByDefault()

--- a/packages/framework/tests/Unit/RelativeLinksAcrossPagesRetainsIntegrityTest.php
+++ b/packages/framework/tests/Unit/RelativeLinksAcrossPagesRetainsIntegrityTest.php
@@ -93,7 +93,7 @@ class RelativeLinksAcrossPagesRetainsIntegrityTest extends TestCase
             '<link rel="stylesheet" href="../media/app.css">',
             '<a href="../docs/index.html">',
             '<a href="../docs/docs.html"',
-            '<a href="../index.html">Back to home page</a>',
+            '<a href="../">Back to home page</a>',
         ]);
     }
 }


### PR DESCRIPTION
Uses the link from the view, in order to simplify the API. A drawback of this is that it no longer resolves dynamic links, but given the increased visibility of the option I think the tradeoff is worth it as it makes it easier to customize.