### PR TITLE
[2.x] Extract back NavItem class for dropdowns

### DIFF
--- a/packages/framework/src/Framework/Features/Navigation/NavGroupItem.php
+++ b/packages/framework/src/Framework/Features/Navigation/NavGroupItem.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Hyde\Framework\Features\Navigation;
+
+class NavGroupItem
+{
+    //
+}

--- a/packages/framework/src/Framework/Features/Navigation/NavGroupItem.php
+++ b/packages/framework/src/Framework/Features/Navigation/NavGroupItem.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Hyde\Framework\Features\Navigation;
 
-class NavGroupItem
+class NavGroupItem extends NavItem
 {
     //
 }


### PR DESCRIPTION
Adds back the dedicated class for grouped navigation items, but implemented better this time. This better separates concerns, and makes the data state of both classes clearer, and reduces the need for conditional returns and type logic. 