### PR TITLE
[2.x] Create better fallbacks when not supplying a navigation item label

### DIFF
--- a/packages/framework/src/Framework/Features/Navigation/NavigationItem.php
+++ b/packages/framework/src/Framework/Features/Navigation/NavigationItem.php
@@ -68,7 +68,7 @@ class NavigationItem implements NavigationElement, Stringable
             $group ??= $destination->getPage()->navigationMenuGroup();
         }
 
-        return new static($destination, $label ?? $destination, $priority ?? NavigationMenu::DEFAULT, $group);
+        return new static($destination, $label ?? static::makeTitleFromUrl($destination), $priority ?? NavigationMenu::DEFAULT, $group);
     }
 
     /**
@@ -136,5 +136,10 @@ class NavigationItem implements NavigationElement, Stringable
     public static function normalizeGroupKey(?string $group): ?string
     {
         return $group ? Str::slug($group) : null;
+    }
+
+    protected static function makeTitleFromUrl(string $url): string
+    {
+        return $url;
     }
 }

--- a/packages/framework/src/Framework/Features/Navigation/NavigationItem.php
+++ b/packages/framework/src/Framework/Features/Navigation/NavigationItem.php
@@ -68,7 +68,7 @@ class NavigationItem implements NavigationElement, Stringable
             $group ??= $destination->getPage()->navigationMenuGroup();
         }
 
-        return new static($destination, $label ?? '', $priority ?? NavigationMenu::DEFAULT, $group);
+        return new static($destination, $label ?? $destination, $priority ?? NavigationMenu::DEFAULT, $group);
     }
 
     /**

--- a/packages/framework/src/Framework/Features/Navigation/NavigationItem.php
+++ b/packages/framework/src/Framework/Features/Navigation/NavigationItem.php
@@ -68,7 +68,7 @@ class NavigationItem implements NavigationElement, Stringable
             $group ??= $destination->getPage()->navigationMenuGroup();
         }
 
-        return new static($destination, $label ?? static::makeTitleFromUrl($destination), $priority ?? NavigationMenu::DEFAULT, $group);
+        return new static($destination, $label ?? $destination, $priority ?? NavigationMenu::DEFAULT, $group);
     }
 
     /**
@@ -136,15 +136,5 @@ class NavigationItem implements NavigationElement, Stringable
     public static function normalizeGroupKey(?string $group): ?string
     {
         return $group ? Str::slug($group) : null;
-    }
-
-    /** @experimental This feature may be removed before release, and the label will just fall back to the input $url */
-    protected static function makeTitleFromUrl(string $url): string
-    {
-        $basename = basename($url);
-        $basename = Str::replaceFirst('www.', '', $basename);
-        $basename = Str::replaceLast('.html', '', $basename);
-
-        return Hyde::makeTitle($basename);
     }
 }

--- a/packages/framework/src/Framework/Features/Navigation/NavigationItem.php
+++ b/packages/framework/src/Framework/Features/Navigation/NavigationItem.php
@@ -138,8 +138,13 @@ class NavigationItem implements NavigationElement, Stringable
         return $group ? Str::slug($group) : null;
     }
 
+    /** @experimental This feature may be removed before release, and the label will just fall back to the input $url */
     protected static function makeTitleFromUrl(string $url): string
     {
-        return $url;
+        $basename = basename($url);
+        $basename = Str::replaceFirst('www.', '', $basename);
+        $basename = Str::replaceLast('.html', '', $basename);
+
+        return Hyde::makeTitle($basename);
     }
 }

--- a/packages/framework/tests/Unit/NavigationItemTest.php
+++ b/packages/framework/tests/Unit/NavigationItemTest.php
@@ -208,6 +208,11 @@ class NavigationItemTest extends UnitTestCase
         $this->assertSame(100, NavigationItem::create(Routes::get('index'), 'foo', 100)->getPriority());
     }
 
