### PR TITLE
[2.x] Rename NavItem fields to normalize its API

### DIFF
--- a/packages/framework/resources/views/components/docs/sidebar-item.blade.php
+++ b/packages/framework/resources/views/components/docs/sidebar-item.blade.php
@@ -1,9 +1,9 @@
 @props(['grouped' => false])
 <li @class(['sidebar-item -ml-4 pl-4', $grouped
         ? 'active -ml-8 pl-8 bg-black/5 dark:bg-black/10'
-        : 'active bg-black/5 dark:bg-black/10' => $item->isCurrent()
+        : 'active bg-black/5 dark:bg-black/10' => $item->isActive()
     ]) role="listitem">
-    @if($item->isCurrent())
+    @if($item->isActive())
         <a href="{{ $item->getRoute() }}" aria-current="true" @class([$grouped
             ? '-ml-8 pl-4 py-1 px-2 block text-indigo-600 dark:text-indigo-400 dark:font-medium border-l-[0.325rem] border-indigo-500 transition-colors duration-300 ease-in-out hover:bg-black/10'
             : '-ml-4 p-2 block hover:bg-black/5 dark:hover:bg-black/10 text-indigo-600 dark:text-indigo-400 dark:font-medium border-l-[0.325rem] border-indigo-500 transition-colors duration-300 ease-in-out'

--- a/packages/framework/resources/views/components/docs/sidebar-item.blade.php
+++ b/packages/framework/resources/views/components/docs/sidebar-item.blade.php
@@ -4,7 +4,7 @@
         : 'active bg-black/5 dark:bg-black/10' => $item->isCurrent()
     ]) role="listitem">
     @if($item->isCurrent())
