### PR TITLE
Create HTML tests for the navigation layouts 

### DIFF
--- a/packages/framework/tests/Unit/Views/NavigationHtmlLayoutsTest.php
+++ b/packages/framework/tests/Unit/Views/NavigationHtmlLayoutsTest.php
@@ -372,14 +372,16 @@ abstract class RenderedNavigationMenu
 
         // Indent each line within remaining uls
         $innerUlCount = substr_count($html, '<ul>');
-        foreach (range(1, $innerUlCount) as $i) {
-            $html = Str::replaceFirst('</ul>', '</ul-first>', $html);
-            $innerUlContent = Str::between($html, '<ul>', '</ul-first>');
-            $id = md5($innerUlContent.$i);
-            $html = Str::replaceFirst($innerUlContent, $id, $html);
-            $innerUlContent = trim(str_replace("\n", "\n  ", $innerUlContent));
+        if ($innerUlCount >= 1) {
+            foreach (range(1, $innerUlCount) as $i) {
+                $html = Str::replaceFirst('</ul>', '</ul-first>', $html);
+                $innerUlContent = Str::between($html, '<ul>', '</ul-first>');
+                $id = md5($innerUlContent.$i);
+                $html = Str::replaceFirst($innerUlContent, $id, $html);
+                $innerUlContent = trim(str_replace("\n", "\n  ", $innerUlContent));
 
-            $html = str_replace('<ul>'.$id.'</ul-first>', "\n  ".$innerUlContent, $html);
+                $html = str_replace('<ul>'.$id.'</ul-first>', "\n  ".$innerUlContent, $html);
+            }
         }
 
         $html = Str::replaceLast('</ul>', '', $html);

--- a/packages/framework/tests/Unit/Views/NavigationHtmlLayoutsTest.php
+++ b/packages/framework/tests/Unit/Views/NavigationHtmlLayoutsTest.php
@@ -77,8 +77,7 @@ class NavigationHtmlLayoutsTest extends TestCase
             ->assertDoesNotHaveElement('dropdown')
             ->assertDoesNotHaveElement('dropdown-items')
             ->assertDoesNotHaveElement('dropdown-button')
-            ->assertHasNoPages()
-            ->finish();
+            ->assertHasNoPages();
     }
 
     public function testDocumentationSidebarMenu()
@@ -91,8 +90,7 @@ class NavigationHtmlLayoutsTest extends TestCase
             ->assertHasElement('sidebar-footer')
             ->assertHasElement('theme-toggle-button')
             ->assertHasElement('sidebar-items')
-            ->assertHasNoPages()
-            ->finish();
+            ->assertHasNoPages();
     }
 
     public function testNavigationMenuWithPages()
@@ -103,8 +101,7 @@ class NavigationHtmlLayoutsTest extends TestCase
                 'first.html' => 'First',
                 'about.html' => 'About',
                 'custom.html' => 'Label',
-            ])
-            ->finish();
+            ]);
     }
 
     public function testNavigationMenuFromNestedRoute()

--- a/packages/framework/tests/Unit/Views/NavigationHtmlLayoutsTest.php
+++ b/packages/framework/tests/Unit/Views/NavigationHtmlLayoutsTest.php
@@ -72,16 +72,7 @@ class NavigationHtmlLayoutsTest extends TestCase
 
     public function testNavigationMenuWithPages()
     {
-        $pages = [
-            new MarkdownPage('index'),
-            new MarkdownPage('404'),
-            new BladePage('about'),
-            new BladePage('hidden', ['navigation.hidden' => true]),
-            new InMemoryPage('custom', ['navigation.label' => 'Label']),
-            new HtmlPage('first', ['navigation.priority' => 1]),
-        ];
-
-        $this->menu($pages)
+        $this->menu($this->withExamplePages())
             ->assertHasPages([
                 'index.html' => 'Home',
                 'first.html' => 'First',
@@ -93,17 +84,8 @@ class NavigationHtmlLayoutsTest extends TestCase
 
     public function testNavigationMenuFromNestedRoute()
     {
-        $pages = [
-            new MarkdownPage('index'),
-            new MarkdownPage('404'),
-            new BladePage('about'),
-            new BladePage('hidden', ['navigation.hidden' => true]),
-            new InMemoryPage('custom', ['navigation.label' => 'Label']),
-            new HtmlPage('first', ['navigation.priority' => 1]),
-        ];
-
         $this->fromPage('nested/page')
-            ->menu($pages)
+            ->menu($this->withExamplePages())
             ->assertHasPages([
                 '../index.html' => 'Home',
                 '../first.html' => 'First',
@@ -150,6 +132,18 @@ class NavigationHtmlLayoutsTest extends TestCase
     protected function render(string $view): string
     {
         return view($view)->render();
+    }
+
+    protected function withExamplePages(): array
+    {
+        return [
+            new MarkdownPage('index'),
+            new MarkdownPage('404'),
+            new BladePage('about'),
+            new BladePage('hidden', ['navigation.hidden' => true]),
+            new InMemoryPage('custom', ['navigation.label' => 'Label']),
+            new HtmlPage('first', ['navigation.priority' => 1]),
+        ];
     }
 }
 

--- a/packages/framework/tests/Unit/Views/NavigationHtmlLayoutsTest.php
+++ b/packages/framework/tests/Unit/Views/NavigationHtmlLayoutsTest.php
@@ -106,7 +106,15 @@ class NavigationHtmlLayoutsTest extends TestCase
                 'first.html' => 'First',
                 'about.html' => 'About',
                 'custom.html' => 'Label',
-            ]);
+            ])
+            ->assertLooksLike(<<<'HTML'
+                HydePHP Toggle theme Toggle menu
+                - Home
+                - First
+                - About
+                - Label
+                HTML
+            );
     }
 
     public function testSidebarWithPages()

--- a/packages/framework/tests/Unit/Views/NavigationHtmlLayoutsTest.php
+++ b/packages/framework/tests/Unit/Views/NavigationHtmlLayoutsTest.php
@@ -397,17 +397,17 @@ class NavigationHtmlLayoutsTest extends TestCase
             new DocumentationPage('foo/bar'),
             new DocumentationPage('foo/baz'),
         ])
-            ->assertHasGroups()
-            ->assertHasPages([
-                'docs/bar.html' => 'Bar',
-                'docs/baz.html' => 'Baz',
-            ])
-            ->assertItemsLookLike(<<<'HTML'
-                - Foo
-                    - Bar
-                    - Baz
-                HTML
-            );
+        ->assertHasGroups()
+        ->assertHasPages([
+            'docs/bar.html' => 'Bar',
+            'docs/baz.html' => 'Baz',
+        ])
+        ->assertItemsLookLike(<<<'HTML'
+            - Foo
+                - Bar
+                - Baz
+            HTML
+        );
     }
 
     protected function fromPage(string $mockedRoute): static

--- a/packages/framework/tests/Unit/Views/NavigationHtmlLayoutsTest.php
+++ b/packages/framework/tests/Unit/Views/NavigationHtmlLayoutsTest.php
@@ -494,8 +494,8 @@ abstract class RenderedNavigationMenu
 
         if ($skipHeaderRow) {
             $actual = trim(Str::after($actual, "\n"));
-            if (str_contains($actual, 'Backtohomepage')) {
-                $actual = trim(str_replace('Backtohomepage', '', $actual));
+            if (str_contains($actual, 'Back to home page')) {
+                $actual = trim(str_replace('Back to home page', '', $actual));
             }
         }
         // If expected omitted dashes, remove them from actual
@@ -631,6 +631,8 @@ abstract class RenderedNavigationMenu
         }
 
         $html = Str::replaceLast('</ul>', '', $html);
+
+        $html = str_replace(['HydePHPDocs', 'Toggledarktheme', 'Togglemenu', 'Backtohomepage'], ['HydePHP Docs', ' Toggle theme', 'Toggle menu', 'Back to home page'], $html);
 
         return trim(implode("\n", array_map('rtrim', explode("\n", $html))));
     }

--- a/packages/framework/tests/Unit/Views/NavigationHtmlLayoutsTest.php
+++ b/packages/framework/tests/Unit/Views/NavigationHtmlLayoutsTest.php
@@ -148,6 +148,30 @@ class NavigationHtmlLayoutsTest extends TestCase
             );
     }
 
+    public function testNavigationMenuWithFlatSubdirectoryPages()
+    {
+        $this->useSubdirectoryConfig('flat')
+            ->menu([
+                new MarkdownPage('index'),
+                new MarkdownPage('foo/bar'),
+                new MarkdownPage('foo/baz'),
+            ])
+            ->assertHasPages([
+                'index.html' => 'Home',
+                'foo/bar.html' => 'Bar',
+                'foo/baz.html' => 'Baz',
+            ])
+            ->assertDoesNotHaveElement('dropdown')
+            ->assertDoesNotHaveElement('dropdown-items')
+            ->assertDoesNotHaveElement('dropdown-button')
+            ->assertItemsLookLike(<<<'HTML'
+                - Home
+                - Bar
+                - Baz
+                HTML
+            );
+    }
+
     protected function withPages(array $pages): static
     {
         $this->kernel->setRoutes(collect($pages)->map(fn (HydePage $page) => $page->getRoute()));

--- a/packages/framework/tests/Unit/Views/NavigationHtmlLayoutsTest.php
+++ b/packages/framework/tests/Unit/Views/NavigationHtmlLayoutsTest.php
@@ -52,8 +52,9 @@ class NavigationHtmlLayoutsTest extends TestCase
             ->assertHasElement('theme-toggle-button')
             ->assertHasElement('navigation-toggle-button')
             ->assertHasElement('main-navigation-links')
-            ->assertDoesNotHaveElement('dropdown-button')
             ->assertDoesNotHaveElement('dropdown')
+            ->assertDoesNotHaveElement('dropdown-items')
+            ->assertDoesNotHaveElement('dropdown-button')
             ->assertHasNoPages()
             ->finish();
     }

