### PR TITLE
[2.x] Create positioning priority constants in the navigation menu class

### DIFF
--- a/packages/framework/src/Framework/Factories/NavigationDataFactory.php
+++ b/packages/framework/src/Framework/Factories/NavigationDataFactory.php
@@ -31,8 +31,6 @@ class NavigationDataFactory extends Concerns\PageDataFactory implements Navigati
      */
     final public const SCHEMA = NavigationSchema::NAVIGATION_SCHEMA;
 
-    protected const CONFIG_OFFSET = 500;
-
     protected readonly ?string $label;
     protected readonly ?string $group;
     protected readonly ?bool $hidden;
@@ -230,7 +228,7 @@ class NavigationDataFactory extends Concerns\PageDataFactory implements Navigati
 
             return $this->offset(
                 array_flip($config)[$pageKey] ?? null,
-                self::CONFIG_OFFSET
+                NavigationMenu::MIDDLE
             );
         }
 

--- a/packages/framework/src/Framework/Factories/NavigationDataFactory.php
+++ b/packages/framework/src/Framework/Factories/NavigationDataFactory.php
@@ -10,6 +10,7 @@ use Hyde\Pages\MarkdownPost;
 use Hyde\Pages\DocumentationPage;
 use Hyde\Markdown\Models\FrontMatter;
 use Hyde\Framework\Factories\Concerns\CoreDataObject;
+use Hyde\Framework\Features\Navigation\NavigationMenu;
 use Hyde\Markdown\Contracts\FrontMatter\SubSchemas\NavigationSchema;
 
 use function basename;
@@ -30,7 +31,6 @@ class NavigationDataFactory extends Concerns\PageDataFactory implements Navigati
      */
     final public const SCHEMA = NavigationSchema::NAVIGATION_SCHEMA;
 
-    protected const FALLBACK_PRIORITY = 999;
     protected const CONFIG_OFFSET = 500;
 
     protected readonly ?string $label;
@@ -99,7 +99,7 @@ class NavigationDataFactory extends Concerns\PageDataFactory implements Navigati
     {
         return $this->searchForPriorityInFrontMatter()
             ?? $this->searchForPriorityInConfigs()
-            ?? self::FALLBACK_PRIORITY;
+            ?? NavigationMenu::LAST;
     }
 
     private function searchForLabelInFrontMatter(): ?string

--- a/packages/framework/src/Framework/Factories/NavigationDataFactory.php
+++ b/packages/framework/src/Framework/Factories/NavigationDataFactory.php
@@ -228,7 +228,7 @@ class NavigationDataFactory extends Concerns\PageDataFactory implements Navigati
 
             return $this->offset(
                 array_flip($config)[$pageKey] ?? null,
-                NavigationMenu::MIDDLE
+                NavigationMenu::DEFAULT
             );
         }
 

--- a/packages/framework/src/Framework/Features/Navigation/NavItem.php
+++ b/packages/framework/src/Framework/Features/Navigation/NavItem.php
@@ -42,7 +42,7 @@ class NavItem implements Stringable
     /**
      * Create a new navigation menu item.
      */
-    public function __construct(Route|string $destination, string $label, int $priority = 500, ?string $group = null, array $children = [])
+    public function __construct(Route|string $destination, string $label, int $priority = NavigationMenu::MIDDLE, ?string $group = null, array $children = [])
     {
         if (is_string($destination)) {
             $destination = Routes::get($destination) ?? new ExternalRoute($destination);
@@ -72,7 +72,7 @@ class NavItem implements Stringable
     /**
      * Create a new navigation menu item leading to an external URI.
      */
-    public static function forLink(string $href, string $label, int $priority = 500): static
+    public static function forLink(string $href, string $label, int $priority = NavigationMenu::MIDDLE): static
     {
         return new static($href, $label, $priority);
     }

--- a/packages/framework/src/Framework/Features/Navigation/NavItem.php
+++ b/packages/framework/src/Framework/Features/Navigation/NavItem.php
@@ -42,7 +42,7 @@ class NavItem implements Stringable
     /**
      * Create a new navigation menu item.
      */
-    public function __construct(Route|string $destination, string $label, int $priority = NavigationMenu::MIDDLE, ?string $group = null, array $children = [])
+    public function __construct(Route|string $destination, string $label, int $priority = NavigationMenu::DEFAULT, ?string $group = null, array $children = [])
     {
         if (is_string($destination)) {
             $destination = Routes::get($destination) ?? new ExternalRoute($destination);
@@ -72,7 +72,7 @@ class NavItem implements Stringable
     /**
      * Create a new navigation menu item leading to an external URI.
      */
-    public static function forLink(string $href, string $label, int $priority = NavigationMenu::MIDDLE): static
+    public static function forLink(string $href, string $label, int $priority = NavigationMenu::DEFAULT): static
     {
         return new static($href, $label, $priority);
     }

--- a/packages/framework/src/Framework/Features/Navigation/NavItem.php
+++ b/packages/framework/src/Framework/Features/Navigation/NavItem.php
@@ -101,7 +101,7 @@ class NavItem implements Stringable
      */
     public static function dropdown(string $label, array $items, ?int $priority = null): static
     {
-        return new static('', $label, $priority ?? 999, $label, $items);
+        return new static('', $label, $priority ?? NavigationMenu::LAST, $label, $items);
     }
 
     /**

--- a/packages/framework/src/Framework/Features/Navigation/NavigationMenu.php
+++ b/packages/framework/src/Framework/Features/Navigation/NavigationMenu.php
@@ -17,6 +17,10 @@ use Illuminate\Contracts\Support\Arrayable;
  */
 abstract class NavigationMenu
 {
+    public const FIRST = 0;
+    public const MIDDLE = 500;
+    public const LAST = 999;
+
     /** @var \Illuminate\Support\Collection<\Hyde\Framework\Features\Navigation\NavItem> */
     protected Collection $items;
 

--- a/packages/framework/src/Framework/Features/Navigation/NavigationMenu.php
+++ b/packages/framework/src/Framework/Features/Navigation/NavigationMenu.php
@@ -17,7 +17,7 @@ use Illuminate\Contracts\Support\Arrayable;
  */
 abstract class NavigationMenu
 {
-    public const MIDDLE = 500;
+    public const DEFAULT = 500;
     public const LAST = 999;
 
     /** @var \Illuminate\Support\Collection<\Hyde\Framework\Features\Navigation\NavItem> */

--- a/packages/framework/src/Framework/Features/Navigation/NavigationMenu.php
+++ b/packages/framework/src/Framework/Features/Navigation/NavigationMenu.php
@@ -17,7 +17,6 @@ use Illuminate\Contracts\Support\Arrayable;
  */
 abstract class NavigationMenu
 {
-    public const FIRST = 0;
     public const MIDDLE = 500;
     public const LAST = 999;
 


### PR DESCRIPTION
Extracts constants for the default priorities used for navigation menu design.

```php
NavigationMenu::DEFAULT = 500
NavigationMenu::LAST = 999
``` 

For example, the following is not very clear: (What does 999 mean and why do we use it?
```php
$priority ?? 999
``` 
But here, with the constant it's clear that we are falling back to putting the item last in the menu.
```php
$priority ?? NavigationMenu::LAST
``` 

It also makes things like this clearer
```php
$priority = NavigationMenu::LAST + 1
``` 

And a good IDE also shows the underlying integer values of the constants.