### PR TITLE
Designate HydePHP v1.x as LTS

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -6,7 +6,7 @@ These are the version ranges of HydePHP, and their support status. We follow [Se
 
 | Version | Supported          | Classification       |
 |---------|--------------------|----------------------|
-| 1.x     | :white_check_mark: | General Availability |
+| 1.x LTS | :white_check_mark: | General Availability |
 | < 0.64  | :x:                | Beta                 |
 | < 0.8   | :x:                | Alpha                |
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -7,8 +7,8 @@ These are the version ranges of HydePHP, and their support status. We follow [Se
 | Version | Supported          | Classification       |
 |---------|--------------------|----------------------|
 | 1.x     | :white_check_mark: | General Availability |
-| < 0.64  | :x:                | Beta (legacy)        |
-| < 0.8   | :x:                | Alpha stage          |
+| < 0.64  | :x:                | Beta                 |
+| < 0.8   | :x:                | Alpha                |
 
 
 ## Reporting a Vulnerability

--- a/packages/framework/SECURITY.md
+++ b/packages/framework/SECURITY.md
@@ -7,9 +7,8 @@ These are the version ranges of HydePHP, and their support status. We follow [Se
 | Version | Supported          | Classification       |
 |---------|--------------------|----------------------|
 | 1.x     | :white_check_mark: | General Availability |
-| < 0.64  | :x:                | Beta (legacy)        |
-| < 0.50  | :x:                | Beta (legacy)        |
-| < 0.8   | :x:                | Alpha stage          |
+| < 0.64  | :x:                | Beta                 |
+| < 0.8   | :x:                | Alpha                |
 
 
 ## Reporting a Vulnerability

--- a/packages/framework/SECURITY.md
+++ b/packages/framework/SECURITY.md
@@ -6,7 +6,7 @@ These are the version ranges of HydePHP, and their support status. We follow [Se
 
 | Version | Supported          | Classification       |
 |---------|--------------------|----------------------|
-| 1.x     | :white_check_mark: | General Availability |
+| 1.x LTS | :white_check_mark: | General Availability |
 | < 0.64  | :x:                | Beta                 |
 | < 0.8   | :x:                | Alpha                |
 

--- a/packages/hydefront/README.md
+++ b/packages/hydefront/README.md
@@ -42,6 +42,6 @@ Changes in HydeFront are tied to those in the Hyde Framework and differing versi
 
 | Hyde Version | Version | Supported          | Notes                   |
 |:-------------|---------|--------------------|-------------------------|
-| 1.x          | 3.x     | :white_check_mark: | Latest                  |
+| 1.x LTS      | 3.x     | :white_check_mark: | Latest                  |
 | 0.x Beta     | 2.x     | :x:                | Unsupported             |
 | 0.x Alpha    | 1.x     | :x:                | Unsupported             |

--- a/packages/realtime-compiler/README.md
+++ b/packages/realtime-compiler/README.md
@@ -14,7 +14,7 @@ The following table shows the supported versions of this package.
 
 | Hyde Version | Version | Supported          | Notes                   |
 |:-------------|---------|--------------------|-------------------------|
-| 1.x Release  | 3.x     | :white_check_mark: | Latest                  |
+| 1.x Release  | 3.x LTS | :white_check_mark: | Latest                  |
 | 0.x Beta     | 2.x     | :x:                | End of Life: 2023-12-31 |
 | 0.x Alpha    | 1.x     | :x:                | End of Life: 2023-03-01 |
 | 0.x Alpha    | < 1.0   | :x:                | Alpha                   |

--- a/packages/realtime-compiler/README.md
+++ b/packages/realtime-compiler/README.md
@@ -14,7 +14,7 @@ The following table shows the supported versions of this package.
 
 | Hyde Version | Version | Supported          | Notes                   |
 |:-------------|---------|--------------------|-------------------------|
-| 1.x Release  | 3.x LTS | :white_check_mark: | Latest                  |
+| 1.x LTS      | 3.x LTS | :white_check_mark: | Latest                  |
 | 0.x Beta     | 2.x     | :x:                | End of Life: 2023-12-31 |
 | 0.x Alpha    | 1.x     | :x:                | End of Life: 2023-03-01 |
 | 0.x Alpha    | < 1.0   | :x:                | Alpha                   |

--- a/packages/realtime-compiler/README.md
+++ b/packages/realtime-compiler/README.md
@@ -16,5 +16,5 @@ The following table shows the supported versions of this package.
 |:-------------|---------|--------------------|-------------------------|
 | 1.x Release  | 3.x     | :white_check_mark: | Latest                  |
 | 0.x Beta     | 2.x     | :x:                | End of Life: 2023-12-31 |
-| 0.x Alpha    | 1.x LTS | :x:                | End of Life: 2023-03-01 |
+| 0.x Alpha    | 1.x     | :x:                | End of Life: 2023-03-01 |
 | 0.x Alpha    | < 1.0   | :x:                | Alpha                   |


### PR DESCRIPTION
While HydePHP v2.x is still some time away, HydePHP v1.x should be supported for a long time, hence this PR officially gives it an LTS status.