--- a/packages/framework/tests/Unit/Views/NavigationHtmlLayoutsTest.php
+++ b/packages/framework/tests/Unit/Views/NavigationHtmlLayoutsTest.php
@@ -98,6 +98,25 @@ class NavigationHtmlLayoutsTest extends TestCase
             ->finish();
     }
 
+    public function testNavigationMenuWithDropdownPages()
+    {
+        $this->useSubdirectoriesAsDropdowns()
+           ->menu([
+               new MarkdownPage('index'),
+               new MarkdownPage('foo/bar'),
+               new MarkdownPage('foo/baz'),
+           ])
+            ->assertHasPages([
+                'index.html' => 'Home',
+                'foo/bar.html' => 'Bar',
+                'foo/baz.html' => 'Baz',
+            ])
+            ->assertHasElement('dropdown')
+            ->assertHasElement('dropdown-items')
+            ->assertHasElement('dropdown-button')
+            ->finish();
+    }
+
     protected function withPages(array $pages): static
     {
         $this->kernel->setRoutes(collect($pages)->map(fn (HydePage $page) => $page->getRoute()));

--- a/packages/framework/tests/Unit/Views/NavigationHtmlLayoutsTest.php
+++ b/packages/framework/tests/Unit/Views/NavigationHtmlLayoutsTest.php
@@ -375,7 +375,7 @@ abstract class RenderedNavigationMenu
             }
 
             // If expected is a list array then remove values from actual
-            if (array_keys($expected) === range(0, count($expected) - 1)) {
+            if (array_values($expected) === $expected) {
                 $actual = array_keys($actual);
             }
 

--- a/packages/framework/tests/Unit/Views/NavigationHtmlLayoutsTest.php
+++ b/packages/framework/tests/Unit/Views/NavigationHtmlLayoutsTest.php
@@ -871,7 +871,24 @@ class RenderedDocumentationSidebarMenu extends RenderedNavigationMenu
 
         return $this;
     }
