### PR TITLE
[2.x] Refactor NavItem class

### DIFF
--- a/packages/framework/src/Framework/Features/Navigation/NavItem.php
+++ b/packages/framework/src/Framework/Features/Navigation/NavItem.php
@@ -59,16 +59,6 @@ class NavItem implements Stringable
     }
 
     /**
-     * Create a new navigation menu item from a route.
-     *
-     * @deprecated Use NavItem::forRoute() instead.
-     */
-    public static function fromRoute(Route $route, ?string $label = null, ?int $priority = null, ?string $group = null): static
-    {
-        return static::forRoute($route, $label, $priority, $group);
-    }
-
-    /**
      * Create a new navigation menu item leading to a Route instance.
      *
      * @param  \Hyde\Support\Models\Route|string<\Hyde\Support\Models\RouteKey>  $route  Route instance or route key

--- a/packages/framework/src/Framework/Features/Navigation/NavItem.php
+++ b/packages/framework/src/Framework/Features/Navigation/NavItem.php
@@ -40,7 +40,7 @@ class NavItem implements Stringable
     protected string $identifier;
 
     /** @var array<\Hyde\Framework\Features\Navigation\NavItem> */
-    protected array $children;
+    protected array $children = [];
 
     /**
      * Create a new navigation menu item.

--- a/packages/framework/src/Framework/Features/Navigation/NavItem.php
+++ b/packages/framework/src/Framework/Features/Navigation/NavItem.php
@@ -199,6 +199,8 @@ class NavItem implements Stringable
 
     /**
      * Add a navigation item to the children of the navigation item.
+     *
+     * This will turn the parent item into a dropdown. Its destination will be set to null.
      */
     public function addChild(NavItem $item): static
     {

--- a/packages/framework/src/Framework/Features/Navigation/NavItem.php
+++ b/packages/framework/src/Framework/Features/Navigation/NavItem.php
@@ -96,7 +96,7 @@ class NavItem implements Stringable
      * @param  array<NavItem>  $items  The items to be included in the dropdown.
      * @param  int|null  $priority  The priority of the dropdown item. Leave blank to use the default priority, which is last in the menu.
      */
-    public static function forGroup(string $label, array $items, ?int $priority = null): static
+    public static function forGroup(string $label, array $items, ?int $priority = NavigationMenu::LAST): static
     {
         return new static(null, $label, $priority ?? NavigationMenu::LAST, $label, $items);
     }

--- a/packages/framework/src/Framework/Features/Navigation/NavItem.php
+++ b/packages/framework/src/Framework/Features/Navigation/NavItem.php
@@ -97,9 +97,9 @@ class NavItem implements Stringable
      *
      * @param  string  $label  The label of the dropdown item.
      * @param  array<NavItem>  $items  The items to be included in the dropdown.
-     * @param  int  $priority  The priority of the dropdown item. Leave blank to use the default priority, which is last in the menu.
+     * @param  int|null  $priority  The priority of the dropdown item. Leave blank to use the default priority, which is last in the menu.
      */
-    public static function forGroup(string $label, array $items, int $priority = NavigationMenu::LAST): static
+    public static function forGroup(string $label, array $items, ?int $priority = NavigationMenu::LAST): static
     {
         return new static('', $label, $priority, $label, $items);
     }

--- a/packages/framework/src/Framework/Features/Navigation/NavItem.php
+++ b/packages/framework/src/Framework/Features/Navigation/NavItem.php
@@ -60,6 +60,8 @@ class NavItem implements Stringable
 
     /**
      * Create a new navigation menu item from a route.
+     *
+     * @deprecated Use NavItem::forRoute() instead.
      */
     public static function fromRoute(Route $route, ?string $label = null, ?int $priority = null, ?string $group = null): static
     {

--- a/packages/framework/src/Framework/Features/Navigation/NavItem.php
+++ b/packages/framework/src/Framework/Features/Navigation/NavItem.php
@@ -45,7 +45,11 @@ class NavItem implements Stringable
     /**
      * Create a new navigation menu item.
      *
-     * @param  array<\Hyde\Framework\Features\Navigation\NavItem>  $children
+     * @param  \Hyde\Support\Models\Route|string|null  $destination  Route instance, route key, or external URI. For dropdowns/groups, this should be null.
+     * @param  string  $label  The label of the navigation item.
+     * @param  int  $priority  The priority to determine the order of the navigation item.
+     * @param  string|null  $group  The dropdown/group identifier of the navigation item, if any.
+     * @param  array<\Hyde\Framework\Features\Navigation\NavItem>  $children  If the item is a dropdown, these are the items to be included in the dropdown.
      */
     public function __construct(Route|string|null $destination, string $label, int $priority = NavigationMenu::DEFAULT, ?string $group = null, array $children = [])
     {

--- a/packages/framework/src/Framework/Features/Navigation/NavItem.php
+++ b/packages/framework/src/Framework/Features/Navigation/NavItem.php
@@ -97,9 +97,9 @@ class NavItem implements Stringable
      *
      * @param  string  $label  The label of the dropdown item.
      * @param  array<NavItem>  $items  The items to be included in the dropdown.
-     * @param  int|null  $priority  The priority of the dropdown item. Leave blank to use the default priority, which is last in the menu.
+     * @param  int  $priority  The priority of the dropdown item. Leave blank to use the default priority, which is last in the menu.
      */
-    public static function forGroup(string $label, array $items, ?int $priority = NavigationMenu::LAST): static
+    public static function forGroup(string $label, array $items, int $priority = NavigationMenu::LAST): static
     {
         return new static('', $label, $priority, $label, $items);
     }

--- a/packages/framework/src/Framework/Features/Navigation/NavItem.php
+++ b/packages/framework/src/Framework/Features/Navigation/NavItem.php
@@ -206,6 +206,10 @@ class NavItem implements Stringable
     {
         $item->group ??= $this->group;
 
+        if (!isset($this->children)) {
+            $this->children = [];
+        }
+
         $this->children[] = $item;
         $this->destination = null;
 

--- a/packages/framework/src/Framework/Features/Navigation/NavItem.php
+++ b/packages/framework/src/Framework/Features/Navigation/NavItem.php
@@ -206,10 +206,6 @@ class NavItem implements Stringable
     {
         $item->group ??= $this->group;
 
-        if (!isset($this->children)) {
-            $this->children = [];
-        }
-
         $this->children[] = $item;
         $this->destination = null;
 

--- a/packages/framework/src/Framework/Features/Navigation/NavItem.php
+++ b/packages/framework/src/Framework/Features/Navigation/NavItem.php
@@ -197,7 +197,7 @@ class NavItem implements Stringable
      */
     public function isCurrent(): bool
     {
-        return Hyde::currentRoute()->getLink() === $this->destination->getLink();
+        return $this->destination->is(Hyde::currentRoute());
     }
 
     /**

--- a/packages/framework/src/Framework/Features/Navigation/NavItem.php
+++ b/packages/framework/src/Framework/Features/Navigation/NavItem.php
@@ -58,7 +58,7 @@ class NavItem implements Stringable
         $this->priority = $priority;
         $this->group = static::normalizeGroupKey($group);
         $this->identifier = static::makeIdentifier($label);
-        $this->children = $children;
+        $this->addChildren($children);
     }
 
     /**

--- a/packages/framework/src/Framework/Features/Navigation/NavItem.php
+++ b/packages/framework/src/Framework/Features/Navigation/NavItem.php
@@ -30,7 +30,7 @@ use function is_string;
  */
 class NavItem implements Stringable
 {
-    protected Route $destination;
+    protected ?Route $destination;
     protected string $label;
     protected int $priority;
     protected ?string $group;
@@ -46,7 +46,7 @@ class NavItem implements Stringable
      *
      * @param  array<\Hyde\Framework\Features\Navigation\NavItem>  $children
      */
-    public function __construct(Route|string $destination, string $label, int $priority = NavigationMenu::DEFAULT, ?string $group = null, array $children = [])
+    public function __construct(Route|string|null $destination, string $label, int $priority = NavigationMenu::DEFAULT, ?string $group = null, array $children = [])
     {
         if (is_string($destination)) {
             $destination = Routes::get($destination) ?? new ExternalRoute($destination);

--- a/packages/framework/src/Framework/Features/Navigation/NavItem.php
+++ b/packages/framework/src/Framework/Features/Navigation/NavItem.php
@@ -99,9 +99,9 @@ class NavItem implements Stringable
      * @param  array<NavItem>  $items  The items to be included in the dropdown.
      * @param  int|null  $priority  The priority of the dropdown item. Leave blank to use the default priority, which is last in the menu.
      */
-    public static function forGroup(string $label, array $items, ?int $priority = NavigationMenu::LAST): static
+    public static function forGroup(string $label, array $items, ?int $priority = null): static
     {
-        return new static('', $label, $priority, $label, $items);
+        return new static('', $label, $priority ?? NavigationMenu::LAST, $label, $items);
     }
 
     /**

--- a/packages/framework/src/Framework/Features/Navigation/NavItem.php
+++ b/packages/framework/src/Framework/Features/Navigation/NavItem.php
@@ -95,13 +95,11 @@ class NavItem implements Stringable
     /**
      * Create a new dropdown navigation menu item.
      *
-     * @TODO: Might be more semantic to have this named something else, as it also includes sidebars groups. (technically it only makes sense for the main navigation menu, but it's not enforced in the code, and the sidebar does use this method)
-     *
      * @param  string  $label  The label of the dropdown item.
      * @param  array<NavItem>  $items  The items to be included in the dropdown.
      * @param  int|null  $priority  The priority of the dropdown item. Leave blank to use the default priority, which is last in the menu.
      */
-    public static function dropdown(string $label, array $items, ?int $priority = null): static
+    public static function forGroup(string $label, array $items, ?int $priority = null): static
     {
         return new static('', $label, $priority ?? NavigationMenu::LAST, $label, $items);
     }

--- a/packages/framework/src/Framework/Features/Navigation/NavItem.php
+++ b/packages/framework/src/Framework/Features/Navigation/NavItem.php
@@ -114,10 +114,6 @@ class NavItem implements Stringable
      */
     public function getDestination(): ?Route
     {
-        if ($this->hasChildren()) {
-            return null;
-        }
-
         return $this->destination;
     }
 

--- a/packages/framework/src/Framework/Features/Navigation/NavItem.php
+++ b/packages/framework/src/Framework/Features/Navigation/NavItem.php
@@ -205,6 +205,7 @@ class NavItem implements Stringable
         $item->group ??= $this->group;
 
         $this->children[] = $item;
+        $this->destination = null;
 
         return $this;
     }

--- a/packages/framework/src/Framework/Features/Navigation/NavItem.php
+++ b/packages/framework/src/Framework/Features/Navigation/NavItem.php
@@ -197,7 +197,7 @@ class NavItem implements Stringable
      */
     public function isCurrent(): bool
     {
-        return $this->destination->is(Hyde::currentRoute());
+        return Hyde::currentRoute()->getLink() === $this->destination->getLink();
     }
 
     /**

--- a/packages/framework/src/Framework/Features/Navigation/NavItem.php
+++ b/packages/framework/src/Framework/Features/Navigation/NavItem.php
@@ -94,9 +94,9 @@ class NavItem implements Stringable
      *
      * @param  string  $label  The label of the dropdown item.
      * @param  array<NavItem>  $items  The items to be included in the dropdown.
-     * @param  int|null  $priority  The priority of the dropdown item. Leave blank to use the default priority, which is last in the menu.
+     * @param  int  $priority  The priority of the dropdown item. Leave blank to use the default priority, which is last in the menu.
      */
-    public static function forGroup(string $label, array $items, ?int $priority = NavigationMenu::LAST): static
+    public static function forGroup(string $label, array $items, int $priority = NavigationMenu::LAST): static
     {
         return new static(null, $label, $priority, $label, $items);
     }

--- a/packages/framework/src/Framework/Features/Navigation/NavItem.php
+++ b/packages/framework/src/Framework/Features/Navigation/NavItem.php
@@ -83,12 +83,7 @@ class NavItem implements Stringable
      */
     public static function forRoute(Route|string $route, ?string $label = null, ?int $priority = null, ?string $group = null): static
     {
-        return new static(
-            $route instanceof Route ? $route : Routes::getOrFail($route),
-            $label ?? $route instanceof Route ? $route : Routes::getOrFail($route)->getPage()->navigationMenuLabel(),
-            $priority ?? $route instanceof Route ? $route : Routes::getOrFail($route)->getPage()->navigationMenuPriority(),
-            $group ?? $route instanceof Route ? $route : Routes::getOrFail($route)->getPage()->navigationMenuGroup(),
-        );
+        return static::fromRoute($route instanceof Route ? $route : Routes::getOrFail($route), $label, $priority, $group);
     }
 
     /**

--- a/packages/framework/src/Framework/Features/Navigation/NavItem.php
+++ b/packages/framework/src/Framework/Features/Navigation/NavItem.php
@@ -97,7 +97,7 @@ class NavItem implements Stringable
      */
     public static function forGroup(string $label, array $items, ?int $priority = null): static
     {
-        return new static('', $label, $priority ?? NavigationMenu::LAST, $label, $items);
+        return new static(null, $label, $priority ?? NavigationMenu::LAST, $label, $items);
     }
 
     /**

--- a/packages/framework/src/Framework/Features/Navigation/NavItem.php
+++ b/packages/framework/src/Framework/Features/Navigation/NavItem.php
@@ -72,14 +72,6 @@ class NavItem implements Stringable
     }
 
     /**
-     * Create a new navigation menu item leading to an external URI.
-     */
-    public static function forLink(string $href, string $label, int $priority = NavigationMenu::DEFAULT): static
-    {
-        return new static($href, $label, $priority);
-    }
-
-    /**
      * Create a new navigation menu item leading to a Route instance.
      *
      * @param  \Hyde\Support\Models\Route|string<\Hyde\Support\Models\RouteKey>  $route  Route instance or route key
@@ -90,6 +82,14 @@ class NavItem implements Stringable
     public static function forRoute(Route|string $route, ?string $label = null, ?int $priority = null, ?string $group = null): static
     {
         return static::fromRoute($route instanceof Route ? $route : Routes::getOrFail($route), $label, $priority, $group);
+    }
+
+    /**
+     * Create a new navigation menu item leading to an external URI.
+     */
+    public static function forLink(string $href, string $label, int $priority = NavigationMenu::DEFAULT): static
+    {
+        return new static($href, $label, $priority);
     }
 
     /**

--- a/packages/framework/src/Framework/Features/Navigation/NavItem.php
+++ b/packages/framework/src/Framework/Features/Navigation/NavItem.php
@@ -197,7 +197,7 @@ class NavItem implements Stringable
      */
     public function isCurrent(): bool
     {
-        return Hyde::currentRoute()->getLink() === (string) $this->destination;
+        return Hyde::currentRoute()->getLink() === $this->destination->getLink();
     }
 
     /**

--- a/packages/framework/src/Framework/Features/Navigation/NavItem.php
+++ b/packages/framework/src/Framework/Features/Navigation/NavItem.php
@@ -27,6 +27,7 @@ use function is_string;
  * Navigation items can be turned into dropdowns or sidebar groups by adding children.
  * Note that doing so will mean that any link on the parent will no longer be clickable,
  * as clicking the parent label will open the dropdown instead of leading to the destination.
+ * For this reason, dropdown items will have their destination set to null.
  */
 class NavItem implements Stringable
 {
@@ -109,7 +110,7 @@ class NavItem implements Stringable
     }
 
     /**
-     * Get the destination route of the navigation item.
+     * Get the destination route of the navigation item. For dropdowns, this will return null.
      */
     public function getDestination(): ?Route
     {

--- a/packages/framework/src/Framework/Features/Navigation/NavItem.php
+++ b/packages/framework/src/Framework/Features/Navigation/NavItem.php
@@ -193,7 +193,7 @@ class NavItem implements Stringable
     }
 
     /**
-     * Check if the NavItem instance is the current page.
+     * Check if the NavItem instance is the current page being rendered.
      */
     public function isCurrent(): bool
     {

--- a/packages/framework/src/Framework/Features/Navigation/NavItem.php
+++ b/packages/framework/src/Framework/Features/Navigation/NavItem.php
@@ -85,7 +85,12 @@ class NavItem implements Stringable
     {
         $route = $route instanceof Route ? $route : Routes::getOrFail($route);
 
-        return static::fromRoute($route, $label, $priority, $group);
+        return new static(
+            $route,
+            $label ?? $route->getPage()->navigationMenuLabel(),
+            $priority ?? $route->getPage()->navigationMenuPriority(),
+            $group ?? $route->getPage()->navigationMenuGroup(),
+        );
     }
 
     /**

--- a/packages/framework/src/Framework/Features/Navigation/NavItem.php
+++ b/packages/framework/src/Framework/Features/Navigation/NavItem.php
@@ -99,9 +99,9 @@ class NavItem implements Stringable
      * @param  array<NavItem>  $items  The items to be included in the dropdown.
      * @param  int|null  $priority  The priority of the dropdown item. Leave blank to use the default priority, which is last in the menu.
      */
-    public static function forGroup(string $label, array $items, ?int $priority = null): static
+    public static function forGroup(string $label, array $items, ?int $priority = NavigationMenu::LAST): static
     {
-        return new static('', $label, $priority ?? NavigationMenu::LAST, $label, $items);
+        return new static('', $label, $priority, $label, $items);
     }
 
     /**

--- a/packages/framework/src/Framework/Features/Navigation/NavItem.php
+++ b/packages/framework/src/Framework/Features/Navigation/NavItem.php
@@ -83,7 +83,12 @@ class NavItem implements Stringable
      */
     public static function forRoute(Route|string $route, ?string $label = null, ?int $priority = null, ?string $group = null): static
     {
-        return static::fromRoute($route instanceof Route ? $route : Routes::getOrFail($route), $label, $priority, $group);
+        return new static(
+            $route instanceof Route ? $route : Routes::getOrFail($route),
+            $label ?? $route instanceof Route ? $route : Routes::getOrFail($route)->getPage()->navigationMenuLabel(),
+            $priority ?? $route instanceof Route ? $route : Routes::getOrFail($route)->getPage()->navigationMenuPriority(),
+            $group ?? $route instanceof Route ? $route : Routes::getOrFail($route)->getPage()->navigationMenuGroup(),
+        );
     }
 
     /**

--- a/packages/framework/src/Framework/Features/Navigation/NavItem.php
+++ b/packages/framework/src/Framework/Features/Navigation/NavItem.php
@@ -98,7 +98,7 @@ class NavItem implements Stringable
      */
     public static function forGroup(string $label, array $items, ?int $priority = NavigationMenu::LAST): static
     {
-        return new static(null, $label, $priority ?? NavigationMenu::LAST, $label, $items);
+        return new static(null, $label, $priority, $label, $items);
     }
 
     /**

--- a/packages/framework/src/Framework/Features/Navigation/NavItem.php
+++ b/packages/framework/src/Framework/Features/Navigation/NavItem.php
@@ -65,12 +65,7 @@ class NavItem implements Stringable
      */
     public static function fromRoute(Route $route, ?string $label = null, ?int $priority = null, ?string $group = null): static
     {
-        return new static(
-            $route,
-            $label ?? $route->getPage()->navigationMenuLabel(),
-            $priority ?? $route->getPage()->navigationMenuPriority(),
-            $group ?? $route->getPage()->navigationMenuGroup(),
-        );
+        return static::forRoute($route, $label, $priority, $group);
     }
 
     /**

--- a/packages/framework/src/Framework/Features/Navigation/NavItem.php
+++ b/packages/framework/src/Framework/Features/Navigation/NavItem.php
@@ -43,6 +43,8 @@ class NavItem implements Stringable
 
     /**
      * Create a new navigation menu item.
+     *
+     * @param  array<\Hyde\Framework\Features\Navigation\NavItem>  $children
      */
     public function __construct(Route|string $destination, string $label, int $priority = NavigationMenu::DEFAULT, ?string $group = null, array $children = [])
     {
@@ -208,6 +210,8 @@ class NavItem implements Stringable
 
     /**
      * Add multiple navigation items to the children of the navigation item.
+     *
+     * @param  array<\Hyde\Framework\Features\Navigation\NavItem>  $items
      */
     public function addChildren(array $items): static
     {

--- a/packages/framework/src/Framework/Features/Navigation/NavItem.php
+++ b/packages/framework/src/Framework/Features/Navigation/NavItem.php
@@ -83,7 +83,9 @@ class NavItem implements Stringable
      */
     public static function forRoute(Route|string $route, ?string $label = null, ?int $priority = null, ?string $group = null): static
     {
-        return static::fromRoute($route instanceof Route ? $route : Routes::getOrFail($route), $label, $priority, $group);
+        $route = $route instanceof Route ? $route : Routes::getOrFail($route);
+
+        return static::fromRoute($route, $label, $priority, $group);
     }
 
     /**

--- a/packages/framework/src/Framework/Features/Navigation/NavItem.php
+++ b/packages/framework/src/Framework/Features/Navigation/NavItem.php
@@ -54,7 +54,7 @@ class NavItem implements Stringable
         $this->label = $label;
         $this->priority = $priority;
         $this->group = static::normalizeGroupKey($group);
-        $this->identifier = $this->makeIdentifier($label);
+        $this->identifier = static::makeIdentifier($label);
         $this->children = $children;
     }
 

--- a/packages/framework/src/Framework/Features/Navigation/NavigationMenuGenerator.php
+++ b/packages/framework/src/Framework/Features/Navigation/NavigationMenuGenerator.php
@@ -160,7 +160,7 @@ class NavigationMenuGenerator
 
         $priority = $this->searchForGroupPriorityInConfig($groupKey);
 
-        return NavItem::dropdown($this->normalizeGroupLabel($label), [], $priority);
+        return NavItem::forGroup($this->normalizeGroupLabel($label), [], $priority);
     }
 
     protected function normalizeGroupLabel(string $label): string

--- a/packages/framework/src/Framework/Features/Navigation/NavigationMenuGenerator.php
+++ b/packages/framework/src/Framework/Features/Navigation/NavigationMenuGenerator.php
@@ -160,7 +160,7 @@ class NavigationMenuGenerator
 
         $priority = $this->searchForGroupPriorityInConfig($groupKey);
 
-        return NavItem::forGroup($this->normalizeGroupLabel($label), [], $priority);
+        return NavItem::forGroup($this->normalizeGroupLabel($label), [], $priority ?? NavigationMenu::LAST);
     }
 
     protected function normalizeGroupLabel(string $label): string

--- a/packages/framework/src/Framework/Features/Navigation/NavigationMenuGenerator.php
+++ b/packages/framework/src/Framework/Features/Navigation/NavigationMenuGenerator.php
@@ -71,7 +71,7 @@ class NavigationMenuGenerator
                 if ($this->canGroupRoute($route)) {
                     $this->addRouteToGroup($route);
                 } else {
-                    $this->items->put($route->getRouteKey(), NavItem::fromRoute($route));
+                    $this->items->put($route->getRouteKey(), NavItem::forRoute($route));
                 }
             }
         });
@@ -79,7 +79,7 @@ class NavigationMenuGenerator
         if ($this->generatesSidebar) {
             // If there are no pages other than the index page, we add it to the sidebar so that it's not empty
             if ($this->items->count() === 0 && DocumentationPage::home() !== null) {
-                $this->items->push(NavItem::fromRoute(DocumentationPage::home()));
+                $this->items->push(NavItem::forRoute(DocumentationPage::home()));
             }
         } else {
             collect(Config::getArray('hyde.navigation.custom', []))->each(function (NavItem $item): void {
@@ -133,7 +133,7 @@ class NavigationMenuGenerator
 
     protected function addRouteToGroup(Route $route): void
     {
-        $item = NavItem::fromRoute($route);
+        $item = NavItem::forRoute($route);
 
         $groupName = $this->generatesSidebar ? ($item->getGroup() ?? 'Other') : $item->getGroup();
 

--- a/packages/framework/tests/Feature/NavigationMenuTest.php
+++ b/packages/framework/tests/Feature/NavigationMenuTest.php
@@ -38,7 +38,7 @@ class NavigationMenuTest extends TestCase
     public function testGetItemsReturnsItems()
     {
         $this->assertEquals(collect([
-            NavItem::fromRoute(Routes::get('index')),
+            NavItem::forRoute(Routes::get('index')),
         ]), $this->createNavigationMenu()->getItems());
     }
 
@@ -67,9 +67,9 @@ class NavigationMenuTest extends TestCase
         $menu = $this->createNavigationMenu();
 
         $expected = collect([
-            NavItem::fromRoute(Routes::get('index')),
-            NavItem::fromRoute(Routes::get('foo')),
-            NavItem::fromRoute(Routes::get('docs/index')),
+            NavItem::forRoute(Routes::get('index')),
+            NavItem::forRoute(Routes::get('foo')),
+            NavItem::forRoute(Routes::get('docs/index')),
         ]);
 
         $this->assertCount(count($expected), $menu->getItems());
@@ -83,8 +83,8 @@ class NavigationMenuTest extends TestCase
         $menu = $this->createNavigationMenu();
 
         $expected = collect([
-            NavItem::fromRoute(Routes::get('index')),
-            NavItem::fromRoute(Routes::get('foo')),
+            NavItem::forRoute(Routes::get('index')),
+            NavItem::forRoute(Routes::get('foo')),
         ]);
 
         $this->assertCount(count($expected), $menu->getItems());
@@ -98,7 +98,7 @@ class NavigationMenuTest extends TestCase
         $menu = $this->createNavigationMenu();
 
         $expected = collect([
-            NavItem::fromRoute(Routes::get('index')),
+            NavItem::forRoute(Routes::get('index')),
             NavItem::forLink('https://example.com', 'foo'),
         ]);
 
@@ -113,7 +113,7 @@ class NavigationMenuTest extends TestCase
         $menu = $this->createNavigationMenu();
 
         $expected = collect([
-            NavItem::fromRoute(Routes::get('index')),
+            NavItem::forRoute(Routes::get('index')),
             NavItem::forLink('foo', 'foo'),
         ]);
 
@@ -131,7 +131,7 @@ class NavigationMenuTest extends TestCase
         $menu = $this->createNavigationMenu();
 
         $expected = collect([
-            NavItem::fromRoute(Routes::get('index')),
+            NavItem::forRoute(Routes::get('index')),
             NavItem::forLink('foo', 'foo'),
             NavItem::forLink('foo', 'foo'),
         ]);
@@ -150,7 +150,7 @@ class NavigationMenuTest extends TestCase
         $menu = $this->createNavigationMenu();
 
         $expected = collect([
-            NavItem::fromRoute(Routes::get('index')),
+            NavItem::forRoute(Routes::get('index')),
             NavItem::forLink('foo', 'foo'),
             NavItem::forLink('bar', 'foo'),
         ]);
@@ -168,9 +168,9 @@ class NavigationMenuTest extends TestCase
         $menu = $this->createNavigationMenu();
 
         $expected = collect([
-            NavItem::fromRoute(Routes::get('index')),
+            NavItem::forRoute(Routes::get('index')),
             NavItem::forLink('bar', 'Foo'),
-            NavItem::fromRoute(Routes::get('foo')),
+            NavItem::forRoute(Routes::get('foo')),
         ]);
 
         $this->assertCount(count($expected), $menu->getItems());
@@ -185,8 +185,8 @@ class NavigationMenuTest extends TestCase
         $menu = $this->createNavigationMenu();
 
         $expected = collect([
-            NavItem::fromRoute(Routes::get('index')),
-            NavItem::fromRoute(Routes::get('docs/index')),
+            NavItem::forRoute(Routes::get('index')),
+            NavItem::forRoute(Routes::get('docs/index')),
         ]);
 
         $this->assertCount(count($expected), $menu->getItems());
@@ -199,7 +199,7 @@ class NavigationMenuTest extends TestCase
         $this->file('_pages/foo/bar.md');
 
         $menu = $this->createNavigationMenu();
-        $expected = collect([NavItem::fromRoute(Routes::get('index'))]);
+        $expected = collect([NavItem::forRoute(Routes::get('index'))]);
 
         $this->assertCount(count($expected), $menu->getItems());
         $this->assertEquals($expected, $menu->getItems());
@@ -213,8 +213,8 @@ class NavigationMenuTest extends TestCase
 
         $menu = $this->createNavigationMenu();
         $expected = collect([
-            NavItem::fromRoute(Routes::get('index')),
-            NavItem::fromRoute(Routes::get('foo/bar')),
+            NavItem::forRoute(Routes::get('index')),
+            NavItem::forRoute(Routes::get('foo/bar')),
         ]);
 
         $this->assertCount(count($expected), $menu->getItems());
@@ -229,9 +229,9 @@ class NavigationMenuTest extends TestCase
 
         $menu = $this->createNavigationMenu();
         $expected = collect([
-            NavItem::fromRoute(Routes::get('index')),
+            NavItem::forRoute(Routes::get('index')),
             NavItem::forGroup('Foo', [
-                NavItem::fromRoute(Routes::get('foo/bar')),
+                NavItem::forRoute(Routes::get('foo/bar')),
             ]),
         ]);
 
@@ -249,10 +249,10 @@ class NavigationMenuTest extends TestCase
 
         $this->assertCount(3, $menu->getItems());
         $this->assertEquals([
-            NavItem::fromRoute(Routes::get('index')),
-            NavItem::fromRoute((new MarkdownPage('foo'))->getRoute()),
+            NavItem::forRoute(Routes::get('index')),
+            NavItem::forRoute((new MarkdownPage('foo'))->getRoute()),
             NavItem::forGroup('Bar', [
-                NavItem::fromRoute((new MarkdownPage('bar/baz'))->getRoute()),
+                NavItem::forRoute((new MarkdownPage('bar/baz'))->getRoute()),
             ]),
         ], $menu->getItems()->all());
     }

--- a/packages/framework/tests/Feature/NavigationMenuTest.php
+++ b/packages/framework/tests/Feature/NavigationMenuTest.php
@@ -230,7 +230,7 @@ class NavigationMenuTest extends TestCase
         $menu = $this->createNavigationMenu();
         $expected = collect([
             NavItem::fromRoute(Routes::get('index')),
-            NavItem::dropdown('Foo', [
+            NavItem::forGroup('Foo', [
                 NavItem::fromRoute(Routes::get('foo/bar')),
             ]),
         ]);
@@ -251,7 +251,7 @@ class NavigationMenuTest extends TestCase
         $this->assertEquals([
             NavItem::fromRoute(Routes::get('index')),
             NavItem::fromRoute((new MarkdownPage('foo'))->getRoute()),
-            NavItem::dropdown('Bar', [
+            NavItem::forGroup('Bar', [
                 NavItem::fromRoute((new MarkdownPage('bar/baz'))->getRoute()),
             ]),
         ], $menu->getItems()->all());

--- a/packages/framework/tests/Feature/Services/DocumentationSidebarTest.php
+++ b/packages/framework/tests/Feature/Services/DocumentationSidebarTest.php
@@ -86,9 +86,9 @@ class DocumentationSidebarTest extends TestCase
 
         $this->assertEquals(
             collect([
-                NavItem::fromRoute(Routes::get('docs/a'), priority: 999),
-                NavItem::fromRoute(Routes::get('docs/b'), priority: 999),
-                NavItem::fromRoute(Routes::get('docs/c'), priority: 999),
+                NavItem::forRoute(Routes::get('docs/a'), priority: 999),
+                NavItem::forRoute(Routes::get('docs/b'), priority: 999),
+                NavItem::forRoute(Routes::get('docs/c'), priority: 999),
             ]),
             NavigationMenuGenerator::handle(DocumentationSidebar::class)->getItems()
         );
@@ -107,9 +107,9 @@ class DocumentationSidebarTest extends TestCase
 
         $this->assertEquals(
             collect([
-                NavItem::fromRoute(Routes::get('docs/c'), priority: 250 + 250),
-                NavItem::fromRoute(Routes::get('docs/b'), priority: 250 + 251),
-                NavItem::fromRoute(Routes::get('docs/a'), priority: 250 + 252),
+                NavItem::forRoute(Routes::get('docs/c'), priority: 250 + 250),
+                NavItem::forRoute(Routes::get('docs/b'), priority: 250 + 251),
+                NavItem::forRoute(Routes::get('docs/a'), priority: 250 + 252),
             ]),
             NavigationMenuGenerator::handle(DocumentationSidebar::class)->getItems()
         );
@@ -146,9 +146,9 @@ class DocumentationSidebarTest extends TestCase
 
         $this->assertEquals(
             collect([
-                NavItem::fromRoute(Routes::get('docs/first'), priority: 250 + 250),
-                NavItem::fromRoute(Routes::get('docs/second'), priority: 250 + 252),
-                NavItem::fromRoute(Routes::get('docs/third'), priority: 250 + 300),
+                NavItem::forRoute(Routes::get('docs/first'), priority: 250 + 250),
+                NavItem::forRoute(Routes::get('docs/second'), priority: 250 + 252),
+                NavItem::forRoute(Routes::get('docs/third'), priority: 250 + 300),
             ]),
             NavigationMenuGenerator::handle(DocumentationSidebar::class)->getItems()
         );
@@ -195,7 +195,7 @@ class DocumentationSidebarTest extends TestCase
         Filesystem::touch('_docs/index.md');
 
         $this->assertEquals(
-            collect([NavItem::fromRoute(Routes::get('docs/foo'), priority: 999)]),
+            collect([NavItem::forRoute(Routes::get('docs/foo'), priority: 999)]),
             NavigationMenuGenerator::handle(DocumentationSidebar::class)->getItems()
         );
     }
@@ -268,10 +268,10 @@ class DocumentationSidebarTest extends TestCase
         $this->assertEquals(
             collect([
                 NavItem::forGroup('Bar', [
-                    NavItem::fromRoute(Routes::get('docs/bar'), priority: 999),
+                    NavItem::forRoute(Routes::get('docs/bar'), priority: 999),
                 ]),
                 NavItem::forGroup('Foo', [
-                    NavItem::fromRoute(Routes::get('docs/foo'), priority: 999),
+                    NavItem::forRoute(Routes::get('docs/foo'), priority: 999),
                 ]),
             ]),
             $sidebar->getItems()
@@ -289,8 +289,8 @@ class DocumentationSidebarTest extends TestCase
         $this->assertEquals(
             collect([
                 NavItem::forGroup('Foo', [
-                    NavItem::fromRoute(Routes::get('docs/bar'), priority: 999),
-                    NavItem::fromRoute(Routes::get('docs/foo'), priority: 999),
+                    NavItem::forRoute(Routes::get('docs/bar'), priority: 999),
+                    NavItem::forRoute(Routes::get('docs/foo'), priority: 999),
                 ]),
             ]),
             $sidebar->getItems()
@@ -312,7 +312,7 @@ class DocumentationSidebarTest extends TestCase
 
         $this->assertCount(1, $sidebar->getItems());
         $this->assertEquals(
-            collect([NavItem::fromRoute(Routes::get('docs/index'))]),
+            collect([NavItem::forRoute(Routes::get('docs/index'))]),
             $sidebar->getItems()
         );
     }
@@ -325,7 +325,7 @@ class DocumentationSidebarTest extends TestCase
 
         $this->assertCount(1, $sidebar->getItems());
         $this->assertEquals(
-            collect([NavItem::fromRoute(Routes::get('docs/test-0'))]),
+            collect([NavItem::forRoute(Routes::get('docs/test-0'))]),
             $sidebar->getItems()
         );
     }

--- a/packages/framework/tests/Feature/Services/DocumentationSidebarTest.php
+++ b/packages/framework/tests/Feature/Services/DocumentationSidebarTest.php
@@ -267,10 +267,10 @@ class DocumentationSidebarTest extends TestCase
 
         $this->assertEquals(
             collect([
-                NavItem::dropdown('Bar', [
+                NavItem::forGroup('Bar', [
                     NavItem::fromRoute(Routes::get('docs/bar'), priority: 999),
                 ]),
-                NavItem::dropdown('Foo', [
+                NavItem::forGroup('Foo', [
                     NavItem::fromRoute(Routes::get('docs/foo'), priority: 999),
                 ]),
             ]),
@@ -288,7 +288,7 @@ class DocumentationSidebarTest extends TestCase
 
         $this->assertEquals(
             collect([
-                NavItem::dropdown('Foo', [
+                NavItem::forGroup('Foo', [
                     NavItem::fromRoute(Routes::get('docs/bar'), priority: 999),
                     NavItem::fromRoute(Routes::get('docs/foo'), priority: 999),
                 ]),

--- a/packages/framework/tests/Unit/DocumentationSidebarUnitTest.php
+++ b/packages/framework/tests/Unit/DocumentationSidebarUnitTest.php
@@ -226,7 +226,7 @@ class DocumentationSidebarUnitTest extends UnitTestCase
         $page = new DocumentationPage('foo');
         $child = new DocumentationPage('bar');
         $menu = new DocumentationSidebar([
-            NavItem::fromRoute($page->getRoute())->addChild(NavItem::fromRoute($child->getRoute())),
+            NavItem::forRoute($page->getRoute())->addChild(NavItem::forRoute($child->getRoute())),
         ]);
 
         $this->assertTrue($menu->hasGroups());

--- a/packages/framework/tests/Unit/NavItemIsCurrentHelperTest.php
+++ b/packages/framework/tests/Unit/NavItemIsCurrentHelperTest.php
@@ -34,19 +34,19 @@ class NavItemIsCurrentHelperTest extends UnitTestCase
     public function testIsCurrent()
     {
         $this->mockRenderData($this->makeRoute('foo'));
-        $this->assertFalse(NavItem::fromRoute($this->makeRoute('bar'))->isCurrent());
+        $this->assertFalse(NavItem::forRoute($this->makeRoute('bar'))->isCurrent());
     }
 
     public function testIsCurrentWhenCurrent()
     {
         $this->mockRenderData($this->makeRoute('foo'));
-        $this->assertTrue(NavItem::fromRoute($this->makeRoute('foo'))->isCurrent());
+        $this->assertTrue(NavItem::forRoute($this->makeRoute('foo'))->isCurrent());
     }
 
     public function testIsCurrentUsingCurrentRoute()
     {
         $this->mockRenderData($this->makeRoute('index'));
-        $this->assertTrue(NavItem::fromRoute(Routes::get('index'))->isCurrent());
+        $this->assertTrue(NavItem::forRoute(Routes::get('index'))->isCurrent());
     }
 
     public function testIsCurrentUsingCurrentLink()
@@ -58,13 +58,13 @@ class NavItemIsCurrentHelperTest extends UnitTestCase
     public function testIsCurrentWhenNotCurrent()
     {
         $this->mockRenderData($this->makeRoute('foo'));
-        $this->assertFalse(NavItem::fromRoute($this->makeRoute('bar'))->isCurrent());
+        $this->assertFalse(NavItem::forRoute($this->makeRoute('bar'))->isCurrent());
     }
 
     public function testIsCurrentUsingNotCurrentRoute()
     {
         $this->mockRenderData($this->makeRoute('foo'));
-        $this->assertFalse(NavItem::fromRoute(Routes::get('index'))->isCurrent());
+        $this->assertFalse(NavItem::forRoute(Routes::get('index'))->isCurrent());
     }
 
     public function testIsCurrentUsingNotCurrentLink()
@@ -76,49 +76,49 @@ class NavItemIsCurrentHelperTest extends UnitTestCase
     public function testIsCurrentWithNestedCurrentPage()
     {
         $this->mockRenderData($this->makeRoute('foo/bar'));
-        $this->assertFalse(NavItem::fromRoute($this->makeRoute('bar'))->isCurrent());
+        $this->assertFalse(NavItem::forRoute($this->makeRoute('bar'))->isCurrent());
     }
 
     public function testIsCurrentWhenCurrentWithNestedCurrentPage()
     {
         $this->mockRenderData($this->makeRoute('foo/bar'));
-        $this->assertTrue(NavItem::fromRoute($this->makeRoute('foo/bar'))->isCurrent());
+        $this->assertTrue(NavItem::forRoute($this->makeRoute('foo/bar'))->isCurrent());
     }
 
     public function testIsCurrentWithNestedCurrentPageWhenNested()
     {
         $this->mockRenderData($this->makeRoute('foo/bar'));
-        $this->assertTrue(NavItem::fromRoute($this->makeRoute('foo/bar'))->isCurrent());
+        $this->assertTrue(NavItem::forRoute($this->makeRoute('foo/bar'))->isCurrent());
     }
 
     public function testIsCurrentWhenCurrentWithNestedCurrentPageWhenNested()
     {
         $this->mockRenderData($this->makeRoute('foo/bar'));
-        $this->assertFalse(NavItem::fromRoute($this->makeRoute('foo/baz'))->isCurrent());
+        $this->assertFalse(NavItem::forRoute($this->makeRoute('foo/baz'))->isCurrent());
     }
 
     public function testIsCurrentWithNestedCurrentPageWhenVeryNested()
     {
         $this->mockRenderData($this->makeRoute('foo/bar/baz'));
-        $this->assertTrue(NavItem::fromRoute($this->makeRoute('foo/bar/baz'))->isCurrent());
+        $this->assertTrue(NavItem::forRoute($this->makeRoute('foo/bar/baz'))->isCurrent());
     }
 
     public function testIsCurrentWhenCurrentWithNestedCurrentPageWhenVeryNested()
     {
         $this->mockRenderData($this->makeRoute('foo/bar/baz'));
-        $this->assertFalse(NavItem::fromRoute($this->makeRoute('foo/baz/bar'))->isCurrent());
+        $this->assertFalse(NavItem::forRoute($this->makeRoute('foo/baz/bar'))->isCurrent());
     }
 
     public function testIsCurrentWithNestedCurrentPageWhenVeryDifferingNested()
     {
         $this->mockRenderData($this->makeRoute('foo'));
-        $this->assertFalse(NavItem::fromRoute($this->makeRoute('foo/bar/baz'))->isCurrent());
+        $this->assertFalse(NavItem::forRoute($this->makeRoute('foo/bar/baz'))->isCurrent());
     }
 
     public function testIsCurrentWithNestedCurrentPageWhenVeryDifferingNestedInverse()
     {
         $this->mockRenderData($this->makeRoute('foo/bar/baz'));
-        $this->assertFalse(NavItem::fromRoute($this->makeRoute('foo'))->isCurrent());
+        $this->assertFalse(NavItem::forRoute($this->makeRoute('foo'))->isCurrent());
     }
 
     public function testIsCurrentUsingCurrentLinkWithNestedCurrentPage()

--- a/packages/framework/tests/Unit/NavItemTest.php
+++ b/packages/framework/tests/Unit/NavItemTest.php
@@ -169,7 +169,7 @@ class NavItemTest extends UnitTestCase
     public function testFromRoute()
     {
         $route = new Route(new MarkdownPage());
-        $item = NavItem::fromRoute($route);
+        $item = NavItem::forRoute($route);
 
         $this->assertSame($route, $item->getDestination());
     }
@@ -178,7 +178,7 @@ class NavItemTest extends UnitTestCase
     {
         Render::shouldReceive('getRouteKey')->once()->andReturn('index');
 
-        $this->assertSame('index.html', (string) NavItem::fromRoute(Routes::get('index')));
+        $this->assertSame('index.html', (string) NavItem::forRoute(Routes::get('index')));
     }
 
     public function testForLink()
@@ -241,24 +241,24 @@ class NavItemTest extends UnitTestCase
             'getRouteKey' => 'foo',
         ]));
 
-        $this->assertSame('foo.html', (string) NavItem::fromRoute(new Route(new InMemoryPage('foo'))));
-        $this->assertSame('foo/bar.html', (string) NavItem::fromRoute(new Route(new InMemoryPage('foo/bar'))));
+        $this->assertSame('foo.html', (string) NavItem::forRoute(new Route(new InMemoryPage('foo'))));
+        $this->assertSame('foo/bar.html', (string) NavItem::forRoute(new Route(new InMemoryPage('foo/bar'))));
 
         Render::swap(Mockery::mock(RenderData::class, [
             'getRoute' => new Route(new InMemoryPage('foo/bar')),
             'getRouteKey' => 'foo/bar',
         ]));
 
-        $this->assertSame('../foo.html', (string) NavItem::fromRoute(new Route(new InMemoryPage('foo'))));
-        $this->assertSame('../foo/bar.html', (string) NavItem::fromRoute(new Route(new InMemoryPage('foo/bar'))));
+        $this->assertSame('../foo.html', (string) NavItem::forRoute(new Route(new InMemoryPage('foo'))));
+        $this->assertSame('../foo/bar.html', (string) NavItem::forRoute(new Route(new InMemoryPage('foo/bar'))));
 
         Render::swap(Mockery::mock(RenderData::class, [
             'getRoute' => new Route(new InMemoryPage('foo/bar/baz')),
             'getRouteKey' => 'foo/bar/baz',
         ]));
 
-        $this->assertSame('../../foo.html', (string) NavItem::fromRoute(new Route(new InMemoryPage('foo'))));
-        $this->assertSame('../../foo/bar.html', (string) NavItem::fromRoute(new Route(new InMemoryPage('foo/bar'))));
+        $this->assertSame('../../foo.html', (string) NavItem::forRoute(new Route(new InMemoryPage('foo'))));
+        $this->assertSame('../../foo/bar.html', (string) NavItem::forRoute(new Route(new InMemoryPage('foo/bar'))));
     }
 
     public function testDropdownFacade()
@@ -309,8 +309,8 @@ class NavItemTest extends UnitTestCase
             'getRoute' => new Route(new InMemoryPage('foo')),
             'getRouteKey' => 'foo',
         ]));
-        $this->assertTrue(NavItem::fromRoute(new Route(new InMemoryPage('foo')))->isCurrent());
-        $this->assertFalse(NavItem::fromRoute(new Route(new InMemoryPage('bar')))->isCurrent());
+        $this->assertTrue(NavItem::forRoute(new Route(new InMemoryPage('foo')))->isCurrent());
+        $this->assertFalse(NavItem::forRoute(new Route(new InMemoryPage('bar')))->isCurrent());
     }
 
     public function testIsCurrentWithExternalRoute()
@@ -335,7 +335,7 @@ class NavItemTest extends UnitTestCase
 
     public function testGetGroupFromRouteWithGroup()
     {
-        $this->assertSame('foo', NavItem::fromRoute(new Route(new MarkdownPage(matter: ['navigation.group' => 'foo'])))->getGroup());
+        $this->assertSame('foo', NavItem::forRoute(new Route(new MarkdownPage(matter: ['navigation.group' => 'foo'])))->getGroup());
     }
 
     public function testGetGroupForRouteWithGroup()
@@ -367,7 +367,7 @@ class NavItemTest extends UnitTestCase
 
     public function testIdentifierFromRouteKey()
     {
-        $item = NavItem::fromRoute(Routes::get('index'));
+        $item = NavItem::forRoute(Routes::get('index'));
         $this->assertSame('home', $item->getIdentifier());
     }
 

--- a/packages/framework/tests/Unit/NavItemTest.php
+++ b/packages/framework/tests/Unit/NavItemTest.php
@@ -263,7 +263,7 @@ class NavItemTest extends UnitTestCase
 
     public function testDropdownFacade()
     {
-        $item = NavItem::dropdown('foo', []);
+        $item = NavItem::forGroup('foo', []);
 
         $this->assertSame('foo', $item->getLabel());
         $this->assertSame([], $item->getChildren());
@@ -276,14 +276,14 @@ class NavItemTest extends UnitTestCase
             new NavItem(new Route(new MarkdownPage()), 'bar'),
         ];
 
-        $item = NavItem::dropdown('foo', $children);
+        $item = NavItem::forGroup('foo', $children);
         $this->assertSame($children, $item->getChildren());
         $this->assertSame(999, $item->getPriority());
     }
 
     public function testDropdownFacadeWithCustomPriority()
     {
-        $item = NavItem::dropdown('foo', [], 500);
+        $item = NavItem::forGroup('foo', [], 500);
 
         $this->assertSame(500, $item->getPriority());
     }


### PR DESCRIPTION
Major/breaking changes:
- Rename dropdown method to forGroup
- Merge fromRoute method into forRoute
- The destination value is now always null for parents with children