+    public function testCreateWithNullLabelForRoute()
+    {
+        $this->assertSame('Home', NavigationItem::create('index')->getLabel());
+    }
+
     public function testCreateWithNullLabel()
     {
         $this->assertSame('', NavigationItem::create('foo')->getLabel());

--- a/packages/framework/tests/Unit/NavigationItemTest.php
+++ b/packages/framework/tests/Unit/NavigationItemTest.php
@@ -215,7 +215,22 @@ class NavigationItemTest extends UnitTestCase
 
     public function testCreateWithNullLabel()
     {
-        $this->assertSame('', NavigationItem::create('foo')->getLabel());
+        $this->assertSame('foo', NavigationItem::create('foo')->getLabel());
+
+        $links = [
+            'www.example.com',
+            'https://example.com',
+            'https://example.com/',
+            'https://example.com/foo',
+            'https://example.com/foo/',
+            'https://example.com/foo/bar',
+            'https://example.com/foo/bar.html',
+            'https://example.com/foo/bar.png',
+        ];
+
+        foreach ($links as $link) {
+            $this->assertSame($link, NavigationItem::create($link)->getLink());
+        }
     }
 
     public function testPassingRouteKeyToStaticConstructorUsesRouteInstance()

--- a/packages/framework/tests/Unit/NavigationItemTest.php
+++ b/packages/framework/tests/Unit/NavigationItemTest.php
@@ -208,6 +208,11 @@ class NavigationItemTest extends UnitTestCase
         $this->assertSame(100, NavigationItem::create(Routes::get('index'), 'foo', 100)->getPriority());
     }
 
