### PR TITLE
Internal: Update continuous integration server integrations to better handle forks

### DIFF
--- a/.github/workflows/smoke-tests.yml
+++ b/.github/workflows/smoke-tests.yml
@@ -31,7 +31,7 @@ jobs:
         run: vendor/bin/pest --stop-on-failure --log-junit report.xml
 
       - name: Ping continuous integration server with test status
-        if: always()
+        if: always() && github.event.repository.full_name == 'hydephp/develop'
         run: |
           bearerToken="${{ secrets.CI_SERVER_TOKEN }}"
           commit="${{ github.event.pull_request.head.sha }}"

--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -22,4 +22,5 @@ jobs:
 
         # Send the reports to the CI server to calculate type coverage and send back commit status checks
       - name: Ping CI server with type coverage results
+        if: github.event.repository.full_name == 'hydephp/develop'
         run: php monorepo/scripts/ping-ci-server-with-type-coverage.php ${{ secrets.CI_SERVER_TOKEN }} ${{ github.event.pull_request.head.sha }} ${{ github.head_ref }} ${{ github.run_id }}


### PR DESCRIPTION
We could probably verify things using the runs api `https://api.github.com/repos/hydephp/develop/actions/runs/<run_id>`, but for now, skipping them seems easiest