-    
+
+    public function assertHasThemeToggleButton(): static
+    {
+        if (! $this->scopeToHeader) {
+            $this->assertHasElement('theme-toggle-button');
+        } else {
+            $header = $this->getAssertedElement('sidebar-header');
+
+            $xpath = new DOMXPath($this->ast);
+            $header = $xpath->query('.//button[contains(concat(" ", normalize-space(@class), " "), " theme-toggle-button ")]', $header)->item(0);
+
+            $this->test->assertNotNull($header, 'No theme toggle button found in sidebar header');
+            $this->test->assertSame('Toggle dark theme', trim($header->textContent));
+        }
+
+        return $this;
+    }
+
     public function header(): static
     {
         $this->scopeToHeader = true;

--- a/packages/framework/tests/Unit/Views/NavigationHtmlLayoutsTest.php
+++ b/packages/framework/tests/Unit/Views/NavigationHtmlLayoutsTest.php
@@ -125,7 +125,7 @@ class NavigationHtmlLayoutsTest extends TestCase
 
     public function testNavigationMenuWithDropdownPages()
     {
-        $this->useSubdirectoriesAsDropdowns()
+        $this->useSubdirectoryConfig('dropdown')
             ->menu([
                 new MarkdownPage('index'),
                 new MarkdownPage('foo/bar'),
@@ -180,9 +180,9 @@ class NavigationHtmlLayoutsTest extends TestCase
         return new RenderedDocumentationSidebarMenu($this, $this->render('hyde::components.docs.sidebar'));
     }
 
-    protected function useSubdirectoriesAsDropdowns(): static
+    protected function useSubdirectoryConfig(string $option): static
     {
-        config(['hyde.navigation.subdirectories' => 'dropdown']);
+        config(['hyde.navigation.subdirectories' => $option]);
 
         return $this;
     }

--- a/packages/framework/tests/Unit/Views/NavigationHtmlLayoutsTest.php
+++ b/packages/framework/tests/Unit/Views/NavigationHtmlLayoutsTest.php
@@ -590,7 +590,7 @@ abstract class RenderedNavigationMenu
         $pages = [];
 
         foreach ($links as $link) {
-            $pages[$link->getAttribute('href')] = $link->textContent;
+            $pages[$link->getAttribute('href')] = trim($link->textContent);
         }
 
         return $pages;

--- a/packages/framework/tests/Unit/Views/NavigationHtmlLayoutsTest.php
+++ b/packages/framework/tests/Unit/Views/NavigationHtmlLayoutsTest.php
@@ -840,6 +840,8 @@ class RenderedDocumentationSidebarMenu extends RenderedNavigationMenu
 {
     protected const TYPE = DocumentationSidebar::class;
 
+    protected bool $scopeToHeader = false;
+
     public function assertHasGroups(): static
     {
         $this->assertHasElement('sidebar-group');
@@ -858,6 +860,13 @@ class RenderedDocumentationSidebarMenu extends RenderedNavigationMenu
         $this->assertDoesNotHaveElement('sidebar-group-heading');
         $this->assertDoesNotHaveElement('sidebar-group-header');
         $this->assertDoesNotHaveElement('sidebar-group-toggle');
+
+        return $this;
+    }
+    
+    public function header(): static
+    {
+        $this->scopeToHeader = true;
 
         return $this;
     }

--- a/packages/framework/tests/Unit/Views/NavigationHtmlLayoutsTest.php
+++ b/packages/framework/tests/Unit/Views/NavigationHtmlLayoutsTest.php
@@ -183,10 +183,7 @@ class NavigationHtmlLayoutsTest extends TestCase
             ->assertHasPages([
                 'index.html' => 'Home',
             ])
-            ->assertItemsLookLike(<<<'HTML'
-                - Home
-                HTML
-            );
+            ->assertItemsLookLike('- Home');
     }
 
     protected function withPages(array $pages): static

--- a/packages/framework/tests/Unit/Views/NavigationHtmlLayoutsTest.php
+++ b/packages/framework/tests/Unit/Views/NavigationHtmlLayoutsTest.php
@@ -24,6 +24,25 @@ use Hyde\Framework\Features\Navigation\MainNavigationMenu;
 use Hyde\Framework\Features\Navigation\DocumentationSidebar;
 use Hyde\Framework\Features\Navigation\NavigationMenuGenerator;
 
+use function app;
+use function md5;
+use function view;
+use function trim;
+use function range;
+use function config;
+use function collect;
+use function sprintf;
+use function explode;
+use function implode;
+use function array_map;
+use function strip_tags;
+use function json_encode;
+use function str_replace;
+use function preg_replace;
+use function substr_count;
+use function class_basename;
+use function file_put_contents;
+
 /**
  * Very high level tests for navigation menu and sidebar view layouts.
  *
@@ -101,11 +120,11 @@ class NavigationHtmlLayoutsTest extends TestCase
     public function testNavigationMenuWithDropdownPages()
     {
         $this->useSubdirectoriesAsDropdowns()
-           ->menu([
-               new MarkdownPage('index'),
-               new MarkdownPage('foo/bar'),
-               new MarkdownPage('foo/baz'),
-           ])
+            ->menu([
+                new MarkdownPage('index'),
+                new MarkdownPage('foo/bar'),
+                new MarkdownPage('foo/baz'),
+            ])
             ->assertHasPages([
                 'index.html' => 'Home',
                 'foo/bar.html' => 'Bar',

--- a/packages/framework/tests/Unit/Views/NavigationHtmlLayoutsTest.php
+++ b/packages/framework/tests/Unit/Views/NavigationHtmlLayoutsTest.php
@@ -181,7 +181,10 @@ abstract class RenderedNavigationMenu
     {
         $renderedPages = $this->getRenderedPages();
 
-        $this->test->assertSame($pages, $renderedPages);
+        $this->test->assertSame($pages, $renderedPages, sprintf('Rendered pages do not match expected pages: %s', json_encode([
+            'expected' => $pages,
+            'rendered' => $renderedPages,
+        ], JSON_PRETTY_PRINT)));
 
         return $this;
     }

--- a/packages/framework/tests/Unit/Views/NavigationHtmlLayoutsTest.php
+++ b/packages/framework/tests/Unit/Views/NavigationHtmlLayoutsTest.php
@@ -91,6 +91,28 @@ class NavigationHtmlLayoutsTest extends TestCase
             ->finish();
     }
 
+    public function testNavigationMenuFromNestedRoute()
+    {
+        $pages = [
+            new MarkdownPage('index'),
+            new MarkdownPage('404'),
+            new BladePage('about'),
+            new BladePage('hidden', ['navigation.hidden' => true]),
+            new InMemoryPage('custom', ['navigation.label' => 'Label']),
+            new HtmlPage('first', ['navigation.priority' => 1]),
+        ];
+
+        $this->fromPage('nested/page')
+            ->menu($pages)
+            ->assertHasPages([
+                '../index.html' => 'Home',
+                '../first.html' => 'First',
+                '../about.html' => 'About',
+                '../custom.html' => 'Label',
+            ])
+            ->finish();
+    }
+
     protected function withPages(array $pages): static
     {
         $this->kernel->setRoutes(collect($pages)->map(fn (HydePage $page) => $page->getRoute()));

--- a/packages/framework/tests/Unit/Views/NavigationHtmlLayoutsTest.php
+++ b/packages/framework/tests/Unit/Views/NavigationHtmlLayoutsTest.php
@@ -631,7 +631,7 @@ abstract class RenderedNavigationMenu
         return trim(implode("\n", array_map('rtrim', explode("\n", $html))));
     }
 
-    protected function printSerializedArray(array $data): string|false
+    protected function printSerializedArray(array $data): string
     {
         $string = json_encode($data, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES);
 

--- a/packages/framework/tests/Unit/Views/NavigationHtmlLayoutsTest.php
+++ b/packages/framework/tests/Unit/Views/NavigationHtmlLayoutsTest.php
@@ -98,6 +98,13 @@ class NavigationHtmlLayoutsTest extends TestCase
         return $this;
     }
 
+    protected function fromPage(string $mockedRoute): static
+    {
+        $this->mockCurrentPage($mockedRoute);
+
+        return $this;
+    }
+
     protected function menu(array $withPages = []): RenderedMainNavigationMenu
     {
         $this->withPages($withPages);

--- a/packages/framework/tests/Unit/Views/NavigationHtmlLayoutsTest.php
+++ b/packages/framework/tests/Unit/Views/NavigationHtmlLayoutsTest.php
@@ -419,7 +419,7 @@ class NavigationHtmlLayoutsTest extends TestCase
 
     public function testSidebarWithGroupedPages()
     {
-        $this->sidebar($this->withSidebarPages())
+        $this->sidebar($this->withGroupedSidebarPages())
             ->assertHasGroups()
             ->assertHasPages([
                 'docs/bar.html' => 'Bar',
@@ -436,7 +436,7 @@ class NavigationHtmlLayoutsTest extends TestCase
     public function testSidebarWithGroupedPagesWithoutFlattenedOutputPaths()
     {
         $this->withoutFlattenedOutputPaths()
-            ->sidebar($this->withSidebarPages())
+            ->sidebar($this->withGroupedSidebarPages())
             ->assertHasGroups()
             ->assertHasPages([
                 'docs/foo/bar.html' => 'Bar',
@@ -506,7 +506,7 @@ class NavigationHtmlLayoutsTest extends TestCase
         ];
     }
 
-    protected function withSidebarPages(): array
+    protected function withGroupedSidebarPages(): array
     {
         return [
             new DocumentationPage('index'),

--- a/packages/framework/tests/Unit/Views/NavigationHtmlLayoutsTest.php
+++ b/packages/framework/tests/Unit/Views/NavigationHtmlLayoutsTest.php
@@ -115,14 +115,12 @@ class NavigationHtmlLayoutsTest extends TestCase
             ->assertHasElement('dropdown-items')
             ->assertHasElement('dropdown-button')
             ->assertItemsLookLike(<<<'HTML'
-- Home
-- Foo
-    - Bar
-    - Baz
-HTML
-
-            )
-            ->finish();
+                - Home
+                - Foo
+                    - Bar
+                    - Baz
+                HTML
+            );
     }
 
     protected function withPages(array $pages): static

--- a/packages/framework/tests/Unit/Views/NavigationHtmlLayoutsTest.php
+++ b/packages/framework/tests/Unit/Views/NavigationHtmlLayoutsTest.php
@@ -54,6 +54,9 @@ use function file_put_contents;
 /**
  * Very high level tests for navigation menu and sidebar view layouts.
  *
+ * These tests provide a sort of structural visual testing that can signal smoke
+ * before end-to-end testing kicks in, as they take a long time to set up and run.
+ *
  * @see \Hyde\Framework\Testing\Feature\AutomaticNavigationConfigurationsTest
  */
 class NavigationHtmlLayoutsTest extends TestCase

--- a/packages/framework/tests/Unit/Views/NavigationHtmlLayoutsTest.php
+++ b/packages/framework/tests/Unit/Views/NavigationHtmlLayoutsTest.php
@@ -559,52 +559,6 @@ abstract class RenderedNavigationMenu
         return $this->assertLooksLike($expected, true);
     }
 
-    public function assertHasDropdowns(?array $expected = null): static
-    {
-        $this->assertHasElement('dropdown');
-        $this->assertHasElement('dropdown-items');
-        $this->assertHasElement('dropdown-button');
-
-        if ($expected) {
-            $xpath = new DOMXPath($this->ast);
-            $dropdownItems = $xpath->query('//ul[contains(concat(" ", normalize-space(@class), " "), " dropdown-items ")]');
-
-            /** @var array<string, array<string> $actual */
-            $actual = [];
-
-            foreach ($dropdownItems as $dropdownItem) {
-                $button = $xpath->query('../preceding-sibling::button', $dropdownItem)->item(0);
-
-                $label = trim($button->textContent);
-
-                $children = array_values(array_filter(array_map('trim', explode("\n", $dropdownItem->textContent))));
-
-                $actual[$label] = $children;
-            }
-
-            // If expected is a list array, then remove values from actual
-            if (array_values($expected) === $expected) {
-                $actual = array_keys($actual);
-            }
-
-            $this->test->assertSame($expected, $actual, sprintf('Rendered dropdown does not match expected format: %s', $this->printSerializedArray([
-                'expected' => $expected,
-                'rendered' => $actual,
-            ])));
-        }
-
-        return $this;
-    }
-
-    public function assertDoesNotHaveDropdowns(): static
-    {
-        $this->assertDoesNotHaveElement('dropdown');
-        $this->assertDoesNotHaveElement('dropdown-items');
-        $this->assertDoesNotHaveElement('dropdown-button');
-
-        return $this;
-    }
-
     #[NoReturn]
     public function dd(bool $writeHtml = true): void
     {
@@ -701,6 +655,52 @@ abstract class RenderedNavigationMenu
 class RenderedMainNavigationMenu extends RenderedNavigationMenu
 {
     protected const TYPE = MainNavigationMenu::class;
+
+    public function assertHasDropdowns(?array $expected = null): static
+    {
+        $this->assertHasElement('dropdown');
+        $this->assertHasElement('dropdown-items');
+        $this->assertHasElement('dropdown-button');
+
+        if ($expected) {
+            $xpath = new DOMXPath($this->ast);
+            $dropdownItems = $xpath->query('//ul[contains(concat(" ", normalize-space(@class), " "), " dropdown-items ")]');
+
+            /** @var array<string, array<string> $actual */
+            $actual = [];
+
+            foreach ($dropdownItems as $dropdownItem) {
+                $button = $xpath->query('../preceding-sibling::button', $dropdownItem)->item(0);
+
+                $label = trim($button->textContent);
+
+                $children = array_values(array_filter(array_map('trim', explode("\n", $dropdownItem->textContent))));
+
+                $actual[$label] = $children;
+            }
+
+            // If expected is a list array, then remove values from actual
+            if (array_values($expected) === $expected) {
+                $actual = array_keys($actual);
+            }
+
+            $this->test->assertSame($expected, $actual, sprintf('Rendered dropdown does not match expected format: %s', $this->printSerializedArray([
+                'expected' => $expected,
+                'rendered' => $actual,
+            ])));
+        }
+
+        return $this;
+    }
+
+    public function assertDoesNotHaveDropdowns(): static
+    {
+        $this->assertDoesNotHaveElement('dropdown');
+        $this->assertDoesNotHaveElement('dropdown-items');
+        $this->assertDoesNotHaveElement('dropdown-button');
+
+        return $this;
+    }
 }
 
 class RenderedDocumentationSidebarMenu extends RenderedNavigationMenu

--- a/packages/framework/tests/Unit/Views/NavigationHtmlLayoutsTest.php
+++ b/packages/framework/tests/Unit/Views/NavigationHtmlLayoutsTest.php
@@ -475,7 +475,7 @@ abstract class RenderedNavigationMenu
         $this->test->assertSame($pages, $renderedPages, sprintf('Rendered pages do not match expected pages: %s', json_encode([
             'expected' => $pages,
             'rendered' => $renderedPages,
-        ], JSON_PRETTY_PRINT)));
+        ], JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES)));
 
         return $this;
     }
@@ -542,7 +542,7 @@ abstract class RenderedNavigationMenu
             $this->test->assertSame($expected, $actual, sprintf('Rendered dropdown does not match expected format: %s', json_encode([
                 'expected' => $expected,
                 'rendered' => $actual,
-            ], JSON_PRETTY_PRINT)));
+            ], JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES)));
         }
 
         return $this;

