### PR TITLE
[2.x] Always place navigation menu items in dropdowns when set in front matter

### DIFF
--- a/packages/framework/src/Framework/Features/Navigation/NavigationMenuGenerator.php
+++ b/packages/framework/src/Framework/Features/Navigation/NavigationMenuGenerator.php
@@ -120,12 +120,12 @@ class NavigationMenuGenerator
 
     protected function canGroupRoute(Route $route): bool
     {
-        if (! $this->usesGroups) {
-            return false;
-        }
-
         if (! $this->generatesSidebar) {
             return $route->getPage()->navigationMenuGroup() !== null;
+        }
+
+        if (! $this->usesGroups) {
+            return false;
         }
 
         return true;

--- a/packages/framework/tests/Feature/AutomaticNavigationConfigurationsTest.php
+++ b/packages/framework/tests/Feature/AutomaticNavigationConfigurationsTest.php
@@ -284,7 +284,10 @@ class AutomaticNavigationConfigurationsTest extends TestCase
     {
         // Since the main key in the navigation schema is 'group', that takes precedence over its 'category' alias
 
-        $this->assertMenuEquals(array_fill(0, 3, ['group' => 'group-1']), [
+        $this->assertMenuEquals([[
+            'label' => 'Group 1',
+            'children' => ['Foo', 'Bar', 'Baz'],
+        ]], [
             new MarkdownPage('foo', ['navigation.group' => 'Group 1', 'navigation.category' => 'Group 2']),
             new MarkdownPage('bar', ['navigation.group' => 'Group 1', 'navigation.category' => 'Group 2']),
             new MarkdownPage('baz', ['navigation.group' => 'Group 1', 'navigation.category' => 'Group 2']),
@@ -486,8 +489,8 @@ class AutomaticNavigationConfigurationsTest extends TestCase
     public function testMainNavigationMenuItemsWithSameLabelButDifferentGroupsAreNotFiltered()
     {
         $this->assertMenuEquals([
-            ['label' => 'Foo', 'group' => 'group-1'],
-            ['label' => 'Foo', 'group' => 'group-2'],
+            ['label' => 'Group 1', 'children' => ['Foo']],
+            ['label' => 'Group 2', 'children' => ['Foo']],
         ], [
             new MarkdownPage('foo', ['navigation.label' => 'Foo', 'navigation.group' => 'Group 1']),
             new MarkdownPage('bar', ['navigation.label' => 'Foo', 'navigation.group' => 'Group 2']),

--- a/packages/framework/tests/Feature/AutomaticNavigationConfigurationsTest.php
+++ b/packages/framework/tests/Feature/AutomaticNavigationConfigurationsTest.php
@@ -202,12 +202,8 @@ class AutomaticNavigationConfigurationsTest extends TestCase
 
     public function testMainNavigationMenuWithExplicitFrontMatterGroupUsesDropdownsRegardlessOfConfigSetting()
     {
-        // TODO: For new v2 system, this should insert a root item with the group name and the children as the pages
-
         $this->assertMenuEquals([
-            ['label' => 'Foo', 'group' => 'group-1'],
-            ['label' => 'Bar', 'group' => 'group-1'],
-            ['label' => 'Baz', 'group' => 'group-1'],
+            ['label' => 'Group 1', 'children' => ['Foo', 'Bar', 'Baz']],
         ], [
             new MarkdownPage('foo', ['navigation.group' => 'Group 1']),
             new MarkdownPage('bar', ['navigation.group' => 'Group 1']),
@@ -217,12 +213,8 @@ class AutomaticNavigationConfigurationsTest extends TestCase
 
     public function testMainNavigationMenuWithExplicitFrontMatterCategoryUsesDropdownsRegardlessOfConfigSetting()
     {
-        // TODO: For new v2 system, this should insert a root item with the group name and the children as the pages
-
         $this->assertMenuEquals([
-            ['label' => 'Foo', 'group' => 'group-1'],
-            ['label' => 'Bar', 'group' => 'group-1'],
-            ['label' => 'Baz', 'group' => 'group-1'],
+            ['label' => 'Group 1', 'children' => ['Foo', 'Bar', 'Baz']],
         ], [
             new MarkdownPage('foo', ['navigation.category' => 'Group 1']),
             new MarkdownPage('bar', ['navigation.category' => 'Group 1']),

--- a/packages/framework/tests/Feature/AutomaticNavigationConfigurationsTest.php
+++ b/packages/framework/tests/Feature/AutomaticNavigationConfigurationsTest.php
@@ -200,7 +200,7 @@ class AutomaticNavigationConfigurationsTest extends TestCase
         ]);
     }
 
-    public function testMainNavigationMenuWithFrontMatterGroup()
+    public function testMainNavigationMenuWithExplicitFrontMatterGroupUsesDropdownsRegardlessOfConfigSetting()
     {
         // TODO: For new v2 system, this should insert a root item with the group name and the children as the pages
 
@@ -215,7 +215,7 @@ class AutomaticNavigationConfigurationsTest extends TestCase
         ]);
     }
 
-    public function testMainNavigationMenuWithFrontMatterCategory()
+    public function testMainNavigationMenuWithExplicitFrontMatterCategoryUsesDropdownsRegardlessOfConfigSetting()
     {
         // TODO: For new v2 system, this should insert a root item with the group name and the children as the pages
 


### PR DESCRIPTION
Makes so that the generator always place navigation menu items in dropdowns when set in front matter, regardless of subdirectory group config.