### PR TITLE
[2.x] Experiment with splitting out the route model

### DIFF
--- a/_ide_helper.php
+++ b/_ide_helper.php
@@ -16,7 +16,7 @@ declare(strict_types=1);
 /** @var \Hyde\Pages\Concerns\HydePage $page The page being compiled/previewed */
 $page = \Hyde\Support\Facades\Render::getPage();
 
-/** @var \Hyde\Support\Models\Route $route The route for the page being compiled/previewed */
+/** @var \Hyde\Support\Models\PageRoute $route The route for the page being compiled/previewed */
 $route = \Hyde\Support\Facades\Render::getRoute();
 
 /** @var string $routeKey The route key for the page being compiled/previewed */

--- a/config/hyde.php
+++ b/config/hyde.php
@@ -317,7 +317,7 @@ return [
     |
     | If you are looking to customize the main navigation menu, this is the place!
     |
-    | All these settings uses Route Keys to identify the page you want to configure.
+    | All these settings uses PageRoute Keys to identify the page you want to configure.
     | A route key is simply the URL path to the page, without the file extension.
     | So `_site/posts/hello-world.html` has the route key 'posts/hello-world'.
     |

--- a/docs/_data/partials/hyde-pages-api/documentation-page-methods.md
+++ b/docs/_data/partials/hyde-pages-api/documentation-page-methods.md
@@ -9,7 +9,7 @@ No description provided.
 
 ```php
 // torchlight! {"lineNumbers": false}
-DocumentationPage::home(): Hyde\Support\Models\Route
+DocumentationPage::home(): Hyde\Support\Models\PageRoute
 ```
 
 #### `homeRouteName()`

--- a/docs/_data/partials/hyde-pages-api/hyde-kernel-foundation-methods.md
+++ b/docs/_data/partials/hyde-pages-api/hyde-kernel-foundation-methods.md
@@ -27,7 +27,7 @@ No description provided.
 
 ```php
 // torchlight! {"lineNumbers": false}
-Hyde::routes(): \Hyde\Foundation\Kernel\RouteCollection<string, \Hyde\Support\Models\Route>
+Hyde::routes(): \Hyde\Foundation\Kernel\RouteCollection<string, \Hyde\Support\Models\PageRoute>
 ```
 
 <!-- End generated docs for Hyde\Foundation\Concerns\HandlesFoundationCollections -->

--- a/docs/_data/partials/hyde-pages-api/hyde-kernel-hyperlink-methods.md
+++ b/docs/_data/partials/hyde-pages-api/hyde-kernel-hyperlink-methods.md
@@ -54,7 +54,7 @@ No description provided.
 
 ```php
 // torchlight! {"lineNumbers": false}
-Hyde::route(string $key): Hyde\Support\Models\Route
+Hyde::route(string $key): Hyde\Support\Models\PageRoute
 ```
 
 #### `hasSiteUrl()`

--- a/docs/_data/partials/hyde-pages-api/hyde-kernel-view-methods.md
+++ b/docs/_data/partials/hyde-pages-api/hyde-kernel-view-methods.md
@@ -27,7 +27,7 @@ Get the route for the page being rendered.
 
 ```php
 // torchlight! {"lineNumbers": false}
-Hyde::currentRoute(): Hyde\Support\Models\Route
+Hyde::currentRoute(): Hyde\Support\Models\PageRoute
 ```
 
 #### `currentPage()`

--- a/docs/_data/partials/hyde-pages-api/hyde-page-methods.md
+++ b/docs/_data/partials/hyde-pages-api/hyde-page-methods.md
@@ -217,7 +217,7 @@ Get the route key for the page.
 
 The route key is the page URL path, relative to the site root, but without any file extensions. For example, if the page will be saved to `_site/docs/index.html`, the key is `docs/index`.
 
-Route keys are used to identify page routes, similar to how named routes work in Laravel, only that here the name is not just arbitrary, but also defines the output location, as the route key is used to determine the output path which is `$routeKey.html`.
+PageRoute keys are used to identify page routes, similar to how named routes work in Laravel, only that here the name is not just arbitrary, but also defines the output location, as the route key is used to determine the output path which is `$routeKey.html`.
 
 ```php
 // torchlight! {"lineNumbers": false}
@@ -230,7 +230,7 @@ Get the route object for the page.
 
 ```php
 // torchlight! {"lineNumbers": false}
-$page->getRoute(): Hyde\Support\Models\Route
+$page->getRoute(): Hyde\Support\Models\PageRoute
 ```
 
 #### `getLink()`

--- a/docs/architecture-concepts/automatic-routing.md
+++ b/docs/architecture-concepts/automatic-routing.md
@@ -23,9 +23,9 @@ php hyde route:list
 
 ### Accessing routes
 
-Each route in your site is represented by a Route object. It's very easy to get a Route object instance from the Router's index.
+Each route in your site is represented by a PageRoute object. It's very easy to get a PageRoute object instance from the Router's index.
 There are a few ways to do this, but most commonly you'll use the Routes facade's `get()` method where you provide a route key,
-and it will return the Route object. The route key is generally `<page-output-directory/page-identifier>`. Here are some examples:
+and it will return the PageRoute object. The route key is generally `<page-output-directory/page-identifier>`. Here are some examples:
 
 ```php
 // Source file: _pages/index.md/index.blade.php

--- a/docs/architecture-concepts/the-hydekernel.md
+++ b/docs/architecture-concepts/the-hydekernel.md
@@ -139,7 +139,7 @@ No description provided.
 
 ```php
 // torchlight! {"lineNumbers": false}
-Hyde::routes(): \Hyde\Foundation\Kernel\RouteCollection<string, \Hyde\Support\Models\Route>
+Hyde::routes(): \Hyde\Foundation\Kernel\RouteCollection<string, \Hyde\Support\Models\PageRoute>
 ```
 
 <!-- End generated docs for Hyde\Foundation\Concerns\HandlesFoundationCollections -->
@@ -546,7 +546,7 @@ Get the route for the page being rendered.
 
 ```php
 // torchlight! {"lineNumbers": false}
-Hyde::currentRoute(): Hyde\Support\Models\Route
+Hyde::currentRoute(): Hyde\Support\Models\PageRoute
 ```
 
 #### `currentPage()`

--- a/docs/digging-deeper/advanced-customization.md
+++ b/docs/digging-deeper/advanced-customization.md
@@ -74,7 +74,7 @@ public function register(): void
 ## Customizing Output Directories
 
 Like source directories, the output directories are also important as they determine the output path for the compiled pages.
->warning Note that changing output directories also affects the route keys, as those are based on the output directory. <p>Scroll down to see the [Route key impact](#route-key-impact) section for more information.</p>
+>warning Note that changing output directories also affects the route keys, as those are based on the output directory. <p>Scroll down to see the [PageRoute key impact](#route-key-impact) section for more information.</p>
 
 Each option is relative to the site's `output_directory` setting. Setting a value to `''` will output the page to the site root.
 
@@ -109,7 +109,7 @@ public function register(): void
 }
 ```
 
-### Route key impact
+### PageRoute key impact
 
 For example, changing the output directory of Markdown posts to `blog` instead of `posts` will change the route key base from `posts` to `blog`.
 This means that a file stored as `_posts/hello-world.md` will have the route key `blog/hello-world` instead of `posts/hello-world`,

--- a/docs/digging-deeper/helpers.md
+++ b/docs/digging-deeper/helpers.md
@@ -237,7 +237,7 @@ This is an alias of the `Hyde::route()` facade method and allows you to get a ro
 route('index'); // Returns the route instance with the given key
 ```
 
-If a route does not exist, `null` will be returned. Route instances can be cast to strings to resolve a link to the page.
+If a route does not exist, `null` will be returned. PageRoute instances can be cast to strings to resolve a link to the page.
 
 **Example usage:**
 

--- a/docs/digging-deeper/troubleshooting.md
+++ b/docs/digging-deeper/troubleshooting.md
@@ -60,7 +60,7 @@ We will use the following definitions to describe the behaviour of Hyde.
 #### Path components
 
 - **Identifier**: The filepath without the extension, relative to the page type source directory.
-- **Route Key**: The page type's output directory plus the identifier. Example: `posts/hello-world`
+- **PageRoute Key**: The page type's output directory plus the identifier. Example: `posts/hello-world`
 - **Basename**: The filename without the extension. Example: `hello-world`
 - **Filename**: The full name of a file with the extension. Example: `hello-world.md`
 - **Filepath**: The full file path including extension. Example: `_posts/hello-world.md`

--- a/docs/getting-started/core-concepts.md
+++ b/docs/getting-started/core-concepts.md
@@ -78,7 +78,7 @@ All source and output directories are configurable, but the defaults are as foll
 | Media Assets   | `_media/`        | `_site/media/`   | Common asset types  |
 
 
-## Paths, Identifiers, and Route Keys
+## Paths, Identifiers, and PageRoute Keys
 
 Since HydePHP automatically discovers and compiles content files, it is important to understand how HydePHP handles paths,
 as the file names and directories they are in will directly influence how the page will be compiled.
@@ -87,7 +87,7 @@ As such, it will be helpful for you to know about the following terms:
 
 - **Path:** The full path to a file, including the file name, directory, and extension.
 - **Identifier:** The unique identifier for a page. Unique only within the same page type.
-- **Route key:** The key used to access the page in the routing system. Unique across all site pages.
+- **PageRoute key:** The key used to access the page in the routing system. Unique across all site pages.
 
 Both the identifier and route key are derived from the path of the page. The identifier is the path without the file
 extension, and relative to the page type source directory. The route key is the output directory plus the identifier.
@@ -180,8 +180,8 @@ During the build of each page, Hyde will inject some data available to all Blade
 any custom Blade templates, you can safely ignore this section. If you are, here are the three global variables you can use:
 
 - `$page`: The [Page Object](#page-models) for the current page.
-- `$route`: The [Route Object](#automatic-routing) for the current page.
-- `$routeKey`: The [Route Key](#paths-identifiers-and-route-keys) for the current page.
+- `$route`: The [PageRoute Object](#automatic-routing) for the current page.
+- `$routeKey`: The [PageRoute Key](#paths-identifiers-and-route-keys) for the current page.
 
 The `$page` variable is likely to the most important one, as it contains all the data for the current page.
 Depending on the page type, you will have different helpers available. But `$page->matter()` is likely to be very helpful.
@@ -240,7 +240,7 @@ This will help you understand the documentation and codebase better, as well as 
 - [Page Types](#page-types)
 - [Page Identifiers](#page-identifiers)
 - [Routes](#routes)
-- [Route Keys](#route-keys)
+- [PageRoute Keys](#route-keys)
 
 </div>
 
@@ -325,7 +325,7 @@ Content files, including Markdown and Blade files, are automatically discovered 
 During autodiscovery, Hyde also generates dynamic data to enrich your content based on the page type.
 
 In short the autodiscovery is split into three steps:
-`File discovery -> Page parsing -> Route generation`
+`File discovery -> Page parsing -> PageRoute generation`
 
 ### Page Types
 
@@ -339,13 +339,13 @@ The identifier is used to generate the route key, which is used to generate the 
 
 ### Routes
 
-All pages are internally bound to a Route object, through the route key. During the build process, each route is
+All pages are internally bound to a PageRoute object, through the route key. During the build process, each route is
 compiled to HTML using the page object's data, and saved to the output directory with a file name created from the route key.
 Since routes are generated automatically during autodiscovery, there is no need to create them manually.
 
-### Route Keys
+### PageRoute Keys
 
 The route key is the URL path relative to the site webroot, without the file extension. The route key is the common
-identifier binding Page objects to Route objects, and is used to generate the file name for the compiled HTML file.
+identifier binding Page objects to PageRoute objects, and is used to generate the file name for the compiled HTML file.
 
-Route keys generation can be visualised as follows: `<PageClass::OutputDirectory>/<PageIdentifier>`
+PageRoute keys generation can be visualised as follows: `<PageClass::OutputDirectory>/<PageIdentifier>`

--- a/packages/framework/config/hyde.php
+++ b/packages/framework/config/hyde.php
@@ -317,7 +317,7 @@ return [
     |
     | If you are looking to customize the main navigation menu, this is the place!
     |
-    | All these settings uses Route Keys to identify the page you want to configure.
+    | All these settings uses PageRoute Keys to identify the page you want to configure.
     | A route key is simply the URL path to the page, without the file extension.
     | So `_site/posts/hello-world.html` has the route key 'posts/hello-world'.
     |

--- a/packages/framework/src/Console/Commands/RouteListCommand.php
+++ b/packages/framework/src/Console/Commands/RouteListCommand.php
@@ -7,7 +7,7 @@ namespace Hyde\Console\Commands;
 use Hyde\Console\Concerns\Command;
 use Hyde\Hyde;
 use Hyde\Pages\InMemoryPage;
-use Hyde\Support\Models\Route;
+use Hyde\Support\Models\PageRoute;
 use Hyde\Support\Models\RouteList;
 use Hyde\Support\Models\RouteListItem;
 
@@ -38,7 +38,7 @@ class RouteListCommand extends Command
     {
         return new class extends RouteList
         {
-            protected static function routeToListItem(Route $route): RouteListItem
+            protected static function routeToListItem(PageRoute $route): RouteListItem
             {
                 return new class($route) extends RouteListItem
                 {

--- a/packages/framework/src/Foundation/Concerns/ForwardsHyperlinks.php
+++ b/packages/framework/src/Foundation/Concerns/ForwardsHyperlinks.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Hyde\Foundation\Concerns;
 
-use Hyde\Support\Models\Route;
+use Hyde\Support\Models\PageRoute;
 
 /**
  * @internal Single-use trait for the HydeKernel class.
@@ -38,7 +38,7 @@ trait ForwardsHyperlinks
         return $this->hyperlinks->url($path);
     }
 
-    public function route(string $key): ?Route
+    public function route(string $key): ?PageRoute
     {
         return $this->hyperlinks->route($key);
     }

--- a/packages/framework/src/Foundation/Concerns/HandlesFoundationCollections.php
+++ b/packages/framework/src/Foundation/Concerns/HandlesFoundationCollections.php
@@ -31,7 +31,7 @@ trait HandlesFoundationCollections
         return $this->pages;
     }
 
-    /** @return \Hyde\Foundation\Kernel\RouteCollection<string, \Hyde\Support\Models\Route> */
+    /** @return \Hyde\Foundation\Kernel\RouteCollection<string, \Hyde\Support\Models\PageRoute> */
     public function routes(): RouteCollection
     {
         $this->needsToBeBooted();

--- a/packages/framework/src/Foundation/Concerns/ManagesViewData.php
+++ b/packages/framework/src/Foundation/Concerns/ManagesViewData.php
@@ -6,7 +6,7 @@ namespace Hyde\Foundation\Concerns;
 
 use Hyde\Pages\Concerns\HydePage;
 use Hyde\Support\Facades\Render;
-use Hyde\Support\Models\Route;
+use Hyde\Support\Models\PageRoute;
 
 /**
  * @internal Single-use trait for the HydeKernel class.
@@ -34,7 +34,7 @@ trait ManagesViewData
     /**
      * Get the route for the page being rendered.
      */
-    public function currentRoute(): ?Route
+    public function currentRoute(): ?PageRoute
     {
         return Render::getRoute();
     }

--- a/packages/framework/src/Foundation/Facades/Routes.php
+++ b/packages/framework/src/Foundation/Facades/Routes.php
@@ -7,7 +7,7 @@ namespace Hyde\Foundation\Facades;
 use Hyde\Foundation\HydeKernel;
 use Hyde\Foundation\Kernel\RouteCollection;
 use Hyde\Hyde;
-use Hyde\Support\Models\Route;
+use Hyde\Support\Models\PageRoute;
 use Illuminate\Support\Facades\Facade;
 
 /**
@@ -19,7 +19,7 @@ use Illuminate\Support\Facades\Facade;
  */
 class Routes extends Facade
 {
-    /** @return \Hyde\Foundation\Kernel\RouteCollection<string, \Hyde\Support\Models\Route> */
+    /** @return \Hyde\Foundation\Kernel\RouteCollection<string, \Hyde\Support\Models\PageRoute> */
     public static function getFacadeRoot(): RouteCollection
     {
         return HydeKernel::getInstance()->routes();
@@ -30,25 +30,25 @@ class Routes extends Facade
         return static::getFacadeRoot()->has($routeKey);
     }
 
-    public static function get(string $routeKey): ?Route
+    public static function get(string $routeKey): ?PageRoute
     {
         return static::getFacadeRoot()->get($routeKey);
     }
 
     /** @throws \Hyde\Framework\Exceptions\RouteNotFoundException */
-    public static function getOrFail(string $routeKey): Route
+    public static function getOrFail(string $routeKey): PageRoute
     {
         return static::getFacadeRoot()->getRoute($routeKey);
     }
 
-    /** @return \Hyde\Foundation\Kernel\RouteCollection<\Hyde\Support\Models\Route> */
+    /** @return \Hyde\Foundation\Kernel\RouteCollection<\Hyde\Support\Models\PageRoute> */
     public static function all(): RouteCollection
     {
         return static::getFacadeRoot()->getRoutes();
     }
 
     /** Get the current route for the page being rendered. */
-    public static function current(): ?Route
+    public static function current(): ?PageRoute
     {
         return Hyde::currentRoute();
     }

--- a/packages/framework/src/Foundation/Kernel/Hyperlinks.php
+++ b/packages/framework/src/Foundation/Kernel/Hyperlinks.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace Hyde\Foundation\Kernel;
 
 use Hyde\Facades\Config;
-use Hyde\Support\Models\Route;
+use Hyde\Support\Models\PageRoute;
 use Hyde\Foundation\HydeKernel;
 use Hyde\Framework\Exceptions\BaseUrlNotSetException;
 use Hyde\Framework\Exceptions\FileNotFoundException;
@@ -153,7 +153,7 @@ class Hyperlinks
     /**
      * Get a route instance by its key from the kernel's route collection.
      */
-    public function route(string $key): ?Route
+    public function route(string $key): ?PageRoute
     {
         return $this->kernel->routes()->get($key);
     }

--- a/packages/framework/src/Foundation/Kernel/RouteCollection.php
+++ b/packages/framework/src/Foundation/Kernel/RouteCollection.php
@@ -7,19 +7,19 @@ namespace Hyde\Foundation\Kernel;
 use Hyde\Foundation\Concerns\BaseFoundationCollection;
 use Hyde\Framework\Exceptions\RouteNotFoundException;
 use Hyde\Pages\Concerns\HydePage;
-use Hyde\Support\Models\Route;
+use Hyde\Support\Models\PageRoute;
 
 /**
  * The RouteCollection contains all the page routes, making it the pseudo-router for Hyde,
  * as it maps each page to the eventual URL that will be used to access it once built.
  *
- * @template T of \Hyde\Support\Models\Route
+ * @template T of \Hyde\Support\Models\PageRoute
  *
  * @template-extends \Hyde\Foundation\Concerns\BaseFoundationCollection<string, T>
  *
- * @property array<string, Route> $items The routes in the collection.
+ * @property array<string, PageRoute> $items The routes in the collection.
  *
- * @method Route|null get(string $key, Route $default = null)
+ * @method PageRoute|null get(string $key, PageRoute $default = null)
  *
  * This class is stored as a singleton in the HydeKernel.
  * You would commonly access it via the facade or Hyde helper:
@@ -29,7 +29,7 @@ use Hyde\Support\Models\Route;
  */
 final class RouteCollection extends BaseFoundationCollection
 {
-    public function addRoute(Route $route): void
+    public function addRoute(PageRoute $route): void
     {
         $this->put($route->getRouteKey(), $route);
     }
@@ -37,7 +37,7 @@ final class RouteCollection extends BaseFoundationCollection
     protected function runDiscovery(): void
     {
         $this->kernel->pages()->each(function (HydePage $page): void {
-            $this->addRoute(new Route($page));
+            $this->addRoute(new PageRoute($page));
         });
     }
 
@@ -48,18 +48,18 @@ final class RouteCollection extends BaseFoundationCollection
         }
     }
 
-    public function getRoute(string $routeKey): Route
+    public function getRoute(string $routeKey): PageRoute
     {
         return $this->get($routeKey) ?? throw new RouteNotFoundException($routeKey);
     }
 
     /**
      * @param  class-string<\Hyde\Pages\Concerns\HydePage>|null  $pageClass
-     * @return \Hyde\Foundation\Kernel\RouteCollection<string, \Hyde\Support\Models\Route>
+     * @return \Hyde\Foundation\Kernel\RouteCollection<string, \Hyde\Support\Models\PageRoute>
      */
     public function getRoutes(?string $pageClass = null): RouteCollection
     {
-        return $pageClass ? $this->filter(function (Route $route) use ($pageClass): bool {
+        return $pageClass ? $this->filter(function (PageRoute $route) use ($pageClass): bool {
             return $route->getPage() instanceof $pageClass;
         }) : $this;
     }

--- a/packages/framework/src/Framework/Exceptions/RouteNotFoundException.php
+++ b/packages/framework/src/Framework/Exceptions/RouteNotFoundException.php
@@ -11,13 +11,13 @@ use function sprintf;
 class RouteNotFoundException extends Exception
 {
     /** @var string */
-    protected $message = 'Route not found.';
+    protected $message = 'PageRoute not found.';
 
     /** @var int */
     protected $code = 404;
 
     public function __construct(?string $routeKey = null)
     {
-        parent::__construct($routeKey ? sprintf('Route [%s] not found.', $routeKey) : $this->message);
+        parent::__construct($routeKey ? sprintf('PageRoute [%s] not found.', $routeKey) : $this->message);
     }
 }

--- a/packages/framework/src/Framework/Features/Navigation/NavigationItem.php
+++ b/packages/framework/src/Framework/Features/Navigation/NavigationItem.php
@@ -6,7 +6,7 @@ namespace Hyde\Framework\Features\Navigation;
 
 use Hyde\Foundation\Facades\Routes;
 use Hyde\Hyde;
-use Hyde\Support\Models\Route;
+use Hyde\Support\Models\PageRoute;
 use Illuminate\Support\Str;
 use Stringable;
 use Hyde\Support\Models\ExternalRoute;
@@ -17,13 +17,13 @@ use function is_string;
  * Abstraction for a navigation menu item. Used by the MainNavigationMenu and DocumentationSidebar classes.
  *
  * You have a few options to construct a navigation menu item:
- *   1. You can supply a Route directly and explicit properties to the constructor
+ *   1. You can supply a PageRoute directly and explicit properties to the constructor
  *   2. You can use NavigationItem::fromRoute() to use data from the route
  *   3. You can use NavigationItem::create() for an external or un-routed link
  */
 class NavigationItem implements NavigationElement, Stringable
 {
-    protected ?Route $route;
+    protected ?PageRoute $route;
     protected string $label;
     protected int $priority;
 
@@ -33,12 +33,12 @@ class NavigationItem implements NavigationElement, Stringable
     /**
      * Create a new navigation menu item with your own properties.
      *
-     * @param  \Hyde\Support\Models\Route|string|null  $destination  Route instance, route key, or external URI. For dropdowns/groups, this should be null.
+     * @param  \Hyde\Support\Models\PageRoute|string|null  $destination  PageRoute instance, route key, or external URI. For dropdowns/groups, this should be null.
      * @param  string  $label  The label of the navigation item.
      * @param  int  $priority  The priority to determine the order of the navigation item.
      * @param  string|null  $group  The dropdown/group key of the navigation item, if any.
      */
-    public function __construct(Route|string|null $destination, string $label, int $priority = NavigationMenu::DEFAULT, ?string $group = null)
+    public function __construct(PageRoute|string|null $destination, string $label, int $priority = NavigationMenu::DEFAULT, ?string $group = null)
     {
         if (is_string($destination)) {
             $destination = Routes::get($destination) ?? new ExternalRoute($destination);
@@ -54,20 +54,20 @@ class NavigationItem implements NavigationElement, Stringable
     }
 
     /**
-     * Create a new navigation menu item, automatically filling in the properties from a Route instance if provided.
+     * Create a new navigation menu item, automatically filling in the properties from a PageRoute instance if provided.
      *
-     * @param  \Hyde\Support\Models\Route|string<\Hyde\Support\Models\RouteKey>|string  $destination  Route instance or route key, or external URI.
+     * @param  \Hyde\Support\Models\PageRoute|string<\Hyde\Support\Models\RouteKey>|string  $destination  PageRoute instance or route key, or external URI.
      * @param  int|null  $priority  Leave blank to use the priority of the route's corresponding page, if there is one tied to the route.
      * @param  string|null  $label  Leave blank to use the label of the route's corresponding page, if there is one tied to the route.
      * @param  string|null  $group  Leave blank to use the group of the route's corresponding page, if there is one tied to the route.
      */
-    public static function create(Route|string $destination, ?string $label = null, ?int $priority = null, ?string $group = null): self
+    public static function create(PageRoute|string $destination, ?string $label = null, ?int $priority = null, ?string $group = null): self
     {
         if (is_string($destination)) {
             $destination = Routes::get($destination) ?? new ExternalRoute($destination);
         }
 
-        if ($destination instanceof Route && ! $destination instanceof ExternalRoute) {
+        if ($destination instanceof PageRoute && ! $destination instanceof ExternalRoute) {
             return new self(
                 $destination,
                 $label ?? $destination->getPage()->navigationMenuLabel(),
@@ -90,7 +90,7 @@ class NavigationItem implements NavigationElement, Stringable
     /**
      * Get the destination route of the navigation item. For dropdowns, this will return null.
      */
-    public function getRoute(): ?Route
+    public function getRoute(): ?PageRoute
     {
         return $this->route;
     }

--- a/packages/framework/src/Framework/Features/Navigation/NavigationMenuGenerator.php
+++ b/packages/framework/src/Framework/Features/Navigation/NavigationMenuGenerator.php
@@ -7,7 +7,7 @@ namespace Hyde\Framework\Features\Navigation;
 use Hyde\Hyde;
 use Hyde\Facades\Config;
 use Illuminate\Support\Str;
-use Hyde\Support\Models\Route;
+use Hyde\Support\Models\PageRoute;
 use Hyde\Pages\DocumentationPage;
 use Illuminate\Support\Collection;
 use Hyde\Foundation\Facades\Routes;
@@ -27,7 +27,7 @@ class NavigationMenuGenerator
     /** @var \Illuminate\Support\Collection<string, \Hyde\Framework\Features\Navigation\NavigationItem> */
     protected Collection $items;
 
-    /** @var \Hyde\Foundation\Kernel\RouteCollection<string, \Hyde\Support\Models\Route> */
+    /** @var \Hyde\Foundation\Kernel\RouteCollection<string, \Hyde\Support\Models\PageRoute> */
     protected RouteCollection $routes;
 
     /** @var class-string<\Hyde\Framework\Features\Navigation\NavigationMenu> */
@@ -66,7 +66,7 @@ class NavigationMenuGenerator
 
     protected function generate(): void
     {
-        $this->routes->each(function (Route $route): void {
+        $this->routes->each(function (PageRoute $route): void {
             if ($this->canAddRoute($route)) {
                 if ($this->canGroupRoute($route)) {
                     $this->addRouteToGroup($route);
@@ -95,13 +95,13 @@ class NavigationMenuGenerator
             // In order to know if we should use groups in the sidebar, we need to loop through the pages and see if they have a group set.
             // This automatically enables the sidebar grouping for all pages if at least one group is set.
 
-            return $this->routes->first(fn (Route $route): bool => filled($route->getPage()->navigationMenuGroup())) !== null;
+            return $this->routes->first(fn (PageRoute $route): bool => filled($route->getPage()->navigationMenuGroup())) !== null;
         } else {
             return Config::getString('hyde.navigation.subdirectories', 'hidden') === 'dropdown';
         }
     }
 
-    protected function canAddRoute(Route $route): bool
+    protected function canAddRoute(PageRoute $route): bool
     {
         if (! $route->getPage()->showInNavigation()) {
             return false;
@@ -118,7 +118,7 @@ class NavigationMenuGenerator
         }
     }
 
-    protected function canGroupRoute(Route $route): bool
+    protected function canGroupRoute(PageRoute $route): bool
     {
         if (! $this->generatesSidebar) {
             return $route->getPage()->navigationMenuGroup() !== null;
@@ -131,7 +131,7 @@ class NavigationMenuGenerator
         return true;
     }
 
-    protected function addRouteToGroup(Route $route): void
+    protected function addRouteToGroup(PageRoute $route): void
     {
         $item = NavigationItem::create($route);
 

--- a/packages/framework/src/Framework/Features/XmlGenerators/SitemapGenerator.php
+++ b/packages/framework/src/Framework/Features/XmlGenerators/SitemapGenerator.php
@@ -12,7 +12,7 @@ use Hyde\Facades\Config;
 use Hyde\Pages\BladePage;
 use Hyde\Pages\MarkdownPage;
 use Hyde\Pages\MarkdownPost;
-use Hyde\Support\Models\Route;
+use Hyde\Support\Models\PageRoute;
 use Hyde\Pages\DocumentationPage;
 use Hyde\Foundation\Facades\Routes;
 use Hyde\Framework\Concerns\TracksExecutionTime;
@@ -33,7 +33,7 @@ class SitemapGenerator extends BaseXmlGenerator
 
     public function generate(): static
     {
-        Routes::all()->each(function (Route $route): void {
+        Routes::all()->each(function (PageRoute $route): void {
             $this->addRoute($route);
         });
 
@@ -55,7 +55,7 @@ class SitemapGenerator extends BaseXmlGenerator
         $this->xmlElement->addAttribute('generator', 'HydePHP '.Hyde::version());
     }
 
-    protected function addRoute(Route $route): void
+    protected function addRoute(PageRoute $route): void
     {
         $urlItem = $this->xmlElement->addChild('url');
 
@@ -106,7 +106,7 @@ class SitemapGenerator extends BaseXmlGenerator
         return (string) $this->getExecutionTimeInMs();
     }
 
-    protected function resolveRouteLink(Route $route): string
+    protected function resolveRouteLink(PageRoute $route): string
     {
         $baseUrl = Config::getNullableString('hyde.url');
 

--- a/packages/framework/src/Framework/Services/BuildService.php
+++ b/packages/framework/src/Framework/Services/BuildService.php
@@ -9,7 +9,7 @@ use Hyde\Foundation\Facades\Routes;
 use Hyde\Foundation\Kernel\RouteCollection;
 use Hyde\Framework\Actions\StaticPageBuilder;
 use Hyde\Pages\Concerns\HydePage;
-use Hyde\Support\Models\Route;
+use Hyde\Support\Models\PageRoute;
 use Illuminate\Console\Concerns\InteractsWithIO;
 use Illuminate\Console\OutputStyle;
 
@@ -53,7 +53,7 @@ class BuildService
 
         $collection = Routes::getRoutes($pageClass);
 
-        $this->withProgressBar($collection, function (Route $route): void {
+        $this->withProgressBar($collection, function (PageRoute $route): void {
             StaticPageBuilder::handle($route->getPage());
         });
 

--- a/packages/framework/src/Hyde.php
+++ b/packages/framework/src/Hyde.php
@@ -11,7 +11,7 @@ use Hyde\Foundation\Kernel\Filesystem;
 use Hyde\Foundation\Kernel\PageCollection;
 use Hyde\Foundation\Kernel\RouteCollection;
 use Hyde\Pages\Concerns\HydePage;
-use Hyde\Support\Models\Route;
+use Hyde\Support\Models\PageRoute;
 use Hyde\Support\Filesystem\SourceFile;
 use Illuminate\Support\Facades\Facade;
 use Illuminate\Support\HtmlString;
@@ -38,7 +38,7 @@ use JetBrains\PhpStorm\Pure;
  * @method static string mediaLink(string $destination, bool $validate = false)
  * @method static string asset(string $name, bool $preferQualifiedUrl = false)
  * @method static string url(string $path = '')
- * @method static Route|null route(string $key)
+ * @method static PageRoute|null route(string $key)
  * @method static string makeTitle(string $value)
  * @method static string normalizeNewlines(string $string)
  * @method static string stripNewlines(string $string)
@@ -53,8 +53,8 @@ use JetBrains\PhpStorm\Pure;
  * @method static Features features()
  * @method static FileCollection<SourceFile> files()
  * @method static PageCollection<HydePage> pages()
- * @method static RouteCollection<Route> routes()
- * @method static Route|null currentRoute()
+ * @method static RouteCollection<PageRoute> routes()
+ * @method static PageRoute|null currentRoute()
  * @method static HydeKernel getInstance()
  * @method static Filesystem filesystem()
  * @method static array getRegisteredExtensions()

--- a/packages/framework/src/Pages/Concerns/HydePage.php
+++ b/packages/framework/src/Pages/Concerns/HydePage.php
@@ -21,7 +21,7 @@ use Hyde\Markdown\Models\FrontMatter;
 use Hyde\Support\Concerns\Serializable;
 use Hyde\Support\Contracts\SerializableContract;
 use Hyde\Support\Filesystem\SourceFile;
-use Hyde\Support\Models\Route;
+use Hyde\Support\Models\PageRoute;
 use Hyde\Support\Models\RouteKey;
 use Illuminate\Support\Str;
 
@@ -295,7 +295,7 @@ abstract class HydePage implements PageSchema, SerializableContract
      * The route key is the page URL path, relative to the site root, but without any file extensions.
      * For example, if the page will be saved to `_site/docs/index.html`, the key is `docs/index`.
      *
-     * Route keys are used to identify page routes, similar to how named routes work in Laravel,
+     * PageRoute keys are used to identify page routes, similar to how named routes work in Laravel,
      * only that here the name is not just arbitrary, but also defines the output location,
      * as the route key is used to determine the output path which is `$routeKey.html`.
      */
@@ -307,9 +307,9 @@ abstract class HydePage implements PageSchema, SerializableContract
     /**
      * Get the route object for the page.
      */
-    public function getRoute(): Route
+    public function getRoute(): PageRoute
     {
-        return Routes::get($this->getRouteKey()) ?? new Route($this);
+        return Routes::get($this->getRouteKey()) ?? new PageRoute($this);
     }
 
     /**

--- a/packages/framework/src/Pages/DocumentationPage.php
+++ b/packages/framework/src/Pages/DocumentationPage.php
@@ -8,7 +8,7 @@ use Hyde\Facades\Config;
 use Hyde\Foundation\Facades\Routes;
 use Hyde\Framework\Actions\GeneratesTableOfContents;
 use Hyde\Pages\Concerns\BaseMarkdownPage;
-use Hyde\Support\Models\Route;
+use Hyde\Support\Models\PageRoute;
 
 use function trim;
 use function sprintf;
@@ -29,7 +29,7 @@ class DocumentationPage extends BaseMarkdownPage
     public static string $outputDirectory = 'docs';
     public static string $template = 'hyde::layouts/docs';
 
-    public static function home(): ?Route
+    public static function home(): ?PageRoute
     {
         return Routes::get(static::homeRouteName());
     }

--- a/packages/framework/src/Support/Contracts/RouteContract.php
+++ b/packages/framework/src/Support/Contracts/RouteContract.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace Hyde\Support\Contracts;
 
 use Stringable;
-use Hyde\Support\Models\Route;
+use Hyde\Support\Models\PageRoute;
 use Hyde\Support\Models\RouteKey;
 
 interface RouteContract extends SerializableContract, Stringable
@@ -18,5 +18,5 @@ interface RouteContract extends SerializableContract, Stringable
     /**
      * Check if the route is the same as the given route.
      */
-    public function is(Route|RouteKey|string $route): bool;
+    public function is(PageRoute|RouteKey|string $route): bool;
 }

--- a/packages/framework/src/Support/Contracts/RouteContract.php
+++ b/packages/framework/src/Support/Contracts/RouteContract.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Hyde\Support\Contracts;
 
-interface RouteContract
+interface RouteContract extends SerializableContract
 {
     //
 }

--- a/packages/framework/src/Support/Contracts/RouteContract.php
+++ b/packages/framework/src/Support/Contracts/RouteContract.php
@@ -5,8 +5,18 @@ declare(strict_types=1);
 namespace Hyde\Support\Contracts;
 
 use Stringable;
+use Hyde\Support\Models\Route;
+use Hyde\Support\Models\RouteKey;
 
 interface RouteContract extends SerializableContract, Stringable
 {
-    //
+    /**
+     * Generate a link that resolves to the route destination.
+     */
+    public function getLink(): string;
+
+    /**
+     * Check if the route is the same as the given route.
+     */
+    public function is(Route|RouteKey|string $route): bool;
 }

--- a/packages/framework/src/Support/Contracts/RouteContract.php
+++ b/packages/framework/src/Support/Contracts/RouteContract.php
@@ -4,7 +4,9 @@ declare(strict_types=1);
 
 namespace Hyde\Support\Contracts;
 
-interface RouteContract extends SerializableContract
+use Stringable;
+
+interface RouteContract extends SerializableContract, Stringable
 {
     //
 }

--- a/packages/framework/src/Support/Contracts/RouteContract.php
+++ b/packages/framework/src/Support/Contracts/RouteContract.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Hyde\Support\Contracts;
+
+interface RouteContract
+{
+    //
+}

--- a/packages/framework/src/Support/Facades/Render.php
+++ b/packages/framework/src/Support/Facades/Render.php
@@ -6,7 +6,7 @@ namespace Hyde\Support\Facades;
 
 use Hyde\Pages\Concerns\HydePage;
 use Hyde\Support\Models\RenderData;
-use Hyde\Support\Models\Route;
+use Hyde\Support\Models\PageRoute;
 use Illuminate\Support\Facades\Facade;
 
 /**
@@ -16,7 +16,7 @@ use Illuminate\Support\Facades\Facade;
  *
  * @method static void setPage(HydePage $page)
  * @method static HydePage|null getPage()
- * @method static Route|null getRoute()
+ * @method static PageRoute|null getRoute()
  * @method static string|null getRouteKey()
  * @method static void share(string $key, mixed $value)
  * @method static void shareToView()

--- a/packages/framework/src/Support/Models/BaseRoute.php
+++ b/packages/framework/src/Support/Models/BaseRoute.php
@@ -6,7 +6,7 @@ namespace Hyde\Support\Models;
 
 use Hyde\Support\Contracts\RouteContract;
 
-class BaseRoute implements RouteContract
+abstract class BaseRoute implements RouteContract
 {
     //
 }

--- a/packages/framework/src/Support/Models/BaseRoute.php
+++ b/packages/framework/src/Support/Models/BaseRoute.php
@@ -4,7 +4,9 @@ declare(strict_types=1);
 
 namespace Hyde\Support\Models;
 
-class BaseRoute
+use Hyde\Support\Contracts\RouteContract;
+
+class BaseRoute implements RouteContract
 {
     //
 }

--- a/packages/framework/src/Support/Models/BaseRoute.php
+++ b/packages/framework/src/Support/Models/BaseRoute.php
@@ -5,9 +5,12 @@ declare(strict_types=1);
 namespace Hyde\Support\Models;
 
 use Hyde\Support\Contracts\RouteContract;
+use Hyde\Support\Concerns\Serializable;
 
 abstract class BaseRoute implements RouteContract
 {
+    use Serializable;
+
     /**
      * Cast a route object into a string that can be used in a href attribute.
      */

--- a/packages/framework/src/Support/Models/BaseRoute.php
+++ b/packages/framework/src/Support/Models/BaseRoute.php
@@ -8,5 +8,11 @@ use Hyde\Support\Contracts\RouteContract;
 
 abstract class BaseRoute implements RouteContract
 {
-    //
+    /**
+     * Cast a route object into a string that can be used in a href attribute.
+     */
+    public function __toString(): string
+    {
+        return $this->getLink();
+    }
 }

--- a/packages/framework/src/Support/Models/BaseRoute.php
+++ b/packages/framework/src/Support/Models/BaseRoute.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Hyde\Support\Models;
+
+class BaseRoute
+{
+    //
+}

--- a/packages/framework/src/Support/Models/ExternalRoute.php
+++ b/packages/framework/src/Support/Models/ExternalRoute.php
@@ -23,9 +23,9 @@ class ExternalRoute extends BaseRoute
         return $this->destination;
     }
 
-    public function is(Route|RouteKey|string $route): bool
+    public function is(PageRoute|RouteKey|string $route): bool
     {
-        if ($route instanceof Route) {
+        if ($route instanceof PageRoute) {
             return $this->getLink() === $route->getLink();
         }
 

--- a/packages/framework/src/Support/Models/ExternalRoute.php
+++ b/packages/framework/src/Support/Models/ExternalRoute.php
@@ -13,7 +13,6 @@ class ExternalRoute extends BaseRoute
 {
     protected string $destination;
 
-    /** @noinspection PhpMissingParentConstructorInspection */
     public function __construct(string $destination)
     {
         $this->destination = $destination;

--- a/packages/framework/src/Support/Models/ExternalRoute.php
+++ b/packages/framework/src/Support/Models/ExternalRoute.php
@@ -9,7 +9,7 @@ namespace Hyde\Support\Models;
  *
  * @experimental Take caution when using this class, as it may be subject to change.
  */
-class ExternalRoute extends Route
+class ExternalRoute extends BaseRoute
 {
     protected string $destination;
 

--- a/packages/framework/src/Support/Models/ExternalRoute.php
+++ b/packages/framework/src/Support/Models/ExternalRoute.php
@@ -23,4 +23,12 @@ class ExternalRoute extends Route
     {
         return $this->destination;
     }
+
+    /** @return array{destination: string} */
+    public function toArray(): array
+    {
+        return [
+            'destination' => $this->destination,
+        ];
+    }
 }

--- a/packages/framework/src/Support/Models/ExternalRoute.php
+++ b/packages/framework/src/Support/Models/ExternalRoute.php
@@ -24,6 +24,11 @@ class ExternalRoute extends Route
         return $this->destination;
     }
 
+    public function is(Route|RouteKey|string $route): bool
+    {
+        return $route instanceof ExternalRoute && $route->destination === $this->destination;
+    }
+
     /** @return array{destination: string} */
     public function toArray(): array
     {

--- a/packages/framework/src/Support/Models/ExternalRoute.php
+++ b/packages/framework/src/Support/Models/ExternalRoute.php
@@ -25,7 +25,11 @@ class ExternalRoute extends BaseRoute
 
     public function is(Route|RouteKey|string $route): bool
     {
-        return $route instanceof ExternalRoute && $route->destination === $this->destination;
+        if ($route instanceof Route) {
+            return $this->getLink() === $route->getLink();
+        }
+
+        return $this->getLink() === (string) $route;
     }
 
     /** @return array{destination: string} */

--- a/packages/framework/src/Support/Models/PageRoute.php
+++ b/packages/framework/src/Support/Models/PageRoute.php
@@ -9,14 +9,14 @@ use Hyde\Pages\Concerns\HydePage;
 use Hyde\Support\Contracts\RouteContract;
 
 /**
- * The Route class bridges the gaps between Hyde pages and their respective compiled static webpages
+ * The PageRoute class bridges the gaps between Hyde pages and their respective compiled static webpages
  * by providing helper methods and information allowing you to easily access and interact with the
  * various paths associated with a page, both source and compiled file paths as well as the URL.
  *
  * If you visualize a web of this class's properties, you should be able to see how this
  * class links them all together, and what powerful information you can gain from it.
  */
-class Route extends BaseRoute implements RouteContract
+class PageRoute extends BaseRoute implements RouteContract
 {
     protected HydePage $page;
 
@@ -67,9 +67,9 @@ class Route extends BaseRoute implements RouteContract
     /**
      * Determine if the route instance matches another route or route key.
      */
-    public function is(Route|RouteKey|string $route): bool
+    public function is(PageRoute|RouteKey|string $route): bool
     {
-        if ($route instanceof Route) {
+        if ($route instanceof PageRoute) {
             return $this->getRouteKey() === $route->getRouteKey();
         }
 

--- a/packages/framework/src/Support/Models/RenderData.php
+++ b/packages/framework/src/Support/Models/RenderData.php
@@ -21,7 +21,7 @@ use function property_exists;
 class RenderData implements Arrayable
 {
     protected HydePage $page;
-    protected Route $route;
+    protected PageRoute $route;
     protected string $routeKey;
 
     public function setPage(HydePage $page): void
@@ -38,7 +38,7 @@ class RenderData implements Arrayable
         return $this->page ?? null;
     }
 
-    public function getRoute(): ?Route
+    public function getRoute(): ?PageRoute
     {
         return $this->route ?? null;
     }
@@ -70,7 +70,7 @@ class RenderData implements Arrayable
     }
 
     /**
-     * @return array{render: \Hyde\Support\Models\RenderData, page: \Hyde\Pages\Concerns\HydePage|null, route: \Hyde\Support\Models\Route|null, routeKey: string|null}
+     * @return array{render: \Hyde\Support\Models\RenderData, page: \Hyde\Pages\Concerns\HydePage|null, route: \Hyde\Support\Models\PageRoute|null, routeKey: string|null}
      */
     public function toArray(): array
     {

--- a/packages/framework/src/Support/Models/Route.php
+++ b/packages/framework/src/Support/Models/Route.php
@@ -6,7 +6,6 @@ namespace Hyde\Support\Models;
 
 use Hyde\Hyde;
 use Hyde\Pages\Concerns\HydePage;
-use Hyde\Support\Concerns\Serializable;
 use Hyde\Support\Contracts\RouteContract;
 
 /**
@@ -19,8 +18,6 @@ use Hyde\Support\Contracts\RouteContract;
  */
 class Route extends BaseRoute implements RouteContract
 {
-    use Serializable;
-
     protected HydePage $page;
 
     public function __construct(HydePage $page)

--- a/packages/framework/src/Support/Models/Route.php
+++ b/packages/framework/src/Support/Models/Route.php
@@ -7,8 +7,7 @@ namespace Hyde\Support\Models;
 use Hyde\Hyde;
 use Hyde\Pages\Concerns\HydePage;
 use Hyde\Support\Concerns\Serializable;
-use Hyde\Support\Contracts\SerializableContract;
-use Stringable;
+use Hyde\Support\Contracts\RouteContract;
 
 /**
  * The Route class bridges the gaps between Hyde pages and their respective compiled static webpages
@@ -18,7 +17,7 @@ use Stringable;
  * If you visualize a web of this class's properties, you should be able to see how this
  * class links them all together, and what powerful information you can gain from it.
  */
-class Route implements Stringable, SerializableContract
+class Route implements RouteContract
 {
     use Serializable;
 

--- a/packages/framework/src/Support/Models/Route.php
+++ b/packages/framework/src/Support/Models/Route.php
@@ -17,7 +17,7 @@ use Hyde\Support\Contracts\RouteContract;
  * If you visualize a web of this class's properties, you should be able to see how this
  * class links them all together, and what powerful information you can gain from it.
  */
-class Route implements RouteContract
+class Route extends BaseRoute implements RouteContract
 {
     use Serializable;
 

--- a/packages/framework/src/Support/Models/Route.php
+++ b/packages/framework/src/Support/Models/Route.php
@@ -29,14 +29,6 @@ class Route extends BaseRoute implements RouteContract
     }
 
     /**
-     * Cast a route object into a string that can be used in a href attribute.
-     */
-    public function __toString(): string
-    {
-        return $this->getLink();
-    }
-
-    /**
      * Generate a link to the route destination, relative to the current route, and supports pretty URLs.
      */
     public function getLink(): string

--- a/packages/framework/src/Support/Models/RouteKey.php
+++ b/packages/framework/src/Support/Models/RouteKey.php
@@ -9,7 +9,7 @@ use Stringable;
 use function unslash;
 
 /**
- * Route keys provide the core bindings of the HydePHP routing system as they are what canonically identifies a page.
+ * PageRoute keys provide the core bindings of the HydePHP routing system as they are what canonically identifies a page.
  * This class both provides a data object for normalized type-hintable values, and general related helper methods.
  *
  * In short, the route key is the URL path relative to the site webroot, without the file extension.

--- a/packages/framework/src/Support/Models/RouteList.php
+++ b/packages/framework/src/Support/Models/RouteList.php
@@ -42,12 +42,12 @@ class RouteList implements Arrayable
 
     protected function generate(): array
     {
-        return collect(Hyde::routes())->map(function (Route $route): array {
+        return collect(Hyde::routes())->map(function (PageRoute $route): array {
             return $this->routeToListItem($route)->toArray();
         })->values()->toArray();
     }
 
-    protected static function routeToListItem(Route $route): RouteListItem
+    protected static function routeToListItem(PageRoute $route): RouteListItem
     {
         return new RouteListItem($route);
     }

--- a/packages/framework/src/Support/Models/RouteListItem.php
+++ b/packages/framework/src/Support/Models/RouteListItem.php
@@ -18,9 +18,9 @@ use function str_starts_with;
  */
 class RouteListItem implements Arrayable
 {
-    protected Route $route;
+    protected PageRoute $route;
 
-    public function __construct(Route $route)
+    public function __construct(PageRoute $route)
     {
         $this->route = $route;
     }

--- a/packages/framework/src/Support/Paginator.php
+++ b/packages/framework/src/Support/Paginator.php
@@ -6,7 +6,7 @@ namespace Hyde\Support;
 
 use Hyde\Hyde;
 use InvalidArgumentException;
-use Hyde\Support\Models\Route;
+use Hyde\Support\Models\PageRoute;
 use Hyde\Foundation\Facades\Routes;
 use Illuminate\Support\Collection;
 use Illuminate\Contracts\Support\Arrayable;
@@ -145,7 +145,7 @@ class Paginator
         return $this->currentPage + 1;
     }
 
-    public function previous(): false|string|Route
+    public function previous(): false|string|PageRoute
     {
         if (! $this->canNavigateBack()) {
             return false;
@@ -158,7 +158,7 @@ class Paginator
         return $this->getRoute(-1);
     }
 
-    public function next(): false|string|Route
+    public function next(): false|string|PageRoute
     {
         if (! $this->canNavigateForward()) {
             return false;
@@ -197,7 +197,7 @@ class Paginator
         return Hyde::formatLink("{$this->formatPageName($offset)}.html");
     }
 
-    protected function getRoute(int $offset): Route|string
+    protected function getRoute(int $offset): PageRoute|string
     {
         return Routes::get("$this->routeBasename/{$this->formatPageName($offset)}") ?? Hyde::formatLink("$this->routeBasename/{$this->formatPageName($offset)}");
     }

--- a/packages/framework/src/helpers.php
+++ b/packages/framework/src/helpers.php
@@ -42,7 +42,7 @@ namespace {
             /**
              * Get a page route by its key.
              */
-            function route(string $key): ?Hyde\Support\Models\Route
+            function route(string $key): ?Hyde\Support\Models\PageRoute
             {
                 return hyde()->route($key);
             }

--- a/packages/framework/tests/Feature/AutomaticNavigationConfigurationsTest.php
+++ b/packages/framework/tests/Feature/AutomaticNavigationConfigurationsTest.php
@@ -1383,7 +1383,7 @@ class TestKernel extends HydeKernel
         $this->mockRoutes = RouteCollection::make($routes);
     }
 
-    /** @return \Hyde\Foundation\Kernel\RouteCollection<string, \Hyde\Support\Models\Route> */
+    /** @return \Hyde\Foundation\Kernel\RouteCollection<string, \Hyde\Support\Models\PageRoute> */
     public function routes(): RouteCollection
     {
         return $this->mockRoutes ?? parent::routes();

--- a/packages/framework/tests/Feature/Commands/RouteListCommandTest.php
+++ b/packages/framework/tests/Feature/Commands/RouteListCommandTest.php
@@ -6,7 +6,7 @@ namespace Hyde\Framework\Testing\Feature\Commands;
 
 use Hyde\Hyde;
 use Hyde\Pages\InMemoryPage;
-use Hyde\Support\Models\Route;
+use Hyde\Support\Models\PageRoute;
 use Hyde\Testing\TestCase;
 
 /**
@@ -67,7 +67,7 @@ class RouteListCommandTest extends TestCase
     {
         Hyde::routes()->forget('404');
         Hyde::routes()->forget('index');
-        Hyde::routes()->put('foo', new Route(new InMemoryPage('foo')));
+        Hyde::routes()->put('foo', new PageRoute(new InMemoryPage('foo')));
 
         $this->artisan('route:list')
             ->expectsTable($this->headers(), [[
@@ -87,7 +87,7 @@ class RouteListCommandTest extends TestCase
         $page->macro('typeLabel', function () {
             return 'Foo';
         });
-        Hyde::routes()->put('foo', new Route($page));
+        Hyde::routes()->put('foo', new PageRoute($page));
 
         $this->artisan('route:list')
             ->expectsTable($this->headers(), [[
@@ -100,6 +100,6 @@ class RouteListCommandTest extends TestCase
 
     protected function headers(): array
     {
-        return ['Page Type', 'Source File', 'Output File', 'Route Key'];
+        return ['Page Type', 'Source File', 'Output File', 'PageRoute Key'];
     }
 }

--- a/packages/framework/tests/Feature/HydeExtensionFeatureTest.php
+++ b/packages/framework/tests/Feature/HydeExtensionFeatureTest.php
@@ -15,7 +15,7 @@ use Hyde\Foundation\Kernel\PageCollection;
 use Hyde\Foundation\Kernel\RouteCollection;
 use Hyde\Pages\Concerns\HydePage;
 use Hyde\Support\Filesystem\SourceFile;
-use Hyde\Support\Models\Route;
+use Hyde\Support\Models\PageRoute;
 use Hyde\Testing\TestCase;
 use InvalidArgumentException;
 use stdClass;
@@ -130,7 +130,7 @@ class HydeExtensionFeatureTest extends TestCase
         RouteCollection::init(app(HydeKernel::class))->boot();
 
         $this->assertArrayHasKey('foo/bar', Routes::all());
-        $this->assertEquals(new Route(new TestPageClass('bar')), Routes::get('foo/bar'));
+        $this->assertEquals(new PageRoute(new TestPageClass('bar')), Routes::get('foo/bar'));
     }
 
     protected function markTestSuccessful(): void

--- a/packages/framework/tests/Feature/HydeKernelTest.php
+++ b/packages/framework/tests/Feature/HydeKernelTest.php
@@ -20,7 +20,7 @@ use Hyde\Pages\InMemoryPage;
 use Hyde\Pages\MarkdownPage;
 use Hyde\Pages\MarkdownPost;
 use Hyde\Support\Facades\Render;
-use Hyde\Support\Models\Route;
+use Hyde\Support\Models\PageRoute;
 use Hyde\Testing\TestCase;
 use Illuminate\Support\Facades\Config;
 use Illuminate\Support\HtmlString;
@@ -87,9 +87,9 @@ class HydeKernelTest extends TestCase
 
     public function testCurrentRouteHelperReturnsCurrentRouteObject()
     {
-        $expected = new Route(new MarkdownPage());
+        $expected = new PageRoute(new MarkdownPage());
         Render::share('route', $expected);
-        $this->assertInstanceOf(Route::class, Hyde::currentRoute());
+        $this->assertInstanceOf(PageRoute::class, Hyde::currentRoute());
         $this->assertSame($expected, Hyde::currentRoute());
     }
 

--- a/packages/framework/tests/Feature/HydePageTest.php
+++ b/packages/framework/tests/Feature/HydePageTest.php
@@ -18,7 +18,7 @@ use Hyde\Pages\DocumentationPage;
 use Hyde\Pages\HtmlPage;
 use Hyde\Pages\MarkdownPage;
 use Hyde\Pages\MarkdownPost;
-use Hyde\Support\Models\Route;
+use Hyde\Support\Models\PageRoute;
 use Hyde\Testing\TestCase;
 
 /**
@@ -623,7 +623,7 @@ class HydePageTest extends TestCase
     public function testGetRouteReturnsPageRoute()
     {
         $page = new MarkdownPage();
-        $this->assertEquals(new Route($page), $page->getRoute());
+        $this->assertEquals(new PageRoute($page), $page->getRoute());
     }
 
     public function testGetRouteReturnsTheRouteObjectFromTheRouterIndex()
@@ -1150,8 +1150,8 @@ class HydePageTest extends TestCase
         foreach ($pages as $page) {
             $page = new $page('foo');
 
-            $this->assertInstanceOf(Route::class, $page->getRoute());
-            $this->assertEquals(new Route($page), $page->getRoute());
+            $this->assertInstanceOf(PageRoute::class, $page->getRoute());
+            $this->assertEquals(new PageRoute($page), $page->getRoute());
             $this->assertSame($page->getRoute()->getLink(), $page->getLink());
 
             Filesystem::touch($page::sourcePath('foo'));

--- a/packages/framework/tests/Feature/NavigationMenuTest.php
+++ b/packages/framework/tests/Feature/NavigationMenuTest.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace Hyde\Framework\Testing\Feature;
 
 use Hyde\Hyde;
-use Hyde\Support\Models\Route;
+use Hyde\Support\Models\PageRoute;
 use Hyde\Foundation\Facades\Routes;
 use Hyde\Support\Models\ExternalRoute;
 use Hyde\Framework\Features\Navigation\NavigationGroup;
@@ -45,17 +45,17 @@ class NavigationMenuTest extends TestCase
 
     public function testItemsAreSortedByPriority()
     {
-        Routes::addRoute(new Route(new MarkdownPage('foo', ['navigation.priority' => 1])));
-        Routes::addRoute(new Route(new MarkdownPage('bar', ['navigation.priority' => 2])));
-        Routes::addRoute(new Route(new MarkdownPage('baz', ['navigation.priority' => 3])));
+        Routes::addRoute(new PageRoute(new MarkdownPage('foo', ['navigation.priority' => 1])));
+        Routes::addRoute(new PageRoute(new MarkdownPage('bar', ['navigation.priority' => 2])));
+        Routes::addRoute(new PageRoute(new MarkdownPage('baz', ['navigation.priority' => 3])));
 
         $this->assertSame(['Home', 'Foo', 'Bar', 'Baz'], $this->createNavigationMenu()->getItems()->map(fn ($item) => $item->getLabel())->toArray());
     }
 
     public function testItemsWithHiddenPropertySetToTrueAreNotAdded()
     {
-        Routes::addRoute(new Route(new MarkdownPage('foo', ['navigation.hidden' => true])));
-        Routes::addRoute(new Route(new MarkdownPage('bar', ['navigation.hidden' => false])));
+        Routes::addRoute(new PageRoute(new MarkdownPage('foo', ['navigation.hidden' => true])));
+        Routes::addRoute(new PageRoute(new MarkdownPage('bar', ['navigation.hidden' => false])));
 
         $this->assertSame(['Home', 'Bar'], $this->createNavigationMenu()->getItems()->map(fn ($item) => $item->getLabel())->toArray());
     }

--- a/packages/framework/tests/Feature/RouteCollectionTest.php
+++ b/packages/framework/tests/Feature/RouteCollectionTest.php
@@ -13,7 +13,7 @@ use Hyde\Pages\DocumentationPage;
 use Hyde\Pages\HtmlPage;
 use Hyde\Pages\MarkdownPage;
 use Hyde\Pages\MarkdownPost;
-use Hyde\Support\Models\Route;
+use Hyde\Support\Models\PageRoute;
 use Hyde\Testing\TestCase;
 use Illuminate\Support\Collection;
 
@@ -32,8 +32,8 @@ class RouteCollectionTest extends TestCase
         $this->assertInstanceOf(Collection::class, $collection);
 
         $this->assertEquals([
-            '404' => new Route(new BladePage('404')),
-            'index' => new Route(new BladePage('index')),
+            '404' => new PageRoute(new BladePage('404')),
+            'index' => new PageRoute(new BladePage('index')),
         ], $collection->all());
     }
 
@@ -54,11 +54,11 @@ class RouteCollectionTest extends TestCase
         $this->assertInstanceOf(Collection::class, $collection);
 
         $this->assertEquals([
-            'blade' => new Route(new BladePage('blade')),
-            'markdown' => new Route(new MarkdownPage('markdown')),
-            'html' => new Route(new HtmlPage('html')),
-            'posts/post' => new Route(new MarkdownPost('post')),
-            'docs/docs' => new Route(new DocumentationPage('docs')),
+            'blade' => new PageRoute(new BladePage('blade')),
+            'markdown' => new PageRoute(new MarkdownPage('markdown')),
+            'html' => new PageRoute(new HtmlPage('html')),
+            'posts/post' => new PageRoute(new MarkdownPost('post')),
+            'docs/docs' => new PageRoute(new DocumentationPage('docs')),
         ], $collection->all());
 
         $this->restoreDefaultPages();
@@ -90,11 +90,11 @@ class RouteCollectionTest extends TestCase
         $collection = Hyde::routes();
 
         $this->assertCount(5, $collection);
-        $this->assertEquals(new Route(new BladePage('blade')), Routes::getRoutes(BladePage::class)->first());
-        $this->assertEquals(new Route(new MarkdownPage('markdown')), Routes::getRoutes(MarkdownPage::class)->first());
-        $this->assertEquals(new Route(new MarkdownPost('post')), Routes::getRoutes(MarkdownPost::class)->first());
-        $this->assertEquals(new Route(new DocumentationPage('docs')), Routes::getRoutes(DocumentationPage::class)->first());
-        $this->assertEquals(new Route(new HtmlPage('html')), Routes::getRoutes(HtmlPage::class)->first());
+        $this->assertEquals(new PageRoute(new BladePage('blade')), Routes::getRoutes(BladePage::class)->first());
+        $this->assertEquals(new PageRoute(new MarkdownPage('markdown')), Routes::getRoutes(MarkdownPage::class)->first());
+        $this->assertEquals(new PageRoute(new MarkdownPost('post')), Routes::getRoutes(MarkdownPost::class)->first());
+        $this->assertEquals(new PageRoute(new DocumentationPage('docs')), Routes::getRoutes(DocumentationPage::class)->first());
+        $this->assertEquals(new PageRoute(new HtmlPage('html')), Routes::getRoutes(HtmlPage::class)->first());
 
         $this->restoreDefaultPages();
         $this->restoreDocumentationSearch();
@@ -104,20 +104,20 @@ class RouteCollectionTest extends TestCase
     {
         $collection = Hyde::routes();
         $this->assertCount(2, $collection);
-        $collection->addRoute(new Route(new BladePage('new')));
+        $collection->addRoute(new PageRoute(new BladePage('new')));
         $this->assertCount(3, $collection);
-        $this->assertEquals(new Route(new BladePage('new')), $collection->last());
+        $this->assertEquals(new PageRoute(new BladePage('new')), $collection->last());
     }
 
     public function testGetRoute()
     {
-        $this->assertEquals(new Route(new BladePage('index')), Routes::getRoute('index'));
+        $this->assertEquals(new PageRoute(new BladePage('index')), Routes::getRoute('index'));
     }
 
     public function testGetRouteWithNonExistingRoute()
     {
         $this->expectException(RouteNotFoundException::class);
-        $this->expectExceptionMessage('Route [non-existing] not found');
+        $this->expectExceptionMessage('PageRoute [non-existing] not found');
         Routes::getRoute('non-existing');
     }
 }

--- a/packages/framework/tests/Feature/RouteListTest.php
+++ b/packages/framework/tests/Feature/RouteListTest.php
@@ -6,7 +6,7 @@ namespace Hyde\Framework\Testing\Feature;
 
 use Hyde\Hyde;
 use Hyde\Pages\InMemoryPage;
-use Hyde\Support\Models\Route;
+use Hyde\Support\Models\PageRoute;
 use Hyde\Support\Models\RouteList;
 use Hyde\Testing\TestCase;
 
@@ -40,7 +40,7 @@ class RouteListTest extends TestCase
             'Page Type',
             'Source File',
             'Output File',
-            'Route Key',
+            'PageRoute Key',
         ], (new RouteList())->headers());
     }
 
@@ -48,7 +48,7 @@ class RouteListTest extends TestCase
     {
         Hyde::routes()->forget('404');
         Hyde::routes()->forget('index');
-        Hyde::routes()->put('foo', new Route(new InMemoryPage('foo')));
+        Hyde::routes()->put('foo', new PageRoute(new InMemoryPage('foo')));
 
         $this->assertSame([
             [

--- a/packages/framework/tests/Unit/BreadcrumbsComponentTest.php
+++ b/packages/framework/tests/Unit/BreadcrumbsComponentTest.php
@@ -7,7 +7,7 @@ namespace Hyde\Framework\Testing\Unit;
 use Hyde\Framework\Views\Components\BreadcrumbsComponent;
 use Hyde\Pages\MarkdownPage;
 use Hyde\Support\Facades\Render;
-use Hyde\Support\Models\Route;
+use Hyde\Support\Models\PageRoute;
 use Hyde\Testing\UnitTestCase;
 use Illuminate\Support\Facades\Facade;
 use Illuminate\Support\Facades\View;
@@ -144,7 +144,7 @@ class BreadcrumbsComponentTest extends UnitTestCase
 
     protected function mockPage(MarkdownPage $page): void
     {
-        Render::shouldReceive('getRoute')->once()->andReturn(new Route($page));
+        Render::shouldReceive('getRoute')->once()->andReturn(new PageRoute($page));
         Render::shouldReceive('getRouteKey')->andReturn($page->getOutputPath());
     }
 }

--- a/packages/framework/tests/Unit/CustomExceptionsTest.php
+++ b/packages/framework/tests/Unit/CustomExceptionsTest.php
@@ -63,12 +63,12 @@ class CustomExceptionsTest extends UnitTestCase
 
     public function testRouteNotFoundExceptionWithDefaultMessage()
     {
-        $this->assertSame('Route not found.', (new RouteNotFoundException())->getMessage());
+        $this->assertSame('PageRoute not found.', (new RouteNotFoundException())->getMessage());
     }
 
     public function testRouteNotFoundExceptionWithRouteKey()
     {
-        $this->assertSame('Route [foo] not found.', (new RouteNotFoundException('foo'))->getMessage());
+        $this->assertSame('PageRoute [foo] not found.', (new RouteNotFoundException('foo'))->getMessage());
     }
 
     public function testUnsupportedPageTypeExceptionWithDefaultMessage()

--- a/packages/framework/tests/Unit/DocumentationPageTest.php
+++ b/packages/framework/tests/Unit/DocumentationPageTest.php
@@ -10,7 +10,7 @@ use Hyde\Framework\HydeServiceProvider;
 use Hyde\Hyde;
 use Hyde\Markdown\Models\FrontMatter;
 use Hyde\Pages\DocumentationPage;
-use Hyde\Support\Models\Route;
+use Hyde\Support\Models\PageRoute;
 use Hyde\Testing\TestCase;
 use Illuminate\Support\Facades\Config;
 use Illuminate\Support\Facades\File;
@@ -148,7 +148,7 @@ class DocumentationPageTest extends TestCase
     public function testHomeMethodReturnsDocsIndexRouteWhenItExists()
     {
         Filesystem::touch('_docs/index.md');
-        $this->assertInstanceOf(Route::class, DocumentationPage::home());
+        $this->assertInstanceOf(PageRoute::class, DocumentationPage::home());
         $this->assertEquals(Routes::get('docs/index'), DocumentationPage::home());
         Filesystem::unlink('_docs/index.md');
     }
@@ -159,7 +159,7 @@ class DocumentationPageTest extends TestCase
         (new HydeServiceProvider($this->app))->register();
         mkdir(Hyde::path('foo'));
         Filesystem::touch('_docs/index.md');
-        $this->assertInstanceOf(Route::class, DocumentationPage::home());
+        $this->assertInstanceOf(PageRoute::class, DocumentationPage::home());
         $this->assertEquals(Routes::get('foo/index'), DocumentationPage::home());
         Filesystem::unlink('_docs/index.md');
         File::deleteDirectory(Hyde::path('foo'));
@@ -172,7 +172,7 @@ class DocumentationPageTest extends TestCase
         mkdir(Hyde::path('foo'));
         mkdir(Hyde::path('foo/bar'));
         Filesystem::touch('_docs/index.md');
-        $this->assertInstanceOf(Route::class, DocumentationPage::home());
+        $this->assertInstanceOf(PageRoute::class, DocumentationPage::home());
         $this->assertEquals(Routes::get('foo/bar/index'), DocumentationPage::home());
         Filesystem::unlink('_docs/index.md');
         File::deleteDirectory(Hyde::path('foo'));

--- a/packages/framework/tests/Unit/Facades/RouteFacadeTest.php
+++ b/packages/framework/tests/Unit/Facades/RouteFacadeTest.php
@@ -12,7 +12,7 @@ use Hyde\Pages\MarkdownPage;
 use Hyde\Pages\MarkdownPost;
 use Hyde\Support\Facades\Render;
 use Hyde\Support\Models\RenderData;
-use Hyde\Support\Models\Route;
+use Hyde\Support\Models\PageRoute;
 use Hyde\Testing\UnitTestCase;
 
 /**
@@ -39,12 +39,12 @@ class RouteFacadeTest extends UnitTestCase
 
     public function testGetReturnsRouteFromRouterIndex()
     {
-        $this->assertInstanceOf(Route::class, Routes::get('index'));
+        $this->assertInstanceOf(PageRoute::class, Routes::get('index'));
     }
 
     public function testGetReturnsRouteFromRouterIndexForTheRightPage()
     {
-        $this->assertEquals(new Route(BladePage::parse('index')), Routes::get('index'));
+        $this->assertEquals(new PageRoute(BladePage::parse('index')), Routes::get('index'));
     }
 
     public function testGetFromReturnsNullIfRouteIsNotFound()
@@ -54,13 +54,13 @@ class RouteFacadeTest extends UnitTestCase
 
     public function testGetSupportsDotNotation()
     {
-        Hyde::routes()->add(new Route(new MarkdownPost('foo')));
+        Hyde::routes()->add(new PageRoute(new MarkdownPost('foo')));
         $this->assertSame(Routes::get('posts/foo'), Routes::get('posts.foo'));
     }
 
     public function testCurrentReturnsCurrentRoute()
     {
-        $route = new Route(new MarkdownPage('foo'));
+        $route = new PageRoute(new MarkdownPage('foo'));
         Render::shouldReceive('getRoute')->andReturn($route);
         $this->assertSame($route, Routes::current());
         Render::swap(new RenderData());

--- a/packages/framework/tests/Unit/NavigationGroupTest.php
+++ b/packages/framework/tests/Unit/NavigationGroupTest.php
@@ -7,7 +7,7 @@ namespace Hyde\Framework\Testing\Unit;
 use Hyde\Pages\MarkdownPage;
 use Hyde\Pages\InMemoryPage;
 use Hyde\Testing\UnitTestCase;
-use Hyde\Support\Models\Route;
+use Hyde\Support\Models\PageRoute;
 use Hyde\Pages\DocumentationPage;
 use Hyde\Foundation\HydeCoreExtension;
 use Hyde\Framework\Features\Navigation\NavigationItem;
@@ -65,8 +65,8 @@ class NavigationGroupTest extends UnitTestCase
     public function testCreate()
     {
         $this->assertEquals(
-            new NavigationGroup('Foo', [new NavigationItem(new Route(new InMemoryPage('foo')), 'Foo')], 100),
-            NavigationGroup::create('Foo', [new NavigationItem(new Route(new InMemoryPage('foo')), 'Foo')], 100)
+            new NavigationGroup('Foo', [new NavigationItem(new PageRoute(new InMemoryPage('foo')), 'Foo')], 100),
+            NavigationGroup::create('Foo', [new NavigationItem(new PageRoute(new InMemoryPage('foo')), 'Foo')], 100)
         );
     }
 
@@ -86,7 +86,7 @@ class NavigationGroupTest extends UnitTestCase
     public function testCanAddItemToDropdown()
     {
         $group = new NavigationGroup('Foo');
-        $child = new NavigationItem(new Route(new MarkdownPage()), 'Bar');
+        $child = new NavigationItem(new PageRoute(new MarkdownPage()), 'Bar');
 
         $this->assertSame([$child], $group->add($child)->getItems());
     }
@@ -94,7 +94,7 @@ class NavigationGroupTest extends UnitTestCase
     public function testAddChildMethodReturnsSelf()
     {
         $group = new NavigationGroup('Foo');
-        $child = new NavigationItem(new Route(new MarkdownPage()), 'Bar');
+        $child = new NavigationItem(new PageRoute(new MarkdownPage()), 'Bar');
 
         $this->assertSame($group, $group->add($child));
     }
@@ -117,7 +117,7 @@ class NavigationGroupTest extends UnitTestCase
     public function testAddingAnItemWithAGroupKeyKeepsTheSetGroupKey()
     {
         $group = new NavigationGroup('Foo');
-        $child = new NavigationItem(new Route(new MarkdownPage()), 'Child', group: 'bar');
+        $child = new NavigationItem(new PageRoute(new MarkdownPage()), 'Child', group: 'bar');
 
         $group->add($child);
 
@@ -127,7 +127,7 @@ class NavigationGroupTest extends UnitTestCase
     public function testAddingAnItemWithNoGroupKeyDoesNotModifyGroupIdentifier()
     {
         $group = new NavigationGroup('Foo');
-        $child = new NavigationItem(new Route(new MarkdownPage()), 'Bar');
+        $child = new NavigationItem(new PageRoute(new MarkdownPage()), 'Bar');
 
         $group->add($child);
 
@@ -146,7 +146,7 @@ class NavigationGroupTest extends UnitTestCase
 
     public function testGetPriorityWithChildrenUsesGroupPriority()
     {
-        $group = new NavigationGroup('Foo', [new NavigationItem(new Route(new MarkdownPage()), 'Bar', 100)]);
+        $group = new NavigationGroup('Foo', [new NavigationItem(new PageRoute(new MarkdownPage()), 'Bar', 100)]);
 
         $this->assertSame(999, $group->getPriority());
     }
@@ -154,9 +154,9 @@ class NavigationGroupTest extends UnitTestCase
     public function testGetPriorityWithDocumentationPageChildrenUsesLowestPriority()
     {
         $items = [
-            new NavigationItem(new Route(new DocumentationPage()), 'Foo', 100),
-            new NavigationItem(new Route(new DocumentationPage()), 'Bar', 200),
-            new NavigationItem(new Route(new DocumentationPage()), 'Baz', 300),
+            new NavigationItem(new PageRoute(new DocumentationPage()), 'Foo', 100),
+            new NavigationItem(new PageRoute(new DocumentationPage()), 'Bar', 200),
+            new NavigationItem(new PageRoute(new DocumentationPage()), 'Baz', 300),
         ];
 
         $this->assertSame(100, (new NavigationGroup('Foo', $items))->getPriority());
@@ -168,7 +168,7 @@ class NavigationGroupTest extends UnitTestCase
         $group = new NavigationGroup('Foo');
 
         foreach (HydeCoreExtension::getPageClasses() as $type) {
-            $child = new NavigationItem(new Route(new $type()), 'Bar', 100);
+            $child = new NavigationItem(new PageRoute(new $type()), 'Bar', 100);
             $group->add($child);
         }
 
@@ -189,15 +189,15 @@ class NavigationGroupTest extends UnitTestCase
     {
         $group = new NavigationGroup('Foo');
 
-        $this->assertSame($group, $group->add(new NavigationItem(new Route(new MarkdownPage()), 'Bar')));
-        $this->assertSame($group, $group->add([new NavigationItem(new Route(new MarkdownPage()), 'Bar')]));
+        $this->assertSame($group, $group->add(new NavigationItem(new PageRoute(new MarkdownPage()), 'Bar')));
+        $this->assertSame($group, $group->add([new NavigationItem(new PageRoute(new MarkdownPage()), 'Bar')]));
     }
 
     protected function createNavigationItems(): array
     {
         return [
-            new NavigationItem(new Route(new InMemoryPage('foo')), 'Foo'),
-            new NavigationItem(new Route(new InMemoryPage('bar')), 'Bar'),
+            new NavigationItem(new PageRoute(new InMemoryPage('foo')), 'Foo'),
+            new NavigationItem(new PageRoute(new InMemoryPage('bar')), 'Bar'),
         ];
     }
 }

--- a/packages/framework/tests/Unit/NavigationItemIsActiveHelperTest.php
+++ b/packages/framework/tests/Unit/NavigationItemIsActiveHelperTest.php
@@ -9,7 +9,7 @@ use Hyde\Framework\Features\Navigation\NavigationItem;
 use Hyde\Pages\InMemoryPage;
 use Hyde\Support\Facades\Render;
 use Hyde\Support\Models\RenderData;
-use Hyde\Support\Models\Route;
+use Hyde\Support\Models\PageRoute;
 use Hyde\Testing\UnitTestCase;
 use Mockery;
 
@@ -235,7 +235,7 @@ class NavigationItemIsActiveHelperTest extends UnitTestCase
         $this->assertFalse(NavigationItem::create('/foo/bar/baz', 'foo')->isActive());
     }
 
-    protected function mockRenderData(Route $route): void
+    protected function mockRenderData(PageRoute $route): void
     {
         Render::swap(Mockery::mock(RenderData::class, [
             'getRoute' => $route,
@@ -243,8 +243,8 @@ class NavigationItemIsActiveHelperTest extends UnitTestCase
         ]));
     }
 
-    protected function makeRoute(string $identifier): Route
+    protected function makeRoute(string $identifier): PageRoute
     {
-        return new Route(new InMemoryPage($identifier));
+        return new PageRoute(new InMemoryPage($identifier));
     }
 }

--- a/packages/framework/tests/Unit/NavigationItemTest.php
+++ b/packages/framework/tests/Unit/NavigationItemTest.php
@@ -11,7 +11,7 @@ use Hyde\Pages\InMemoryPage;
 use Hyde\Pages\MarkdownPage;
 use Hyde\Support\Facades\Render;
 use Hyde\Support\Models\RenderData;
-use Hyde\Support\Models\Route;
+use Hyde\Support\Models\PageRoute;
 use Hyde\Testing\UnitTestCase;
 use Mockery;
 use Hyde\Framework\Features\Navigation\NavigationGroup;
@@ -42,7 +42,7 @@ class NavigationItemTest extends UnitTestCase
 
     public function testConstruct()
     {
-        $route = new Route(new MarkdownPage());
+        $route = new PageRoute(new MarkdownPage());
         $item = new NavigationItem($route, 'Test', 500);
 
         $this->assertSame($route, $item->getRoute());
@@ -50,12 +50,12 @@ class NavigationItemTest extends UnitTestCase
 
     public function testIsInstanceOfNavigationElement()
     {
-        $this->assertInstanceOf(NavigationElement::class, new NavigationItem(new Route(new MarkdownPage()), 'Test', 500));
+        $this->assertInstanceOf(NavigationElement::class, new NavigationItem(new PageRoute(new MarkdownPage()), 'Test', 500));
     }
 
     public function testPassingRouteInstanceToConstructorUsesRouteInstance()
     {
-        $route = new Route(new MarkdownPage());
+        $route = new PageRoute(new MarkdownPage());
         $this->assertSame($route, (new NavigationItem($route, 'Home'))->getRoute());
     }
 
@@ -84,7 +84,7 @@ class NavigationItemTest extends UnitTestCase
 
     public function testGetDestination()
     {
-        $route = new Route(new InMemoryPage('foo'));
+        $route = new PageRoute(new InMemoryPage('foo'));
         $NavigationItem = new NavigationItem($route, 'Page', 500);
 
         $this->assertSame($route, $NavigationItem->getRoute());
@@ -92,31 +92,31 @@ class NavigationItemTest extends UnitTestCase
 
     public function testGetLink()
     {
-        $NavigationItem = new NavigationItem(new Route(new InMemoryPage('foo')), 'Page', 500);
+        $NavigationItem = new NavigationItem(new PageRoute(new InMemoryPage('foo')), 'Page', 500);
         $this->assertSame('foo.html', $NavigationItem->getUrl());
     }
 
     public function testGetLabel()
     {
-        $NavigationItem = new NavigationItem(new Route(new InMemoryPage('foo')), 'Page', 500);
+        $NavigationItem = new NavigationItem(new PageRoute(new InMemoryPage('foo')), 'Page', 500);
         $this->assertSame('Page', $NavigationItem->getLabel());
     }
 
     public function testGetPriority()
     {
-        $NavigationItem = new NavigationItem(new Route(new InMemoryPage('foo')), 'Page', 500);
+        $NavigationItem = new NavigationItem(new PageRoute(new InMemoryPage('foo')), 'Page', 500);
         $this->assertSame(500, $NavigationItem->getPriority());
     }
 
     public function testGetGroup()
     {
-        $NavigationItem = new NavigationItem(new Route(new InMemoryPage('foo')), 'Page', 500);
+        $NavigationItem = new NavigationItem(new PageRoute(new InMemoryPage('foo')), 'Page', 500);
         $this->assertNull($NavigationItem->getGroupKey());
     }
 
     public function testFromRoute()
     {
-        $route = new Route(new MarkdownPage());
+        $route = new PageRoute(new MarkdownPage());
         $item = NavigationItem::create($route);
 
         $this->assertSame($route, $item->getRoute());
@@ -184,28 +184,28 @@ class NavigationItemTest extends UnitTestCase
     public function testRouteBasedNavigationItemDestinationsAreResolvedRelatively()
     {
         Render::swap(Mockery::mock(RenderData::class, [
-            'getRoute' => new Route(new InMemoryPage('foo')),
+            'getRoute' => new PageRoute(new InMemoryPage('foo')),
             'getRouteKey' => 'foo',
         ]));
 
-        $this->assertSame('foo.html', (string) NavigationItem::create(new Route(new InMemoryPage('foo'))));
-        $this->assertSame('foo/bar.html', (string) NavigationItem::create(new Route(new InMemoryPage('foo/bar'))));
+        $this->assertSame('foo.html', (string) NavigationItem::create(new PageRoute(new InMemoryPage('foo'))));
+        $this->assertSame('foo/bar.html', (string) NavigationItem::create(new PageRoute(new InMemoryPage('foo/bar'))));
 
         Render::swap(Mockery::mock(RenderData::class, [
-            'getRoute' => new Route(new InMemoryPage('foo/bar')),
+            'getRoute' => new PageRoute(new InMemoryPage('foo/bar')),
             'getRouteKey' => 'foo/bar',
         ]));
 
-        $this->assertSame('../foo.html', (string) NavigationItem::create(new Route(new InMemoryPage('foo'))));
-        $this->assertSame('../foo/bar.html', (string) NavigationItem::create(new Route(new InMemoryPage('foo/bar'))));
+        $this->assertSame('../foo.html', (string) NavigationItem::create(new PageRoute(new InMemoryPage('foo'))));
+        $this->assertSame('../foo/bar.html', (string) NavigationItem::create(new PageRoute(new InMemoryPage('foo/bar'))));
 
         Render::swap(Mockery::mock(RenderData::class, [
-            'getRoute' => new Route(new InMemoryPage('foo/bar/baz')),
+            'getRoute' => new PageRoute(new InMemoryPage('foo/bar/baz')),
             'getRouteKey' => 'foo/bar/baz',
         ]));
 
-        $this->assertSame('../../foo.html', (string) NavigationItem::create(new Route(new InMemoryPage('foo'))));
-        $this->assertSame('../../foo/bar.html', (string) NavigationItem::create(new Route(new InMemoryPage('foo/bar'))));
+        $this->assertSame('../../foo.html', (string) NavigationItem::create(new PageRoute(new InMemoryPage('foo'))));
+        $this->assertSame('../../foo/bar.html', (string) NavigationItem::create(new PageRoute(new InMemoryPage('foo/bar'))));
     }
 
     public function testDropdownFacade()
@@ -220,7 +220,7 @@ class NavigationItemTest extends UnitTestCase
     public function testDropdownFacadeWithChildren()
     {
         $children = [
-            new NavigationItem(new Route(new MarkdownPage()), 'bar'),
+            new NavigationItem(new PageRoute(new MarkdownPage()), 'bar'),
         ];
 
         $item = NavigationGroup::create('foo', $children);
@@ -238,17 +238,17 @@ class NavigationItemTest extends UnitTestCase
     public function testIsCurrent()
     {
         Render::swap(Mockery::mock(RenderData::class, [
-            'getRoute' => new Route(new InMemoryPage('foo')),
+            'getRoute' => new PageRoute(new InMemoryPage('foo')),
             'getRouteKey' => 'foo',
         ]));
-        $this->assertTrue(NavigationItem::create(new Route(new InMemoryPage('foo')))->isActive());
-        $this->assertFalse(NavigationItem::create(new Route(new InMemoryPage('bar')))->isActive());
+        $this->assertTrue(NavigationItem::create(new PageRoute(new InMemoryPage('foo')))->isActive());
+        $this->assertFalse(NavigationItem::create(new PageRoute(new InMemoryPage('bar')))->isActive());
     }
 
     public function testIsCurrentWithExternalRoute()
     {
         Render::swap(Mockery::mock(RenderData::class, [
-            'getRoute' => new Route(new InMemoryPage('foo')),
+            'getRoute' => new PageRoute(new InMemoryPage('foo')),
             'getRouteKey' => 'foo',
         ]));
         $this->assertFalse(NavigationItem::create('foo', 'bar')->isActive());
@@ -257,27 +257,27 @@ class NavigationItemTest extends UnitTestCase
 
     public function testGetGroupWithNoGroup()
     {
-        $this->assertNull((new NavigationItem(new Route(new MarkdownPage()), 'Test', 500))->getGroupKey());
+        $this->assertNull((new NavigationItem(new PageRoute(new MarkdownPage()), 'Test', 500))->getGroupKey());
     }
 
     public function testGetGroupWithGroup()
     {
-        $this->assertSame('foo', (new NavigationItem(new Route(new MarkdownPage()), 'Test', 500, 'foo'))->getGroupKey());
+        $this->assertSame('foo', (new NavigationItem(new PageRoute(new MarkdownPage()), 'Test', 500, 'foo'))->getGroupKey());
     }
 
     public function testGetGroupFromRouteWithGroup()
     {
-        $this->assertSame('foo', NavigationItem::create(new Route(new MarkdownPage(matter: ['navigation.group' => 'foo'])))->getGroupKey());
+        $this->assertSame('foo', NavigationItem::create(new PageRoute(new MarkdownPage(matter: ['navigation.group' => 'foo'])))->getGroupKey());
     }
 
     public function testGetGroupCreateWithGroup()
     {
-        $this->assertSame('foo', NavigationItem::create(new Route(new MarkdownPage(matter: ['navigation.group' => 'foo'])), 'foo')->getGroupKey());
+        $this->assertSame('foo', NavigationItem::create(new PageRoute(new MarkdownPage(matter: ['navigation.group' => 'foo'])), 'foo')->getGroupKey());
     }
 
     public function testGroupKeysAreNormalized()
     {
-        $item = new NavigationItem(new Route(new MarkdownPage()), 'Test', 500, 'Foo Bar');
+        $item = new NavigationItem(new PageRoute(new MarkdownPage()), 'Test', 500, 'Foo Bar');
         $this->assertSame('foo-bar', $item->getGroupKey());
     }
 

--- a/packages/framework/tests/Unit/Pages/BladePageUnitTest.php
+++ b/packages/framework/tests/Unit/Pages/BladePageUnitTest.php
@@ -6,7 +6,7 @@ namespace Hyde\Framework\Testing\Unit\Pages;
 
 use Hyde\Hyde;
 use Hyde\Pages\BladePage;
-use Hyde\Support\Models\Route;
+use Hyde\Support\Models\PageRoute;
 use Hyde\Markdown\Models\FrontMatter;
 use Hyde\Foundation\Kernel\PageCollection;
 use Hyde\Testing\Common\BaseHydePageUnitTest;
@@ -152,7 +152,7 @@ class BladePageUnitTest extends BaseHydePageUnitTest
 
     public function testGetRoute()
     {
-        $this->assertInstanceOf(Route::class, (new BladePage())->getRoute());
+        $this->assertInstanceOf(PageRoute::class, (new BladePage())->getRoute());
     }
 
     public function testGetIdentifier()

--- a/packages/framework/tests/Unit/Pages/DocumentationPageUnitTest.php
+++ b/packages/framework/tests/Unit/Pages/DocumentationPageUnitTest.php
@@ -6,7 +6,7 @@ namespace Hyde\Framework\Testing\Unit\Pages;
 
 use Hyde\Hyde;
 use Hyde\Facades\Filesystem;
-use Hyde\Support\Models\Route;
+use Hyde\Support\Models\PageRoute;
 use Hyde\Pages\DocumentationPage;
 use Hyde\Markdown\Models\Markdown;
 use Hyde\Markdown\Models\FrontMatter;
@@ -160,7 +160,7 @@ class DocumentationPageUnitTest extends BaseMarkdownPageUnitTest
 
     public function testGetRoute()
     {
-        $this->assertInstanceOf(Route::class, (new DocumentationPage())->getRoute());
+        $this->assertInstanceOf(PageRoute::class, (new DocumentationPage())->getRoute());
     }
 
     public function testGetIdentifier()

--- a/packages/framework/tests/Unit/Pages/HtmlPageUnitTest.php
+++ b/packages/framework/tests/Unit/Pages/HtmlPageUnitTest.php
@@ -6,7 +6,7 @@ namespace Hyde\Framework\Testing\Unit\Pages;
 
 use Hyde\Hyde;
 use Hyde\Pages\HtmlPage;
-use Hyde\Support\Models\Route;
+use Hyde\Support\Models\PageRoute;
 use Hyde\Markdown\Models\FrontMatter;
 use Hyde\Foundation\Kernel\PageCollection;
 use Hyde\Testing\Common\BaseHydePageUnitTest;
@@ -186,7 +186,7 @@ class HtmlPageUnitTest extends BaseHydePageUnitTest
 
     public function testGetRoute()
     {
-        $this->assertInstanceOf(Route::class, (new HtmlPage())->getRoute());
+        $this->assertInstanceOf(PageRoute::class, (new HtmlPage())->getRoute());
     }
 
     public function testGetIdentifier()

--- a/packages/framework/tests/Unit/Pages/InMemoryPageUnitTest.php
+++ b/packages/framework/tests/Unit/Pages/InMemoryPageUnitTest.php
@@ -6,7 +6,7 @@ namespace Hyde\Framework\Testing\Unit\Pages;
 
 use Hyde\Hyde;
 use Hyde\Pages\InMemoryPage;
-use Hyde\Support\Models\Route;
+use Hyde\Support\Models\PageRoute;
 use Hyde\Foundation\HydeKernel;
 use Hyde\Markdown\Models\FrontMatter;
 use Hyde\Foundation\Kernel\PageCollection;
@@ -190,7 +190,7 @@ class InMemoryPageUnitTest extends BaseHydePageUnitTest
 
     public function testGetRoute()
     {
-        $this->assertInstanceOf(Route::class, (new InMemoryPage('foo'))->getRoute());
+        $this->assertInstanceOf(PageRoute::class, (new InMemoryPage('foo'))->getRoute());
     }
 
     public function testGetIdentifier()

--- a/packages/framework/tests/Unit/Pages/MarkdownPageUnitTest.php
+++ b/packages/framework/tests/Unit/Pages/MarkdownPageUnitTest.php
@@ -7,7 +7,7 @@ namespace Hyde\Framework\Testing\Unit\Pages;
 use Hyde\Hyde;
 use Hyde\Facades\Filesystem;
 use Hyde\Pages\MarkdownPage;
-use Hyde\Support\Models\Route;
+use Hyde\Support\Models\PageRoute;
 use Hyde\Markdown\Models\Markdown;
 use Hyde\Markdown\Models\FrontMatter;
 use Hyde\Foundation\Kernel\PageCollection;
@@ -188,7 +188,7 @@ class MarkdownPageUnitTest extends BaseMarkdownPageUnitTest
 
     public function testGetRoute()
     {
-        $this->assertInstanceOf(Route::class, (new MarkdownPage())->getRoute());
+        $this->assertInstanceOf(PageRoute::class, (new MarkdownPage())->getRoute());
     }
 
     public function testGetIdentifier()

--- a/packages/framework/tests/Unit/Pages/MarkdownPostUnitTest.php
+++ b/packages/framework/tests/Unit/Pages/MarkdownPostUnitTest.php
@@ -7,7 +7,7 @@ namespace Hyde\Framework\Testing\Unit\Pages;
 use Hyde\Hyde;
 use Hyde\Facades\Filesystem;
 use Hyde\Pages\MarkdownPost;
-use Hyde\Support\Models\Route;
+use Hyde\Support\Models\PageRoute;
 use Hyde\Markdown\Models\Markdown;
 use Hyde\Markdown\Models\FrontMatter;
 use Hyde\Foundation\Kernel\PageCollection;
@@ -188,7 +188,7 @@ class MarkdownPostUnitTest extends BaseMarkdownPageUnitTest
 
     public function testGetRoute()
     {
-        $this->assertInstanceOf(Route::class, (new MarkdownPost())->getRoute());
+        $this->assertInstanceOf(PageRoute::class, (new MarkdownPost())->getRoute());
     }
 
     public function testGetIdentifier()

--- a/packages/framework/tests/Unit/RelativeLinksAcrossPagesRetainsIntegrityTest.php
+++ b/packages/framework/tests/Unit/RelativeLinksAcrossPagesRetainsIntegrityTest.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace Hyde\Framework\Testing\Unit;
 
 use Hyde\Facades\Filesystem;
-use Hyde\Support\Models\Route;
+use Hyde\Support\Models\PageRoute;
 use Hyde\Foundation\Facades\Routes;
 use Hyde\Framework\Actions\StaticPageBuilder;
 use Hyde\Framework\Actions\CreatesNewMarkdownPostFile;
@@ -65,7 +65,7 @@ class RelativeLinksAcrossPagesRetainsIntegrityTest extends TestCase
 
     public function testRelativeLinksAcrossPagesRetainsIntegrity()
     {
-        Routes::getRoutes()->each(function (Route $route): void {
+        Routes::getRoutes()->each(function (PageRoute $route): void {
             StaticPageBuilder::handle($route->getPage());
         });
 

--- a/packages/framework/tests/Unit/RouteNotFoundExceptionTest.php
+++ b/packages/framework/tests/Unit/RouteNotFoundExceptionTest.php
@@ -22,7 +22,7 @@ class RouteNotFoundExceptionTest extends UnitTestCase
     public function testItThrowsAnExceptionWhenPageTypeIsNotSupported()
     {
         $this->expectException(RouteNotFoundException::class);
-        $this->expectExceptionMessage('Route [not-found] not found.');
+        $this->expectExceptionMessage('PageRoute [not-found] not found.');
         $this->expectExceptionCode(404);
 
         throw new RouteNotFoundException('not-found');

--- a/packages/framework/tests/Unit/RouteTest.php
+++ b/packages/framework/tests/Unit/RouteTest.php
@@ -8,12 +8,12 @@ use Hyde\Hyde;
 use Hyde\Pages\MarkdownPage;
 use Hyde\Support\Facades\Render;
 use Hyde\Support\Models\RenderData;
-use Hyde\Support\Models\Route;
+use Hyde\Support\Models\PageRoute;
 use Hyde\Support\Models\RouteKey;
 use Hyde\Testing\UnitTestCase;
 
 /**
- * @covers \Hyde\Support\Models\Route
+ * @covers \Hyde\Support\Models\PageRoute
  */
 class RouteTest extends UnitTestCase
 {
@@ -26,18 +26,18 @@ class RouteTest extends UnitTestCase
 
     public function testConstructorCreatesRouteFromPageModel()
     {
-        $this->assertInstanceOf(Route::class, new Route(new MarkdownPage()));
+        $this->assertInstanceOf(PageRoute::class, new PageRoute(new MarkdownPage()));
     }
 
     public function testGetPageTypeReturnsFullyQualifiedClassName()
     {
-        $this->assertSame(MarkdownPage::class, (new Route(new MarkdownPage()))->getPageClass());
+        $this->assertSame(MarkdownPage::class, (new PageRoute(new MarkdownPage()))->getPageClass());
     }
 
     public function testGetSourceModelReturnsPageModel()
     {
         $page = new MarkdownPage();
-        $route = new Route($page);
+        $route = new PageRoute($page);
 
         $this->assertInstanceOf(MarkdownPage::class, $route->getPage());
         $this->assertSame($page, $route->getPage());
@@ -46,24 +46,24 @@ class RouteTest extends UnitTestCase
     public function testGetRouteKeyReturnsPagePath()
     {
         $page = new MarkdownPage();
-        $this->assertSame($page->getRouteKey(), (new Route($page))->getRouteKey());
+        $this->assertSame($page->getRouteKey(), (new PageRoute($page))->getRouteKey());
     }
 
     public function testGetSourceFilePathReturnsPageSourcePath()
     {
         $page = new MarkdownPage();
-        $this->assertSame($page->getSourcePath(), (new Route($page))->getSourcePath());
+        $this->assertSame($page->getSourcePath(), (new PageRoute($page))->getSourcePath());
     }
 
     public function testGetOutputFilePathReturnsPageOutputPath()
     {
         $page = new MarkdownPage();
-        $this->assertSame($page->getOutputPath(), (new Route($page))->getOutputPath());
+        $this->assertSame($page->getOutputPath(), (new PageRoute($page))->getOutputPath());
     }
 
     public function testGetLinkReturnsCorrectPathForRootPages()
     {
-        $route = new Route(new MarkdownPage('foo'));
+        $route = new PageRoute(new MarkdownPage('foo'));
 
         $this->assertSame(Hyde::relativeLink($route->getOutputPath()), $route->getLink());
         $this->assertSame('foo.html', $route->getLink());
@@ -71,7 +71,7 @@ class RouteTest extends UnitTestCase
 
     public function testGetLinkReturnsCorrectPathForNestedPages()
     {
-        $route = new Route(new MarkdownPage('foo/bar'));
+        $route = new PageRoute(new MarkdownPage('foo/bar'));
 
         $this->assertSame(Hyde::relativeLink($route->getOutputPath()), $route->getLink());
         $this->assertSame('foo/bar.html', $route->getLink());
@@ -79,7 +79,7 @@ class RouteTest extends UnitTestCase
 
     public function testGetLinkReturnsCorrectPathForNestedCurrentPage()
     {
-        $route = new Route(new MarkdownPage('foo'));
+        $route = new PageRoute(new MarkdownPage('foo'));
         Render::shouldReceive('getRouteKey')->andReturn('foo/bar');
 
         $this->assertSame(Hyde::relativeLink($route->getOutputPath()), $route->getLink());
@@ -89,7 +89,7 @@ class RouteTest extends UnitTestCase
     public function testGetLinkReturnsPrettyUrlIfEnabled()
     {
         self::mockConfig(['hyde.pretty_urls' => true]);
-        $route = new Route(new MarkdownPage('foo'));
+        $route = new PageRoute(new MarkdownPage('foo'));
 
         $this->assertSame(Hyde::relativeLink($route->getOutputPath()), $route->getLink());
         $this->assertSame('foo', $route->getLink());
@@ -97,44 +97,44 @@ class RouteTest extends UnitTestCase
 
     public function testToStringIsAliasForGetLink()
     {
-        $route = new Route(new MarkdownPage('foo'));
+        $route = new PageRoute(new MarkdownPage('foo'));
         $this->assertSame($route->getLink(), (string) $route);
     }
 
     public function testIsWithRouteReturnsTrueWhenTrue()
     {
-        $route = new Route(new MarkdownPage('foo'));
+        $route = new PageRoute(new MarkdownPage('foo'));
         $this->assertTrue($route->is($route));
     }
 
     public function testIsWithRouteReturnsFalseWhenFalse()
     {
-        $route = new Route(new MarkdownPage('foo'));
-        $route2 = new Route(new MarkdownPage('bar'));
+        $route = new PageRoute(new MarkdownPage('foo'));
+        $route2 = new PageRoute(new MarkdownPage('bar'));
         $this->assertFalse($route->is($route2));
     }
 
     public function testIsWithRouteKeyReturnsTrueWhenTrue()
     {
-        $route = new Route(new MarkdownPage('foo'));
+        $route = new PageRoute(new MarkdownPage('foo'));
         $this->assertTrue($route->is('foo'));
     }
 
     public function testIsWithRouteKeyReturnsFalseWhenFalse()
     {
-        $route = new Route(new MarkdownPage('foo'));
+        $route = new PageRoute(new MarkdownPage('foo'));
         $this->assertFalse($route->is('bar'));
     }
 
     public function testIsWithRouteKeyObjectReturnsTrueWhenTrue()
     {
-        $route = new Route(new MarkdownPage('foo'));
+        $route = new PageRoute(new MarkdownPage('foo'));
         $this->assertTrue($route->is(new RouteKey('foo')));
     }
 
     public function testIsWithRouteKeyObjectReturnsTrueWhenFalse()
     {
-        $route = new Route(new MarkdownPage('foo'));
+        $route = new PageRoute(new MarkdownPage('foo'));
         $this->assertFalse($route->is(new RouteKey('bar')));
     }
 

--- a/packages/framework/tests/Unit/Views/NavigationHtmlLayoutsTest.php
+++ b/packages/framework/tests/Unit/Views/NavigationHtmlLayoutsTest.php
@@ -952,7 +952,7 @@ class TestKernel extends HydeKernel
         $this->mockRoutes = RouteCollection::make($routes);
     }
 
-    /** @return \Hyde\Foundation\Kernel\RouteCollection<string, \Hyde\Support\Models\Route> */
+    /** @return \Hyde\Foundation\Kernel\RouteCollection<string, \Hyde\Support\Models\PageRoute> */
     public function routes(): RouteCollection
     {
         return $this->mockRoutes ?? parent::routes();

--- a/packages/framework/tests/Unit/Views/NavigationLinkViewTest.php
+++ b/packages/framework/tests/Unit/Views/NavigationLinkViewTest.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace Hyde\Framework\Testing\Unit\Views;
 
 use Hyde\Pages\InMemoryPage;
-use Hyde\Support\Models\Route;
+use Hyde\Support\Models\PageRoute;
 use Hyde\Testing\TestsBladeViews;
 use Hyde\Testing\Support\TestView;
 use Illuminate\View\ComponentAttributeBag;
@@ -29,7 +29,7 @@ class NavigationLinkViewTest extends TestCase
     protected function testView(): TestView
     {
         return $this->view(view('hyde::components.navigation.navigation-link', [
-            'item' => NavigationItem::create(new Route(new InMemoryPage('foo')), 'Foo'),
+            'item' => NavigationItem::create(new PageRoute(new InMemoryPage('foo')), 'Foo'),
             'attributes' => new ComponentAttributeBag(),
         ]));
     }

--- a/packages/framework/tests/Unit/Views/SidebarItemsViewTest.php
+++ b/packages/framework/tests/Unit/Views/SidebarItemsViewTest.php
@@ -6,7 +6,7 @@ namespace Hyde\Framework\Testing\Unit\Views;
 
 use Hyde\Hyde;
 use Hyde\Testing\TestCase;
-use Hyde\Support\Models\Route;
+use Hyde\Support\Models\PageRoute;
 use Hyde\Testing\TestsBladeViews;
 use Hyde\Pages\DocumentationPage;
 use Hyde\Testing\Support\TestView;
@@ -29,9 +29,9 @@ class SidebarItemsViewTest extends TestCase
 
     protected function testView(): TestView
     {
-        Hyde::routes()->addRoute(new Route(new DocumentationPage('foo')));
-        Hyde::routes()->addRoute(new Route(new DocumentationPage('bar')));
-        Hyde::routes()->addRoute(new Route(new DocumentationPage('baz')));
+        Hyde::routes()->addRoute(new PageRoute(new DocumentationPage('foo')));
+        Hyde::routes()->addRoute(new PageRoute(new DocumentationPage('bar')));
+        Hyde::routes()->addRoute(new PageRoute(new DocumentationPage('baz')));
 
         return $this->view(view('hyde::components.docs.sidebar-items', [
             'sidebar' => NavigationMenuGenerator::handle(DocumentationSidebar::class),

--- a/packages/publications/tests/Feature/PublicationPageTest.php
+++ b/packages/publications/tests/Feature/PublicationPageTest.php
@@ -7,7 +7,7 @@ namespace Hyde\Publications\Testing\Feature;
 use Hyde\Hyde;
 use Hyde\Publications\Models\PublicationType;
 use Hyde\Publications\Pages\PublicationPage;
-use Hyde\Support\Models\Route;
+use Hyde\Support\Models\PageRoute;
 use Hyde\Testing\TestCase;
 
 /**
@@ -32,8 +32,8 @@ class PublicationPageTest extends TestCase
         $this->createPublicationFiles();
 
         $page = PublicationPage::get('test-publication/foo');
-        $this->assertInstanceOf(Route::class, $page->getRoute());
-        $this->assertEquals(new Route($page), $page->getRoute());
+        $this->assertInstanceOf(PageRoute::class, $page->getRoute());
+        $this->assertEquals(new PageRoute($page), $page->getRoute());
         $this->assertSame($page->getRoute()->getLink(), $page->getLink());
         $this->assertArrayHasKey($page->getSourcePath(), Hyde::pages());
         $this->assertArrayHasKey($page->getRouteKey(), Hyde::routes());

--- a/packages/publications/tests/Feature/PublicationPageUnitTest.php
+++ b/packages/publications/tests/Feature/PublicationPageUnitTest.php
@@ -15,7 +15,7 @@ use Hyde\Markdown\Models\FrontMatter;
 use Hyde\Markdown\Models\Markdown;
 use Hyde\Publications\Models\PublicationType;
 use Hyde\Publications\Pages\PublicationPage;
-use Hyde\Support\Models\Route;
+use Hyde\Support\Models\PageRoute;
 use Hyde\Testing\TestCase;
 
 /**
@@ -189,7 +189,7 @@ class PublicationPageUnitTest extends TestCase
 
     public function testGetRoute()
     {
-        $this->assertInstanceOf(Route::class, (new PublicationPage('', [], '', $this->pubType()))->getRoute());
+        $this->assertInstanceOf(PageRoute::class, (new PublicationPage('', [], '', $this->pubType()))->getRoute());
     }
 
     public function testGetIdentifier()

--- a/packages/publications/tests/Feature/PublicationsExtensionTest.php
+++ b/packages/publications/tests/Feature/PublicationsExtensionTest.php
@@ -15,7 +15,7 @@ use Hyde\Publications\Pages\PublicationPage;
 use Hyde\Publications\PublicationsExtension;
 use Hyde\Support\Filesystem\MediaFile;
 use Hyde\Support\Filesystem\SourceFile;
-use Hyde\Support\Models\Route;
+use Hyde\Support\Models\PageRoute;
 use Hyde\Testing\TestCase;
 
 /**
@@ -219,13 +219,13 @@ class PublicationsExtensionTest extends TestCase
             'publication/index',
         ], $routes);
 
-        $this->assertContainsOnlyInstancesOf(Route::class, $booted->getRoutes());
+        $this->assertContainsOnlyInstancesOf(PageRoute::class, $booted->getRoutes());
 
-        $this->assertEquals(new Route(new PublicationPage('foo', [], '', PublicationType::get('publication'))),
+        $this->assertEquals(new PageRoute(new PublicationPage('foo', [], '', PublicationType::get('publication'))),
             $booted->getRoutes()->get('publication/foo')
         );
 
-        $this->assertEquals(new Route(new PublicationListPage(PublicationType::get('publication'))),
+        $this->assertEquals(new PageRoute(new PublicationListPage(PublicationType::get('publication'))),
             $booted->getRoutes()->get('publication/index')
         );
     }

--- a/packages/publications/tests/Feature/RelatedPublicationsComponentTest.php
+++ b/packages/publications/tests/Feature/RelatedPublicationsComponentTest.php
@@ -9,7 +9,7 @@ use Hyde\Hyde;
 use Hyde\Publications\Models\PublicationType;
 use Hyde\Publications\Pages\PublicationPage;
 use Hyde\Publications\Views\Components\RelatedPublicationsComponent;
-use Hyde\Support\Models\Route;
+use Hyde\Support\Models\PageRoute;
 use Hyde\Testing\TestCase;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\View;
@@ -32,7 +32,7 @@ class RelatedPublicationsComponentTest extends TestCase
     {
         $type = new PublicationType('foo');
         $page = new PublicationPage('foo', type: $type);
-        $this->mockRoute(new Route($page));
+        $this->mockRoute(new PageRoute($page));
 
         $component = new RelatedPublicationsComponent();
         $this->assertEquals(new Collection(), $component->relatedPublications);
@@ -42,7 +42,7 @@ class RelatedPublicationsComponentTest extends TestCase
     {
         $type = new PublicationType('foo', fields: [['name' => 'foo', 'type' => 'tag']]);
         $page = new PublicationPage('foo', type: $type);
-        $this->mockRoute(new Route($page));
+        $this->mockRoute(new PageRoute($page));
 
         $component = new RelatedPublicationsComponent();
         $this->assertEquals(new Collection(), $component->relatedPublications);
@@ -52,7 +52,7 @@ class RelatedPublicationsComponentTest extends TestCase
     {
         $type = new PublicationType('foo', fields: [['name' => 'foo', 'type' => 'tag']]);
         $page = new PublicationPage('foo', ['foo' => 'bar'], type: $type);
-        $this->mockRoute(new Route($page));
+        $this->mockRoute(new PageRoute($page));
 
         $component = new RelatedPublicationsComponent();
         $this->assertEquals(new Collection(), $component->relatedPublications);
@@ -62,7 +62,7 @@ class RelatedPublicationsComponentTest extends TestCase
     {
         $type = new PublicationType('foo', fields: [['name' => 'foo', 'type' => 'tag']]);
         $page = new PublicationPage('foo', ['foo' => 'bar'], type: $type);
-        $this->mockRoute(new Route($page));
+        $this->mockRoute(new PageRoute($page));
 
         $otherPage = new PublicationPage('bar', ['foo' => 'bar'], type: $type);
         Hyde::pages()->addPage($page);
@@ -76,7 +76,7 @@ class RelatedPublicationsComponentTest extends TestCase
     {
         $type = new PublicationType('foo', fields: [['name' => 'foo', 'type' => 'tag']]);
         $page = new PublicationPage('foo', ['foo' => 'bar'], type: $type);
-        $this->mockRoute(new Route($page));
+        $this->mockRoute(new PageRoute($page));
 
         $otherPage = new PublicationPage('bar', ['foo' => 'baz'], type: $type);
         Hyde::pages()->addPage($page);
@@ -90,7 +90,7 @@ class RelatedPublicationsComponentTest extends TestCase
     {
         $type = new PublicationType('foo', fields: [['name' => 'foo', 'type' => 'tag']]);
         $page = new PublicationPage('foo', type: $type);
-        $this->mockRoute(new Route($page));
+        $this->mockRoute(new PageRoute($page));
 
         $otherPage = new PublicationPage('bar', ['foo' => 'bar'], type: $type);
         Hyde::pages()->addPage($page);
@@ -104,7 +104,7 @@ class RelatedPublicationsComponentTest extends TestCase
     {
         $type = new PublicationType('foo', fields: [['name' => 'foo', 'type' => 'tag']]);
         $page = new PublicationPage('foo', ['foo' => 'bar'], type: $type);
-        $this->mockRoute(new Route($page));
+        $this->mockRoute(new PageRoute($page));
 
         $page1 = new PublicationPage('page-1', ['foo' => 'bar'], type: $type);
         $page2 = new PublicationPage('page-2', ['foo' => 'bar'], type: $type);
@@ -132,7 +132,7 @@ class RelatedPublicationsComponentTest extends TestCase
     {
         $type = new PublicationType('foo', fields: [['name' => 'foo', 'type' => 'tag']]);
         $page = new PublicationPage('foo', ['foo' => 'bar'], type: $type);
-        $this->mockRoute(new Route($page));
+        $this->mockRoute(new PageRoute($page));
 
         $page1 = new PublicationPage('page-1', ['foo' => 'bar'], type: $type);
         $page2 = new PublicationPage('page-2', ['foo' => 'bar'], type: $type);
@@ -158,7 +158,7 @@ class RelatedPublicationsComponentTest extends TestCase
     {
         $type = new PublicationType('foo', fields: [['name' => 'foo', 'type' => 'tag']]);
         $page = new PublicationPage('foo', ['foo' => 'bar'], type: $type);
-        $this->mockRoute(new Route($page));
+        $this->mockRoute(new PageRoute($page));
 
         $page1 = new PublicationPage('page-1', ['foo' => 'foo'], type: $type);
         $page2 = new PublicationPage('page-2', ['foo' => 'bar'], type: $type);
@@ -183,7 +183,7 @@ class RelatedPublicationsComponentTest extends TestCase
     {
         $type = new PublicationType('foo', fields: [['name' => 'foo', 'type' => 'tag']]);
         $page = new PublicationPage('foo', ['foo' => 'bar'], type: $type);
-        $this->mockRoute(new Route($page));
+        $this->mockRoute(new PageRoute($page));
 
         $page1 = new PublicationPage('page-1', ['foo' => 'bar', '__createdAt' => Carbon::now()->addDays(1)], type: $type);
         $page2 = new PublicationPage('page-2', ['foo' => 'bar', '__createdAt' => Carbon::now()->addDays(2)], type: $type);
@@ -211,7 +211,7 @@ class RelatedPublicationsComponentTest extends TestCase
     {
         $type = new PublicationType('foo', fields: [['name' => 'foo', 'type' => 'tag']]);
         $page = new PublicationPage('foo', ['foo' => 'bar'], type: $type);
-        $this->mockRoute(new Route($page));
+        $this->mockRoute(new PageRoute($page));
 
         $time = time();
         $page1 = new PublicationPage('page-1', ['foo' => 'bar', '__createdAt' => $time], type: $type);

--- a/packages/realtime-compiler/resources/dashboard.blade.php
+++ b/packages/realtime-compiler/resources/dashboard.blade.php
@@ -231,7 +231,7 @@
                         <div class="table-responsive">
                             <table class="table table-bordered">
                                 <tr>
-                                    @foreach(['Page Type', 'Route Key', 'Source File', 'Output File', 'Identifier'] as $header)
+                                    @foreach(['Page Type', 'PageRoute Key', 'Source File', 'Output File', 'Identifier'] as $header)
                                         <th>{{ $header }}</th>
                                     @endforeach
                                     <th class="text-end">Actions</th>

--- a/packages/realtime-compiler/src/Http/DashboardController.php
+++ b/packages/realtime-compiler/src/Http/DashboardController.php
@@ -129,7 +129,7 @@ class DashboardController extends BaseController
         ];
     }
 
-    /** @return array<string, \Hyde\Support\Models\Route> */
+    /** @return array<string, \Hyde\Support\Models\PageRoute> */
     public function getPageList(): array
     {
         return Hyde::routes()->all();

--- a/packages/realtime-compiler/src/Http/LiveEditController.php
+++ b/packages/realtime-compiler/src/Http/LiveEditController.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace Hyde\RealtimeCompiler\Http;
 
 use Hyde\Hyde;
-use Hyde\Support\Models\Route;
+use Hyde\Support\Models\PageRoute;
 use Desilva\Microserve\Response;
 use Hyde\Support\Models\Redirect;
 use Hyde\Markdown\Models\Markdown;
@@ -84,7 +84,7 @@ class LiveEditController extends BaseController
         ])), $html);
     }
 
-    protected function redirectToPage(Route $route): HtmlResponse
+    protected function redirectToPage(PageRoute $route): HtmlResponse
     {
         $redirectPage = new Redirect($this->request->path, "../$route");
         Hyde::shareViewData($redirectPage);

--- a/packages/realtime-compiler/tests/RealtimeCompilerTest.php
+++ b/packages/realtime-compiler/tests/RealtimeCompilerTest.php
@@ -94,7 +94,7 @@ test('handle throws route not found exception for missing route', function () {
 
     $kernel = new HttpKernel();
     $kernel->handle(new Request());
-})->throws(RouteNotFoundException::class, 'Route [missing] not found');
+})->throws(RouteNotFoundException::class, 'PageRoute [missing] not found');
 
 test('handle sends 404 error response for missing asset', function () {
     mockRoute('missing.css');

--- a/packages/testing/src/InteractsWithPages.php
+++ b/packages/testing/src/InteractsWithPages.php
@@ -7,13 +7,13 @@ namespace Hyde\Testing;
 use Hyde\Pages\InMemoryPage;
 use Hyde\Pages\Concerns\HydePage;
 use Hyde\Support\Facades\Render;
-use Hyde\Support\Models\Route;
+use Hyde\Support\Models\PageRoute;
 
 trait InteractsWithPages
 {
-    protected function mockRoute(?Route $route = null): static
+    protected function mockRoute(?PageRoute $route = null): static
     {
-        Render::share('route', $route ?? (new Route(new InMemoryPage())));
+        Render::share('route', $route ?? (new PageRoute(new InMemoryPage())));
 
         return $this;
     }
@@ -29,7 +29,7 @@ trait InteractsWithPages
     protected function mockCurrentPage(string $currentPage): static
     {
         Render::share('routeKey', $currentPage);
-        Render::share('route', new Route(new InMemoryPage($currentPage)));
+        Render::share('route', new PageRoute(new InMemoryPage($currentPage)));
 
         return $this;
     }


### PR DESCRIPTION
Targets https://github.com/hydephp/develop/pull/1568 and experiments with extracting a PageRoute model.

This may add too much complexity, and not solve the right problem (as the issue is with ExternalRoutes being hacky, but since they are new and just used in navigation it may be better to improve that instead), but I wanted to visualize what this could look like before making a decision.