--- a/packages/framework/tests/Unit/Views/NavigationHtmlLayoutsTest.php
+++ b/packages/framework/tests/Unit/Views/NavigationHtmlLayoutsTest.php
@@ -351,9 +351,6 @@ abstract class RenderedNavigationMenu
         $this->assertHasElement('dropdown-button');
 
         if ($expected) {
-            // Assert contains only the same count of dropdown labels
-
-            // Get all ul.dropdown-items elements
             $xpath = new DOMXPath($this->ast);
             $dropdownItems = $xpath->query('//ul[contains(concat(" ", normalize-space(@class), " "), " dropdown-items ")]');
 
@@ -361,20 +358,16 @@ abstract class RenderedNavigationMenu
             $actual = [];
 
             foreach ($dropdownItems as $dropdownItem) {
-                // Get the preceding sibling button element
                 $button = $xpath->query('../preceding-sibling::button', $dropdownItem)->item(0);
 
-                // Get the text content of the button (label)
                 $label = trim($button->textContent);
 
-                $innerText = $dropdownItem->textContent;
-                $children = array_values(array_filter(array_map('trim', explode("\n", $innerText))));
+                $children = array_values(array_filter(array_map('trim', explode("\n", $dropdownItem->textContent))));
 
-                // Trim and add the label to the array
                 $actual[$label] = $children;
             }
 
-            // If expected is a list array then remove values from actual
+            // If expected is a list array, then remove values from actual
             if (array_values($expected) === $expected) {
                 $actual = array_keys($actual);
             }

--- a/packages/framework/tests/Unit/Views/NavigationHtmlLayoutsTest.php
+++ b/packages/framework/tests/Unit/Views/NavigationHtmlLayoutsTest.php
@@ -636,7 +636,6 @@ abstract class RenderedNavigationMenu
         $string = json_encode($data, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES);
 
         // Convert JSON to PHP array syntax
-
         $string = str_replace(['{', '}'], ['[', ']'], $string);
         $string = str_replace('": "', "' => '", $string);
         $string = str_replace('": [', "' => [", $string);

--- a/packages/framework/tests/Unit/Views/NavigationHtmlLayoutsTest.php
+++ b/packages/framework/tests/Unit/Views/NavigationHtmlLayoutsTest.php
@@ -131,12 +131,12 @@ class NavigationHtmlLayoutsTest extends TestCase
                 new MarkdownPage('foo/bar'),
                 new MarkdownPage('foo/baz'),
             ])
+            ->assertHasDropdowns()
             ->assertHasPages([
                 'index.html' => 'Home',
                 'foo/bar.html' => 'Bar',
                 'foo/baz.html' => 'Baz',
             ])
-            ->assertHasDropdowns()
             ->assertItemsLookLike(<<<'HTML'
                 - Home
                 - Foo
@@ -154,12 +154,12 @@ class NavigationHtmlLayoutsTest extends TestCase
                 new MarkdownPage('foo/bar'),
                 new MarkdownPage('foo/baz'),
             ])
+            ->assertDoesNotHaveDropdowns()
             ->assertHasPages([
                 'index.html' => 'Home',
                 'foo/bar.html' => 'Bar',
                 'foo/baz.html' => 'Baz',
             ])
-            ->assertDoesNotHaveDropdowns()
             ->assertItemsLookLike(<<<'HTML'
                 - Home
                 - Bar

--- a/packages/framework/tests/Unit/Views/NavigationHtmlLayoutsTest.php
+++ b/packages/framework/tests/Unit/Views/NavigationHtmlLayoutsTest.php
@@ -755,7 +755,11 @@ abstract class RenderedNavigationMenu
 
         $html = Str::replaceLast('</ul>', '', $html);
 
-        $html = str_replace(['HydePHPDocs', 'themeToggle', 'Toggledarktheme', 'Togglemenu', 'Backtohomepage'], ['HydePHP Docs', 'theme Toggle', ' Toggle theme', 'Toggle menu', 'Back to home page'], $html);
+        $html = str_replace(
+            ['HydePHPDocs', 'themeToggle', 'Toggledarktheme', 'Togglemenu', 'Backtohomepage'],
+            ['HydePHP Docs', 'theme Toggle', ' Toggle theme', 'Toggle menu', 'Back to home page'],
+            $html
+        );
 
         return trim(implode("\n", array_map('rtrim', explode("\n", $html))));
     }

--- a/packages/framework/tests/Unit/Views/NavigationHtmlLayoutsTest.php
+++ b/packages/framework/tests/Unit/Views/NavigationHtmlLayoutsTest.php
@@ -52,6 +52,8 @@ class NavigationHtmlLayoutsTest extends TestCase
             ->assertHasElement('theme-toggle-button')
             ->assertHasElement('navigation-toggle-button')
             ->assertHasElement('main-navigation-links')
+            ->assertDoesNotHaveElement('dropdown-button')
+            ->assertDoesNotHaveElement('dropdown')
             ->assertHasNoPages()
             ->finish();
     }
@@ -201,6 +203,26 @@ abstract class RenderedNavigationMenu
         }
 
         $this->test->assertNotNull($element, "Element with '$id' not found in the HTML.");
+
+        return $this;
+    }
+
+    public function assertDoesNotHaveElement(string $id): static
+    {
+        $element = $this->ast->getElementById($id);
+
+        if ($element === null) {
+            // Search for the element in the entire HTML.
+            $xpath = new DOMXPath($this->ast);
+            $element = $xpath->query("//*[@id='$id']")->item(0);
+
+            if ($element === null) {
+                // See if there is an element containing the ID as a class.
+                $element = $xpath->query("//*[contains(concat(' ', normalize-space(@class), ' '), ' $id ')]")->item(0);
+            }
+        }
+
+        $this->test->assertNull($element, "Element with '$id' found in the HTML.");
 
         return $this;
     }

--- a/packages/framework/tests/Unit/Views/NavigationHtmlLayoutsTest.php
+++ b/packages/framework/tests/Unit/Views/NavigationHtmlLayoutsTest.php
@@ -410,6 +410,27 @@ class NavigationHtmlLayoutsTest extends TestCase
         );
     }
 
+    public function testSidebarWithGroupedPagesWithoutFlattenedOutputPaths()
+    {
+        $this->withoutFlattenedOutputPaths()
+            ->sidebar([
+                new DocumentationPage('index'),
+                new DocumentationPage('foo/bar'),
+                new DocumentationPage('foo/baz'),
+            ])
+            ->assertHasGroups()
+            ->assertHasPages([
+                'docs/foo/bar.html' => 'Bar',
+                'docs/foo/baz.html' => 'Baz',
+            ])
+            ->assertItemsLookLike(<<<'HTML'
+            - Foo
+                - Bar
+                - Baz
+            HTML
+            );
+    }
+
     protected function fromPage(string $mockedRoute): static
     {
         $this->mockCurrentPage($mockedRoute);
@@ -438,6 +459,13 @@ class NavigationHtmlLayoutsTest extends TestCase
     protected function useSubdirectoryConfig(string $option): static
     {
         config(['hyde.navigation.subdirectories' => $option]);
+
+        return $this;
+    }
+
+    protected function withoutFlattenedOutputPaths(): static
+    {
+        config(['docs.flattened_output_paths' => false]);
 
         return $this;
     }

--- a/packages/framework/tests/Unit/Views/NavigationHtmlLayoutsTest.php
+++ b/packages/framework/tests/Unit/Views/NavigationHtmlLayoutsTest.php
@@ -14,6 +14,7 @@ use Hyde\Pages\HtmlPage;
 use Hyde\Facades\Config;
 use Hyde\Pages\BladePage;
 use Hyde\Testing\TestCase;
+use Hyde\Facades\Features;
 use Illuminate\Support\Str;
 use Hyde\Pages\MarkdownPage;
 use Hyde\Pages\InMemoryPage;
@@ -165,6 +166,13 @@ class NavigationHtmlLayoutsTest extends TestCase
     public function testSidebarHeaderHasThemeToggleButton()
     {
         $this->sidebar()->header()->assertHasThemeToggleButton();
+    }
+
+    public function testSidebarHeaderDoesNotHaveThemeToggleButtonWhenDarkmodeIsDisabled()
+    {
+        Features::mock('darkmode', false);
+
+        $this->sidebar()->header()->assertDoesNotHaveThemeToggleButton();
     }
 
     public function testNavigationMenuFromNestedRoute()
@@ -889,6 +897,22 @@ class RenderedDocumentationSidebarMenu extends RenderedNavigationMenu
 
             $this->test->assertNotNull($header, 'No theme toggle button found in sidebar header');
             $this->test->assertSame('Toggle dark theme', trim($header->textContent));
+        }
+
+        return $this;
+    }
+
+    public function assertDoesNotHaveThemeToggleButton(): static
+    {
+        if (! $this->scopeToHeader) {
+            $this->assertDoesNotHaveElement('theme-toggle-button');
+        } else {
+            $header = $this->getAssertedElement('sidebar-header');
+
+            $xpath = new DOMXPath($this->ast);
+            $header = $xpath->query('.//button[contains(concat(" ", normalize-space(@class), " "), " theme-toggle-button ")]', $header)->item(0);
+
+            $this->test->assertNull($header, 'Theme toggle button found in sidebar header');
         }
 
         return $this;

--- a/packages/framework/tests/Unit/Views/NavigationHtmlLayoutsTest.php
+++ b/packages/framework/tests/Unit/Views/NavigationHtmlLayoutsTest.php
@@ -29,6 +29,7 @@ use function md5;
 use function view;
 use function trim;
 use function range;
+use function rtrim;
 use function config;
 use function collect;
 use function sprintf;

--- a/packages/framework/tests/Unit/Views/NavigationHtmlLayoutsTest.php
+++ b/packages/framework/tests/Unit/Views/NavigationHtmlLayoutsTest.php
@@ -358,17 +358,17 @@ class NavigationHtmlLayoutsTest extends TestCase
             new DocumentationPage('bar'),
             new DocumentationPage('baz'),
         ])
