### PR TITLE
[2.x] Expand abbreviated navigation item class names

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -12,15 +12,15 @@ This serves two purposes:
 ### Added
 - Added a new `\Hyde\Framework\Actions\PreBuildTasks\TransferMediaAssets` build task handle media assets transfers for site builds.
 - Added a new `ExternalRoute` class to represent external routes.
-- Added a new `NavItem::getLink()` method contain the previous `NavItem::getDestination()` logic, to return the link URL.
+- Added a new `NavigationItem::getLink()` method contain the previous `NavigationItem::getDestination()` logic, to return the link URL.
 
 ### Changed
 - Changed how the documentation search is generated, to be an `InMemoryPage` instead of a post-build task.
 - Media asset files are now copied using the new build task instead of the deprecated `BuildService::transferMediaAssets()` method.
 - Minor: The documentation article component now supports disabling the semantic rendering using a falsy value in https://github.com/hydephp/develop/pull/1566
 - Navigation menu items are now no longer filtered by duplicates (meaning two items with the same label can now exist in the same menu) in https://github.com/hydephp/develop/pull/1573
-- Breaking: The `NavItem` class now always stores the destination as a `Route` instance.
-- Breaking: The `NavItem::getDestination()` method now returns its `Route` instance.
+- Breaking: The `NavigationItem` class now always stores the destination as a `Route` instance.
+- Breaking: The `NavigationItem::getDestination()` method now returns its `Route` instance.
 
 ### Deprecated
 - for soon-to-be removed features.
@@ -63,11 +63,11 @@ For more information, see https://github.com/hydephp/develop/pull/1498.
 
 ### Navigation item changes
 
-The `NavItem::getDestination()` method now returns its `Route` instance. This allows for deferring the route evaluation.
+The `NavigationItem::getDestination()` method now returns its `Route` instance. This allows for deferring the route evaluation.
 
 If you have previously used this method directly and expected a string to be returned, you may need to adapt your code to handle the new return type.
 
-If you want to retain the previous state where a string is always returned, you can use the new `NavItem::getLink()` method instead, which will resolve the route immediately.
+If you want to retain the previous state where a string is always returned, you can use the new `NavigationItem::getLink()` method instead, which will resolve the route immediately.
 
 ### HTML ID changes
 