-        <a href="{{ $item->getDestination() }}" aria-current="true" @class([$grouped
+        <a href="{{ $item->getRoute() }}" aria-current="true" @class([$grouped
             ? '-ml-8 pl-4 py-1 px-2 block text-indigo-600 dark:text-indigo-400 dark:font-medium border-l-[0.325rem] border-indigo-500 transition-colors duration-300 ease-in-out hover:bg-black/10'
             : '-ml-4 p-2 block hover:bg-black/5 dark:hover:bg-black/10 text-indigo-600 dark:text-indigo-400 dark:font-medium border-l-[0.325rem] border-indigo-500 transition-colors duration-300 ease-in-out'
         ])>
@@ -16,7 +16,7 @@
             {!! $page->getTableOfContents() !!}
         @endif
     @else
-        <a href="{{ $item->getDestination() }}" @class([$grouped
+        <a href="{{ $item->getRoute() }}" @class([$grouped
             ? '-ml-8 pl-4 py-1 px-2 block border-l-[0.325rem] border-transparent transition-colors duration-300 ease-in-out hover:bg-black/10'
             : 'block -ml-4 p-2 border-l-[0.325rem] border-transparent hover:bg-black/5 dark:hover:bg-black/10'
         ])>

--- a/packages/framework/resources/views/components/navigation/navigation-link.blade.php
+++ b/packages/framework/resources/views/components/navigation/navigation-link.blade.php
@@ -1,4 +1,4 @@
-<a href="{{ $item }}" {!! $item->isCurrent() ? 'aria-current="page"' : '' !!} @class([
+<a href="{{ $item }}" {!! $item->isActive() ? 'aria-current="page"' : '' !!} @class([
     'block my-2 md:my-0 md:inline-block py-1 text-gray-700 hover:text-gray-900 dark:text-gray-100',
-    'border-l-4 border-indigo-500 md:border-none font-medium -ml-6 pl-5 md:ml-0 md:pl-0 bg-gray-100 dark:bg-gray-800 md:bg-transparent dark:md:bg-transparent' => $item->isCurrent()
+    'border-l-4 border-indigo-500 md:border-none font-medium -ml-6 pl-5 md:ml-0 md:pl-0 bg-gray-100 dark:bg-gray-800 md:bg-transparent dark:md:bg-transparent' => $item->isActive()
 ])>{{ $item->getLabel() }}</a>

--- a/packages/framework/src/Framework/Features/Navigation/NavItem.php
+++ b/packages/framework/src/Framework/Features/Navigation/NavItem.php
@@ -192,7 +192,7 @@ class NavItem implements Stringable
     /**
      * Check if the NavItem instance is the current page being rendered.
      */
-    public function isCurrent(): bool
+    public function isActive(): bool
     {
         return Hyde::currentRoute()->getLink() === $this->route->getLink();
     }

--- a/packages/framework/src/Framework/Features/Navigation/NavItem.php
+++ b/packages/framework/src/Framework/Features/Navigation/NavItem.php
@@ -156,7 +156,7 @@ class NavItem implements Stringable
      *
      * For sidebars this is the category key, for navigation menus this is the dropdown key.
      */
-    public function getGroup(): ?string
+    public function getGroupIdentifier(): ?string
     {
         return $this->group;
     }

--- a/packages/framework/src/Framework/Features/Navigation/NavItem.php
+++ b/packages/framework/src/Framework/Features/Navigation/NavItem.php
@@ -110,7 +110,7 @@ class NavItem implements Stringable
      */
     public function __toString(): string
     {
-        return $this->getLink();
+        return $this->getUrl();
     }
 
     /**
@@ -124,7 +124,7 @@ class NavItem implements Stringable
     /**
      * Resolve the destination link of the navigation item.
      */
-    public function getLink(): string
+    public function getUrl(): string
     {
         return (string) $this->route;
     }

--- a/packages/framework/src/Framework/Features/Navigation/NavItem.php
+++ b/packages/framework/src/Framework/Features/Navigation/NavItem.php
@@ -31,7 +31,7 @@ use function is_string;
  */
 class NavItem implements Stringable
 {
-    protected ?Route $destination;
+    protected ?Route $route;
     protected string $label;
     protected int $priority;
     protected ?string $group;
@@ -57,7 +57,7 @@ class NavItem implements Stringable
             $destination = Routes::get($destination) ?? new ExternalRoute($destination);
         }
 
-        $this->destination = $destination;
+        $this->route = $destination;
         $this->label = $label;
         $this->priority = $priority;
         $this->group = static::normalizeGroupKey($group);
@@ -118,7 +118,7 @@ class NavItem implements Stringable
      */
     public function getDestination(): ?Route
     {
-        return $this->destination;
+        return $this->route;
     }
 
     /**
@@ -126,7 +126,7 @@ class NavItem implements Stringable
      */
     public function getLink(): string
     {
-        return (string) $this->destination;
+        return (string) $this->route;
     }
 
     /**
@@ -194,7 +194,7 @@ class NavItem implements Stringable
      */
     public function isCurrent(): bool
     {
-        return Hyde::currentRoute()->getLink() === $this->destination->getLink();
+        return Hyde::currentRoute()->getLink() === $this->route->getLink();
     }
 
     /**
@@ -207,7 +207,7 @@ class NavItem implements Stringable
         $item->group ??= $this->group;
 
         $this->children[] = $item;
-        $this->destination = null;
+        $this->route = null;
 
         return $this;
     }

--- a/packages/framework/src/Framework/Features/Navigation/NavItem.php
+++ b/packages/framework/src/Framework/Features/Navigation/NavItem.php
@@ -116,7 +116,7 @@ class NavItem implements Stringable
     /**
      * Get the destination route of the navigation item. For dropdowns, this will return null.
      */
-    public function getDestination(): ?Route
+    public function getRoute(): ?Route
     {
         return $this->route;
     }
@@ -144,7 +144,7 @@ class NavItem implements Stringable
      */
     public function getPriority(): int
     {
-        if ($this->hasChildren() && $this->children[0]->getDestination()->getPageClass() === DocumentationPage::class) {
+        if ($this->hasChildren() && $this->children[0]->getRoute()->getPageClass() === DocumentationPage::class) {
             return min($this->priority, collect($this->getChildren())->min(fn (NavItem $child): int => $child->getPriority()));
         }
 

--- a/packages/framework/src/Framework/Features/Navigation/NavigationMenuGenerator.php
+++ b/packages/framework/src/Framework/Features/Navigation/NavigationMenuGenerator.php
@@ -135,7 +135,7 @@ class NavigationMenuGenerator
     {
         $item = NavItem::forRoute($route);
 
-        $groupName = $this->generatesSidebar ? ($item->getGroup() ?? 'Other') : $item->getGroup();
+        $groupName = $this->generatesSidebar ? ($item->getGroupIdentifier() ?? 'Other') : $item->getGroupIdentifier();
 
         $groupItem = $this->getOrCreateGroupItem($groupName);
 

--- a/packages/framework/tests/Feature/AutomaticNavigationConfigurationsTest.php
+++ b/packages/framework/tests/Feature/AutomaticNavigationConfigurationsTest.php
@@ -1317,7 +1317,7 @@ class AssertableNavigationMenu
     public function state(): array
     {
         return $this->items->map(function (NavItem $item): TestNavItem {
-            return new TestNavItem($item->getLabel(), $item->getGroup(), $item->getPriority(), $item->getChildren());
+            return new TestNavItem($item->getLabel(), $item->getGroupIdentifier(), $item->getPriority(), $item->getChildren());
         })->toArray();
     }
 

--- a/packages/framework/tests/Feature/Services/DocumentationSidebarTest.php
+++ b/packages/framework/tests/Feature/Services/DocumentationSidebarTest.php
@@ -157,7 +157,7 @@ class DocumentationSidebarTest extends TestCase
     public function testGroupCanBeSetInFrontMatter()
     {
         $this->makePage('foo', ['navigation.group' => 'bar']);
-        $this->assertEquals('bar', collect(NavigationMenuGenerator::handle(DocumentationSidebar::class)->getItems()->first()->getChildren())->first()->getGroup());
+        $this->assertEquals('bar', collect(NavigationMenuGenerator::handle(DocumentationSidebar::class)->getItems()->first()->getChildren())->first()->getGroupIdentifier());
     }
 
     public function testHasGroupsReturnsFalseWhenThereAreNoGroups()

--- a/packages/framework/tests/Unit/NavItemIsActiveHelperTest.php
+++ b/packages/framework/tests/Unit/NavItemIsActiveHelperTest.php
@@ -18,7 +18,7 @@ use Mockery;
  *
  * @see \Hyde\Framework\Testing\Unit\NavItemTest
  */
-class NavItemIsCurrentHelperTest extends UnitTestCase
+class NavItemIsActiveHelperTest extends UnitTestCase
 {
     public static function setUpBeforeClass(): void
     {
@@ -34,205 +34,205 @@ class NavItemIsCurrentHelperTest extends UnitTestCase
     public function testIsCurrent()
     {
         $this->mockRenderData($this->makeRoute('foo'));
-        $this->assertFalse(NavItem::forRoute($this->makeRoute('bar'))->isCurrent());
+        $this->assertFalse(NavItem::forRoute($this->makeRoute('bar'))->isActive());
     }
 
     public function testIsCurrentWhenCurrent()
     {
         $this->mockRenderData($this->makeRoute('foo'));
-        $this->assertTrue(NavItem::forRoute($this->makeRoute('foo'))->isCurrent());
+        $this->assertTrue(NavItem::forRoute($this->makeRoute('foo'))->isActive());
     }
 
     public function testIsCurrentUsingCurrentRoute()
     {
         $this->mockRenderData($this->makeRoute('index'));
-        $this->assertTrue(NavItem::forRoute(Routes::get('index'))->isCurrent());
+        $this->assertTrue(NavItem::forRoute(Routes::get('index'))->isActive());
     }
 
     public function testIsCurrentUsingCurrentLink()
     {
         $this->mockRenderData($this->makeRoute('index'));
-        $this->assertTrue(NavItem::forLink('index.html', 'Home')->isCurrent());
+        $this->assertTrue(NavItem::forLink('index.html', 'Home')->isActive());
     }
 
     public function testIsCurrentWhenNotCurrent()
     {
         $this->mockRenderData($this->makeRoute('foo'));
-        $this->assertFalse(NavItem::forRoute($this->makeRoute('bar'))->isCurrent());
+        $this->assertFalse(NavItem::forRoute($this->makeRoute('bar'))->isActive());
     }
 
     public function testIsCurrentUsingNotCurrentRoute()
     {
         $this->mockRenderData($this->makeRoute('foo'));
-        $this->assertFalse(NavItem::forRoute(Routes::get('index'))->isCurrent());
+        $this->assertFalse(NavItem::forRoute(Routes::get('index'))->isActive());
     }
 
     public function testIsCurrentUsingNotCurrentLink()
     {
         $this->mockRenderData($this->makeRoute('foo'));
-        $this->assertFalse(NavItem::forLink('index.html', 'Home')->isCurrent());
+        $this->assertFalse(NavItem::forLink('index.html', 'Home')->isActive());
     }
 
     public function testIsCurrentWithNestedCurrentPage()
     {
         $this->mockRenderData($this->makeRoute('foo/bar'));
-        $this->assertFalse(NavItem::forRoute($this->makeRoute('bar'))->isCurrent());
+        $this->assertFalse(NavItem::forRoute($this->makeRoute('bar'))->isActive());
     }
 
     public function testIsCurrentWhenCurrentWithNestedCurrentPage()
     {
         $this->mockRenderData($this->makeRoute('foo/bar'));
-        $this->assertTrue(NavItem::forRoute($this->makeRoute('foo/bar'))->isCurrent());
+        $this->assertTrue(NavItem::forRoute($this->makeRoute('foo/bar'))->isActive());
     }
 
     public function testIsCurrentWithNestedCurrentPageWhenNested()
     {
         $this->mockRenderData($this->makeRoute('foo/bar'));
-        $this->assertTrue(NavItem::forRoute($this->makeRoute('foo/bar'))->isCurrent());
+        $this->assertTrue(NavItem::forRoute($this->makeRoute('foo/bar'))->isActive());
     }
 
     public function testIsCurrentWhenCurrentWithNestedCurrentPageWhenNested()
     {
         $this->mockRenderData($this->makeRoute('foo/bar'));
-        $this->assertFalse(NavItem::forRoute($this->makeRoute('foo/baz'))->isCurrent());
+        $this->assertFalse(NavItem::forRoute($this->makeRoute('foo/baz'))->isActive());
     }
 
     public function testIsCurrentWithNestedCurrentPageWhenVeryNested()
     {
         $this->mockRenderData($this->makeRoute('foo/bar/baz'));
-        $this->assertTrue(NavItem::forRoute($this->makeRoute('foo/bar/baz'))->isCurrent());
+        $this->assertTrue(NavItem::forRoute($this->makeRoute('foo/bar/baz'))->isActive());
     }
 
     public function testIsCurrentWhenCurrentWithNestedCurrentPageWhenVeryNested()
     {
         $this->mockRenderData($this->makeRoute('foo/bar/baz'));
-        $this->assertFalse(NavItem::forRoute($this->makeRoute('foo/baz/bar'))->isCurrent());
+        $this->assertFalse(NavItem::forRoute($this->makeRoute('foo/baz/bar'))->isActive());
     }
 
     public function testIsCurrentWithNestedCurrentPageWhenVeryDifferingNested()
     {
         $this->mockRenderData($this->makeRoute('foo'));
-        $this->assertFalse(NavItem::forRoute($this->makeRoute('foo/bar/baz'))->isCurrent());
+        $this->assertFalse(NavItem::forRoute($this->makeRoute('foo/bar/baz'))->isActive());
     }
 
     public function testIsCurrentWithNestedCurrentPageWhenVeryDifferingNestedInverse()
     {
         $this->mockRenderData($this->makeRoute('foo/bar/baz'));
-        $this->assertFalse(NavItem::forRoute($this->makeRoute('foo'))->isCurrent());
+        $this->assertFalse(NavItem::forRoute($this->makeRoute('foo'))->isActive());
     }
 
     public function testIsCurrentUsingCurrentLinkWithNestedCurrentPage()
     {
         $this->mockRenderData($this->makeRoute('foo/bar'));
-        $this->assertFalse(NavItem::forLink('foo/bar.html', 'foo')->isCurrent());
+        $this->assertFalse(NavItem::forLink('foo/bar.html', 'foo')->isActive());
     }
 
     public function testIsCurrentUsingNotCurrentLinkWithNestedCurrentPage()
     {
         $this->mockRenderData($this->makeRoute('foo/bar'));
-        $this->assertFalse(NavItem::forLink('foo.html', 'foo')->isCurrent());
+        $this->assertFalse(NavItem::forLink('foo.html', 'foo')->isActive());
     }
 
     public function testIsCurrentWhenCurrentWithNestedCurrentPageAndSubjectPage()
     {
         $this->mockRenderData($this->makeRoute('foo/bar'));
-        $this->assertFalse(NavItem::forLink('foo/bar.html', 'foo')->isCurrent());
+        $this->assertFalse(NavItem::forLink('foo/bar.html', 'foo')->isActive());
     }
 
     public function testIsCurrentWhenNotCurrentWithNestedCurrentPageAndSubjectPage()
     {
         $this->mockRenderData($this->makeRoute('foo/bar'));
-        $this->assertFalse(NavItem::forLink('foo/baz.html', 'foo')->isCurrent());
+        $this->assertFalse(NavItem::forLink('foo/baz.html', 'foo')->isActive());
     }
 
     public function testIsCurrentWithNestedCurrentPageWhenNestedUsingLinkItem()
     {
         $this->mockRenderData($this->makeRoute('foo/bar'));
-        $this->assertFalse(NavItem::forLink('foo/bar.html', 'foo')->isCurrent());
+        $this->assertFalse(NavItem::forLink('foo/bar.html', 'foo')->isActive());
     }
 
     public function testIsCurrentWhenCurrentWithNestedCurrentPageWhenNestedUsingLinkItem()
     {
         $this->mockRenderData($this->makeRoute('foo/bar'));
-        $this->assertFalse(NavItem::forLink('foo/baz.html', 'foo')->isCurrent());
+        $this->assertFalse(NavItem::forLink('foo/baz.html', 'foo')->isActive());
     }
 
     public function testIsCurrentWithNestedCurrentPageWhenVeryNestedUsingLinkItem()
     {
         $this->mockRenderData($this->makeRoute('foo/bar/baz'));
-        $this->assertFalse(NavItem::forLink('foo/bar/baz.html', 'foo')->isCurrent());
+        $this->assertFalse(NavItem::forLink('foo/bar/baz.html', 'foo')->isActive());
     }
 
     public function testIsCurrentWhenCurrentWithNestedCurrentPageWhenVeryNestedUsingLinkItem()
     {
         $this->mockRenderData($this->makeRoute('foo/bar/baz'));
-        $this->assertFalse(NavItem::forLink('foo/baz/bar.html', 'foo')->isCurrent());
+        $this->assertFalse(NavItem::forLink('foo/baz/bar.html', 'foo')->isActive());
     }
 
     public function testIsCurrentWithNestedCurrentPageWhenVeryDifferingNestedUsingLinkItem()
     {
         $this->mockRenderData($this->makeRoute('foo'));
-        $this->assertFalse(NavItem::forLink('foo/bar/baz.html', 'foo')->isCurrent());
+        $this->assertFalse(NavItem::forLink('foo/bar/baz.html', 'foo')->isActive());
     }
 
     public function testIsCurrentWithNestedCurrentPageWhenVeryDifferingNestedInverseUsingLinkItem()
     {
         $this->mockRenderData($this->makeRoute('foo/bar/baz'));
-        $this->assertFalse(NavItem::forLink('foo.html', 'foo')->isCurrent());
+        $this->assertFalse(NavItem::forLink('foo.html', 'foo')->isActive());
     }
 
     public function testIsCurrentWithNestedCurrentPageWhenNestedUsingPrettyLinkItem()
     {
         $this->mockRenderData($this->makeRoute('foo/bar'));
-        $this->assertFalse(NavItem::forLink('foo/bar', 'foo')->isCurrent());
+        $this->assertFalse(NavItem::forLink('foo/bar', 'foo')->isActive());
     }
 
     public function testIsCurrentWhenCurrentWithNestedCurrentPageWhenNestedUsingPrettyLinkItem()
     {
         $this->mockRenderData($this->makeRoute('foo/bar'));
-        $this->assertFalse(NavItem::forLink('foo/baz', 'foo')->isCurrent());
+        $this->assertFalse(NavItem::forLink('foo/baz', 'foo')->isActive());
     }
 
     public function testIsCurrentWithNestedCurrentPageWhenVeryNestedUsingPrettyLinkItem()
     {
         $this->mockRenderData($this->makeRoute('foo/bar/baz'));
-        $this->assertFalse(NavItem::forLink('foo/bar/baz', 'foo')->isCurrent());
+        $this->assertFalse(NavItem::forLink('foo/bar/baz', 'foo')->isActive());
     }
 
     public function testIsCurrentWhenCurrentWithNestedCurrentPageWhenVeryNestedUsingPrettyLinkItem()
     {
         $this->mockRenderData($this->makeRoute('foo/bar/baz'));
-        $this->assertFalse(NavItem::forLink('foo/baz/bar', 'foo')->isCurrent());
+        $this->assertFalse(NavItem::forLink('foo/baz/bar', 'foo')->isActive());
     }
 
     public function testIsCurrentWithNestedCurrentPageWhenVeryDifferingNestedUsingPrettyLinkItem()
     {
         $this->mockRenderData($this->makeRoute('foo'));
-        $this->assertFalse(NavItem::forLink('foo/bar/baz', 'foo')->isCurrent());
+        $this->assertFalse(NavItem::forLink('foo/bar/baz', 'foo')->isActive());
     }
 
     public function testIsCurrentWithNestedCurrentPageWhenVeryDifferingNestedInverseUsingPrettyLinkItem()
     {
         $this->mockRenderData($this->makeRoute('foo/bar/baz'));
-        $this->assertFalse(NavItem::forLink('foo', 'foo')->isCurrent());
+        $this->assertFalse(NavItem::forLink('foo', 'foo')->isActive());
     }
 
     public function testIsCurrentWithAbsoluteLink()
     {
         $this->mockRenderData($this->makeRoute('foo'));
-        $this->assertFalse(NavItem::forLink('/foo', 'foo')->isCurrent());
+        $this->assertFalse(NavItem::forLink('/foo', 'foo')->isActive());
     }
 
     public function testIsCurrentWithNestedCurrentPageWhenNestedUsingAbsoluteLinkItem()
     {
         $this->mockRenderData($this->makeRoute('foo/bar'));
-        $this->assertFalse(NavItem::forLink('/foo/bar', 'foo')->isCurrent());
+        $this->assertFalse(NavItem::forLink('/foo/bar', 'foo')->isActive());
     }
 
     public function testIsCurrentWhenCurrentWithNestedCurrentPageWhenNestedUsingAbsoluteLinkItem()
     {
         $this->mockRenderData($this->makeRoute('foo/bar/baz'));
-        $this->assertFalse(NavItem::forLink('/foo/bar/baz', 'foo')->isCurrent());
+        $this->assertFalse(NavItem::forLink('/foo/bar/baz', 'foo')->isActive());
     }
 
     protected function mockRenderData(Route $route): void

--- a/packages/framework/tests/Unit/NavItemTest.php
+++ b/packages/framework/tests/Unit/NavItemTest.php
@@ -95,8 +95,8 @@ class NavItemTest extends UnitTestCase
         $this->assertSame('Foo', $item->getChildren()[0]->getLabel());
         $this->assertSame('Bar', $item->getChildren()[1]->getLabel());
 
-        $this->assertSame('foo.html', $item->getChildren()[0]->getLink());
-        $this->assertSame('bar.html', $item->getChildren()[1]->getLink());
+        $this->assertSame('foo.html', $item->getChildren()[0]->getUrl());
+        $this->assertSame('bar.html', $item->getChildren()[1]->getUrl());
 
         $this->assertSame(500, $item->getChildren()[0]->getPriority());
         $this->assertSame(500, $item->getChildren()[1]->getPriority());
@@ -128,7 +128,7 @@ class NavItemTest extends UnitTestCase
     public function testGetLink()
     {
         $navItem = new NavItem(new Route(new InMemoryPage('foo')), 'Page', 500);
-        $this->assertSame('foo.html', $navItem->getLink());
+        $this->assertSame('foo.html', $navItem->getUrl());
     }
 
     public function testGetLabel()

--- a/packages/framework/tests/Unit/NavItemTest.php
+++ b/packages/framework/tests/Unit/NavItemTest.php
@@ -22,7 +22,7 @@ use Mockery;
  *
  * @covers \Hyde\Framework\Features\Navigation\NavItem
  *
- * @see \Hyde\Framework\Testing\Unit\NavItemIsCurrentHelperTest
+ * @see \Hyde\Framework\Testing\Unit\NavItemIsActiveHelperTest
  */
 class NavItemTest extends UnitTestCase
 {
@@ -309,8 +309,8 @@ class NavItemTest extends UnitTestCase
             'getRoute' => new Route(new InMemoryPage('foo')),
             'getRouteKey' => 'foo',
         ]));
-        $this->assertTrue(NavItem::forRoute(new Route(new InMemoryPage('foo')))->isCurrent());
-        $this->assertFalse(NavItem::forRoute(new Route(new InMemoryPage('bar')))->isCurrent());
+        $this->assertTrue(NavItem::forRoute(new Route(new InMemoryPage('foo')))->isActive());
+        $this->assertFalse(NavItem::forRoute(new Route(new InMemoryPage('bar')))->isActive());
     }
 
     public function testIsCurrentWithExternalRoute()
@@ -319,8 +319,8 @@ class NavItemTest extends UnitTestCase
             'getRoute' => new Route(new InMemoryPage('foo')),
             'getRouteKey' => 'foo',
         ]));
-        $this->assertFalse(NavItem::forLink('foo', 'bar')->isCurrent());
-        $this->assertFalse(NavItem::forLink('https://example.com', 'bar')->isCurrent());
+        $this->assertFalse(NavItem::forLink('foo', 'bar')->isActive());
+        $this->assertFalse(NavItem::forLink('https://example.com', 'bar')->isActive());
     }
 
     public function testGetGroupWithNoGroup()

--- a/packages/framework/tests/Unit/NavItemTest.php
+++ b/packages/framework/tests/Unit/NavItemTest.php
@@ -146,7 +146,7 @@ class NavItemTest extends UnitTestCase
     public function testGetGroup()
     {
         $navItem = new NavItem(new Route(new InMemoryPage('foo')), 'Page', 500);
-        $this->assertNull($navItem->getGroup());
+        $this->assertNull($navItem->getGroupIdentifier());
     }
 
     public function testGetChildren()
@@ -325,28 +325,28 @@ class NavItemTest extends UnitTestCase
 
     public function testGetGroupWithNoGroup()
     {
-        $this->assertNull((new NavItem(new Route(new MarkdownPage()), 'Test', 500))->getGroup());
+        $this->assertNull((new NavItem(new Route(new MarkdownPage()), 'Test', 500))->getGroupIdentifier());
     }
 
     public function testGetGroupWithGroup()
     {
-        $this->assertSame('foo', (new NavItem(new Route(new MarkdownPage()), 'Test', 500, 'foo'))->getGroup());
+        $this->assertSame('foo', (new NavItem(new Route(new MarkdownPage()), 'Test', 500, 'foo'))->getGroupIdentifier());
     }
 
     public function testGetGroupFromRouteWithGroup()
     {
-        $this->assertSame('foo', NavItem::forRoute(new Route(new MarkdownPage(matter: ['navigation.group' => 'foo'])))->getGroup());
+        $this->assertSame('foo', NavItem::forRoute(new Route(new MarkdownPage(matter: ['navigation.group' => 'foo'])))->getGroupIdentifier());
     }
 
     public function testGetGroupForRouteWithGroup()
     {
-        $this->assertSame('foo', NavItem::forRoute(new Route(new MarkdownPage(matter: ['navigation.group' => 'foo'])), 'foo')->getGroup());
+        $this->assertSame('foo', NavItem::forRoute(new Route(new MarkdownPage(matter: ['navigation.group' => 'foo'])), 'foo')->getGroupIdentifier());
     }
 
     public function testGroupKeysAreNormalized()
     {
         $item = new NavItem(new Route(new MarkdownPage()), 'Test', 500, 'Foo Bar');
-        $this->assertSame('foo-bar', $item->getGroup());
+        $this->assertSame('foo-bar', $item->getGroupIdentifier());
     }
 
     public function testIdentifier()
@@ -434,8 +434,8 @@ class NavItemTest extends UnitTestCase
 
         $parent->addChild($child);
 
-        $this->assertSame('foo', $parent->getGroup());
-        $this->assertSame('bar', $child->getGroup());
+        $this->assertSame('foo', $parent->getGroupIdentifier());
+        $this->assertSame('bar', $child->getGroupIdentifier());
     }
 
     public function testAddingAnItemWithNoGroupKeyUsesParentIdentifier()
@@ -445,7 +445,7 @@ class NavItemTest extends UnitTestCase
 
         $parent->addChild($child);
 
-        $this->assertSame('foo', $parent->getGroup());
-        $this->assertSame('foo', $child->getGroup());
+        $this->assertSame('foo', $parent->getGroupIdentifier());
+        $this->assertSame('foo', $child->getGroupIdentifier());
     }
 }

--- a/packages/framework/tests/Unit/NavItemTest.php
+++ b/packages/framework/tests/Unit/NavItemTest.php
@@ -44,36 +44,36 @@ class NavItemTest extends UnitTestCase
         $route = new Route(new MarkdownPage());
         $item = new NavItem($route, 'Test', 500);
 
-        $this->assertSame($route, $item->getDestination());
+        $this->assertSame($route, $item->getRoute());
     }
 
     public function testPassingRouteInstanceToConstructorUsesRouteInstance()
     {
         $route = new Route(new MarkdownPage());
-        $this->assertSame($route, (new NavItem($route, 'Home'))->getDestination());
+        $this->assertSame($route, (new NavItem($route, 'Home'))->getRoute());
     }
 
     public function testPassingRouteKeyToConstructorUsesRouteInstance()
     {
         $route = Routes::get('index');
 
-        $this->assertSame($route, (new NavItem('index', 'Home'))->getDestination());
+        $this->assertSame($route, (new NavItem('index', 'Home'))->getRoute());
     }
 
     public function testPassingUrlToConstructorUsesExternalRoute()
     {
         $item = new NavItem('https://example.com', 'Home');
-        $this->assertInstanceOf(ExternalRoute::class, $item->getDestination());
-        $this->assertEquals(new ExternalRoute('https://example.com'), $item->getDestination());
-        $this->assertSame('https://example.com', (string) $item->getDestination());
+        $this->assertInstanceOf(ExternalRoute::class, $item->getRoute());
+        $this->assertEquals(new ExternalRoute('https://example.com'), $item->getRoute());
+        $this->assertSame('https://example.com', (string) $item->getRoute());
     }
 
     public function testPassingUnknownRouteKeyToConstructorUsesExternalRoute()
     {
         $item = new NavItem('foo', 'Home');
-        $this->assertInstanceOf(ExternalRoute::class, $item->getDestination());
-        $this->assertEquals(new ExternalRoute('foo'), $item->getDestination());
-        $this->assertSame('foo', (string) $item->getDestination());
+        $this->assertInstanceOf(ExternalRoute::class, $item->getRoute());
+        $this->assertEquals(new ExternalRoute('foo'), $item->getRoute());
+        $this->assertSame('foo', (string) $item->getRoute());
     }
 
     public function testCanConstructWithChildren()