-        ->assertHasPages([
-            'docs/foo.html' => 'Foo',
-            'docs/bar.html' => 'Bar',
-            'docs/baz.html' => 'Baz',
-        ])
-        ->assertItemsLookLike(<<<'HTML'
+            ->assertHasPages([
+                'docs/foo.html' => 'Foo',
+                'docs/bar.html' => 'Bar',
+                'docs/baz.html' => 'Baz',
+            ])
+            ->assertItemsLookLike(<<<'HTML'
             Foo
             Bar
             Baz
             HTML
-        );
+            );
     }
 
     public function testSidebarFromNestedRoute()
@@ -395,32 +395,24 @@ class NavigationHtmlLayoutsTest extends TestCase
 
     public function testSidebarWithGroupedPages()
     {
-        $this->sidebar([
-            new DocumentationPage('index'),
-            new DocumentationPage('foo/bar'),
-            new DocumentationPage('foo/baz'),
-        ])
-        ->assertHasGroups()
-        ->assertHasPages([
-            'docs/bar.html' => 'Bar',
-            'docs/baz.html' => 'Baz',
-        ])
-        ->assertItemsLookLike(<<<'HTML'
+        $this->sidebar($this->withSidebarPages())
+            ->assertHasGroups()
+            ->assertHasPages([
+                'docs/bar.html' => 'Bar',
+                'docs/baz.html' => 'Baz',
+            ])
+            ->assertItemsLookLike(<<<'HTML'
             - Foo
                 - Bar
                 - Baz
             HTML
-        );
+            );
     }
 
     public function testSidebarWithGroupedPagesWithoutFlattenedOutputPaths()
     {
         $this->withoutFlattenedOutputPaths()
-            ->sidebar([
-                new DocumentationPage('index'),
-                new DocumentationPage('foo/bar'),
-                new DocumentationPage('foo/baz'),
-            ])
+            ->sidebar($this->withSidebarPages())
             ->assertHasGroups()
             ->assertHasPages([
                 'docs/foo/bar.html' => 'Bar',
@@ -511,6 +503,15 @@ class NavigationHtmlLayoutsTest extends TestCase
             new BladePage('hidden', ['navigation.hidden' => true]),
             new InMemoryPage('custom', ['navigation.label' => 'Label']),
             new HtmlPage('first', ['navigation.priority' => 1]),
+        ];
+    }
+
+    protected function withSidebarPages(): array
+    {
+        return [
+            new DocumentationPage('index'),
+            new DocumentationPage('foo/bar'),
+            new DocumentationPage('foo/baz'),
         ];
     }
 }

--- a/packages/framework/tests/Unit/Views/NavigationHtmlLayoutsTest.php
+++ b/packages/framework/tests/Unit/Views/NavigationHtmlLayoutsTest.php
@@ -114,7 +114,13 @@ class NavigationHtmlLayoutsTest extends TestCase
                 '../about.html' => 'About',
                 '../custom.html' => 'Label',
             ])
-            ->finish();
+            ->assertItemsLookLike(<<<'HTML'
+                - Home
+                - First
+                - About
+                - Label
+                HTML
+            );
     }
 
     public function testNavigationMenuWithDropdownPages()

--- a/packages/framework/tests/Unit/Views/NavigationHtmlLayoutsTest.php
+++ b/packages/framework/tests/Unit/Views/NavigationHtmlLayoutsTest.php
@@ -745,7 +745,7 @@ abstract class RenderedNavigationMenu
 
         $html = Str::replaceLast('</ul>', '', $html);
 
-        $html = str_replace(['HydePHPDocs', 'Toggledarktheme', 'Togglemenu', 'Backtohomepage'], ['HydePHP Docs', ' Toggle theme', 'Toggle menu', 'Back to home page'], $html);
+        $html = str_replace(['HydePHPDocs', 'themeToggle', 'Toggledarktheme', 'Togglemenu', 'Backtohomepage'], ['HydePHP Docs', 'theme Toggle', ' Toggle theme', 'Toggle menu', 'Back to home page'], $html);
 
         return trim(implode("\n", array_map('rtrim', explode("\n", $html))));
     }

--- a/packages/framework/tests/Unit/Views/NavigationHtmlLayoutsTest.php
+++ b/packages/framework/tests/Unit/Views/NavigationHtmlLayoutsTest.php
@@ -755,6 +755,7 @@ abstract class RenderedNavigationMenu
 
         $html = Str::replaceLast('</ul>', '', $html);
 
+        /** @noinspection SpellCheckingInspection */
         $html = str_replace(
             ['HydePHPDocs', 'themeToggle', 'Toggledarktheme', 'Togglemenu', 'Backtohomepage'],
             ['HydePHP Docs', 'theme Toggle', ' Toggle theme', 'Toggle menu', 'Back to home page'],

--- a/packages/framework/tests/Unit/Views/NavigationHtmlLayoutsTest.php
+++ b/packages/framework/tests/Unit/Views/NavigationHtmlLayoutsTest.php
@@ -343,16 +343,20 @@ abstract class RenderedNavigationMenu
 
     public function assertHasDropdowns(): static
     {
-        return $this->assertHasElement('dropdown')
-            ->assertHasElement('dropdown-items')
-            ->assertHasElement('dropdown-button');
+        $this->assertHasElement('dropdown');
+        $this->assertHasElement('dropdown-items');
+        $this->assertHasElement('dropdown-button');
+
+        return $this;
     }
 
     public function assertDoesNotHaveDropdowns(): static
     {
-        return $this->assertDoesNotHaveElement('dropdown')
-            ->assertDoesNotHaveElement('dropdown-items')
-            ->assertDoesNotHaveElement('dropdown-button');
+        $this->assertDoesNotHaveElement('dropdown');
+        $this->assertDoesNotHaveElement('dropdown-items');
+        $this->assertDoesNotHaveElement('dropdown-button');
+
+        return $this;
     }
 
     #[NoReturn]

--- a/packages/framework/tests/Unit/Views/NavigationHtmlLayoutsTest.php
+++ b/packages/framework/tests/Unit/Views/NavigationHtmlLayoutsTest.php
@@ -472,10 +472,10 @@ abstract class RenderedNavigationMenu
     {
         $renderedPages = $this->getRenderedPages();
 
-        $this->test->assertSame($pages, $renderedPages, sprintf('Rendered pages do not match expected pages: %s', json_encode([
+        $this->test->assertSame($pages, $renderedPages, sprintf('Rendered pages do not match expected pages: %s', $this->printSerializedArray([
             'expected' => $pages,
             'rendered' => $renderedPages,
-        ], JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES)));
+        ])));
 
         return $this;
     }
@@ -539,10 +539,10 @@ abstract class RenderedNavigationMenu
                 $actual = array_keys($actual);
             }
 
-            $this->test->assertSame($expected, $actual, sprintf('Rendered dropdown does not match expected format: %s', json_encode([
+            $this->test->assertSame($expected, $actual, sprintf('Rendered dropdown does not match expected format: %s', $this->printSerializedArray([
                 'expected' => $expected,
                 'rendered' => $actual,
-            ], JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES)));
+            ])));
         }
 
         return $this;
@@ -629,6 +629,11 @@ abstract class RenderedNavigationMenu
         $html = Str::replaceLast('</ul>', '', $html);
 
         return trim(implode("\n", array_map('rtrim', explode("\n", $html))));
+    }
+
+    protected function printSerializedArray(array $data): string|false
+    {
+        return json_encode($data, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES);
     }
 }
 

--- a/packages/framework/tests/Unit/Views/NavigationHtmlLayoutsTest.php
+++ b/packages/framework/tests/Unit/Views/NavigationHtmlLayoutsTest.php
@@ -109,6 +109,51 @@ class NavigationHtmlLayoutsTest extends TestCase
             ]);
     }
 
+    public function testSidebarWithPages()
+    {
+        $this->sidebar([
+            new DocumentationPage('index'),
+            new DocumentationPage('foo'),
+            new DocumentationPage('bar'),
+            new DocumentationPage('baz'),
+        ])
+            ->assertHasPages([
+                'docs/foo.html' => 'Foo',
+                'docs/bar.html' => 'Bar',
+                'docs/baz.html' => 'Baz',
+            ])
+            ->assertItemsLookLike(<<<'HTML'
+            Foo
+            Bar
+            Baz
+            HTML
+            );
+    }
+
+    public function testMenuHeader()
+    {
+        $this->menu()->assertHeaderIs('HydePHP');
+    }
+
+    public function testSidebarHeader()
+    {
+        $this->sidebar()->assertHeaderIs('HydePHP Docs');
+    }
+
+    public function testCustomMenuHeader()
+    {
+        Config::set('hyde.name', 'Example');
+
+        $this->menu()->assertHeaderIs('Example');
+    }
+
+    public function testCustomSidebarHeader()
+    {
+        Config::set('docs.sidebar.header', 'Documentation');
+
+        $this->sidebar()->assertHeaderIs('Documentation');
+    }
+
     public function testNavigationMenuFromNestedRoute()
     {
         $this->fromPage('nested/page')
@@ -350,27 +395,6 @@ class NavigationHtmlLayoutsTest extends TestCase
             );
     }
 