--- a/config/hyde.php
+++ b/config/hyde.php
@@ -350,7 +350,7 @@ return [
         // To get started quickly, you can uncomment the defaults here.
         // See the documentation link above for more information.
         'custom' => [
-            // NavItem::forLink('https://github.com/hydephp/hyde', 'GitHub', 200),
+            // NavigationItem::forLink('https://github.com/hydephp/hyde', 'GitHub', 200),
         ],
 
         // How should pages in subdirectories be displayed in the menu?

--- a/docs/digging-deeper/navigation.md
+++ b/docs/digging-deeper/navigation.md
@@ -230,18 +230,18 @@ To remove items from being automatically added, simply add the page's route key 
 
 ### Adding Custom Navigation Menu Links
 
-You can easily add custom navigation menu links similar to how we add Authors. Simply add a `NavItem` model to the `navigation.custom` array.
+You can easily add custom navigation menu links similar to how we add Authors. Simply add a `NavigationItem` model to the `navigation.custom` array.
 
-When linking to an external site, you should use the `NavItem::forLink()` method facade. The first two arguments are the
+When linking to an external site, you should use the `NavigationItem::forLink()` method facade. The first two arguments are the
 destination and label, both required. The third argument is the priority, which is optional, and defaults to `500`.
 
 ```php
 // filepath config/hyde.php
-use Hyde\Framework\Features\Navigation\NavItem;
+use Hyde\Framework\Features\Navigation\NavigationItem;
 
 'navigation' => [
     'custom' => [
-        NavItem::forLink('https://github.com/hydephp/hyde', 'GitHub', 200),
+        NavigationItem::forLink('https://github.com/hydephp/hyde', 'GitHub', 200),
     ]
 ]
 ```
@@ -314,14 +314,14 @@ use Hyde\Framework\Features\Navigation\BaseNavigationMenu;
 Within the `BaseNavigationMenu` class, you will find the main logic for how the menus are generated,
 while the child implementations contain the extra logic tailored for their specific use cases.
 
-All the navigation menus store the menu items in their `$items` array containing instances of the `NavItem` class.
+All the navigation menus store the menu items in their `$items` array containing instances of the `NavigationItem` class.
 
-The `NavItem` class is a simple class that contains the label and URL of the menu item and is used to represent each item in the menu.
-Dropdowns are represented by `DropdownNavItem` instances, which extend the `NavItem` class and contain an array of additional `NavItem` instances.
+The `NavigationItem` class is a simple class that contains the label and URL of the menu item and is used to represent each item in the menu.
+Dropdowns are represented by `DropdownNavigationItem` instances, which extend the `NavigationItem` class and contain an array of additional `NavigationItem` instances.
 
 ```php
-use Hyde\Framework\Features\Navigation\NavItem;
-use Hyde\Framework\Features\Navigation\DropdownNavItem;
+use Hyde\Framework\Features\Navigation\NavigationItem;
+use Hyde\Framework\Features\Navigation\DropdownNavigationItem;
 ```
 
 ## The Navigation API

--- a/packages/framework/config/hyde.php
+++ b/packages/framework/config/hyde.php
@@ -350,7 +350,7 @@ return [
         // To get started quickly, you can uncomment the defaults here.
         // See the documentation link above for more information.
         'custom' => [
-            // NavItem::forLink('https://github.com/hydephp/hyde', 'GitHub', 200),
+            // NavigationItem::forLink('https://github.com/hydephp/hyde', 'GitHub', 200),
         ],
 
         // How should pages in subdirectories be displayed in the menu?

--- a/packages/framework/resources/views/components/docs/sidebar-items.blade.php
+++ b/packages/framework/resources/views/components/docs/sidebar-items.blade.php
@@ -6,7 +6,7 @@
     </ul>
 @else
     <ul id="sidebar-items" role="list">
-        @php /** @var \Hyde\Framework\Features\Navigation\NavGroupItem $group */ @endphp
+        @php /** @var \Hyde\Framework\Features\Navigation\GroupedNavigationItem $group */ @endphp
         @foreach ($sidebar->getItems() as $group)
             <li class="sidebar-group" role="listitem" @if($sidebar->isCollapsible()) x-data="{ groupOpen: {{ $sidebar->isGroupActive($group->getGroupKey()) ? 'true' : 'false' }} }" @endif>
                 <header @class(['sidebar-group-header p-2 px-4 -ml-2 flex justify-between items-center', 'group hover:bg-black/10' => $sidebar->isCollapsible()]) @if($sidebar->isCollapsible()) @click="groupOpen = ! groupOpen" @endif>

--- a/packages/framework/resources/views/layouts/navigation.blade.php
+++ b/packages/framework/resources/views/layouts/navigation.blade.php
@@ -17,13 +17,15 @@
             <svg x-show="! navigationOpen" title="Open Navigation Menu" class="dark:fill-gray-200"
                  style="display: block;"
                  id="open-main-navigation-menu-icon" xmlns="http://www.w3.org/2000/svg" height="24" viewBox="0 0 24 24"
-                 width="24"><title>Open Menu</title>
+                 width="24">
+                <title>Open Menu</title>
                 <path d="M0 0h24v24H0z" fill="none"/>
                 <path d="M3 18h18v-2H3v2zm0-5h18v-2H3v2zm0-7v2h18V6H3z"/>
             </svg>
             <svg x-show="navigationOpen" title="Close Navigation Menu" class="dark:fill-gray-200" style="display: none;"
                  id="close-main-navigation-menu-icon" xmlns="http://www.w3.org/2000/svg" height="24" viewBox="0 0 24 24"
-                 width="24"><title>Close Menu</title>
+                 width="24">
+                <title>Close Menu</title>
                 <path d="M0 0h24v24H0z" fill="none"></path>
                 <path d="M19 6.41L17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12z"></path>
             </svg>

--- a/packages/framework/resources/views/layouts/navigation.blade.php
+++ b/packages/framework/resources/views/layouts/navigation.blade.php
@@ -37,7 +37,7 @@
         <ul aria-label="Navigation links" class="md:flex-grow md:flex justify-end">
             @foreach ($navigation->getItems() as $item)
                 <li class="md:mx-2">
-                    @if($item instanceof \Hyde\Framework\Features\Navigation\NavGroupItem)
+                    @if($item instanceof \Hyde\Framework\Features\Navigation\GroupedNavigationItem)
                         <x-hyde::navigation.dropdown :label="$item->getLabel()" :items="$item->getItems()"/>
                     @else
                         <x-hyde::navigation.navigation-link :item="$item"/>

--- a/packages/framework/src/Framework/Features/Navigation/DocumentationSidebar.php
+++ b/packages/framework/src/Framework/Features/Navigation/DocumentationSidebar.php
@@ -56,7 +56,7 @@ class DocumentationSidebar extends NavigationMenu
 
     public function hasGroups(): bool
     {
-        return $this->getItems()->contains(fn (NavItem $item): bool => $item instanceof NavGroupItem);
+        return $this->getItems()->contains(fn (NavigationItem $item): bool => $item instanceof NavGroupItem);
     }
 
     /**
@@ -66,11 +66,11 @@ class DocumentationSidebar extends NavigationMenu
      *
      * For index pages, this will also return true for the first group in the menu, unless the index page has a specific group set.
      *
-     * We have this logic here because not all NavItem instances belong to sidebars, and we need data from both.
+     * We have this logic here because not all NavigationItem instances belong to sidebars, and we need data from both.
      */
     public function isGroupActive(string $group): bool
     {
-        $groupMatchesCurrentPageGroup = NavItem::normalizeGroupKey(Render::getPage()->navigationMenuGroup()) === $group;
+        $groupMatchesCurrentPageGroup = NavigationItem::normalizeGroupKey(Render::getPage()->navigationMenuGroup()) === $group;
 
         if ($this->isCurrentPageIndexPage()) {
             return $this->shouldIndexPageBeActive($group) || $groupMatchesCurrentPageGroup;

--- a/packages/framework/src/Framework/Features/Navigation/DocumentationSidebar.php
+++ b/packages/framework/src/Framework/Features/Navigation/DocumentationSidebar.php
@@ -56,7 +56,7 @@ class DocumentationSidebar extends NavigationMenu
 
     public function hasGroups(): bool
     {
-        return $this->getItems()->contains(fn (NavigationItem $item): bool => $item instanceof NavGroupItem);
+        return $this->getItems()->contains(fn (NavigationItem $item): bool => $item instanceof GroupedNavigationItem);
     }
 
     /**

--- a/packages/framework/src/Framework/Features/Navigation/GroupedNavigationItem.php
+++ b/packages/framework/src/Framework/Features/Navigation/GroupedNavigationItem.php
@@ -15,7 +15,7 @@ use function collect;
  *
  * @todo Consider extracting trait for shared code with navigation menu class
  */
-class NavGroupItem extends NavigationItem
+class GroupedNavigationItem extends NavigationItem
 {
     /** @var array<\Hyde\Framework\Features\Navigation\NavigationItem> */
     protected array $items = [];

--- a/packages/framework/src/Framework/Features/Navigation/NavGroupItem.php
+++ b/packages/framework/src/Framework/Features/Navigation/NavGroupItem.php
@@ -15,9 +15,9 @@ use function collect;
  *
  * @todo Consider extracting trait for shared code with navigation menu class
  */
-class NavGroupItem extends NavItem
+class NavGroupItem extends NavigationItem
 {
-    /** @var array<\Hyde\Framework\Features\Navigation\NavItem> */
+    /** @var array<\Hyde\Framework\Features\Navigation\NavigationItem> */
     protected array $items = [];
 
     public function __construct(string $label, array $items = [], int $priority = NavigationMenu::LAST)
@@ -32,7 +32,7 @@ class NavGroupItem extends NavItem
      *
      * For the main navigation menu, this stores any dropdown items.
      *
-     * @return array<\Hyde\Framework\Features\Navigation\NavItem>
+     * @return array<\Hyde\Framework\Features\Navigation\NavigationItem>
      */
     public function getItems(): array
     {
@@ -42,7 +42,7 @@ class NavGroupItem extends NavItem
     /**
      * Add a navigation item to the grouped navigation item.
      */
-    public function addItem(NavItem $item): static
+    public function addItem(NavigationItem $item): static
     {
         $item->group ??= $this->group;
 
@@ -54,7 +54,7 @@ class NavGroupItem extends NavItem
     /**
      * Add multiple navigation items to the grouped navigation item.
      *
-     * @param  array<\Hyde\Framework\Features\Navigation\NavItem>  $items
+     * @param  array<\Hyde\Framework\Features\Navigation\NavigationItem>  $items
      */
     public function addItems(array $items): static
     {
@@ -73,7 +73,7 @@ class NavGroupItem extends NavItem
     public function getPriority(): int
     {
         if ($this->containsOnlyDocumentationPages()) {
-            return min($this->priority, collect($this->getItems())->min(fn (NavItem $child): int => $child->getPriority()));
+            return min($this->priority, collect($this->getItems())->min(fn (NavigationItem $child): int => $child->getPriority()));
         }
 
         return parent::getPriority();
@@ -85,7 +85,7 @@ class NavGroupItem extends NavItem
             return false;
         }
 
-        return collect($this->getItems())->every(function (NavItem $child): bool {
+        return collect($this->getItems())->every(function (NavigationItem $child): bool {
             return (! $child->getRoute() instanceof ExternalRoute) && $child->getRoute()->getPage() instanceof DocumentationPage;
         });
     }

--- a/packages/framework/src/Framework/Features/Navigation/NavigationItem.php
+++ b/packages/framework/src/Framework/Features/Navigation/NavigationItem.php
@@ -86,9 +86,9 @@ class NavigationItem implements Stringable
      * @param  array<NavigationItem>  $items  The items to be included in the dropdown.
      * @param  int  $priority  The priority of the dropdown item. Leave blank to use the default priority, which is last in the menu.
      */
-    public static function forGroup(string $label, array $items, int $priority = NavigationMenu::LAST): NavGroupItem
+    public static function forGroup(string $label, array $items, int $priority = NavigationMenu::LAST): GroupedNavigationItem
     {
-        return new NavGroupItem($label, $items, $priority);
+        return new GroupedNavigationItem($label, $items, $priority);
     }
 
     /**

--- a/packages/framework/src/Framework/Features/Navigation/NavigationItem.php
+++ b/packages/framework/src/Framework/Features/Navigation/NavigationItem.php
@@ -18,10 +18,10 @@ use function is_string;
  *
  * You have a few options to construct a navigation menu item:
  *   1. You can supply a Route directly and explicit properties to the constructor
- *   2. You can use NavItem::fromRoute() to use data from the route
- *   3. You can use NavItem::forLink() for an external or un-routed link
+ *   2. You can use NavigationItem::fromRoute() to use data from the route
+ *   3. You can use NavigationItem::forLink() for an external or un-routed link
  */
-class NavItem implements Stringable
+class NavigationItem implements Stringable
 {
     protected ?Route $route;
     protected string $label;
@@ -83,7 +83,7 @@ class NavItem implements Stringable
      * Create a new dropdown navigation menu item.
      *
      * @param  string  $label  The label of the dropdown item.
-     * @param  array<NavItem>  $items  The items to be included in the dropdown.
+     * @param  array<NavigationItem>  $items  The items to be included in the dropdown.
      * @param  int  $priority  The priority of the dropdown item. Leave blank to use the default priority, which is last in the menu.
      */
     public static function forGroup(string $label, array $items, int $priority = NavigationMenu::LAST): NavGroupItem
@@ -145,7 +145,7 @@ class NavItem implements Stringable
     }
 
     /**
-     * Check if the NavItem instance is the current page being rendered.
+     * Check if the NavigationItem instance is the current page being rendered.
      */
     public function isActive(): bool
     {

--- a/packages/framework/src/Framework/Features/Navigation/NavigationMenu.php
+++ b/packages/framework/src/Framework/Features/Navigation/NavigationMenu.php
@@ -20,7 +20,7 @@ abstract class NavigationMenu
     public const DEFAULT = 500;
     public const LAST = 999;
 
-    /** @var \Illuminate\Support\Collection<\Hyde\Framework\Features\Navigation\NavItem> */
+    /** @var \Illuminate\Support\Collection<\Hyde\Framework\Features\Navigation\NavigationItem> */
     protected Collection $items;
 
     public function __construct(Arrayable|array $items = [])
@@ -41,7 +41,7 @@ abstract class NavigationMenu
      *
      * Items are automatically sorted by their priority, falling back to the order they were added.
      *
-     * @return \Illuminate\Support\Collection<\Hyde\Framework\Features\Navigation\NavItem>
+     * @return \Illuminate\Support\Collection<\Hyde\Framework\Features\Navigation\NavigationItem>
      */
     public function getItems(): Collection
     {
@@ -49,13 +49,13 @@ abstract class NavigationMenu
         // so any sorting we do in generator actions will only be partial. This way, we can ensure
         // that the items are always freshly sorted by their priorities when they are retrieved.
 
-        return $this->items->sortBy(fn (NavItem $item) => $item->getPriority())->values();
+        return $this->items->sortBy(fn (NavigationItem $item) => $item->getPriority())->values();
     }
 
     /**
      * Add a navigation item to the navigation menu.
      */
-    public function add(NavItem $item): void
+    public function add(NavigationItem $item): void
     {
         $this->items->push($item);
     }

--- a/packages/framework/src/Framework/Features/Navigation/NavigationMenuGenerator.php
+++ b/packages/framework/src/Framework/Features/Navigation/NavigationMenuGenerator.php
@@ -24,7 +24,7 @@ use function strtolower;
  */
 class NavigationMenuGenerator
 {
-    /** @var \Illuminate\Support\Collection<string, \Hyde\Framework\Features\Navigation\NavItem> */
+    /** @var \Illuminate\Support\Collection<string, \Hyde\Framework\Features\Navigation\NavigationItem> */
     protected Collection $items;
 
     /** @var \Hyde\Foundation\Kernel\RouteCollection<string, \Hyde\Support\Models\Route> */
@@ -71,7 +71,7 @@ class NavigationMenuGenerator
                 if ($this->canGroupRoute($route)) {
                     $this->addRouteToGroup($route);
                 } else {
-                    $this->items->put($route->getRouteKey(), NavItem::forRoute($route));
+                    $this->items->put($route->getRouteKey(), NavigationItem::forRoute($route));
                 }
             }
         });
@@ -79,10 +79,10 @@ class NavigationMenuGenerator
         if ($this->generatesSidebar) {
             // If there are no pages other than the index page, we add it to the sidebar so that it's not empty
             if ($this->items->count() === 0 && DocumentationPage::home() !== null) {
-                $this->items->push(NavItem::forRoute(DocumentationPage::home()));
+                $this->items->push(NavigationItem::forRoute(DocumentationPage::home()));
             }
         } else {
-            collect(Config::getArray('hyde.navigation.custom', []))->each(function (NavItem $item): void {
+            collect(Config::getArray('hyde.navigation.custom', []))->each(function (NavigationItem $item): void {
                 // Since these were added explicitly by the user, we can assume they should always be shown
                 $this->items->push($item);
             });
@@ -133,7 +133,7 @@ class NavigationMenuGenerator
 
     protected function addRouteToGroup(Route $route): void
     {
-        $item = NavItem::forRoute($route);
+        $item = NavigationItem::forRoute($route);
 
         $groupName = $this->generatesSidebar ? ($item->getGroupKey() ?? 'Other') : $item->getGroupKey();
 
@@ -153,7 +153,7 @@ class NavigationMenuGenerator
 
         if ($group instanceof NavGroupItem) {
             return $group;
-        } elseif ($group instanceof NavItem) {
+        } elseif ($group instanceof NavigationItem) {
             // We are trying to add children to an existing navigation menu item,
             // so here we create a new instance to replace the base one, this
             // does mean we lose the destination as we can't link to them.
@@ -177,7 +177,7 @@ class NavigationMenuGenerator
 
         $priority = $this->searchForGroupPriorityInConfig($groupKey);
 
-        return NavItem::forGroup($this->normalizeGroupLabel($label), [], $priority ?? NavigationMenu::LAST);
+        return NavigationItem::forGroup($this->normalizeGroupLabel($label), [], $priority ?? NavigationMenu::LAST);
     }
 
     protected function normalizeGroupLabel(string $label): string

--- a/packages/framework/src/Framework/Features/Navigation/NavigationMenuGenerator.php
+++ b/packages/framework/src/Framework/Features/Navigation/NavigationMenuGenerator.php
@@ -146,12 +146,12 @@ class NavigationMenuGenerator
         }
     }
 
-    protected function getOrCreateGroupItem(string $groupName): NavGroupItem
+    protected function getOrCreateGroupItem(string $groupName): GroupedNavigationItem
     {
         $groupKey = Str::slug($groupName);
         $group = $this->items->get($groupKey);
 
-        if ($group instanceof NavGroupItem) {
+        if ($group instanceof GroupedNavigationItem) {
             return $group;
         } elseif ($group instanceof NavigationItem) {
             // We are trying to add children to an existing navigation menu item,
@@ -161,7 +161,7 @@ class NavigationMenuGenerator
             // Todo: Add note in documentation about this behavior
             // Example file structure: _pages/foo.md, _pages/foo/bar.md, _pages/foo/baz.md, here the link to foo will be lost.
 
-            $item = new NavGroupItem($group->getLabel(), [], $group->getPriority());
+            $item = new GroupedNavigationItem($group->getLabel(), [], $group->getPriority());
 
             $this->items->put($groupKey, $item);
 
@@ -171,7 +171,7 @@ class NavigationMenuGenerator
         return $this->createGroupItem($groupKey, $groupName);
     }
 
-    protected function createGroupItem(string $groupKey, string $groupName): NavGroupItem
+    protected function createGroupItem(string $groupKey, string $groupName): GroupedNavigationItem
     {
         $label = $this->searchForGroupLabelInConfig($groupKey) ?? $groupName;
 

--- a/packages/framework/tests/Feature/AutomaticNavigationConfigurationsTest.php
+++ b/packages/framework/tests/Feature/AutomaticNavigationConfigurationsTest.php
@@ -17,7 +17,7 @@ use Hyde\Pages\DocumentationPage;
 use Hyde\Support\Models\Redirect;
 use Illuminate\Support\Collection;
 use Hyde\Foundation\Kernel\RouteCollection;
-use Hyde\Framework\Features\Navigation\NavItem;
+use Hyde\Framework\Features\Navigation\NavigationItem;
 use Hyde\Framework\Features\Navigation\NavGroupItem;
 use Hyde\Framework\Features\Navigation\MainNavigationMenu;
 use Hyde\Framework\Features\Navigation\DocumentationSidebar;
@@ -33,7 +33,7 @@ use Hyde\Framework\Features\Navigation\NavigationMenuGenerator;
  * @covers \Hyde\Framework\Features\Navigation\DocumentationSidebar
  * @covers \Hyde\Framework\Features\Navigation\MainNavigationMenu
  * @covers \Hyde\Framework\Features\Navigation\NavigationMenu
- * @covers \Hyde\Framework\Features\Navigation\NavItem
+ * @covers \Hyde\Framework\Features\Navigation\NavigationItem
  */
 class AutomaticNavigationConfigurationsTest extends TestCase
 {
@@ -1281,7 +1281,7 @@ class AutomaticNavigationConfigurationsTest extends TestCase
     }
 }
 
-class TestNavItem
+class TestNavigationItem
 {
     public readonly string $label;
     public readonly ?string $group;
@@ -1293,7 +1293,7 @@ class TestNavItem
         $this->label = $label;
         $this->group = $group;
         $this->priority = $priority;
-        $this->children = collect($children)->map(fn (NavItem $child) => $child->getLabel())->toArray();
+        $this->children = collect($children)->map(fn (NavigationItem $child) => $child->getLabel())->toArray();
     }
 
     public static function properties(): array
@@ -1319,12 +1319,12 @@ class AssertableNavigationMenu
     /** A simplified serialized format for comparisons */
     public function state(): array
     {
-        return $this->items->map(function (NavItem $item): TestNavItem {
-            return new TestNavItem($item->getLabel(), $item->getGroupKey(), $item->getPriority(), $item instanceof NavGroupItem ? $item->getItems() : []);
+        return $this->items->map(function (NavigationItem $item): TestNavigationItem {
+            return new TestNavigationItem($item->getLabel(), $item->getGroupKey(), $item->getPriority(), $item instanceof NavGroupItem ? $item->getItems() : []);
         })->toArray();
     }
 
-    public function getState(int $index): ?TestNavItem
+    public function getState(int $index): ?TestNavigationItem
     {
         return $this->state()[$index] ?? null;
     }
@@ -1345,7 +1345,7 @@ class AssertableNavigationMenu
                 $item = ['label' => $item];
             }
 
-            foreach (TestNavItem::properties() as $property) {
+            foreach (TestNavigationItem::properties() as $property) {
                 if ($this->getState($index) !== null) {
                     if (isset($item[$property])) {
                         $a = $item[$property];

--- a/packages/framework/tests/Feature/AutomaticNavigationConfigurationsTest.php
+++ b/packages/framework/tests/Feature/AutomaticNavigationConfigurationsTest.php
@@ -18,7 +18,7 @@ use Hyde\Support\Models\Redirect;
 use Illuminate\Support\Collection;
 use Hyde\Foundation\Kernel\RouteCollection;
 use Hyde\Framework\Features\Navigation\NavigationItem;
-use Hyde\Framework\Features\Navigation\NavGroupItem;
+use Hyde\Framework\Features\Navigation\GroupedNavigationItem;
 use Hyde\Framework\Features\Navigation\MainNavigationMenu;
 use Hyde\Framework\Features\Navigation\DocumentationSidebar;
 use Hyde\Framework\Features\Navigation\NavigationMenuGenerator;
@@ -1320,7 +1320,7 @@ class AssertableNavigationMenu
     public function state(): array
     {
         return $this->items->map(function (NavigationItem $item): TestNavigationItem {
-            return new TestNavigationItem($item->getLabel(), $item->getGroupKey(), $item->getPriority(), $item instanceof NavGroupItem ? $item->getItems() : []);
+            return new TestNavigationItem($item->getLabel(), $item->getGroupKey(), $item->getPriority(), $item instanceof GroupedNavigationItem ? $item->getItems() : []);
         })->toArray();
     }
 

--- a/packages/framework/tests/Feature/NavigationMenuTest.php
+++ b/packages/framework/tests/Feature/NavigationMenuTest.php
@@ -9,7 +9,7 @@ use Hyde\Support\Models\Route;
 use Hyde\Foundation\Facades\Routes;
 use Hyde\Support\Models\ExternalRoute;
 use Hyde\Framework\Features\Navigation\MainNavigationMenu;
-use Hyde\Framework\Features\Navigation\NavItem;
+use Hyde\Framework\Features\Navigation\NavigationItem;
 use Hyde\Pages\MarkdownPage;
 use Hyde\Testing\TestCase;
 use Illuminate\Support\Collection;
@@ -29,16 +29,16 @@ class NavigationMenuTest extends TestCase
         $this->assertInstanceOf(MainNavigationMenu::class, $this->createNavigationMenu());
     }
 
-    public function testGenerateMethodCreatesCollectionOfNavItems()
+    public function testGenerateMethodCreatesCollectionOfNavigationItems()
     {
         $this->assertInstanceOf(Collection::class, $this->createNavigationMenu()->getItems());
-        $this->assertContainsOnlyInstancesOf(NavItem::class, $this->createNavigationMenu()->getItems());
+        $this->assertContainsOnlyInstancesOf(NavigationItem::class, $this->createNavigationMenu()->getItems());
     }
 
     public function testGetItemsReturnsItems()
     {
         $this->assertEquals(collect([
-            NavItem::forRoute(Routes::get('index')),
+            NavigationItem::forRoute(Routes::get('index')),
         ]), $this->createNavigationMenu()->getItems());
     }
 
@@ -67,9 +67,9 @@ class NavigationMenuTest extends TestCase
         $menu = $this->createNavigationMenu();
 
         $expected = collect([
-            NavItem::forRoute(Routes::get('index')),
-            NavItem::forRoute(Routes::get('foo')),
-            NavItem::forRoute(Routes::get('docs/index')),
+            NavigationItem::forRoute(Routes::get('index')),
+            NavigationItem::forRoute(Routes::get('foo')),
+            NavigationItem::forRoute(Routes::get('docs/index')),
         ]);
 
         $this->assertCount(count($expected), $menu->getItems());
@@ -83,8 +83,8 @@ class NavigationMenuTest extends TestCase
         $menu = $this->createNavigationMenu();
 
         $expected = collect([
-            NavItem::forRoute(Routes::get('index')),
-            NavItem::forRoute(Routes::get('foo')),
+            NavigationItem::forRoute(Routes::get('index')),
+            NavigationItem::forRoute(Routes::get('foo')),
         ]);
 
         $this->assertCount(count($expected), $menu->getItems());
@@ -93,13 +93,13 @@ class NavigationMenuTest extends TestCase
 
     public function testExternalLinkCanBeAddedInConfig()
     {
-        config(['hyde.navigation.custom' => [NavItem::forLink('https://example.com', 'foo')]]);
+        config(['hyde.navigation.custom' => [NavigationItem::forLink('https://example.com', 'foo')]]);
 
         $menu = $this->createNavigationMenu();
 
         $expected = collect([
-            NavItem::forRoute(Routes::get('index')),
-            NavItem::forLink('https://example.com', 'foo'),
+            NavigationItem::forRoute(Routes::get('index')),
+            NavigationItem::forLink('https://example.com', 'foo'),
         ]);
 
         $this->assertCount(count($expected), $menu->getItems());
@@ -108,13 +108,13 @@ class NavigationMenuTest extends TestCase
 
     public function testPathLinkCanBeAddedInConfig()
     {
-        config(['hyde.navigation.custom' => [NavItem::forLink('foo', 'foo')]]);
+        config(['hyde.navigation.custom' => [NavigationItem::forLink('foo', 'foo')]]);
 
         $menu = $this->createNavigationMenu();
 
         $expected = collect([
-            NavItem::forRoute(Routes::get('index')),
-            NavItem::forLink('foo', 'foo'),
+            NavigationItem::forRoute(Routes::get('index')),
+            NavigationItem::forLink('foo', 'foo'),
         ]);
 
         $this->assertCount(count($expected), $menu->getItems());
@@ -124,16 +124,16 @@ class NavigationMenuTest extends TestCase
     public function testDuplicatesAreNotRemovedWhenAddingInConfig()
     {
         config(['hyde.navigation.custom' => [
-            NavItem::forLink('foo', 'foo'),
-            NavItem::forLink('foo', 'foo'),
+            NavigationItem::forLink('foo', 'foo'),
+            NavigationItem::forLink('foo', 'foo'),
         ]]);
 
         $menu = $this->createNavigationMenu();
 
         $expected = collect([
-            NavItem::forRoute(Routes::get('index')),
-            NavItem::forLink('foo', 'foo'),
-            NavItem::forLink('foo', 'foo'),
+            NavigationItem::forRoute(Routes::get('index')),
+            NavigationItem::forLink('foo', 'foo'),
+            NavigationItem::forLink('foo', 'foo'),
         ]);
 
         $this->assertCount(count($expected), $menu->getItems());
@@ -143,16 +143,16 @@ class NavigationMenuTest extends TestCase
     public function testDuplicatesAreNotRemovedWhenAddingInConfigRegardlessOfDestination()
     {
         config(['hyde.navigation.custom' => [
-            NavItem::forLink('foo', 'foo'),
-            NavItem::forLink('bar', 'foo'),
+            NavigationItem::forLink('foo', 'foo'),
+            NavigationItem::forLink('bar', 'foo'),
         ]]);
 
         $menu = $this->createNavigationMenu();
 
         $expected = collect([
-            NavItem::forRoute(Routes::get('index')),
-            NavItem::forLink('foo', 'foo'),
-            NavItem::forLink('bar', 'foo'),
+            NavigationItem::forRoute(Routes::get('index')),
+            NavigationItem::forLink('foo', 'foo'),
+            NavigationItem::forLink('bar', 'foo'),
         ]);
 
         $this->assertCount(count($expected), $menu->getItems());
@@ -163,14 +163,14 @@ class NavigationMenuTest extends TestCase
     {
         $this->file('_pages/foo.md');
 
-        config(['hyde.navigation.custom' => [NavItem::forLink('bar', 'Foo')]]);
+        config(['hyde.navigation.custom' => [NavigationItem::forLink('bar', 'Foo')]]);
 
         $menu = $this->createNavigationMenu();
 
         $expected = collect([
-            NavItem::forRoute(Routes::get('index')),
-            NavItem::forLink('bar', 'Foo'),
-            NavItem::forRoute(Routes::get('foo')),
+            NavigationItem::forRoute(Routes::get('index')),
+            NavigationItem::forLink('bar', 'Foo'),
+            NavigationItem::forRoute(Routes::get('foo')),
         ]);
 
         $this->assertCount(count($expected), $menu->getItems());
@@ -185,8 +185,8 @@ class NavigationMenuTest extends TestCase
         $menu = $this->createNavigationMenu();
 
         $expected = collect([
-            NavItem::forRoute(Routes::get('index')),
-            NavItem::forRoute(Routes::get('docs/index')),
+            NavigationItem::forRoute(Routes::get('index')),
+            NavigationItem::forRoute(Routes::get('docs/index')),
         ]);
 
         $this->assertCount(count($expected), $menu->getItems());
@@ -199,7 +199,7 @@ class NavigationMenuTest extends TestCase
         $this->file('_pages/foo/bar.md');
 
         $menu = $this->createNavigationMenu();
-        $expected = collect([NavItem::forRoute(Routes::get('index'))]);
+        $expected = collect([NavigationItem::forRoute(Routes::get('index'))]);
 
         $this->assertCount(count($expected), $menu->getItems());
         $this->assertEquals($expected, $menu->getItems());
@@ -213,8 +213,8 @@ class NavigationMenuTest extends TestCase
 
         $menu = $this->createNavigationMenu();
         $expected = collect([
-            NavItem::forRoute(Routes::get('index')),
-            NavItem::forRoute(Routes::get('foo/bar')),
+            NavigationItem::forRoute(Routes::get('index')),
+            NavigationItem::forRoute(Routes::get('foo/bar')),
         ]);
 
         $this->assertCount(count($expected), $menu->getItems());
@@ -229,9 +229,9 @@ class NavigationMenuTest extends TestCase
 
         $menu = $this->createNavigationMenu();
         $expected = collect([
-            NavItem::forRoute(Routes::get('index')),
-            NavItem::forGroup('Foo', [
-                NavItem::forRoute(Routes::get('foo/bar')),
+            NavigationItem::forRoute(Routes::get('index')),
+            NavigationItem::forGroup('Foo', [
+                NavigationItem::forRoute(Routes::get('foo/bar')),
             ]),
         ]);
 
@@ -249,10 +249,10 @@ class NavigationMenuTest extends TestCase
 
         $this->assertCount(3, $menu->getItems());
         $this->assertEquals([
-            NavItem::forRoute(Routes::get('index')),
-            NavItem::forRoute((new MarkdownPage('foo'))->getRoute()),
-            NavItem::forGroup('Bar', [
-                NavItem::forRoute((new MarkdownPage('bar/baz'))->getRoute()),
+            NavigationItem::forRoute(Routes::get('index')),
+            NavigationItem::forRoute((new MarkdownPage('foo'))->getRoute()),
+            NavigationItem::forGroup('Bar', [
+                NavigationItem::forRoute((new MarkdownPage('bar/baz'))->getRoute()),
             ]),
         ], $menu->getItems()->all());
     }
@@ -267,7 +267,7 @@ class NavigationMenuTest extends TestCase
         Hyde::boot();
 
         $navigation = app('navigation.main');
-        $navigation->add(new NavItem(new ExternalRoute('/foo'), 'Foo'));
+        $navigation->add(new NavigationItem(new ExternalRoute('/foo'), 'Foo'));
 
         $this->assertCount(2, $navigation->getItems());
         $this->assertSame('Foo', $navigation->getItems()->last()->getLabel());

--- a/packages/framework/tests/Feature/Services/DocumentationSidebarTest.php
+++ b/packages/framework/tests/Feature/Services/DocumentationSidebarTest.php
@@ -8,7 +8,7 @@ use Hyde\Facades\Filesystem;
 use Hyde\Foundation\Facades\Routes;
 use Hyde\Framework\Actions\ConvertsArrayToFrontMatter;
 use Hyde\Framework\Features\Navigation\DocumentationSidebar;
-use Hyde\Framework\Features\Navigation\NavItem;
+use Hyde\Framework\Features\Navigation\NavigationItem;
 use Hyde\Hyde;
 use Hyde\Pages\DocumentationPage;
 use Hyde\Support\Facades\Render;
@@ -23,7 +23,7 @@ use Hyde\Framework\Features\Navigation\NavigationMenuGenerator;
  * @covers \Hyde\Framework\Features\Navigation\NavigationMenu
  * @covers \Hyde\Framework\Factories\Concerns\HasFactory
  * @covers \Hyde\Framework\Factories\NavigationDataFactory
- * @covers \Hyde\Framework\Features\Navigation\NavItem
+ * @covers \Hyde\Framework\Features\Navigation\NavigationItem
  *
  * @see \Hyde\Framework\Testing\Unit\DocumentationSidebarUnitTest
  */
@@ -86,9 +86,9 @@ class DocumentationSidebarTest extends TestCase
 
         $this->assertEquals(
             collect([
-                NavItem::forRoute(Routes::get('docs/a'), priority: 999),
-                NavItem::forRoute(Routes::get('docs/b'), priority: 999),
-                NavItem::forRoute(Routes::get('docs/c'), priority: 999),
+                NavigationItem::forRoute(Routes::get('docs/a'), priority: 999),
+                NavigationItem::forRoute(Routes::get('docs/b'), priority: 999),
+                NavigationItem::forRoute(Routes::get('docs/c'), priority: 999),
             ]),
             NavigationMenuGenerator::handle(DocumentationSidebar::class)->getItems()
         );
@@ -107,9 +107,9 @@ class DocumentationSidebarTest extends TestCase
 
         $this->assertEquals(
             collect([
-                NavItem::forRoute(Routes::get('docs/c'), priority: 250 + 250),
-                NavItem::forRoute(Routes::get('docs/b'), priority: 250 + 251),
-                NavItem::forRoute(Routes::get('docs/a'), priority: 250 + 252),
+                NavigationItem::forRoute(Routes::get('docs/c'), priority: 250 + 250),
+                NavigationItem::forRoute(Routes::get('docs/b'), priority: 250 + 251),
+                NavigationItem::forRoute(Routes::get('docs/a'), priority: 250 + 252),
             ]),
             NavigationMenuGenerator::handle(DocumentationSidebar::class)->getItems()
         );
@@ -146,9 +146,9 @@ class DocumentationSidebarTest extends TestCase
 
         $this->assertEquals(
             collect([
-                NavItem::forRoute(Routes::get('docs/first'), priority: 250 + 250),
-                NavItem::forRoute(Routes::get('docs/second'), priority: 250 + 252),
-                NavItem::forRoute(Routes::get('docs/third'), priority: 250 + 300),
+                NavigationItem::forRoute(Routes::get('docs/first'), priority: 250 + 250),
+                NavigationItem::forRoute(Routes::get('docs/second'), priority: 250 + 252),
+                NavigationItem::forRoute(Routes::get('docs/third'), priority: 250 + 300),
             ]),
             NavigationMenuGenerator::handle(DocumentationSidebar::class)->getItems()
         );
@@ -195,7 +195,7 @@ class DocumentationSidebarTest extends TestCase
         Filesystem::touch('_docs/index.md');
 
         $this->assertEquals(
-            collect([NavItem::forRoute(Routes::get('docs/foo'), priority: 999)]),
+            collect([NavigationItem::forRoute(Routes::get('docs/foo'), priority: 999)]),
             NavigationMenuGenerator::handle(DocumentationSidebar::class)->getItems()
         );
     }
@@ -267,11 +267,11 @@ class DocumentationSidebarTest extends TestCase
 
         $this->assertEquals(
             collect([
-                NavItem::forGroup('Bar', [
-                    NavItem::forRoute(Routes::get('docs/bar'), priority: 999),
+                NavigationItem::forGroup('Bar', [
+                    NavigationItem::forRoute(Routes::get('docs/bar'), priority: 999),
                 ]),
-                NavItem::forGroup('Foo', [
-                    NavItem::forRoute(Routes::get('docs/foo'), priority: 999),
+                NavigationItem::forGroup('Foo', [
+                    NavigationItem::forRoute(Routes::get('docs/foo'), priority: 999),
                 ]),
             ]),
             $sidebar->getItems()
@@ -288,9 +288,9 @@ class DocumentationSidebarTest extends TestCase
 
         $this->assertEquals(
             collect([
-                NavItem::forGroup('Foo', [
-                    NavItem::forRoute(Routes::get('docs/bar'), priority: 999),
-                    NavItem::forRoute(Routes::get('docs/foo'), priority: 999),
+                NavigationItem::forGroup('Foo', [
+                    NavigationItem::forRoute(Routes::get('docs/bar'), priority: 999),
+                    NavigationItem::forRoute(Routes::get('docs/foo'), priority: 999),
                 ]),
             ]),
             $sidebar->getItems()
@@ -312,7 +312,7 @@ class DocumentationSidebarTest extends TestCase
 
         $this->assertCount(1, $sidebar->getItems());
         $this->assertEquals(
-            collect([NavItem::forRoute(Routes::get('docs/index'))]),
+            collect([NavigationItem::forRoute(Routes::get('docs/index'))]),
             $sidebar->getItems()
         );
     }
@@ -325,7 +325,7 @@ class DocumentationSidebarTest extends TestCase
 
         $this->assertCount(1, $sidebar->getItems());
         $this->assertEquals(
-            collect([NavItem::forRoute(Routes::get('docs/test-0'))]),
+            collect([NavigationItem::forRoute(Routes::get('docs/test-0'))]),
             $sidebar->getItems()
         );
     }

--- a/packages/framework/tests/Unit/DocumentationSidebarUnitTest.php
+++ b/packages/framework/tests/Unit/DocumentationSidebarUnitTest.php
@@ -7,7 +7,7 @@ namespace Hyde\Framework\Testing\Unit;
 use Hyde\Testing\UnitTestCase;
 use Illuminate\Support\Collection;
 use Hyde\Support\Models\ExternalRoute;
-use Hyde\Framework\Features\Navigation\NavItem;
+use Hyde\Framework\Features\Navigation\NavigationItem;
 use Hyde\Framework\Features\Navigation\NavGroupItem;
 use Hyde\Framework\Features\Navigation\DocumentationSidebar;
 
@@ -225,8 +225,8 @@ class DocumentationSidebarUnitTest extends UnitTestCase
         ];
     }
 
-    protected function item(string $destination, string $label, int $priority = 500): NavItem
+    protected function item(string $destination, string $label, int $priority = 500): NavigationItem
     {
-        return new NavItem(new ExternalRoute($destination), $label, $priority);
+        return new NavigationItem(new ExternalRoute($destination), $label, $priority);
     }
 }

--- a/packages/framework/tests/Unit/DocumentationSidebarUnitTest.php
+++ b/packages/framework/tests/Unit/DocumentationSidebarUnitTest.php
@@ -8,7 +8,7 @@ use Hyde\Testing\UnitTestCase;
 use Illuminate\Support\Collection;
 use Hyde\Support\Models\ExternalRoute;
 use Hyde\Framework\Features\Navigation\NavigationItem;
-use Hyde\Framework\Features\Navigation\NavGroupItem;
+use Hyde\Framework\Features\Navigation\GroupedNavigationItem;
 use Hyde\Framework\Features\Navigation\DocumentationSidebar;
 
 /**
@@ -204,13 +204,13 @@ class DocumentationSidebarUnitTest extends UnitTestCase
         $this->assertFalse((new DocumentationSidebar())->hasGroups());
     }
 
-    public function testHasGroupsReturnsTrueWhenAtLeastOneItemIsNavGroupItemInstance()
+    public function testHasGroupsReturnsTrueWhenAtLeastOneItemIsGroupedNavigationItemInstance()
     {
         self::mockConfig();
         self::setupKernel();
 
         $menu = new DocumentationSidebar([
-            new NavGroupItem('foo', []),
+            new GroupedNavigationItem('foo', []),
         ]);
 
         $this->assertTrue($menu->hasGroups());

--- a/packages/framework/tests/Unit/GroupedNavigationItemTest.php
+++ b/packages/framework/tests/Unit/GroupedNavigationItemTest.php
@@ -11,12 +11,12 @@ use Hyde\Support\Models\Route;
 use Hyde\Pages\DocumentationPage;
 use Hyde\Foundation\HydeCoreExtension;
 use Hyde\Framework\Features\Navigation\NavigationItem;
-use Hyde\Framework\Features\Navigation\NavGroupItem;
+use Hyde\Framework\Features\Navigation\GroupedNavigationItem;
 
 /**
- * @covers \Hyde\Framework\Features\Navigation\NavGroupItem
+ * @covers \Hyde\Framework\Features\Navigation\GroupedNavigationItem
  */
-class NavGroupItemTest extends UnitTestCase
+class GroupedNavigationItemTest extends UnitTestCase
 {
     public static function setUpBeforeClass(): void
     {
@@ -26,28 +26,28 @@ class NavGroupItemTest extends UnitTestCase
 
     public function testCanConstruct()
     {
-        $this->assertSame('Foo', (new NavGroupItem('Foo'))->getLabel());
+        $this->assertSame('Foo', (new GroupedNavigationItem('Foo'))->getLabel());
     }
 
     public function testCanConstructWithPriority()
     {
-        $this->assertSame(500, (new NavGroupItem('Foo', priority: 500))->getPriority());
+        $this->assertSame(500, (new GroupedNavigationItem('Foo', priority: 500))->getPriority());
     }
 
     public function testDefaultPriorityValueIsLast()
     {
-        $this->assertSame(999, (new NavGroupItem('Foo'))->getPriority());
+        $this->assertSame(999, (new GroupedNavigationItem('Foo'))->getPriority());
     }
 
     public function testDestinationIsAlwaysNull()
     {
-        $this->assertNull((new NavGroupItem('Foo'))->getRoute());
+        $this->assertNull((new GroupedNavigationItem('Foo'))->getRoute());
     }
 
     public function testCanConstructWithChildren()
     {
         $children = $this->createNavigationItems();
-        $item = new NavGroupItem('Foo', $children);
+        $item = new GroupedNavigationItem('Foo', $children);
 
         $this->assertCount(2, $item->getItems());
         $this->assertSame($children, $item->getItems());
@@ -56,7 +56,7 @@ class NavGroupItemTest extends UnitTestCase
     public function testCanConstructWithChildrenWithoutRoute()
     {
         $children = $this->createNavigationItems();
-        $item = new NavGroupItem('Foo', $children);
+        $item = new GroupedNavigationItem('Foo', $children);
 
         $this->assertCount(2, $item->getItems());
         $this->assertSame($children, $item->getItems());
@@ -65,19 +65,19 @@ class NavGroupItemTest extends UnitTestCase
     public function testGetItems()
     {
         $children = $this->createNavigationItems();
-        $item = new NavGroupItem('Foo', $children);
+        $item = new GroupedNavigationItem('Foo', $children);
 
         $this->assertSame($children, $item->getItems());
     }
 
     public function testGetItemsWithNoItems()
     {
-        $this->assertEmpty((new NavGroupItem('Foo'))->getItems());
+        $this->assertEmpty((new GroupedNavigationItem('Foo'))->getItems());
     }
 
     public function testCanAddItemToDropdown()
     {
-        $group = new NavGroupItem('Foo');
+        $group = new GroupedNavigationItem('Foo');
         $child = new NavigationItem(new Route(new MarkdownPage()), 'Bar');
 
         $this->assertSame([$child], $group->addItem($child)->getItems());
@@ -85,7 +85,7 @@ class NavGroupItemTest extends UnitTestCase
 
     public function testAddChildMethodReturnsSelf()
     {
-        $group = new NavGroupItem('Foo');
+        $group = new GroupedNavigationItem('Foo');
         $child = new NavigationItem(new Route(new MarkdownPage()), 'Bar');
 
         $this->assertSame($group, $group->addItem($child));
@@ -93,7 +93,7 @@ class NavGroupItemTest extends UnitTestCase
 
     public function testCanAddMultipleItemsToDropdown()
     {
-        $group = new NavGroupItem('Foo');
+        $group = new GroupedNavigationItem('Foo');
         $items = $this->createNavigationItems();
 
         $this->assertSame($items, $group->addItems($items)->getItems());
@@ -101,14 +101,14 @@ class NavGroupItemTest extends UnitTestCase
 
     public function testAddChildrenMethodReturnsSelf()
     {
-        $group = new NavGroupItem('Foo');
+        $group = new GroupedNavigationItem('Foo');
 
         $this->assertSame($group, $group->addItems([]));
     }
 
     public function testAddingAnItemWithAGroupKeyKeepsTheSetGroupKey()
     {
-        $group = new NavGroupItem('Foo');
+        $group = new GroupedNavigationItem('Foo');
         $child = new NavigationItem(new Route(new MarkdownPage()), 'Child', group: 'bar');
 
         $group->addItem($child);
@@ -119,7 +119,7 @@ class NavGroupItemTest extends UnitTestCase
 
     public function testAddingAnItemWithNoGroupKeyUsesGroupIdentifier()
     {
-        $group = new NavGroupItem('Foo');
+        $group = new GroupedNavigationItem('Foo');
         $child = new NavigationItem(new Route(new MarkdownPage()), 'Bar');
 
         $group->addItem($child);
@@ -130,17 +130,17 @@ class NavGroupItemTest extends UnitTestCase
 
     public function testGetPriorityUsesDefaultPriority()
     {
-        $this->assertSame(999, (new NavGroupItem('Foo'))->getPriority());
+        $this->assertSame(999, (new GroupedNavigationItem('Foo'))->getPriority());
     }
 
     public function testGetPriorityWithNoChildrenUsesGroupPriority()
     {
-        $this->assertSame(999, (new NavGroupItem('Foo'))->getPriority());
+        $this->assertSame(999, (new GroupedNavigationItem('Foo'))->getPriority());
     }
 
     public function testGetPriorityWithChildrenUsesGroupPriority()
     {
-        $group = new NavGroupItem('Foo', [new NavigationItem(new Route(new MarkdownPage()), 'Bar', 100)]);
+        $group = new GroupedNavigationItem('Foo', [new NavigationItem(new Route(new MarkdownPage()), 'Bar', 100)]);
 
         $this->assertSame(999, $group->getPriority());
     }
@@ -153,13 +153,13 @@ class NavGroupItemTest extends UnitTestCase
             new NavigationItem(new Route(new DocumentationPage()), 'Baz', 300),
         ];
 
-        $this->assertSame(100, (new NavGroupItem('Foo', $items))->getPriority());
-        $this->assertSame(100, (new NavGroupItem('Foo', array_reverse($items)))->getPriority());
+        $this->assertSame(100, (new GroupedNavigationItem('Foo', $items))->getPriority());
+        $this->assertSame(100, (new GroupedNavigationItem('Foo', array_reverse($items)))->getPriority());
     }
 
     public function testGetPriorityUsesGroupPriorityForMixedChildTypes()
     {
-        $group = new NavGroupItem('Foo');
+        $group = new GroupedNavigationItem('Foo');
 
         foreach (HydeCoreExtension::getPageClasses() as $type) {
             $child = new NavigationItem(new Route(new $type()), 'Bar', 100);
@@ -171,29 +171,29 @@ class NavGroupItemTest extends UnitTestCase
 
     public function testGetPriorityHandlesStringUrlChildGracefully()
     {
-        $this->assertSame(999, (new NavGroupItem('Foo', [new NavigationItem('foo', 'Bar', 100)]))->getPriority());
+        $this->assertSame(999, (new GroupedNavigationItem('Foo', [new NavigationItem('foo', 'Bar', 100)]))->getPriority());
     }
 
     public function testGetPriorityHandlesExternalUrlChildGracefully()
     {
-        $this->assertSame(999, (new NavGroupItem('Foo', [new NavigationItem('https://example.com', 'Bar', 100)]))->getPriority());
+        $this->assertSame(999, (new GroupedNavigationItem('Foo', [new NavigationItem('https://example.com', 'Bar', 100)]))->getPriority());
     }
 
     public function testForRoute()
     {
-        $item = NavGroupItem::forRoute(new Route(new InMemoryPage('foo')));
+        $item = GroupedNavigationItem::forRoute(new Route(new InMemoryPage('foo')));
 
         $this->assertInstanceOf(NavigationItem::class, $item);
-        $this->assertNotInstanceOf(NavGroupItem::class, $item);
+        $this->assertNotInstanceOf(GroupedNavigationItem::class, $item);
         $this->assertSame(NavigationItem::class, $item::class);
     }
 
     public function testForLink()
     {
-        $item = NavGroupItem::forLink('foo', 'bar');
+        $item = GroupedNavigationItem::forLink('foo', 'bar');
 
         $this->assertInstanceOf(NavigationItem::class, $item);
-        $this->assertNotInstanceOf(NavGroupItem::class, $item);
+        $this->assertNotInstanceOf(GroupedNavigationItem::class, $item);
         $this->assertSame(NavigationItem::class, $item::class);
     }
 

--- a/packages/framework/tests/Unit/NavGroupItemTest.php
+++ b/packages/framework/tests/Unit/NavGroupItemTest.php
@@ -10,7 +10,7 @@ use Hyde\Testing\UnitTestCase;
 use Hyde\Support\Models\Route;
 use Hyde\Pages\DocumentationPage;
 use Hyde\Foundation\HydeCoreExtension;
-use Hyde\Framework\Features\Navigation\NavItem;
+use Hyde\Framework\Features\Navigation\NavigationItem;
 use Hyde\Framework\Features\Navigation\NavGroupItem;
 
 /**
@@ -46,7 +46,7 @@ class NavGroupItemTest extends UnitTestCase
 
     public function testCanConstructWithChildren()
     {
-        $children = $this->createNavItems();
+        $children = $this->createNavigationItems();
         $item = new NavGroupItem('Foo', $children);
 
         $this->assertCount(2, $item->getItems());
@@ -55,7 +55,7 @@ class NavGroupItemTest extends UnitTestCase
 
     public function testCanConstructWithChildrenWithoutRoute()
     {
-        $children = $this->createNavItems();
+        $children = $this->createNavigationItems();
         $item = new NavGroupItem('Foo', $children);
 
         $this->assertCount(2, $item->getItems());
@@ -64,7 +64,7 @@ class NavGroupItemTest extends UnitTestCase
 
     public function testGetItems()
     {
-        $children = $this->createNavItems();
+        $children = $this->createNavigationItems();
         $item = new NavGroupItem('Foo', $children);
 
         $this->assertSame($children, $item->getItems());
@@ -78,7 +78,7 @@ class NavGroupItemTest extends UnitTestCase
     public function testCanAddItemToDropdown()
     {
         $group = new NavGroupItem('Foo');
-        $child = new NavItem(new Route(new MarkdownPage()), 'Bar');
+        $child = new NavigationItem(new Route(new MarkdownPage()), 'Bar');
 
         $this->assertSame([$child], $group->addItem($child)->getItems());
     }
@@ -86,7 +86,7 @@ class NavGroupItemTest extends UnitTestCase
     public function testAddChildMethodReturnsSelf()
     {
         $group = new NavGroupItem('Foo');
-        $child = new NavItem(new Route(new MarkdownPage()), 'Bar');
+        $child = new NavigationItem(new Route(new MarkdownPage()), 'Bar');
 
         $this->assertSame($group, $group->addItem($child));
     }
@@ -94,7 +94,7 @@ class NavGroupItemTest extends UnitTestCase
     public function testCanAddMultipleItemsToDropdown()
     {
         $group = new NavGroupItem('Foo');
-        $items = $this->createNavItems();
+        $items = $this->createNavigationItems();
 
         $this->assertSame($items, $group->addItems($items)->getItems());
     }
@@ -109,7 +109,7 @@ class NavGroupItemTest extends UnitTestCase
     public function testAddingAnItemWithAGroupKeyKeepsTheSetGroupKey()
     {
         $group = new NavGroupItem('Foo');
-        $child = new NavItem(new Route(new MarkdownPage()), 'Child', group: 'bar');
+        $child = new NavigationItem(new Route(new MarkdownPage()), 'Child', group: 'bar');
 
         $group->addItem($child);
 
@@ -120,7 +120,7 @@ class NavGroupItemTest extends UnitTestCase
     public function testAddingAnItemWithNoGroupKeyUsesGroupIdentifier()
     {
         $group = new NavGroupItem('Foo');
-        $child = new NavItem(new Route(new MarkdownPage()), 'Bar');
+        $child = new NavigationItem(new Route(new MarkdownPage()), 'Bar');
 
         $group->addItem($child);
 
@@ -140,7 +140,7 @@ class NavGroupItemTest extends UnitTestCase
 
     public function testGetPriorityWithChildrenUsesGroupPriority()
     {
-        $group = new NavGroupItem('Foo', [new NavItem(new Route(new MarkdownPage()), 'Bar', 100)]);
+        $group = new NavGroupItem('Foo', [new NavigationItem(new Route(new MarkdownPage()), 'Bar', 100)]);
 
         $this->assertSame(999, $group->getPriority());
     }
@@ -148,9 +148,9 @@ class NavGroupItemTest extends UnitTestCase
     public function testGetPriorityWithDocumentationPageChildrenUsesLowestPriority()
     {
         $items = [
-            new NavItem(new Route(new DocumentationPage()), 'Foo', 100),
-            new NavItem(new Route(new DocumentationPage()), 'Bar', 200),
-            new NavItem(new Route(new DocumentationPage()), 'Baz', 300),
+            new NavigationItem(new Route(new DocumentationPage()), 'Foo', 100),
+            new NavigationItem(new Route(new DocumentationPage()), 'Bar', 200),
+            new NavigationItem(new Route(new DocumentationPage()), 'Baz', 300),
         ];
 
         $this->assertSame(100, (new NavGroupItem('Foo', $items))->getPriority());
@@ -162,7 +162,7 @@ class NavGroupItemTest extends UnitTestCase
         $group = new NavGroupItem('Foo');
 
         foreach (HydeCoreExtension::getPageClasses() as $type) {
-            $child = new NavItem(new Route(new $type()), 'Bar', 100);
+            $child = new NavigationItem(new Route(new $type()), 'Bar', 100);
             $group->addItem($child);
         }
 
@@ -171,37 +171,37 @@ class NavGroupItemTest extends UnitTestCase
 
     public function testGetPriorityHandlesStringUrlChildGracefully()
     {
-        $this->assertSame(999, (new NavGroupItem('Foo', [new NavItem('foo', 'Bar', 100)]))->getPriority());
+        $this->assertSame(999, (new NavGroupItem('Foo', [new NavigationItem('foo', 'Bar', 100)]))->getPriority());
     }
 
     public function testGetPriorityHandlesExternalUrlChildGracefully()
     {
-        $this->assertSame(999, (new NavGroupItem('Foo', [new NavItem('https://example.com', 'Bar', 100)]))->getPriority());
+        $this->assertSame(999, (new NavGroupItem('Foo', [new NavigationItem('https://example.com', 'Bar', 100)]))->getPriority());
     }
 
     public function testForRoute()
     {
         $item = NavGroupItem::forRoute(new Route(new InMemoryPage('foo')));
 
-        $this->assertInstanceOf(NavItem::class, $item);
+        $this->assertInstanceOf(NavigationItem::class, $item);
         $this->assertNotInstanceOf(NavGroupItem::class, $item);
-        $this->assertSame(NavItem::class, $item::class);
+        $this->assertSame(NavigationItem::class, $item::class);
     }
 
     public function testForLink()
     {
         $item = NavGroupItem::forLink('foo', 'bar');
 
-        $this->assertInstanceOf(NavItem::class, $item);
+        $this->assertInstanceOf(NavigationItem::class, $item);
         $this->assertNotInstanceOf(NavGroupItem::class, $item);
-        $this->assertSame(NavItem::class, $item::class);
+        $this->assertSame(NavigationItem::class, $item::class);
     }
 
-    protected function createNavItems(): array
+    protected function createNavigationItems(): array
     {
         return [
-            new NavItem(new Route(new InMemoryPage('foo')), 'Foo'),
-            new NavItem(new Route(new InMemoryPage('bar')), 'Bar'),
+            new NavigationItem(new Route(new InMemoryPage('foo')), 'Foo'),
+            new NavigationItem(new Route(new InMemoryPage('bar')), 'Bar'),
         ];
     }
 }

--- a/packages/framework/tests/Unit/NavigationItemIsActiveHelperTest.php
+++ b/packages/framework/tests/Unit/NavigationItemIsActiveHelperTest.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace Hyde\Framework\Testing\Unit;
 
 use Hyde\Foundation\Facades\Routes;
-use Hyde\Framework\Features\Navigation\NavItem;
+use Hyde\Framework\Features\Navigation\NavigationItem;
 use Hyde\Pages\InMemoryPage;
 use Hyde\Support\Facades\Render;
 use Hyde\Support\Models\RenderData;
@@ -14,11 +14,11 @@ use Hyde\Testing\UnitTestCase;
 use Mockery;
 
 /**
- * @covers \Hyde\Framework\Features\Navigation\NavItem
+ * @covers \Hyde\Framework\Features\Navigation\NavigationItem
  *
- * @see \Hyde\Framework\Testing\Unit\NavItemTest
+ * @see \Hyde\Framework\Testing\Unit\NavigationItemTest
  */
-class NavItemIsActiveHelperTest extends UnitTestCase
+class NavigationItemIsActiveHelperTest extends UnitTestCase
 {
     public static function setUpBeforeClass(): void
     {
@@ -34,205 +34,205 @@ class NavItemIsActiveHelperTest extends UnitTestCase
     public function testIsCurrent()
     {
         $this->mockRenderData($this->makeRoute('foo'));
-        $this->assertFalse(NavItem::forRoute($this->makeRoute('bar'))->isActive());
+        $this->assertFalse(NavigationItem::forRoute($this->makeRoute('bar'))->isActive());
     }
 
     public function testIsCurrentWhenCurrent()
     {
         $this->mockRenderData($this->makeRoute('foo'));
-        $this->assertTrue(NavItem::forRoute($this->makeRoute('foo'))->isActive());
+        $this->assertTrue(NavigationItem::forRoute($this->makeRoute('foo'))->isActive());
     }
 
     public function testIsCurrentUsingCurrentRoute()
     {
         $this->mockRenderData($this->makeRoute('index'));
-        $this->assertTrue(NavItem::forRoute(Routes::get('index'))->isActive());
+        $this->assertTrue(NavigationItem::forRoute(Routes::get('index'))->isActive());
     }
 
     public function testIsCurrentUsingCurrentLink()
     {
         $this->mockRenderData($this->makeRoute('index'));
-        $this->assertTrue(NavItem::forLink('index.html', 'Home')->isActive());
+        $this->assertTrue(NavigationItem::forLink('index.html', 'Home')->isActive());
     }
 
     public function testIsCurrentWhenNotCurrent()
     {
         $this->mockRenderData($this->makeRoute('foo'));
-        $this->assertFalse(NavItem::forRoute($this->makeRoute('bar'))->isActive());
+        $this->assertFalse(NavigationItem::forRoute($this->makeRoute('bar'))->isActive());
     }
 
     public function testIsCurrentUsingNotCurrentRoute()
     {
         $this->mockRenderData($this->makeRoute('foo'));
-        $this->assertFalse(NavItem::forRoute(Routes::get('index'))->isActive());
+        $this->assertFalse(NavigationItem::forRoute(Routes::get('index'))->isActive());
     }
 
     public function testIsCurrentUsingNotCurrentLink()
     {
         $this->mockRenderData($this->makeRoute('foo'));
-        $this->assertFalse(NavItem::forLink('index.html', 'Home')->isActive());
+        $this->assertFalse(NavigationItem::forLink('index.html', 'Home')->isActive());
     }
 
     public function testIsCurrentWithNestedCurrentPage()
     {
         $this->mockRenderData($this->makeRoute('foo/bar'));
-        $this->assertFalse(NavItem::forRoute($this->makeRoute('bar'))->isActive());
+        $this->assertFalse(NavigationItem::forRoute($this->makeRoute('bar'))->isActive());
     }
 
     public function testIsCurrentWhenCurrentWithNestedCurrentPage()
     {
         $this->mockRenderData($this->makeRoute('foo/bar'));
-        $this->assertTrue(NavItem::forRoute($this->makeRoute('foo/bar'))->isActive());
+        $this->assertTrue(NavigationItem::forRoute($this->makeRoute('foo/bar'))->isActive());
     }
 
     public function testIsCurrentWithNestedCurrentPageWhenNested()
     {
         $this->mockRenderData($this->makeRoute('foo/bar'));
-        $this->assertTrue(NavItem::forRoute($this->makeRoute('foo/bar'))->isActive());
+        $this->assertTrue(NavigationItem::forRoute($this->makeRoute('foo/bar'))->isActive());
     }
 
     public function testIsCurrentWhenCurrentWithNestedCurrentPageWhenNested()
     {
         $this->mockRenderData($this->makeRoute('foo/bar'));
-        $this->assertFalse(NavItem::forRoute($this->makeRoute('foo/baz'))->isActive());
+        $this->assertFalse(NavigationItem::forRoute($this->makeRoute('foo/baz'))->isActive());
     }
 
     public function testIsCurrentWithNestedCurrentPageWhenVeryNested()
     {
         $this->mockRenderData($this->makeRoute('foo/bar/baz'));
-        $this->assertTrue(NavItem::forRoute($this->makeRoute('foo/bar/baz'))->isActive());
+        $this->assertTrue(NavigationItem::forRoute($this->makeRoute('foo/bar/baz'))->isActive());
     }
 
     public function testIsCurrentWhenCurrentWithNestedCurrentPageWhenVeryNested()
     {
         $this->mockRenderData($this->makeRoute('foo/bar/baz'));
-        $this->assertFalse(NavItem::forRoute($this->makeRoute('foo/baz/bar'))->isActive());
+        $this->assertFalse(NavigationItem::forRoute($this->makeRoute('foo/baz/bar'))->isActive());
     }
 
     public function testIsCurrentWithNestedCurrentPageWhenVeryDifferingNested()
     {
         $this->mockRenderData($this->makeRoute('foo'));
-        $this->assertFalse(NavItem::forRoute($this->makeRoute('foo/bar/baz'))->isActive());
+        $this->assertFalse(NavigationItem::forRoute($this->makeRoute('foo/bar/baz'))->isActive());
     }
 
     public function testIsCurrentWithNestedCurrentPageWhenVeryDifferingNestedInverse()
     {
         $this->mockRenderData($this->makeRoute('foo/bar/baz'));
-        $this->assertFalse(NavItem::forRoute($this->makeRoute('foo'))->isActive());
+        $this->assertFalse(NavigationItem::forRoute($this->makeRoute('foo'))->isActive());
     }
 
     public function testIsCurrentUsingCurrentLinkWithNestedCurrentPage()
     {
         $this->mockRenderData($this->makeRoute('foo/bar'));
-        $this->assertFalse(NavItem::forLink('foo/bar.html', 'foo')->isActive());
+        $this->assertFalse(NavigationItem::forLink('foo/bar.html', 'foo')->isActive());
     }
 
     public function testIsCurrentUsingNotCurrentLinkWithNestedCurrentPage()
     {
         $this->mockRenderData($this->makeRoute('foo/bar'));
-        $this->assertFalse(NavItem::forLink('foo.html', 'foo')->isActive());
+        $this->assertFalse(NavigationItem::forLink('foo.html', 'foo')->isActive());
     }
 
     public function testIsCurrentWhenCurrentWithNestedCurrentPageAndSubjectPage()
     {
         $this->mockRenderData($this->makeRoute('foo/bar'));
-        $this->assertFalse(NavItem::forLink('foo/bar.html', 'foo')->isActive());
+        $this->assertFalse(NavigationItem::forLink('foo/bar.html', 'foo')->isActive());
     }
 
     public function testIsCurrentWhenNotCurrentWithNestedCurrentPageAndSubjectPage()
     {
         $this->mockRenderData($this->makeRoute('foo/bar'));
-        $this->assertFalse(NavItem::forLink('foo/baz.html', 'foo')->isActive());
+        $this->assertFalse(NavigationItem::forLink('foo/baz.html', 'foo')->isActive());
     }
 
     public function testIsCurrentWithNestedCurrentPageWhenNestedUsingLinkItem()
     {
         $this->mockRenderData($this->makeRoute('foo/bar'));
-        $this->assertFalse(NavItem::forLink('foo/bar.html', 'foo')->isActive());
+        $this->assertFalse(NavigationItem::forLink('foo/bar.html', 'foo')->isActive());
     }
 
     public function testIsCurrentWhenCurrentWithNestedCurrentPageWhenNestedUsingLinkItem()
     {
         $this->mockRenderData($this->makeRoute('foo/bar'));
-        $this->assertFalse(NavItem::forLink('foo/baz.html', 'foo')->isActive());
+        $this->assertFalse(NavigationItem::forLink('foo/baz.html', 'foo')->isActive());
     }
 
     public function testIsCurrentWithNestedCurrentPageWhenVeryNestedUsingLinkItem()
     {
         $this->mockRenderData($this->makeRoute('foo/bar/baz'));
-        $this->assertFalse(NavItem::forLink('foo/bar/baz.html', 'foo')->isActive());
+        $this->assertFalse(NavigationItem::forLink('foo/bar/baz.html', 'foo')->isActive());
     }
 
     public function testIsCurrentWhenCurrentWithNestedCurrentPageWhenVeryNestedUsingLinkItem()
     {
         $this->mockRenderData($this->makeRoute('foo/bar/baz'));
-        $this->assertFalse(NavItem::forLink('foo/baz/bar.html', 'foo')->isActive());
+        $this->assertFalse(NavigationItem::forLink('foo/baz/bar.html', 'foo')->isActive());
     }
 
     public function testIsCurrentWithNestedCurrentPageWhenVeryDifferingNestedUsingLinkItem()
     {
         $this->mockRenderData($this->makeRoute('foo'));
-        $this->assertFalse(NavItem::forLink('foo/bar/baz.html', 'foo')->isActive());
+        $this->assertFalse(NavigationItem::forLink('foo/bar/baz.html', 'foo')->isActive());
     }
 
     public function testIsCurrentWithNestedCurrentPageWhenVeryDifferingNestedInverseUsingLinkItem()
     {
         $this->mockRenderData($this->makeRoute('foo/bar/baz'));
-        $this->assertFalse(NavItem::forLink('foo.html', 'foo')->isActive());
+        $this->assertFalse(NavigationItem::forLink('foo.html', 'foo')->isActive());
     }
 
     public function testIsCurrentWithNestedCurrentPageWhenNestedUsingPrettyLinkItem()
     {
         $this->mockRenderData($this->makeRoute('foo/bar'));
-        $this->assertFalse(NavItem::forLink('foo/bar', 'foo')->isActive());
+        $this->assertFalse(NavigationItem::forLink('foo/bar', 'foo')->isActive());
     }
 
     public function testIsCurrentWhenCurrentWithNestedCurrentPageWhenNestedUsingPrettyLinkItem()
     {
         $this->mockRenderData($this->makeRoute('foo/bar'));
-        $this->assertFalse(NavItem::forLink('foo/baz', 'foo')->isActive());
+        $this->assertFalse(NavigationItem::forLink('foo/baz', 'foo')->isActive());
     }
 
     public function testIsCurrentWithNestedCurrentPageWhenVeryNestedUsingPrettyLinkItem()
     {
         $this->mockRenderData($this->makeRoute('foo/bar/baz'));
-        $this->assertFalse(NavItem::forLink('foo/bar/baz', 'foo')->isActive());
+        $this->assertFalse(NavigationItem::forLink('foo/bar/baz', 'foo')->isActive());
     }
 
     public function testIsCurrentWhenCurrentWithNestedCurrentPageWhenVeryNestedUsingPrettyLinkItem()
     {
         $this->mockRenderData($this->makeRoute('foo/bar/baz'));
-        $this->assertFalse(NavItem::forLink('foo/baz/bar', 'foo')->isActive());
+        $this->assertFalse(NavigationItem::forLink('foo/baz/bar', 'foo')->isActive());
     }
 
     public function testIsCurrentWithNestedCurrentPageWhenVeryDifferingNestedUsingPrettyLinkItem()
     {
         $this->mockRenderData($this->makeRoute('foo'));
-        $this->assertFalse(NavItem::forLink('foo/bar/baz', 'foo')->isActive());
+        $this->assertFalse(NavigationItem::forLink('foo/bar/baz', 'foo')->isActive());
     }
 
     public function testIsCurrentWithNestedCurrentPageWhenVeryDifferingNestedInverseUsingPrettyLinkItem()
     {
         $this->mockRenderData($this->makeRoute('foo/bar/baz'));
-        $this->assertFalse(NavItem::forLink('foo', 'foo')->isActive());
+        $this->assertFalse(NavigationItem::forLink('foo', 'foo')->isActive());
     }
 
     public function testIsCurrentWithAbsoluteLink()
     {
         $this->mockRenderData($this->makeRoute('foo'));
-        $this->assertFalse(NavItem::forLink('/foo', 'foo')->isActive());
+        $this->assertFalse(NavigationItem::forLink('/foo', 'foo')->isActive());
     }
 
     public function testIsCurrentWithNestedCurrentPageWhenNestedUsingAbsoluteLinkItem()
     {
         $this->mockRenderData($this->makeRoute('foo/bar'));
-        $this->assertFalse(NavItem::forLink('/foo/bar', 'foo')->isActive());
+        $this->assertFalse(NavigationItem::forLink('/foo/bar', 'foo')->isActive());
     }
 
     public function testIsCurrentWhenCurrentWithNestedCurrentPageWhenNestedUsingAbsoluteLinkItem()
     {
         $this->mockRenderData($this->makeRoute('foo/bar/baz'));
-        $this->assertFalse(NavItem::forLink('/foo/bar/baz', 'foo')->isActive());
+        $this->assertFalse(NavigationItem::forLink('/foo/bar/baz', 'foo')->isActive());
     }
 
     protected function mockRenderData(Route $route): void

--- a/packages/framework/tests/Unit/NavigationItemTest.php
+++ b/packages/framework/tests/Unit/NavigationItemTest.php
@@ -7,7 +7,7 @@ namespace Hyde\Framework\Testing\Unit;
 use Hyde\Foundation\Facades\Routes;
 use Hyde\Support\Models\ExternalRoute;
 use Hyde\Framework\Exceptions\RouteNotFoundException;
-use Hyde\Framework\Features\Navigation\NavItem;
+use Hyde\Framework\Features\Navigation\NavigationItem;
 use Hyde\Pages\InMemoryPage;
 use Hyde\Pages\MarkdownPage;
 use Hyde\Support\Facades\Render;
@@ -17,14 +17,14 @@ use Hyde\Testing\UnitTestCase;
 use Mockery;
 
 /**
- * This unit test covers the basics of the NavItem class.
+ * This unit test covers the basics of the NavigationItem class.
  * For the full feature test, see the MainNavigationMenuTest class.
  *
- * @covers \Hyde\Framework\Features\Navigation\NavItem
+ * @covers \Hyde\Framework\Features\Navigation\NavigationItem
  *
- * @see \Hyde\Framework\Testing\Unit\NavItemIsActiveHelperTest
+ * @see \Hyde\Framework\Testing\Unit\NavigationItemIsActiveHelperTest
  */
-class NavItemTest extends UnitTestCase
+class NavigationItemTest extends UnitTestCase
 {
     public static function setUpBeforeClass(): void
     {
@@ -42,7 +42,7 @@ class NavItemTest extends UnitTestCase
     public function testConstruct()
     {
         $route = new Route(new MarkdownPage());
-        $item = new NavItem($route, 'Test', 500);
+        $item = new NavigationItem($route, 'Test', 500);
 
         $this->assertSame($route, $item->getRoute());
     }
@@ -50,19 +50,19 @@ class NavItemTest extends UnitTestCase
     public function testPassingRouteInstanceToConstructorUsesRouteInstance()
     {
         $route = new Route(new MarkdownPage());
-        $this->assertSame($route, (new NavItem($route, 'Home'))->getRoute());
+        $this->assertSame($route, (new NavigationItem($route, 'Home'))->getRoute());
     }
 
     public function testPassingRouteKeyToConstructorUsesRouteInstance()
     {
         $route = Routes::get('index');
 
-        $this->assertSame($route, (new NavItem('index', 'Home'))->getRoute());
+        $this->assertSame($route, (new NavigationItem('index', 'Home'))->getRoute());
     }
 
     public function testPassingUrlToConstructorUsesExternalRoute()
     {
-        $item = new NavItem('https://example.com', 'Home');
+        $item = new NavigationItem('https://example.com', 'Home');
         $this->assertInstanceOf(ExternalRoute::class, $item->getRoute());
         $this->assertEquals(new ExternalRoute('https://example.com'), $item->getRoute());
         $this->assertSame('https://example.com', (string) $item->getRoute());
@@ -70,7 +70,7 @@ class NavItemTest extends UnitTestCase
 
     public function testPassingUnknownRouteKeyToConstructorUsesExternalRoute()
     {
-        $item = new NavItem('foo', 'Home');
+        $item = new NavigationItem('foo', 'Home');
         $this->assertInstanceOf(ExternalRoute::class, $item->getRoute());
         $this->assertEquals(new ExternalRoute('foo'), $item->getRoute());
         $this->assertSame('foo', (string) $item->getRoute());
@@ -79,39 +79,39 @@ class NavItemTest extends UnitTestCase
     public function testGetDestination()
     {
         $route = new Route(new InMemoryPage('foo'));
-        $navItem = new NavItem($route, 'Page', 500);
+        $NavigationItem = new NavigationItem($route, 'Page', 500);
 
-        $this->assertSame($route, $navItem->getRoute());
+        $this->assertSame($route, $NavigationItem->getRoute());
     }
 
     public function testGetLink()
     {
-        $navItem = new NavItem(new Route(new InMemoryPage('foo')), 'Page', 500);
-        $this->assertSame('foo.html', $navItem->getUrl());
+        $NavigationItem = new NavigationItem(new Route(new InMemoryPage('foo')), 'Page', 500);
+        $this->assertSame('foo.html', $NavigationItem->getUrl());
     }
 
     public function testGetLabel()
     {
-        $navItem = new NavItem(new Route(new InMemoryPage('foo')), 'Page', 500);
-        $this->assertSame('Page', $navItem->getLabel());
+        $NavigationItem = new NavigationItem(new Route(new InMemoryPage('foo')), 'Page', 500);
+        $this->assertSame('Page', $NavigationItem->getLabel());
     }
 
     public function testGetPriority()
     {
-        $navItem = new NavItem(new Route(new InMemoryPage('foo')), 'Page', 500);
-        $this->assertSame(500, $navItem->getPriority());
+        $NavigationItem = new NavigationItem(new Route(new InMemoryPage('foo')), 'Page', 500);
+        $this->assertSame(500, $NavigationItem->getPriority());
     }
 
     public function testGetGroup()
     {
-        $navItem = new NavItem(new Route(new InMemoryPage('foo')), 'Page', 500);
-        $this->assertNull($navItem->getGroupKey());
+        $NavigationItem = new NavigationItem(new Route(new InMemoryPage('foo')), 'Page', 500);
+        $this->assertNull($NavigationItem->getGroupKey());
     }
 
     public function testFromRoute()
     {
         $route = new Route(new MarkdownPage());
-        $item = NavItem::forRoute($route);
+        $item = NavigationItem::forRoute($route);
 
         $this->assertSame($route, $item->getRoute());
     }
@@ -120,12 +120,12 @@ class NavItemTest extends UnitTestCase
     {
         Render::shouldReceive('getRouteKey')->once()->andReturn('index');
 
-        $this->assertSame('index.html', (string) NavItem::forRoute(Routes::get('index')));
+        $this->assertSame('index.html', (string) NavigationItem::forRoute(Routes::get('index')));
     }
 
     public function testForLink()
     {
-        $item = NavItem::forLink('foo', 'bar');
+        $item = NavigationItem::forLink('foo', 'bar');
 
         $this->assertEquals(new ExternalRoute('foo'), $item->getRoute());
         $this->assertSame('bar', $item->getLabel());
@@ -134,13 +134,13 @@ class NavItemTest extends UnitTestCase
 
     public function testForLinkWithCustomPriority()
     {
-        $this->assertSame(100, NavItem::forLink('foo', 'bar', 100)->getPriority());
+        $this->assertSame(100, NavigationItem::forLink('foo', 'bar', 100)->getPriority());
     }
 
     public function testForRoute()
     {
         $route = Routes::get('404');
-        $item = NavItem::forRoute($route, 'foo');
+        $item = NavigationItem::forRoute($route, 'foo');
 
         $this->assertSame($route, $item->getRoute());
         $this->assertSame('foo', $item->getLabel());
@@ -150,7 +150,7 @@ class NavItemTest extends UnitTestCase
     public function testForIndexRoute()
     {
         $route = Routes::get('index');
-        $item = NavItem::forRoute($route, 'foo');
+        $item = NavigationItem::forRoute($route, 'foo');
 
         $this->assertSame($route, $item->getRoute());
         $this->assertSame('foo', $item->getLabel());
@@ -160,52 +160,52 @@ class NavItemTest extends UnitTestCase
     public function testForRouteWithRouteKey()
     {
         $this->assertEquals(
-            NavItem::forRoute(Routes::get('index'), 'foo'),
-            NavItem::forRoute('index', 'foo')
+            NavigationItem::forRoute(Routes::get('index'), 'foo'),
+            NavigationItem::forRoute('index', 'foo')
         );
     }
 
     public function testForRouteWithMissingRouteKey()
     {
         $this->expectException(RouteNotFoundException::class);
-        NavItem::forRoute('foo', 'foo');
+        NavigationItem::forRoute('foo', 'foo');
     }
 
     public function testForRouteWithCustomPriority()
     {
-        $this->assertSame(100, NavItem::forRoute(Routes::get('index'), 'foo', 100)->getPriority());
+        $this->assertSame(100, NavigationItem::forRoute(Routes::get('index'), 'foo', 100)->getPriority());
     }
 
-    public function testRouteBasedNavItemDestinationsAreResolvedRelatively()
+    public function testRouteBasedNavigationItemDestinationsAreResolvedRelatively()
     {
         Render::swap(Mockery::mock(RenderData::class, [
             'getRoute' => new Route(new InMemoryPage('foo')),
             'getRouteKey' => 'foo',
         ]));
 
-        $this->assertSame('foo.html', (string) NavItem::forRoute(new Route(new InMemoryPage('foo'))));
-        $this->assertSame('foo/bar.html', (string) NavItem::forRoute(new Route(new InMemoryPage('foo/bar'))));
+        $this->assertSame('foo.html', (string) NavigationItem::forRoute(new Route(new InMemoryPage('foo'))));
+        $this->assertSame('foo/bar.html', (string) NavigationItem::forRoute(new Route(new InMemoryPage('foo/bar'))));
 
         Render::swap(Mockery::mock(RenderData::class, [
             'getRoute' => new Route(new InMemoryPage('foo/bar')),
             'getRouteKey' => 'foo/bar',
         ]));
 
-        $this->assertSame('../foo.html', (string) NavItem::forRoute(new Route(new InMemoryPage('foo'))));
-        $this->assertSame('../foo/bar.html', (string) NavItem::forRoute(new Route(new InMemoryPage('foo/bar'))));
+        $this->assertSame('../foo.html', (string) NavigationItem::forRoute(new Route(new InMemoryPage('foo'))));
+        $this->assertSame('../foo/bar.html', (string) NavigationItem::forRoute(new Route(new InMemoryPage('foo/bar'))));
 
         Render::swap(Mockery::mock(RenderData::class, [
             'getRoute' => new Route(new InMemoryPage('foo/bar/baz')),
             'getRouteKey' => 'foo/bar/baz',
         ]));
 
-        $this->assertSame('../../foo.html', (string) NavItem::forRoute(new Route(new InMemoryPage('foo'))));
-        $this->assertSame('../../foo/bar.html', (string) NavItem::forRoute(new Route(new InMemoryPage('foo/bar'))));
+        $this->assertSame('../../foo.html', (string) NavigationItem::forRoute(new Route(new InMemoryPage('foo'))));
+        $this->assertSame('../../foo/bar.html', (string) NavigationItem::forRoute(new Route(new InMemoryPage('foo/bar'))));
     }
 
     public function testDropdownFacade()
     {
-        $item = NavItem::forGroup('foo', []);
+        $item = NavigationItem::forGroup('foo', []);
 
         $this->assertSame('foo', $item->getLabel());
         $this->assertSame([], $item->getItems());
@@ -215,17 +215,17 @@ class NavItemTest extends UnitTestCase
     public function testDropdownFacadeWithChildren()
     {
         $children = [
-            new NavItem(new Route(new MarkdownPage()), 'bar'),
+            new NavigationItem(new Route(new MarkdownPage()), 'bar'),
         ];
 
-        $item = NavItem::forGroup('foo', $children);
+        $item = NavigationItem::forGroup('foo', $children);
         $this->assertSame($children, $item->getItems());
         $this->assertSame(999, $item->getPriority());
     }
 
     public function testDropdownFacadeWithCustomPriority()
     {
-        $item = NavItem::forGroup('foo', [], 500);
+        $item = NavigationItem::forGroup('foo', [], 500);
 
         $this->assertSame(500, $item->getPriority());
     }
@@ -236,8 +236,8 @@ class NavItemTest extends UnitTestCase
             'getRoute' => new Route(new InMemoryPage('foo')),
             'getRouteKey' => 'foo',
         ]));
-        $this->assertTrue(NavItem::forRoute(new Route(new InMemoryPage('foo')))->isActive());
-        $this->assertFalse(NavItem::forRoute(new Route(new InMemoryPage('bar')))->isActive());
+        $this->assertTrue(NavigationItem::forRoute(new Route(new InMemoryPage('foo')))->isActive());
+        $this->assertFalse(NavigationItem::forRoute(new Route(new InMemoryPage('bar')))->isActive());
     }
 
     public function testIsCurrentWithExternalRoute()
@@ -246,47 +246,47 @@ class NavItemTest extends UnitTestCase
             'getRoute' => new Route(new InMemoryPage('foo')),
             'getRouteKey' => 'foo',
         ]));
-        $this->assertFalse(NavItem::forLink('foo', 'bar')->isActive());
-        $this->assertFalse(NavItem::forLink('https://example.com', 'bar')->isActive());
+        $this->assertFalse(NavigationItem::forLink('foo', 'bar')->isActive());
+        $this->assertFalse(NavigationItem::forLink('https://example.com', 'bar')->isActive());
     }
 
     public function testGetGroupWithNoGroup()
     {
-        $this->assertNull((new NavItem(new Route(new MarkdownPage()), 'Test', 500))->getGroupKey());
+        $this->assertNull((new NavigationItem(new Route(new MarkdownPage()), 'Test', 500))->getGroupKey());
     }
 
     public function testGetGroupWithGroup()
     {
-        $this->assertSame('foo', (new NavItem(new Route(new MarkdownPage()), 'Test', 500, 'foo'))->getGroupKey());
+        $this->assertSame('foo', (new NavigationItem(new Route(new MarkdownPage()), 'Test', 500, 'foo'))->getGroupKey());
     }
 
     public function testGetGroupFromRouteWithGroup()
     {
-        $this->assertSame('foo', NavItem::forRoute(new Route(new MarkdownPage(matter: ['navigation.group' => 'foo'])))->getGroupKey());
+        $this->assertSame('foo', NavigationItem::forRoute(new Route(new MarkdownPage(matter: ['navigation.group' => 'foo'])))->getGroupKey());
     }
 
     public function testGetGroupForRouteWithGroup()
     {
-        $this->assertSame('foo', NavItem::forRoute(new Route(new MarkdownPage(matter: ['navigation.group' => 'foo'])), 'foo')->getGroupKey());
+        $this->assertSame('foo', NavigationItem::forRoute(new Route(new MarkdownPage(matter: ['navigation.group' => 'foo'])), 'foo')->getGroupKey());
     }
 
     public function testGroupKeysAreNormalized()
     {
-        $item = new NavItem(new Route(new MarkdownPage()), 'Test', 500, 'Foo Bar');
+        $item = new NavigationItem(new Route(new MarkdownPage()), 'Test', 500, 'Foo Bar');
         $this->assertSame('foo-bar', $item->getGroupKey());
     }
 
     public function testNormalizeGroupKeyCreatesSlugs()
     {
-        $this->assertSame('foo-bar', NavItem::normalizeGroupKey('Foo Bar'));
-        $this->assertSame('foo-bar', NavItem::normalizeGroupKey('foo bar'));
-        $this->assertSame('foo-bar', NavItem::normalizeGroupKey('foo_bar'));
-        $this->assertSame('foo-bar', NavItem::normalizeGroupKey('foo-bar'));
-        $this->assertSame('foo-bar', NavItem::normalizeGroupKey(' foo bar '));
+        $this->assertSame('foo-bar', NavigationItem::normalizeGroupKey('Foo Bar'));
+        $this->assertSame('foo-bar', NavigationItem::normalizeGroupKey('foo bar'));
+        $this->assertSame('foo-bar', NavigationItem::normalizeGroupKey('foo_bar'));
+        $this->assertSame('foo-bar', NavigationItem::normalizeGroupKey('foo-bar'));
+        $this->assertSame('foo-bar', NavigationItem::normalizeGroupKey(' foo bar '));
     }
 
     public function testNormalizeGroupKeyReturnsNullForNull()
     {
-        $this->assertNull(NavItem::normalizeGroupKey(null));
+        $this->assertNull(NavigationItem::normalizeGroupKey(null));
     }
 }

--- a/packages/framework/tests/Unit/NavigationMenuUnitTest.php
+++ b/packages/framework/tests/Unit/NavigationMenuUnitTest.php
@@ -7,7 +7,7 @@ namespace Hyde\Framework\Testing\Unit;
 use Hyde\Testing\UnitTestCase;
 use Illuminate\Support\Collection;
 use Hyde\Support\Models\ExternalRoute;
-use Hyde\Framework\Features\Navigation\NavItem;
+use Hyde\Framework\Features\Navigation\NavigationItem;
 use Hyde\Framework\Features\Navigation\MainNavigationMenu;
 
 /**
@@ -121,8 +121,8 @@ class NavigationMenuUnitTest extends UnitTestCase
         ];
     }
 
-    protected function item(string $destination, string $label, int $priority = 500): NavItem
+    protected function item(string $destination, string $label, int $priority = 500): NavigationItem
     {
-        return new NavItem(new ExternalRoute($destination), $label, $priority);
+        return new NavigationItem(new ExternalRoute($destination), $label, $priority);
     }
 }

--- a/packages/framework/tests/Unit/Views/NavigationLinkViewTest.php
+++ b/packages/framework/tests/Unit/Views/NavigationLinkViewTest.php
@@ -9,7 +9,7 @@ use Hyde\Support\Models\Route;
 use Hyde\Testing\TestsBladeViews;
 use Hyde\Testing\Support\TestView;
 use Illuminate\View\ComponentAttributeBag;
-use Hyde\Framework\Features\Navigation\NavItem;
+use Hyde\Framework\Features\Navigation\NavigationItem;
 use Hyde\Testing\TestCase;
 
 /**
@@ -29,7 +29,7 @@ class NavigationLinkViewTest extends TestCase
     protected function testView(): TestView
     {
         return $this->view(view('hyde::components.navigation.navigation-link', [
-            'item' => NavItem::forRoute(new Route(new InMemoryPage('foo')), 'Foo'),
+            'item' => NavigationItem::forRoute(new Route(new InMemoryPage('foo')), 'Foo'),
             'attributes' => new ComponentAttributeBag(),
         ]));
     }


### PR DESCRIPTION
Renames the NavItem and NavItemGroup classes to not be abbreviated. Sure, the NavItem naming is very broadly understood and there is a balance between verboseness and conciseness, but these are the only two abbreviated classes in all of HydePHP and I think the consistency weights in most here. 

Targets https://github.com/hydephp/develop/pull/1568