+    public function testCreateWithNullLabel()
+    {
+        $this->assertSame('', NavigationItem::create('foo')->getLabel());
+    }
+
     public function testPassingRouteKeyToStaticConstructorUsesRouteInstance()
     {
         $route = Routes::get('index');

--- a/packages/framework/tests/Unit/NavigationItemTest.php
+++ b/packages/framework/tests/Unit/NavigationItemTest.php
@@ -215,40 +215,22 @@ class NavigationItemTest extends UnitTestCase
 
     public function testCreateWithNullLabel()
     {
-        $this->assertSame('Foo', NavigationItem::create('foo')->getLabel());
-    }
+        $this->assertSame('foo', NavigationItem::create('foo')->getLabel());
 
-    public function testCreateWithNullLabelForLinks()
-    {
-        $this->assertSame('Example.com', NavigationItem::create('example.com')->getLabel());
-        $this->assertSame('Example.com', NavigationItem::create('example.com/')->getLabel());
-        $this->assertSame('Example.com', NavigationItem::create('https://example.com/')->getLabel());
-    }
+        $links = [
+            'www.example.com',
+            'https://example.com',
+            'https://example.com/',
+            'https://example.com/foo',
+            'https://example.com/foo/',
+            'https://example.com/foo/bar',
+            'https://example.com/foo/bar.html',
+            'https://example.com/foo/bar.png',
+        ];
 
-    public function testCreateWithNullLabelForLinksWithSubdomain()
-    {
-        $this->assertSame('Example.com', NavigationItem::create('www.example.com')->getLabel());
-        $this->assertSame('Example.com', NavigationItem::create('www.example.com/')->getLabel());
-        $this->assertSame('Example.com', NavigationItem::create('https://www.example.com')->getLabel());
-        $this->assertSame('Example.com', NavigationItem::create('https://www.example.com/')->getLabel());
-    }
-
-    public function testCreateWithNullLabelForLinksWithPages()
-    {
-        $this->assertSame('Foo', NavigationItem::create('https://example.com/foo')->getLabel());
-        $this->assertSame('Foo', NavigationItem::create('https://example.com/foo/')->getLabel());
-        $this->assertSame('Bar', NavigationItem::create('https://example.com/foo/bar')->getLabel());
-        $this->assertSame('Bar', NavigationItem::create('https://example.com/foo/bar/')->getLabel());
-    }
-
-    public function testCreateWithNullLabelForLinkWithPageWithHtmlExtension()
-    {
-        $this->assertSame('Bar', NavigationItem::create('https://example.com/foo/bar.html')->getLabel());
-    }
-
-    public function testCreateWithNullLabelForLinkWithPageWithOtherExtension()
-    {
-        $this->assertSame('Bar.png', NavigationItem::create('https://example.com/foo/bar.png')->getLabel());
+        foreach ($links as $link) {
+            $this->assertSame($link, NavigationItem::create($link)->getLabel());
+        }
     }
 
     public function testPassingRouteKeyToStaticConstructorUsesRouteInstance()

--- a/packages/framework/tests/Unit/NavigationItemTest.php
+++ b/packages/framework/tests/Unit/NavigationItemTest.php
@@ -215,22 +215,40 @@ class NavigationItemTest extends UnitTestCase
 
     public function testCreateWithNullLabel()
     {
-        $this->assertSame('foo', NavigationItem::create('foo')->getLabel());
+        $this->assertSame('Foo', NavigationItem::create('foo')->getLabel());
+    }
 
-        $links = [
-            'www.example.com',
-            'https://example.com',
-            'https://example.com/',
-            'https://example.com/foo',
-            'https://example.com/foo/',
-            'https://example.com/foo/bar',
-            'https://example.com/foo/bar.html',
-            'https://example.com/foo/bar.png',
-        ];
+    public function testCreateWithNullLabelForLinks()
+    {
+        $this->assertSame('Example.com', NavigationItem::create('example.com')->getLabel());
+        $this->assertSame('Example.com', NavigationItem::create('example.com/')->getLabel());
+        $this->assertSame('Example.com', NavigationItem::create('https://example.com/')->getLabel());
+    }
 
-        foreach ($links as $link) {
-            $this->assertSame($link, NavigationItem::create($link)->getLabel());
-        }
+    public function testCreateWithNullLabelForLinksWithSubdomain()
+    {
+        $this->assertSame('Example.com', NavigationItem::create('www.example.com')->getLabel());
+        $this->assertSame('Example.com', NavigationItem::create('www.example.com/')->getLabel());
+        $this->assertSame('Example.com', NavigationItem::create('https://www.example.com')->getLabel());
+        $this->assertSame('Example.com', NavigationItem::create('https://www.example.com/')->getLabel());
+    }
+
+    public function testCreateWithNullLabelForLinksWithPages()
+    {
+        $this->assertSame('Foo', NavigationItem::create('https://example.com/foo')->getLabel());
+        $this->assertSame('Foo', NavigationItem::create('https://example.com/foo/')->getLabel());
+        $this->assertSame('Bar', NavigationItem::create('https://example.com/foo/bar')->getLabel());
+        $this->assertSame('Bar', NavigationItem::create('https://example.com/foo/bar/')->getLabel());
+    }
+
+    public function testCreateWithNullLabelForLinkWithPageWithHtmlExtension()
+    {
+        $this->assertSame('Bar', NavigationItem::create('https://example.com/foo/bar.html')->getLabel());
+    }
+
+    public function testCreateWithNullLabelForLinkWithPageWithOtherExtension()
+    {
+        $this->assertSame('Bar.png', NavigationItem::create('https://example.com/foo/bar.png')->getLabel());
     }
 
     public function testPassingRouteKeyToStaticConstructorUsesRouteInstance()

--- a/packages/framework/tests/Unit/NavigationItemTest.php
+++ b/packages/framework/tests/Unit/NavigationItemTest.php
@@ -229,7 +229,7 @@ class NavigationItemTest extends UnitTestCase
         ];
 
         foreach ($links as $link) {
-            $this->assertSame($link, NavigationItem::create($link)->getLink());
+            $this->assertSame($link, NavigationItem::create($link)->getLabel());
         }
     }
 


### PR DESCRIPTION
Targets https://github.com/hydephp/develop/pull/1568

Since null is not allowed, we needed to coalesce to an empty string. This makes no sense from a practical usability perspective: What's the point of a link in the menu that you can't click because there is no label to click? It makes more sense to fall back to the link to make it usable, and give a nudge to the developer that they may want to change it into something more visually pleasing.