-    public function testSidebarWithPages()
-    {
-        $this->sidebar([
-            new DocumentationPage('index'),
-            new DocumentationPage('foo'),
-            new DocumentationPage('bar'),
-            new DocumentationPage('baz'),
-        ])
-            ->assertHasPages([
-                'docs/foo.html' => 'Foo',
-                'docs/bar.html' => 'Bar',
-                'docs/baz.html' => 'Baz',
-            ])
-            ->assertItemsLookLike(<<<'HTML'
-            Foo
-            Bar
-            Baz
-            HTML
-            );
-    }
-
     public function testSidebarFromNestedRoute()
     {
         $this->fromPage('nested/page')
@@ -424,30 +448,6 @@ class NavigationHtmlLayoutsTest extends TestCase
                 - Baz
             HTML
             );
-    }
-
-    public function testMenuHeader()
-    {
-        $this->menu()->assertHeaderIs('HydePHP');
-    }
-
-    public function testSidebarHeader()
-    {
-        $this->sidebar()->assertHeaderIs('HydePHP Docs');
-    }
-
-    public function testCustomMenuHeader()
-    {
-        Config::set('hyde.name', 'Example');
-
-        $this->menu()->assertHeaderIs('Example');
-    }
-
-    public function testCustomSidebarHeader()
-    {
-        Config::set('docs.sidebar.header', 'Documentation');
-
-        $this->sidebar()->assertHeaderIs('Documentation');
     }
 
     protected function fromPage(string $mockedRoute): static

--- a/packages/framework/tests/Unit/Views/NavigationHtmlLayoutsTest.php
+++ b/packages/framework/tests/Unit/Views/NavigationHtmlLayoutsTest.php
@@ -113,8 +113,7 @@ class NavigationHtmlLayoutsTest extends TestCase
     {
         $this->withPages($withPages);
 
-        $menu = NavigationMenuGenerator::handle(MainNavigationMenu::class);
-        app()->instance('navigation.main', $menu);
+        app()->instance('navigation.main', NavigationMenuGenerator::handle(MainNavigationMenu::class));
 
         return new RenderedMainNavigationMenu($this, $this->render('hyde::layouts.navigation'));
     }
@@ -123,8 +122,7 @@ class NavigationHtmlLayoutsTest extends TestCase
     {
         $this->withPages($withPages);
 
-        $menu = NavigationMenuGenerator::handle(DocumentationSidebar::class);
-        app()->instance('navigation.sidebar', $menu);
+        app()->instance('navigation.sidebar', NavigationMenuGenerator::handle(DocumentationSidebar::class));
 
         return new RenderedDocumentationSidebarMenu($this, $this->render('hyde::components.docs.sidebar'));
     }

--- a/packages/framework/tests/Unit/Views/NavigationHtmlLayoutsTest.php
+++ b/packages/framework/tests/Unit/Views/NavigationHtmlLayoutsTest.php
@@ -11,6 +11,7 @@ use Hyde\Hyde;
 use DOMElement;
 use DOMDocument;
 use Hyde\Pages\HtmlPage;
+use Hyde\Facades\Config;
 use Hyde\Pages\BladePage;
 use Hyde\Testing\TestCase;
 use Illuminate\Support\Str;
@@ -441,6 +442,20 @@ class NavigationHtmlLayoutsTest extends TestCase
     public function testSidebarHeader()
     {
         $this->sidebar()->assertHeaderIs('HydePHP Docs');
+    }
+
+    public function testCustomMenuHeader()
+    {
+        Config::set('hyde.name', 'Example');
+
+        $this->menu()->assertHeaderIs('Example');
+    }
+
+    public function testCustomSidebarHeader()
+    {
+        Config::set('docs.sidebar.header', 'Documentation');
+
+        $this->sidebar()->assertHeaderIs('Documentation');
     }
 
     protected function fromPage(string $mockedRoute): static

--- a/packages/framework/tests/Unit/Views/NavigationHtmlLayoutsTest.php
+++ b/packages/framework/tests/Unit/Views/NavigationHtmlLayoutsTest.php
@@ -8,6 +8,7 @@ namespace Hyde\Framework\Testing\Unit\Views;
 
 use DOMXPath;
 use Hyde\Hyde;
+use DOMElement;
 use DOMDocument;
 use Hyde\Pages\HtmlPage;
 use Hyde\Pages\BladePage;
@@ -37,6 +38,7 @@ use function sprintf;
 use function explode;
 use function implode;
 use function array_map;
+use function is_string;
 use function strip_tags;
 use function array_keys;
 use function json_encode;
@@ -557,6 +559,19 @@ abstract class RenderedNavigationMenu
         }
 
         $this->test->assertNull($element, "Element with '$id' found in the HTML.");
+
+        return $this;
+    }
+
+    public function assertElementTextIs(DOMElement|string $element, string $expected): static
+    {
+        if (is_string($element)) {
+            $this->assertHasElement($element);
+
+            $element = $this->ast->getElementById($element);
+        }
+
+        $this->test->assertSame($expected, trim($element->textContent));
 
         return $this;
     }

--- a/packages/framework/tests/Unit/Views/NavigationHtmlLayoutsTest.php
+++ b/packages/framework/tests/Unit/Views/NavigationHtmlLayoutsTest.php
@@ -18,6 +18,7 @@ use Hyde\Pages\InMemoryPage;
 use Hyde\Foundation\HydeKernel;
 use JetBrains\PhpStorm\NoReturn;
 use Hyde\Pages\Concerns\HydePage;
+use Hyde\Pages\DocumentationPage;
 use Illuminate\Support\Collection;
 use Hyde\Foundation\Kernel\RouteCollection;
 use Hyde\Framework\Features\Navigation\MainNavigationMenu;
@@ -342,6 +343,49 @@ class NavigationHtmlLayoutsTest extends TestCase
                     - Foo
                     - Bar
                     - Baz
+                HTML
+            );
+    }
+
+    public function testSidebarWithPages()
+    {
+        $this->sidebar([
+            new DocumentationPage('index'),
+            new DocumentationPage('foo'),
+            new DocumentationPage('bar'),
+            new DocumentationPage('baz'),
+        ])
+        ->assertHasPages([
+            'docs/foo.html' => 'Foo',
+            'docs/bar.html' => 'Bar',
+            'docs/baz.html' => 'Baz',
+        ])
+        ->assertItemsLookLike(<<<'HTML'
+            Foo
+            Bar
+            Baz
+            HTML
+        );
+    }
+
+    public function testSidebarFromNestedRoute()
+    {
+        $this->fromPage('nested/page')
+            ->sidebar([
+                new DocumentationPage('index'),
+                new DocumentationPage('foo'),
+                new DocumentationPage('bar'),
+                new DocumentationPage('baz'),
+            ])
+            ->assertHasPages([
+                '../docs/foo.html' => 'Foo',
+                '../docs/bar.html' => 'Bar',
+                '../docs/baz.html' => 'Baz',
+            ])
+            ->assertItemsLookLike(<<<'HTML'
+                - Foo
+                - Bar
+                - Baz
                 HTML
             );
     }

--- a/packages/framework/tests/Unit/Views/NavigationHtmlLayoutsTest.php
+++ b/packages/framework/tests/Unit/Views/NavigationHtmlLayoutsTest.php
@@ -136,9 +136,7 @@ class NavigationHtmlLayoutsTest extends TestCase
                 'foo/bar.html' => 'Bar',
                 'foo/baz.html' => 'Baz',
             ])
-            ->assertHasElement('dropdown')
-            ->assertHasElement('dropdown-items')
-            ->assertHasElement('dropdown-button')
+            ->assertHasDropdowns()
             ->assertItemsLookLike(<<<'HTML'
                 - Home
                 - Foo
@@ -161,9 +159,7 @@ class NavigationHtmlLayoutsTest extends TestCase
                 'foo/bar.html' => 'Bar',
                 'foo/baz.html' => 'Baz',
             ])
-            ->assertDoesNotHaveElement('dropdown')
-            ->assertDoesNotHaveElement('dropdown-items')
-            ->assertDoesNotHaveElement('dropdown-button')
+            ->assertDoesNotHaveDropdowns()
             ->assertItemsLookLike(<<<'HTML'
                 - Home
                 - Bar
@@ -343,6 +339,20 @@ abstract class RenderedNavigationMenu
     public function assertItemsLookLike(string $expected): static
     {
         return $this->assertLooksLike($expected, true);
+    }
+
+    public function assertHasDropdowns(): static
+    {
+        return $this->assertHasElement('dropdown')
+            ->assertHasElement('dropdown-items')
+            ->assertHasElement('dropdown-button');
+    }
+
+    public function assertDoesNotHaveDropdowns(): static
+    {
+        return $this->assertDoesNotHaveElement('dropdown')
+            ->assertDoesNotHaveElement('dropdown-items')
+            ->assertDoesNotHaveElement('dropdown-button');
     }
 
     #[NoReturn]

--- a/packages/framework/tests/Unit/Views/NavigationHtmlLayoutsTest.php
+++ b/packages/framework/tests/Unit/Views/NavigationHtmlLayoutsTest.php
@@ -97,7 +97,9 @@ class NavigationHtmlLayoutsTest extends TestCase
 
     protected function withPages(array $pages): static
     {
-        return tap($this, fn () => $this->kernel->setRoutes(collect($pages)->map(fn (HydePage $page) => $page->getRoute())));
+        $this->kernel->setRoutes(collect($pages)->map(fn (HydePage $page) => $page->getRoute()));
+
+        return $this;
     }
 
     protected function fromPage(string $mockedRoute): static

--- a/packages/framework/tests/Unit/Views/NavigationHtmlLayoutsTest.php
+++ b/packages/framework/tests/Unit/Views/NavigationHtmlLayoutsTest.php
@@ -118,10 +118,10 @@ class NavigationHtmlLayoutsTest extends TestCase
                 'docs/baz.html' => 'Baz',
             ])
             ->assertItemsLookLike(<<<'HTML'
-            Foo
-            Bar
-            Baz
-            HTML
+                Foo
+                Bar
+                Baz
+                HTML
             );
     }
 