@@ -86,7 +86,7 @@ class NavItemTest extends UnitTestCase
         $item = new NavItem($route, 'Test', 500, null, $children);
 
         $this->assertSame('Test', $item->getLabel());
-        $this->assertNull($item->getDestination());
+        $this->assertNull($item->getRoute());
         $this->assertSame(500, $item->getPriority());
 
         $this->assertCount(2, $item->getChildren());
@@ -111,7 +111,7 @@ class NavItemTest extends UnitTestCase
         $item = new NavItem('', 'Test', 500, null, $children);
 
         $this->assertSame('Test', $item->getLabel());
-        $this->assertNull($item->getDestination());
+        $this->assertNull($item->getRoute());
 
         $this->assertCount(2, $item->getChildren());
         $this->assertSame($children, $item->getChildren());
@@ -122,7 +122,7 @@ class NavItemTest extends UnitTestCase
         $route = new Route(new InMemoryPage('foo'));
         $navItem = new NavItem($route, 'Page', 500);
 
-        $this->assertSame($route, $navItem->getDestination());
+        $this->assertSame($route, $navItem->getRoute());
     }
 
     public function testGetLink()
@@ -171,7 +171,7 @@ class NavItemTest extends UnitTestCase
         $route = new Route(new MarkdownPage());
         $item = NavItem::forRoute($route);
 