--- a/packages/framework/tests/Unit/Views/NavigationHtmlLayoutsTest.php
+++ b/packages/framework/tests/Unit/Views/NavigationHtmlLayoutsTest.php
@@ -445,17 +445,17 @@ abstract class RenderedNavigationMenu
         $html = str_replace('<li>', '- ', $html);
         $html = Str::replaceFirst('<ul>', "\n", $html);
 
-        // Indent each line within remaining uls
         $innerUlCount = substr_count($html, '<ul>');
         if ($innerUlCount >= 1) {
-            foreach (range(1, $innerUlCount) as $i) {
+            // Indent each line within the remaining UL elements
+            foreach (range(1, $innerUlCount) as $item) {
                 $html = Str::replaceFirst('</ul>', '</ul-first>', $html);
                 $innerUlContent = Str::between($html, '<ul>', '</ul-first>');
-                $id = md5($innerUlContent.$i);
+                $id = md5("$innerUlContent-$item");
                 $html = Str::replaceFirst($innerUlContent, $id, $html);
                 $innerUlContent = trim(str_replace("\n", "\n  ", $innerUlContent));
 
-                $html = str_replace('<ul>'.$id.'</ul-first>', "\n  ".$innerUlContent, $html);
+                $html = str_replace("<ul>$id</ul-first>", "\n  $innerUlContent", $html);
             }
         }
 

--- a/packages/framework/tests/Unit/Views/NavigationHtmlLayoutsTest.php
+++ b/packages/framework/tests/Unit/Views/NavigationHtmlLayoutsTest.php
@@ -633,7 +633,19 @@ abstract class RenderedNavigationMenu
 
     protected function printSerializedArray(array $data): string|false
     {
-        return json_encode($data, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES);
+        $string = json_encode($data, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES);
+
+        // Convert JSON to PHP array syntax
+
+        $string = str_replace(['{', '}'], ['[', ']'], $string);
+        $string = str_replace('": "', "' => '", $string);
+        $string = str_replace('": [', "' => [", $string);
+        $string = str_replace('"', "'", $string);
+        $string = str_replace("'\n", "',\n", $string);
+        $string = str_replace(']', '],', $string);
+        $string = str_replace(',,', ',', $string);
+
+        return rtrim($string, ',');
     }
 }
 

--- a/packages/framework/tests/Unit/Views/NavigationHtmlLayoutsTest.php
+++ b/packages/framework/tests/Unit/Views/NavigationHtmlLayoutsTest.php
@@ -97,9 +97,7 @@ class NavigationHtmlLayoutsTest extends TestCase
 
     protected function withPages(array $pages): static
     {
-        $this->kernel->setRoutes(collect($pages)->map(fn (HydePage $page) => $page->getRoute()));
-
-        return $this;
+        return tap($this, fn () => $this->kernel->setRoutes(collect($pages)->map(fn (HydePage $page) => $page->getRoute())));
     }
 
     protected function fromPage(string $mockedRoute): static

--- a/packages/framework/tests/Unit/Views/NavigationHtmlLayoutsTest.php
+++ b/packages/framework/tests/Unit/Views/NavigationHtmlLayoutsTest.php
@@ -127,6 +127,13 @@ class NavigationHtmlLayoutsTest extends TestCase
         return new RenderedDocumentationSidebarMenu($this, $this->render('hyde::components.docs.sidebar'));
     }
 
+    protected function useSubdirectoriesAsDropdowns(): static
+    {
+        config(['hyde.navigation.subdirectories' => 'dropdown']);
+
+        return $this;
+    }
+
     protected function render(string $view): string
     {
         return view($view)->render();

--- a/packages/framework/tests/Unit/Views/NavigationHtmlLayoutsTest.php
+++ b/packages/framework/tests/Unit/Views/NavigationHtmlLayoutsTest.php
@@ -111,12 +111,7 @@ class NavigationHtmlLayoutsTest extends TestCase
 
     public function testSidebarWithPages()
     {
-        $this->sidebar([
-            new DocumentationPage('index'),
-            new DocumentationPage('foo'),
-            new DocumentationPage('bar'),
-            new DocumentationPage('baz'),
-        ])
+        $this->sidebar($this->withSidebarPages())
             ->assertHasPages([
                 'docs/foo.html' => 'Foo',
                 'docs/bar.html' => 'Bar',
@@ -503,6 +498,16 @@ class NavigationHtmlLayoutsTest extends TestCase
             new BladePage('hidden', ['navigation.hidden' => true]),
             new InMemoryPage('custom', ['navigation.label' => 'Label']),
             new HtmlPage('first', ['navigation.priority' => 1]),
+        ];
+    }
+
+    protected function withSidebarPages(): array
+    {
+        return [
+            new DocumentationPage('index'),
+            new DocumentationPage('foo'),
+            new DocumentationPage('bar'),
+            new DocumentationPage('baz'),
         ];
     }
 

--- a/packages/framework/tests/Unit/Views/NavigationHtmlLayoutsTest.php
+++ b/packages/framework/tests/Unit/Views/NavigationHtmlLayoutsTest.php
@@ -162,6 +162,11 @@ class NavigationHtmlLayoutsTest extends TestCase
         $this->sidebar()->assertHeaderIs('Documentation');
     }
 
+    public function testSidebarHeaderHasThemeToggleButton()
+    {
+        $this->sidebar()->header()->assertHasThemeToggleButton();
+    }
+
     public function testNavigationMenuFromNestedRoute()
     {
         $this->fromPage('nested/page')

--- a/packages/framework/tests/Unit/Views/NavigationHtmlLayoutsTest.php
+++ b/packages/framework/tests/Unit/Views/NavigationHtmlLayoutsTest.php
@@ -697,6 +697,14 @@ abstract class RenderedNavigationMenu
         exit(trim($this->html)."\n\n");
     }
 
+    /** Get an element node and assert it is not null */
+    protected function getAssertedElement(string $id): DOMElement
+    {
+        $this->assertHasElement($id);
+
+        return $this->ast->getElementById($id);
+    }
+
     protected function parseHtml(): DOMDocument
     {
         $dom = new DOMDocument();

--- a/packages/framework/tests/Unit/Views/NavigationHtmlLayoutsTest.php
+++ b/packages/framework/tests/Unit/Views/NavigationHtmlLayoutsTest.php
@@ -193,6 +193,161 @@ class NavigationHtmlLayoutsTest extends TestCase
         return $this;
     }
 
+    public function testNavigationMenuWithFlatSubdirectoryPagesAndMatchingSubdirectoryPage()
+    {
+        $this->useSubdirectoryConfig('flat')
+            ->menu([
+                new MarkdownPage('index'),
+                new MarkdownPage('foo'),
+                new MarkdownPage('foo/bar'),
+                new MarkdownPage('foo/baz'),
+            ])
+            ->assertDoesNotHaveDropdowns()
+            ->assertHasPages([
+                'index.html' => 'Home',
+                'foo.html' => 'Foo',
+                'foo/bar.html' => 'Bar',
+                'foo/baz.html' => 'Baz',
+            ])
+            ->assertItemsLookLike(<<<'HTML'
+                - Home
+                - Foo
+                - Bar
+                - Baz
+                HTML
+            );
+    }
+
+    public function testNavigationMenuWithFlatSubdirectoryPagesAndMatchingSubdirectoryIndexPage()
+    {
+        $this->useSubdirectoryConfig('flat')
+            ->menu([
+                new MarkdownPage('index'),
+                new MarkdownPage('foo/index'),
+                new MarkdownPage('foo/bar'),
+                new MarkdownPage('foo/baz'),
+            ])
+            ->assertDoesNotHaveDropdowns()
+            ->assertHasPages([
+                'index.html' => 'Home',
+                'foo/index.html' => 'Foo',
+                'foo/bar.html' => 'Bar',
+                'foo/baz.html' => 'Baz',
+            ])
+            ->assertItemsLookLike(<<<'HTML'
+                - Home
+                - Foo
+                - Bar
+                - Baz
+                HTML
+            );
+    }
+
+    public function testNavigationMenuWithFlatSubdirectoryPagesAndMatchingSubdirectoryAndIndexPage()
+    {
+        $this->useSubdirectoryConfig('flat')
+            ->menu([
+                new MarkdownPage('index'),
+                new MarkdownPage('foo'),
+                new MarkdownPage('foo/index'),
+                new MarkdownPage('foo/bar'),
+                new MarkdownPage('foo/baz'),
+            ])
+            ->assertDoesNotHaveDropdowns()
+            ->assertHasPages([
+                'index.html' => 'Home',
+                'foo.html' => 'Foo',
+                'foo/index.html' => 'Foo',
+                'foo/bar.html' => 'Bar',
+                'foo/baz.html' => 'Baz',
+            ])
+            ->assertItemsLookLike(<<<'HTML'
+                - Home
+                - Foo
+                - Foo
+                - Bar
+                - Baz
+                HTML
+            );
+    }
+
+    public function testNavigationMenuWithDropdownSubdirectoryPagesAndMatchingSubdirectoryPage()
+    {
+        $this->useSubdirectoryConfig('dropdown')
+            ->menu([
+                new MarkdownPage('index'),
+                new MarkdownPage('foo'),
+                new MarkdownPage('foo/bar'),
+                new MarkdownPage('foo/baz'),
+            ])
+            ->assertHasDropdowns()
+            ->assertHasPages([
+                'index.html' => 'Home',
+                'foo/bar.html' => 'Bar',
+                'foo/baz.html' => 'Baz',
+            ])
+            ->assertItemsLookLike(<<<'HTML'
+                - Home
+                - Foo
+                    - Bar
+                    - Baz
+                HTML
+            );
+    }
+
+    public function testNavigationMenuWithDropdownSubdirectoryPagesAndMatchingSubdirectoryIndexPage()
+    {
+        $this->useSubdirectoryConfig('dropdown')
+            ->menu([
+                new MarkdownPage('index'),
+                new MarkdownPage('foo/index'),
+                new MarkdownPage('foo/bar'),
+                new MarkdownPage('foo/baz'),
+            ])
+            ->assertHasDropdowns()
+            ->assertHasPages([
+                'index.html' => 'Home',
+                'foo/index.html' => 'Foo',
+                'foo/bar.html' => 'Bar',
+                'foo/baz.html' => 'Baz',
+            ])
+            ->assertItemsLookLike(<<<'HTML'
+                - Home
+                - Foo
+                    - Foo
+                    - Bar
+                    - Baz
+                HTML
+            );
+    }
+
+    public function testNavigationMenuWithDropdownSubdirectoryPagesAndMatchingSubdirectoryAndIndexPage()
+    {
+        $this->useSubdirectoryConfig('dropdown')
+            ->menu([
+                new MarkdownPage('index'),
+                new MarkdownPage('foo'),
+                new MarkdownPage('foo/index'),
+                new MarkdownPage('foo/bar'),
+                new MarkdownPage('foo/baz'),
+            ])
+            ->assertHasDropdowns()
+            ->assertHasPages([
+                'index.html' => 'Home',
+                'foo/index.html' => 'Foo',
+                'foo/bar.html' => 'Bar',
+                'foo/baz.html' => 'Baz',
+            ])
+            ->assertItemsLookLike(<<<'HTML'
+                - Home
+                - Foo
+                    - Foo
+                    - Bar
+                    - Baz
+                HTML
+            );
+    }
+
     protected function fromPage(string $mockedRoute): static
     {
         $this->mockCurrentPage($mockedRoute);

--- a/packages/framework/tests/Unit/Views/NavigationHtmlLayoutsTest.php
+++ b/packages/framework/tests/Unit/Views/NavigationHtmlLayoutsTest.php
@@ -171,6 +171,24 @@ class NavigationHtmlLayoutsTest extends TestCase
             );
     }
 
+    public function testNavigationMenuWithHiddenSubdirectoryPages()
+    {
+        $this->useSubdirectoryConfig('hidden')
+            ->menu([
+                new MarkdownPage('index'),
+                new MarkdownPage('foo/bar'),
+                new MarkdownPage('foo/baz'),
+            ])
+            ->assertDoesNotHaveDropdowns()
+            ->assertHasPages([
+                'index.html' => 'Home',
+            ])
+            ->assertItemsLookLike(<<<'HTML'
+                - Home
+                HTML
+            );
+    }
+
     protected function withPages(array $pages): static
     {
         $this->kernel->setRoutes(collect($pages)->map(fn (HydePage $page) => $page->getRoute()));

--- a/packages/framework/tests/Unit/Views/NavigationHtmlLayoutsTest.php
+++ b/packages/framework/tests/Unit/Views/NavigationHtmlLayoutsTest.php
@@ -390,6 +390,26 @@ class NavigationHtmlLayoutsTest extends TestCase
             );
     }
 
+    public function testSidebarWithGroupedPages()
+    {
+        $this->sidebar([
+            new DocumentationPage('index'),
+            new DocumentationPage('foo/bar'),
+            new DocumentationPage('foo/baz'),
+        ])
+            ->assertHasGroups()
+            ->assertHasPages([
+                'docs/bar.html' => 'Bar',
+                'docs/baz.html' => 'Baz',
+            ])
+            ->assertItemsLookLike(<<<'HTML'
+                - Foo
+                    - Bar
+                    - Baz
+                HTML
+            );
+    }
+
     protected function fromPage(string $mockedRoute): static
     {
         $this->mockCurrentPage($mockedRoute);
@@ -706,6 +726,28 @@ class RenderedMainNavigationMenu extends RenderedNavigationMenu
 class RenderedDocumentationSidebarMenu extends RenderedNavigationMenu
 {
     protected const TYPE = DocumentationSidebar::class;
+
+    public function assertHasGroups(): static
+    {
+        $this->assertHasElement('sidebar-group');
+        $this->assertHasElement('sidebar-group-items');
+        $this->assertHasElement('sidebar-group-heading');
+        $this->assertHasElement('sidebar-group-header');
+        $this->assertHasElement('sidebar-group-toggle');
+
+        return $this;
+    }
+
+    public function assertHasNoGroups(): static
+    {
+        $this->assertDoesNotHaveElement('sidebar-group');
+        $this->assertDoesNotHaveElement('sidebar-group-items');
+        $this->assertDoesNotHaveElement('sidebar-group-heading');
+        $this->assertDoesNotHaveElement('sidebar-group-header');
+        $this->assertDoesNotHaveElement('sidebar-group-toggle');
+
+        return $this;
+    }
 }
 
 class TestKernel extends HydeKernel

--- a/packages/framework/tests/Unit/Views/NavigationHtmlLayoutsTest.php
+++ b/packages/framework/tests/Unit/Views/NavigationHtmlLayoutsTest.php
@@ -117,10 +117,12 @@ class NavigationHtmlLayoutsTest extends TestCase
                 'docs/bar.html' => 'Bar',
                 'docs/baz.html' => 'Baz',
             ])
-            ->assertItemsLookLike(<<<'HTML'
+            ->assertLooksLike(<<<'HTML'
+                HydePHP Docs Toggle theme
                 Foo
                 Bar
                 Baz
+                Back to home page
                 HTML
             );
     }

--- a/packages/framework/tests/Unit/Views/NavigationHtmlLayoutsTest.php
+++ b/packages/framework/tests/Unit/Views/NavigationHtmlLayoutsTest.php
@@ -433,6 +433,16 @@ class NavigationHtmlLayoutsTest extends TestCase
             );
     }
 
+    public function testMenuHeader()
+    {
+        $this->menu()->assertHeaderIs('HydePHP');
+    }
+
+    public function testSidebarHeader()
+    {
+        $this->sidebar()->assertHeaderIs('HydePHP Docs');
+    }
+
     protected function fromPage(string $mockedRoute): static
     {
         $this->mockCurrentPage($mockedRoute);
@@ -620,6 +630,27 @@ abstract class RenderedNavigationMenu
     public function assertItemsLookLike(string $expected): static
     {
         return $this->assertLooksLike($expected, true);
+    }
+
+    public function assertHeaderIs(string $expected): static
+    {
+        if (static::TYPE === DocumentationSidebar::class) {
+            $elementId = 'sidebar-brand';
+            $nodeName = 'strong';
+        } else {
+            $elementId = 'main-navigation-brand';
+            $nodeName = 'a';
+        }
+
+        $this->assertHasElement($elementId);
+
+        $element = $this->ast->getElementById($elementId)->getElementsByTagName($nodeName)->item(0);
+
+        $this->test->assertNotNull($element, "No <$nodeName> element found in menu header");
+
+        $this->assertElementTextIs($element, $expected);
+
+        return $this;
     }
 
     #[NoReturn]

--- a/packages/framework/tests/Unit/Views/NavigationHtmlLayoutsTest.php
+++ b/packages/framework/tests/Unit/Views/NavigationHtmlLayoutsTest.php
@@ -494,6 +494,9 @@ abstract class RenderedNavigationMenu
 
         if ($skipHeaderRow) {
             $actual = trim(Str::after($actual, "\n"));
+            if (str_contains($actual, 'Backtohomepage')) {
+                $actual = trim(str_replace('Backtohomepage', '', $actual));
+            }
         }
         // If expected omitted dashes, remove them from actual
         if (! str_contains($expected, '- ')) {


### PR DESCRIPTION
Adds another test for https://github.com/hydephp/develop/pull/1568. This might be slightly overkill, but considering how important these features are, it's nice to have high level visual-style tests that can signal smoke before end-to-end testing kicks in (as that is painfully slow).