-        $this->assertSame($route, $item->getDestination());
+        $this->assertSame($route, $item->getRoute());
     }
 
     public function testToString()
@@ -185,7 +185,7 @@ class NavItemTest extends UnitTestCase
     {
         $item = NavItem::forLink('foo', 'bar');
 
-        $this->assertEquals(new ExternalRoute('foo'), $item->getDestination());
+        $this->assertEquals(new ExternalRoute('foo'), $item->getRoute());
         $this->assertSame('bar', $item->getLabel());
         $this->assertSame(500, $item->getPriority());
     }
@@ -200,7 +200,7 @@ class NavItemTest extends UnitTestCase
         $route = Routes::get('404');
         $item = NavItem::forRoute($route, 'foo');
 
-        $this->assertSame($route, $item->getDestination());
+        $this->assertSame($route, $item->getRoute());
         $this->assertSame('foo', $item->getLabel());
         $this->assertSame(999, $item->getPriority());
     }
@@ -210,7 +210,7 @@ class NavItemTest extends UnitTestCase
         $route = Routes::get('index');
         $item = NavItem::forRoute($route, 'foo');
 
-        $this->assertSame($route, $item->getDestination());
+        $this->assertSame($route, $item->getRoute());
         $this->assertSame('foo', $item->getLabel());
         $this->assertSame(0, $item->getPriority());
     }


### PR DESCRIPTION
## Changes


**Makes some breaking changes to the NavItem class.**


### Rename protected `$destination` property to `$route`



### Breaking: Rename `NavItem` method `getDestination` to `getRoute`

Since the destination property in v2 is normalized to always be a route it no longer makes sense to have a divergent name for it.

### Breaking: Rename `NavItem` method `isCurrent` to `isActive`

While the method is implemented by using the `currentRoute` helper, the actual end usage is to compare active state, so it makes more sense for this to use that in the name.

### Breaking: Rename `NavItem` method `getGroup` to `getGroupIdentifier`

Renames `getGroup()` to `getGroupIdentifier()` to clarify the purpose of the method.


### Breaking: Rename `NavItem` method `getLink` to `getUrl`

Renames `getLink()` to `getUrl()` for clarity on what the method returns.
