### PR TITLE
[2.x] Remove the group property from the navigation item class

### DIFF
--- a/packages/framework/src/Framework/Features/Navigation/DocumentationSidebar.php
+++ b/packages/framework/src/Framework/Features/Navigation/DocumentationSidebar.php
@@ -78,7 +78,7 @@ class DocumentationSidebar extends NavigationMenu
 
         return $this->items->first(function (NavigationGroup $group) use ($currentPage): bool {
             // A group is active when it contains the current page being rendered.
-            return $group->getGroupKey() === NavigationItem::normalizeGroupKey($currentPage->navigationMenuGroup());
+            return $group->getGroupKey() === NavigationGroup::normalizeGroupKey($currentPage->navigationMenuGroup());
         });
     }
 }

--- a/packages/framework/src/Framework/Features/Navigation/DocumentationSidebar.php
+++ b/packages/framework/src/Framework/Features/Navigation/DocumentationSidebar.php
@@ -78,7 +78,7 @@ class DocumentationSidebar extends NavigationMenu
 
         return $this->items->first(function (NavigationGroup $group) use ($currentPage): bool {
             // A group is active when it contains the current page being rendered.
-            return $group->getGroupKey() === NavigationGroup::normalizeGroupKey($currentPage->navigationMenuGroup());
+            return $currentPage->navigationMenuGroup() && $group->getGroupKey() === NavigationGroup::normalizeGroupKey($currentPage->navigationMenuGroup());
         });
     }
 }

--- a/packages/framework/src/Framework/Features/Navigation/NavigationElement.php
+++ b/packages/framework/src/Framework/Features/Navigation/NavigationElement.php
@@ -15,9 +15,4 @@ interface NavigationElement
      * Get the priority to determine the order of the navigation item.
      */
     public function getPriority(): int;
-
-    /**
-     * Get the group identifier key of the navigation item, if any.
-     */
-    public function getGroupKey(): ?string;
 }

--- a/packages/framework/src/Framework/Features/Navigation/NavigationGroup.php
+++ b/packages/framework/src/Framework/Features/Navigation/NavigationGroup.php
@@ -82,9 +82,8 @@ class NavigationGroup implements NavigationElement
         });
     }
 
-    /** @return ($group is null ? null : string) */
-    public static function normalizeGroupKey(?string $group): ?string
+    public static function normalizeGroupKey(string $group): string
     {
-        return $group ? Str::slug($group) : null;
+        return Str::slug($group);
     }
 }

--- a/packages/framework/src/Framework/Features/Navigation/NavigationGroup.php
+++ b/packages/framework/src/Framework/Features/Navigation/NavigationGroup.php
@@ -81,4 +81,10 @@ class NavigationGroup implements NavigationElement
             return $child->getPage() instanceof DocumentationPage;
         });
     }
+
+    /** @return ($group is null ? null : string) */
+    public static function normalizeGroupKey(?string $group): ?string
+    {
+        return $group ? Str::slug($group) : null;
+    }
 }

--- a/packages/framework/src/Framework/Features/Navigation/NavigationGroup.php
+++ b/packages/framework/src/Framework/Features/Navigation/NavigationGroup.php
@@ -82,6 +82,7 @@ class NavigationGroup implements NavigationElement
         });
     }
 
+    /** @experimental This method is subject to change before its release. */
     public static function normalizeGroupKey(string $group): string
     {
         return Str::slug($group);

--- a/packages/framework/src/Framework/Features/Navigation/NavigationItem.php
+++ b/packages/framework/src/Framework/Features/Navigation/NavigationItem.php
@@ -35,7 +35,7 @@ class NavigationItem implements NavigationElement, Stringable
      * @param  string  $label  The label of the navigation item.
      * @param  int  $priority  The priority to determine the order of the navigation item.
      */
-    public function __construct(Route|string $destination, string $label, int $priority = NavigationMenu::DEFAULT, #[Deprecated] ?string $group = null)
+    public function __construct(Route|string $destination, string $label, int $priority = NavigationMenu::DEFAULT)
     {
         $this->destination = $destination;
 
@@ -62,7 +62,7 @@ class NavigationItem implements NavigationElement, Stringable
             $group ??= $destination->getPage()->navigationMenuGroup();
         }
 
-        return new static($destination, $label ?? $destination, $priority ?? NavigationMenu::DEFAULT, $group);
+        return new static($destination, $label ?? $destination, $priority ?? NavigationMenu::DEFAULT);
     }
 
     /**

--- a/packages/framework/src/Framework/Features/Navigation/NavigationItem.php
+++ b/packages/framework/src/Framework/Features/Navigation/NavigationItem.php
@@ -34,7 +34,6 @@ class NavigationItem implements NavigationElement, Stringable
      * @param  \Hyde\Support\Models\Route|string  $destination  Route instance, route key, or external URI.
      * @param  string  $label  The label of the navigation item.
      * @param  int  $priority  The priority to determine the order of the navigation item.
-     * @param  string|null  $group  The dropdown/group key of the navigation item, if any.
      */
     public function __construct(Route|string $destination, string $label, int $priority = NavigationMenu::DEFAULT, #[Deprecated] ?string $group = null)
     {
@@ -52,7 +51,6 @@ class NavigationItem implements NavigationElement, Stringable
      * @param  \Hyde\Support\Models\Route|string<\Hyde\Support\Models\RouteKey>|string  $destination  Route instance or route key, or external URI.
      * @param  int|null  $priority  Leave blank to use the priority of the route's corresponding page, if there is one tied to the route.
      * @param  string|null  $label  Leave blank to use the label of the route's corresponding page, if there is one tied to the route.
-     * @param  string|null  $group  Leave blank to use the group of the route's corresponding page, if there is one tied to the route.
      */
     public static function create(Route|string $destination, ?string $label = null, ?int $priority = null, #[Deprecated] ?string $group = null): static
     {

--- a/packages/framework/src/Framework/Features/Navigation/NavigationItem.php
+++ b/packages/framework/src/Framework/Features/Navigation/NavigationItem.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Hyde\Framework\Features\Navigation;
 
 use Hyde\Pages\Concerns\HydePage;
+use JetBrains\PhpStorm\Deprecated;
 use Hyde\Foundation\Facades\Routes;
 use Hyde\Hyde;
 use Hyde\Support\Models\Route;
@@ -38,7 +39,7 @@ class NavigationItem implements NavigationElement, Stringable
      * @param  int  $priority  The priority to determine the order of the navigation item.
      * @param  string|null  $group  The dropdown/group key of the navigation item, if any.
      */
-    public function __construct(Route|string $destination, string $label, int $priority = NavigationMenu::DEFAULT, ?string $group = null)
+    public function __construct(Route|string $destination, string $label, int $priority = NavigationMenu::DEFAULT, #[Deprecated] ?string $group = null)
     {
         $this->destination = $destination;
 
@@ -56,7 +57,7 @@ class NavigationItem implements NavigationElement, Stringable
      * @param  string|null  $label  Leave blank to use the label of the route's corresponding page, if there is one tied to the route.
      * @param  string|null  $group  Leave blank to use the group of the route's corresponding page, if there is one tied to the route.
      */
-    public static function create(Route|string $destination, ?string $label = null, ?int $priority = null, ?string $group = null): static
+    public static function create(Route|string $destination, ?string $label = null, ?int $priority = null, #[Deprecated] ?string $group = null): static
     {
         if (is_string($destination) && Routes::has($destination)) {
             $destination = Routes::get($destination);

--- a/packages/framework/src/Framework/Features/Navigation/NavigationItem.php
+++ b/packages/framework/src/Framework/Features/Navigation/NavigationItem.php
@@ -47,8 +47,8 @@ class NavigationItem implements NavigationElement, Stringable
      * Create a new navigation menu item, automatically filling in the properties from a Route instance if provided.
      *
      * @param  \Hyde\Support\Models\Route|string<\Hyde\Support\Models\RouteKey>|string  $destination  Route instance or route key, or external URI.
-     * @param  int|null  $priority  Leave blank to use the priority of the route's corresponding page, if there is one tied to the route.
      * @param  string|null  $label  Leave blank to use the label of the route's corresponding page, if there is one tied to the route.
+     * @param  int|null  $priority  Leave blank to use the priority of the route's corresponding page, if there is one tied to the route.
      */
     public static function create(Route|string $destination, ?string $label = null, ?int $priority = null): static
     {

--- a/packages/framework/src/Framework/Features/Navigation/NavigationItem.php
+++ b/packages/framework/src/Framework/Features/Navigation/NavigationItem.php
@@ -50,7 +50,7 @@ class NavigationItem implements NavigationElement, Stringable
      * @param  int|null  $priority  Leave blank to use the priority of the route's corresponding page, if there is one tied to the route.
      * @param  string|null  $label  Leave blank to use the label of the route's corresponding page, if there is one tied to the route.
      */
-    public static function create(Route|string $destination, ?string $label = null, ?int $priority = null, #[Deprecated] ?string $group = null): static
+    public static function create(Route|string $destination, ?string $label = null, ?int $priority = null): static
     {
         if (is_string($destination) && Routes::has($destination)) {
             $destination = Routes::get($destination);

--- a/packages/framework/src/Framework/Features/Navigation/NavigationItem.php
+++ b/packages/framework/src/Framework/Features/Navigation/NavigationItem.php
@@ -41,8 +41,6 @@ class NavigationItem implements NavigationElement, Stringable
 
         $this->label = $label;
         $this->priority = $priority;
-
-        $this->group = static::normalizeGroupKey($group);
     }
 
     /**

--- a/packages/framework/src/Framework/Features/Navigation/NavigationItem.php
+++ b/packages/framework/src/Framework/Features/Navigation/NavigationItem.php
@@ -59,7 +59,6 @@ class NavigationItem implements NavigationElement, Stringable
         if ($destination instanceof Route) {
             $label ??= $destination->getPage()->navigationMenuLabel();
             $priority ??= $destination->getPage()->navigationMenuPriority();
-            $group ??= $destination->getPage()->navigationMenuGroup();
         }
 
         return new static($destination, $label ?? $destination, $priority ?? NavigationMenu::DEFAULT);

--- a/packages/framework/src/Framework/Features/Navigation/NavigationItem.php
+++ b/packages/framework/src/Framework/Features/Navigation/NavigationItem.php
@@ -27,7 +27,7 @@ class NavigationItem implements NavigationElement, Stringable
     protected string $label;
     protected int $priority;
 
-    // TODO: Do we actually need this? We should just care if it's physically stored in a group. Adding the group key here doesn't magically make it appear in the group, it needs to be added to the group's items array, so why should we care about the key here?
+    /** @deprecated Do we actually need this? We should just care if it's physically stored in a group. Adding the group key here doesn't magically make it appear in the group, it needs to be added to the group's items array, so why should we care about the key here? */
     protected ?string $group = null;
 
     /**

--- a/packages/framework/src/Framework/Features/Navigation/NavigationItem.php
+++ b/packages/framework/src/Framework/Features/Navigation/NavigationItem.php
@@ -27,7 +27,7 @@ class NavigationItem implements NavigationElement, Stringable
     protected string $label;
     protected int $priority;
 
-    // TODO: Do we actually need this? We should just care if it's physically stored in a group.
+    // TODO: Do we actually need this? We should just care if it's physically stored in a group. Adding the group key here doesn't magically make it appear in the group, it needs to be added to the group's items array, so why should we care about the key here?
     protected ?string $group = null;
 
     /**

--- a/packages/framework/src/Framework/Features/Navigation/NavigationItem.php
+++ b/packages/framework/src/Framework/Features/Navigation/NavigationItem.php
@@ -106,6 +106,8 @@ class NavigationItem implements NavigationElement, Stringable
     /**
      * Get the group identifier key of the navigation item, if any.
      *
+     * @deprecated as the property is deprecated.
+     *
      *  For sidebars this is the category key, for navigation menus this is the dropdown key.
      *
      *  When using automatic subdirectory based groups, the subdirectory name is the group key.

--- a/packages/framework/src/Framework/Features/Navigation/NavigationItem.php
+++ b/packages/framework/src/Framework/Features/Navigation/NavigationItem.php
@@ -8,7 +8,6 @@ use Hyde\Pages\Concerns\HydePage;
 use Hyde\Foundation\Facades\Routes;
 use Hyde\Hyde;
 use Hyde\Support\Models\Route;
-use Illuminate\Support\Str;
 use Stringable;
 
 use function is_string;
@@ -109,11 +108,5 @@ class NavigationItem implements NavigationElement, Stringable
     public function isActive(): bool
     {
         return Hyde::currentRoute()->getLink() === $this->getLink();
-    }
-
-    /** @return ($group is null ? null : string) */
-    public static function normalizeGroupKey(?string $group): ?string
-    {
-        return $group ? Str::slug($group) : null;
     }
 }

--- a/packages/framework/src/Framework/Features/Navigation/NavigationItem.php
+++ b/packages/framework/src/Framework/Features/Navigation/NavigationItem.php
@@ -28,9 +28,6 @@ class NavigationItem implements NavigationElement, Stringable
     protected string $label;
     protected int $priority;
 
-    /** @deprecated Do we actually need this? We should just care if it's physically stored in a group. Adding the group key here doesn't magically make it appear in the group, it needs to be added to the group's items array, so why should we care about the key here? */
-    protected ?string $group = null;
-
     /**
      * Create a new navigation menu item with your own properties.
      *

--- a/packages/framework/src/Framework/Features/Navigation/NavigationItem.php
+++ b/packages/framework/src/Framework/Features/Navigation/NavigationItem.php
@@ -116,7 +116,7 @@ class NavigationItem implements NavigationElement, Stringable
      */
     public function getGroupKey(): ?string
     {
-        return $this->group;
+        return $this->getPage()?->navigationMenuGroup();
     }
 
     /**

--- a/packages/framework/src/Framework/Features/Navigation/NavigationItem.php
+++ b/packages/framework/src/Framework/Features/Navigation/NavigationItem.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Hyde\Framework\Features\Navigation;
 
 use Hyde\Pages\Concerns\HydePage;
-use JetBrains\PhpStorm\Deprecated;
 use Hyde\Foundation\Facades\Routes;
 use Hyde\Hyde;
 use Hyde\Support\Models\Route;
@@ -94,21 +93,6 @@ class NavigationItem implements NavigationElement, Stringable
     public function getPriority(): int
     {
         return $this->priority;
-    }
-
-    /**
-     * Get the group identifier key of the navigation item, if any.
-     *
-     * @deprecated as the property is deprecated.
-     *
-     *  For sidebars this is the category key, for navigation menus this is the dropdown key.
-     *
-     *  When using automatic subdirectory based groups, the subdirectory name is the group key.
-     *  Otherwise, the group key is a 'slugified' version of the group's label.
-     */
-    public function getGroupKey(): ?string
-    {
-        return $this->getPage()?->navigationMenuGroup();
     }
 
     /**

--- a/packages/framework/src/Framework/Features/Navigation/NavigationMenuGenerator.php
+++ b/packages/framework/src/Framework/Features/Navigation/NavigationMenuGenerator.php
@@ -135,7 +135,11 @@ class NavigationMenuGenerator
     {
         $item = NavigationItem::create($route);
 
-        $groupName = $this->generatesSidebar ? ($item->getGroupKey() ?? 'Other') : $item->getGroupKey();
+        if ($this->generatesSidebar) {
+            $groupName = ($item->getGroupKey() ?? 'Other');
+        } else {
+            $groupName = $item->getGroupKey();
+        }
 
         $groupItem = $this->getOrCreateGroupItem($groupName);
 

--- a/packages/framework/src/Framework/Features/Navigation/NavigationMenuGenerator.php
+++ b/packages/framework/src/Framework/Features/Navigation/NavigationMenuGenerator.php
@@ -148,7 +148,7 @@ class NavigationMenuGenerator
 
     protected function getOrCreateGroupItem(string $groupName): NavigationGroup
     {
-        $groupKey = NavigationItem::normalizeGroupKey($groupName);
+        $groupKey = NavigationGroup::normalizeGroupKey($groupName);
         $group = $this->items->get($groupKey);
 
         if ($group instanceof NavigationGroup) {

--- a/packages/framework/src/Framework/Features/Navigation/NavigationMenuGenerator.php
+++ b/packages/framework/src/Framework/Features/Navigation/NavigationMenuGenerator.php
@@ -135,10 +135,11 @@ class NavigationMenuGenerator
     {
         $item = NavigationItem::create($route);
 
+        $groupKey = $item->getGroupKey();
         if ($this->generatesSidebar) {
-            $groupName = ($item->getGroupKey() ?? 'Other');
+            $groupName = ($groupKey ?? 'Other');
         } else {
-            $groupName = $item->getGroupKey();
+            $groupName = $groupKey;
         }
 
         $groupItem = $this->getOrCreateGroupItem($groupName);

--- a/packages/framework/src/Framework/Features/Navigation/NavigationMenuGenerator.php
+++ b/packages/framework/src/Framework/Features/Navigation/NavigationMenuGenerator.php
@@ -135,7 +135,7 @@ class NavigationMenuGenerator
     {
         $item = NavigationItem::create($route);
 
-        $groupKey = $item->getGroupKey();
+        $groupKey = $item->getPage()->navigationMenuGroup();
         if ($this->generatesSidebar) {
             $groupName = ($groupKey ?? 'Other');
         } else {

--- a/packages/framework/src/Framework/Features/Navigation/NavigationMenuGenerator.php
+++ b/packages/framework/src/Framework/Features/Navigation/NavigationMenuGenerator.php
@@ -136,7 +136,7 @@ class NavigationMenuGenerator
         $item = NavigationItem::create($route);
 
         $groupKey = $item->getPage()->navigationMenuGroup();
-        $groupName = $this->generatesSidebar ? $groupKey ?? 'Other' : $groupKey;
+        $groupName = $this->generatesSidebar ? ($groupKey ?? 'Other') : $groupKey;
 
         $groupItem = $this->getOrCreateGroupItem($groupName);
 

--- a/packages/framework/src/Framework/Features/Navigation/NavigationMenuGenerator.php
+++ b/packages/framework/src/Framework/Features/Navigation/NavigationMenuGenerator.php
@@ -6,7 +6,6 @@ namespace Hyde\Framework\Features\Navigation;
 
 use Hyde\Hyde;
 use Hyde\Facades\Config;
-use Illuminate\Support\Str;
 use Hyde\Support\Models\Route;
 use Hyde\Pages\DocumentationPage;
 use Illuminate\Support\Collection;
@@ -149,7 +148,7 @@ class NavigationMenuGenerator
 
     protected function getOrCreateGroupItem(string $groupName): NavigationGroup
     {
-        $groupKey = Str::slug($groupName);
+        $groupKey = NavigationItem::normalizeGroupKey($groupName);
         $group = $this->items->get($groupKey);
 
         if ($group instanceof NavigationGroup) {

--- a/packages/framework/src/Framework/Features/Navigation/NavigationMenuGenerator.php
+++ b/packages/framework/src/Framework/Features/Navigation/NavigationMenuGenerator.php
@@ -136,11 +136,7 @@ class NavigationMenuGenerator
         $item = NavigationItem::create($route);
 
         $groupKey = $item->getPage()->navigationMenuGroup();
-        if ($this->generatesSidebar) {
-            $groupName = ($groupKey ?? 'Other');
-        } else {
-            $groupName = $groupKey;
-        }
+        $groupName = $this->generatesSidebar ? $groupKey ?? 'Other' : $groupKey;
 
         $groupItem = $this->getOrCreateGroupItem($groupName);
 

--- a/packages/framework/tests/Feature/AutomaticNavigationConfigurationsTest.php
+++ b/packages/framework/tests/Feature/AutomaticNavigationConfigurationsTest.php
@@ -1284,21 +1284,19 @@ class AutomaticNavigationConfigurationsTest extends TestCase
 class TestNavigationItem
 {
     public readonly string $label;
-    public readonly ?string $group;
     public readonly int $priority;
     public readonly array $children;
 
-    public function __construct(string $label, ?string $group, int $priority, array $children)
+    public function __construct(string $label, int $priority, array $children)
     {
         $this->label = $label;
-        $this->group = $group;
         $this->priority = $priority;
         $this->children = collect($children)->map(fn (NavigationItem|NavigationGroup $child) => $child->getLabel())->toArray();
     }
 
     public static function properties(): array
     {
-        return ['label', 'group', 'priority', 'children'];
+        return ['label', 'priority', 'children'];
     }
 }
 
@@ -1320,7 +1318,7 @@ class AssertableNavigationMenu
     public function state(): array
     {
         return $this->items->map(function (NavigationItem|NavigationGroup $item): TestNavigationItem {
-            return new TestNavigationItem($item->getLabel(), $item->getGroupKey(), $item->getPriority(), $item instanceof NavigationGroup ? $item->getItems() : []);
+            return new TestNavigationItem($item->getLabel(), $item->getPriority(), $item instanceof NavigationGroup ? $item->getItems() : []);
         })->toArray();
     }
 

--- a/packages/framework/tests/Feature/Services/DocumentationSidebarTest.php
+++ b/packages/framework/tests/Feature/Services/DocumentationSidebarTest.php
@@ -159,9 +159,9 @@ class DocumentationSidebarTest extends TestCase
     public function testGroupCanBeSetInFrontMatter()
     {
         $this->makePage('foo', ['navigation.group' => 'bar']);
-        /** @var NavigationItem $firstItem */
-        $firstItem = collect(NavigationMenuGenerator::handle(DocumentationSidebar::class)->getItems()->first()->getItems())->first();
-        $this->assertEquals('bar', $firstItem->getGroupKey());
+        /** @var NavigationItem $item */
+        $item = collect(NavigationMenuGenerator::handle(DocumentationSidebar::class)->getItems()->first()->getItems())->first();
+        $this->assertEquals('bar', $item->getGroupKey());
     }
 
     public function testHasGroupsReturnsFalseWhenThereAreNoGroups()

--- a/packages/framework/tests/Feature/Services/DocumentationSidebarTest.php
+++ b/packages/framework/tests/Feature/Services/DocumentationSidebarTest.php
@@ -162,7 +162,7 @@ class DocumentationSidebarTest extends TestCase
 
         /** @var NavigationItem $item */
         $item = collect(NavigationMenuGenerator::handle(DocumentationSidebar::class)->getItems()->first()->getItems())->first();
-        $this->assertSame('bar', $item->getGroupKey());
+        $this->assertSame('bar', $item->getPage()->navigationMenuGroup());
     }
 
     public function testHasGroupsReturnsFalseWhenThereAreNoGroups()

--- a/packages/framework/tests/Feature/Services/DocumentationSidebarTest.php
+++ b/packages/framework/tests/Feature/Services/DocumentationSidebarTest.php
@@ -159,6 +159,7 @@ class DocumentationSidebarTest extends TestCase
     public function testGroupCanBeSetInFrontMatter()
     {
         $this->makePage('foo', ['navigation.group' => 'bar']);
+        /** @var NavigationItem $firstItem */
         $firstItem = collect(NavigationMenuGenerator::handle(DocumentationSidebar::class)->getItems()->first()->getItems())->first();
         $this->assertEquals('bar', $firstItem->getGroupKey());
     }

--- a/packages/framework/tests/Feature/Services/DocumentationSidebarTest.php
+++ b/packages/framework/tests/Feature/Services/DocumentationSidebarTest.php
@@ -159,7 +159,8 @@ class DocumentationSidebarTest extends TestCase
     public function testGroupCanBeSetInFrontMatter()
     {
         $this->makePage('foo', ['navigation.group' => 'bar']);
-        $this->assertEquals('bar', collect(NavigationMenuGenerator::handle(DocumentationSidebar::class)->getItems()->first()->getItems())->first()->getGroupKey());
+        $firstItem = collect(NavigationMenuGenerator::handle(DocumentationSidebar::class)->getItems()->first()->getItems())->first();
+        $this->assertEquals('bar', $firstItem->getGroupKey());
     }
 
     public function testHasGroupsReturnsFalseWhenThereAreNoGroups()

--- a/packages/framework/tests/Feature/Services/DocumentationSidebarTest.php
+++ b/packages/framework/tests/Feature/Services/DocumentationSidebarTest.php
@@ -225,7 +225,7 @@ class DocumentationSidebarTest extends TestCase
     {
         Render::setPage(new DocumentationPage(matter: ['navigation.group' => 'foo']));
         $mainNavigationMenu = NavigationMenuGenerator::handle(DocumentationSidebar::class);
-        $this->assertFalse('bar' === $mainNavigationMenu->getActiveGroup()?->getGroupKey());
+        $this->assertFalse('bar' === $this->getGroupKey($mainNavigationMenu));
     }
 
     public function testIsGroupActiveReturnsTrueWhenSuppliedGroupIsActive()
@@ -233,7 +233,7 @@ class DocumentationSidebarTest extends TestCase
         $this->makePage('foo', ['navigation.group' => 'foo']);
         Render::setPage(new DocumentationPage(matter: ['navigation.group' => 'foo']));
         $mainNavigationMenu = NavigationMenuGenerator::handle(DocumentationSidebar::class);
-        $this->assertTrue('foo' === $mainNavigationMenu->getActiveGroup()?->getGroupKey());
+        $this->assertTrue('foo' === $this->getGroupKey($mainNavigationMenu));
     }
 
     public function testIsGroupActiveReturnsTrueForDifferingCasing()
@@ -241,7 +241,7 @@ class DocumentationSidebarTest extends TestCase
         $this->makePage('foo', ['navigation.group' => 'Foo Bar']);
         Render::setPage(new DocumentationPage(matter: ['navigation.group' => 'Foo Bar']));
         $mainNavigationMenu = NavigationMenuGenerator::handle(DocumentationSidebar::class);
-        $this->assertTrue('foo-bar' === $mainNavigationMenu->getActiveGroup()?->getGroupKey());
+        $this->assertTrue('foo-bar' === $this->getGroupKey($mainNavigationMenu));
     }
 
     public function testIsGroupActiveReturnsTrueFirstGroupOfIndexPage()
@@ -253,11 +253,11 @@ class DocumentationSidebarTest extends TestCase
 
         Render::setPage(DocumentationPage::get('index'));
         $mainNavigationMenu2 = NavigationMenuGenerator::handle(DocumentationSidebar::class);
-        $this->assertTrue('bar' === $mainNavigationMenu2->getActiveGroup()?->getGroupKey());
+        $this->assertTrue('bar' === $this->getGroupKey($mainNavigationMenu2));
         $mainNavigationMenu1 = NavigationMenuGenerator::handle(DocumentationSidebar::class);
-        $this->assertFalse('foo' === $mainNavigationMenu1->getActiveGroup()?->getGroupKey());
+        $this->assertFalse('foo' === $this->getGroupKey($mainNavigationMenu1));
         $mainNavigationMenu = NavigationMenuGenerator::handle(DocumentationSidebar::class);
-        $this->assertFalse('baz' === $mainNavigationMenu->getActiveGroup()?->getGroupKey());
+        $this->assertFalse('baz' === $this->getGroupKey($mainNavigationMenu));
     }
 
     public function testIsGroupActiveReturnsTrueFirstSortedGroupOfIndexPage()
@@ -269,11 +269,11 @@ class DocumentationSidebarTest extends TestCase
 
         Render::setPage(DocumentationPage::get('index'));
         $mainNavigationMenu2 = NavigationMenuGenerator::handle(DocumentationSidebar::class);
-        $this->assertTrue('foo' === $mainNavigationMenu2->getActiveGroup()?->getGroupKey());
+        $this->assertTrue('foo' === $this->getGroupKey($mainNavigationMenu2));
         $mainNavigationMenu1 = NavigationMenuGenerator::handle(DocumentationSidebar::class);
-        $this->assertFalse('bar' === $mainNavigationMenu1->getActiveGroup()?->getGroupKey());
+        $this->assertFalse('bar' === $this->getGroupKey($mainNavigationMenu1));
         $mainNavigationMenu = NavigationMenuGenerator::handle(DocumentationSidebar::class);
-        $this->assertFalse('baz' === $mainNavigationMenu->getActiveGroup()?->getGroupKey());
+        $this->assertFalse('baz' === $this->getGroupKey($mainNavigationMenu));
     }
 
     public function testAutomaticIndexPageGroupExpansionRespectsCustomNavigationMenuSettings()
@@ -285,11 +285,11 @@ class DocumentationSidebarTest extends TestCase
 
         Render::setPage(DocumentationPage::get('index'));
         $mainNavigationMenu2 = NavigationMenuGenerator::handle(DocumentationSidebar::class);
-        $this->assertFalse('foo' === $mainNavigationMenu2->getActiveGroup()?->getGroupKey());
+        $this->assertFalse('foo' === $this->getGroupKey($mainNavigationMenu2));
         $mainNavigationMenu1 = NavigationMenuGenerator::handle(DocumentationSidebar::class);
-        $this->assertFalse('bar' === $mainNavigationMenu1->getActiveGroup()?->getGroupKey());
+        $this->assertFalse('bar' === $this->getGroupKey($mainNavigationMenu1));
         $mainNavigationMenu = NavigationMenuGenerator::handle(DocumentationSidebar::class);
-        $this->assertTrue('baz' === $mainNavigationMenu->getActiveGroup()?->getGroupKey());
+        $this->assertTrue('baz' === $this->getGroupKey($mainNavigationMenu));
     }
 
     public function testCanHaveMultipleGroupedPagesWithTheSameNameLabels()
@@ -338,7 +338,7 @@ class DocumentationSidebarTest extends TestCase
 
         Render::setPage(DocumentationPage::get('index'));
         $mainNavigationMenu = NavigationMenuGenerator::handle(DocumentationSidebar::class);
-        $this->assertFalse('foo' === $mainNavigationMenu->getActiveGroup()?->getGroupKey());
+        $this->assertFalse('foo' === $this->getGroupKey($mainNavigationMenu));
     }
 
     public function testIndexPageAddedToSidebarWhenItIsTheOnlyPage()
@@ -379,5 +379,10 @@ class DocumentationSidebarTest extends TestCase
             Hyde::path('_docs/'.$name.'.md'),
             (new ConvertsArrayToFrontMatter)->execute($matter ?? [])
         );
+    }
+
+    protected function getGroupKey(DocumentationSidebar $menu): ?string
+    {
+        return $menu->getActiveGroup()?->getGroupKey();
     }
 }

--- a/packages/framework/tests/Feature/Services/DocumentationSidebarTest.php
+++ b/packages/framework/tests/Feature/Services/DocumentationSidebarTest.php
@@ -162,7 +162,7 @@ class DocumentationSidebarTest extends TestCase
 
         /** @var NavigationItem $item */
         $item = collect(NavigationMenuGenerator::handle(DocumentationSidebar::class)->getItems()->first()->getItems())->first();
-        $this->assertEquals('bar', $item->getGroupKey());
+        $this->assertSame('bar', $item->getGroupKey());
     }
 
     public function testHasGroupsReturnsFalseWhenThereAreNoGroups()

--- a/packages/framework/tests/Feature/Services/DocumentationSidebarTest.php
+++ b/packages/framework/tests/Feature/Services/DocumentationSidebarTest.php
@@ -159,6 +159,7 @@ class DocumentationSidebarTest extends TestCase
     public function testGroupCanBeSetInFrontMatter()
     {
         $this->makePage('foo', ['navigation.group' => 'bar']);
+
         /** @var NavigationItem $item */
         $item = collect(NavigationMenuGenerator::handle(DocumentationSidebar::class)->getItems()->first()->getItems())->first();
         $this->assertEquals('bar', $item->getGroupKey());

--- a/packages/framework/tests/Unit/DocumentationSidebarGetActiveGroupUnitTest.php
+++ b/packages/framework/tests/Unit/DocumentationSidebarGetActiveGroupUnitTest.php
@@ -162,6 +162,12 @@ class DocumentationSidebarGetActiveGroupUnitTest extends UnitTestCase
         $this->assertSame('getting-started', $this->getActiveGroupKey());
     }
 
+    public function testGetActiveGroupReturnsExplicitlySetIndexPageGroupWhenRenderingIndexPage()
+    {
+        $this->renderData->setPage(new DocumentationPage('index', ['navigation.group' => 'usage']));
+        $this->assertSame('usage', $this->getActiveGroupKey($this->createSidebar()));
+    }
+
     public function testGetActiveGroupReturnsFirstGroupByLowestPriorityWhenRenderingIndexPage()
     {
         $sidebar = $this->createSidebar();
@@ -169,12 +175,6 @@ class DocumentationSidebarGetActiveGroupUnitTest extends UnitTestCase
 
         $this->renderData->setPage(new DocumentationPage('index'));
         $this->assertSame('other', $this->getActiveGroupKey($sidebar));
-    }
-
-    public function testGetActiveGroupReturnsExplicitlySetIndexPageGroupWhenRenderingIndexPage()
-    {
-        $this->renderData->setPage(new DocumentationPage('index', ['navigation.group' => 'usage']));
-        $this->assertSame('usage', $this->getActiveGroupKey($this->createSidebar()));
     }
 
     public function testGetActiveGroupReturnsExplicitlySetIndexPageGroupWhenRenderingIndexPageRegardlessOfPriorities()

--- a/packages/framework/tests/Unit/DocumentationSidebarGetActiveGroupUnitTest.php
+++ b/packages/framework/tests/Unit/DocumentationSidebarGetActiveGroupUnitTest.php
@@ -89,55 +89,55 @@ class DocumentationSidebarGetActiveGroupUnitTest extends UnitTestCase
     public function testActiveGroupGettingStarted()
     {
         $this->mockCurrentPageForActiveGroup('getting-started');
-        $this->assertSame('getting-started', $this->createSidebar()->getActiveGroup()->getGroupKey());
+        $this->assertSame('getting-started', $this->getActiveGroupKey());
     }
 
     public function testActiveGroupConfiguration()
     {
         $this->mockCurrentPageForActiveGroup('configuration');
-        $this->assertSame('configuration', $this->createSidebar()->getActiveGroup()->getGroupKey());
+        $this->assertSame('configuration', $this->getActiveGroupKey());
     }
 
     public function testActiveGroupUsage()
     {
         $this->mockCurrentPageForActiveGroup('usage');
-        $this->assertSame('usage', $this->createSidebar()->getActiveGroup()->getGroupKey());
+        $this->assertSame('usage', $this->getActiveGroupKey());
     }
 
     public function testActiveGroupWithIdentifierGettingStarted()
     {
         $this->mockCurrentPageForActiveGroup('getting-started', 'Introduction');
-        $this->assertSame('getting-started', $this->createSidebar()->getActiveGroup()->getGroupKey());
+        $this->assertSame('getting-started', $this->getActiveGroupKey());
     }
 
     public function testActiveGroupWithIdentifierConfiguration()
     {
         $this->mockCurrentPageForActiveGroup('configuration', 'Configuration');
-        $this->assertSame('configuration', $this->createSidebar()->getActiveGroup()->getGroupKey());
+        $this->assertSame('configuration', $this->getActiveGroupKey());
     }
 
     public function testActiveGroupWithIdentifierUsage()
     {
         $this->mockCurrentPageForActiveGroup('usage', 'Routing');
-        $this->assertSame('usage', $this->createSidebar()->getActiveGroup()->getGroupKey());
+        $this->assertSame('usage', $this->getActiveGroupKey());
     }
 
     public function testActiveGroupDifferentCasingGettingStarted()
     {
         $this->mockCurrentPageForActiveGroup('GETTING-STARTED');
-        $this->assertSame('getting-started', $this->createSidebar()->getActiveGroup()->getGroupKey());
+        $this->assertSame('getting-started', $this->getActiveGroupKey());
     }
 
     public function testActiveGroupDifferentCasingGettingStarted2()
     {
         $this->mockCurrentPageForActiveGroup('Getting-Started');
-        $this->assertSame('getting-started', $this->createSidebar()->getActiveGroup()->getGroupKey());
+        $this->assertSame('getting-started', $this->getActiveGroupKey());
     }
 
     public function testActiveGroupDifferentCasingGettingStarted3()
     {
         $this->mockCurrentPageForActiveGroup('getting-started');
-        $this->assertSame('getting-started', $this->createSidebar()->getActiveGroup()->getGroupKey());
+        $this->assertSame('getting-started', $this->getActiveGroupKey());
     }
 
     public function testGetActiveGroupIsNullWhenNoItemsExist()
@@ -159,7 +159,7 @@ class DocumentationSidebarGetActiveGroupUnitTest extends UnitTestCase
     public function testGetActiveGroupReturnsFirstGroupWhenRenderingIndexPage()
     {
         $this->renderData->setPage(new DocumentationPage('index'));
-        $this->assertSame('getting-started', $this->createSidebar()->getActiveGroup()->getGroupKey());
+        $this->assertSame('getting-started', $this->getActiveGroupKey());
     }
 
     public function testGetActiveGroupReturnsFirstGroupByLowestPriorityWhenRenderingIndexPage()
@@ -168,7 +168,7 @@ class DocumentationSidebarGetActiveGroupUnitTest extends UnitTestCase
         $sidebar->add(new NavigationGroup('other', [new NavigationItem('Other', 'Other')], 0));
 
         $this->renderData->setPage(new DocumentationPage('index'));
-        $this->assertSame('other', $sidebar->getActiveGroup()->getGroupKey());
+        $this->assertSame('other', $this->getActiveGroupKey($sidebar));
     }
 
     public function testGetActiveGroupReturnsExplicitlySetIndexPageGroupWhenRenderingIndexPage()
@@ -176,7 +176,7 @@ class DocumentationSidebarGetActiveGroupUnitTest extends UnitTestCase
         $sidebar = $this->createSidebar();
 
         $this->renderData->setPage(new DocumentationPage('index', ['navigation.group' => 'usage']));
-        $this->assertSame('usage', $sidebar->getActiveGroup()->getGroupKey());
+        $this->assertSame('usage', $this->getActiveGroupKey($sidebar));
     }
 
     public function testGetActiveGroupReturnsExplicitlySetIndexPageGroupWhenRenderingIndexPageRegardlessOfPriorities()
@@ -185,11 +185,18 @@ class DocumentationSidebarGetActiveGroupUnitTest extends UnitTestCase
         $sidebar->add(new NavigationGroup('other', [new NavigationItem('Other', 'Other')], 0));
 
         $this->renderData->setPage(new DocumentationPage('index', ['navigation.group' => 'usage']));
-        $this->assertSame('usage', $sidebar->getActiveGroup()->getGroupKey());
+        $this->assertSame('usage', $this->getActiveGroupKey($sidebar));
     }
 
     protected function mockCurrentPageForActiveGroup(string $group, string $identifier = 'foo'): void
     {
         $this->renderData->setPage(new DocumentationPage($identifier, ['navigation.group' => $group]));
+    }
+
+    protected function getActiveGroupKey(?DocumentationSidebar $sidebar = null): string
+    {
+        $sidebar ??= $this->createSidebar();
+
+        return $sidebar->getActiveGroup()->getGroupKey();
     }
 }

--- a/packages/framework/tests/Unit/DocumentationSidebarGetActiveGroupUnitTest.php
+++ b/packages/framework/tests/Unit/DocumentationSidebarGetActiveGroupUnitTest.php
@@ -173,10 +173,8 @@ class DocumentationSidebarGetActiveGroupUnitTest extends UnitTestCase
 
     public function testGetActiveGroupReturnsExplicitlySetIndexPageGroupWhenRenderingIndexPage()
     {
-        $sidebar = $this->createSidebar();
-
         $this->renderData->setPage(new DocumentationPage('index', ['navigation.group' => 'usage']));
-        $this->assertSame('usage', $this->getActiveGroupKey($sidebar));
+        $this->assertSame('usage', $this->getActiveGroupKey($this->createSidebar()));
     }
 
     public function testGetActiveGroupReturnsExplicitlySetIndexPageGroupWhenRenderingIndexPageRegardlessOfPriorities()

--- a/packages/framework/tests/Unit/DocumentationSidebarGetActiveGroupUnitTest.php
+++ b/packages/framework/tests/Unit/DocumentationSidebarGetActiveGroupUnitTest.php
@@ -170,8 +170,7 @@ class DocumentationSidebarGetActiveGroupUnitTest extends UnitTestCase
 
     public function testGetActiveGroupReturnsFirstGroupByLowestPriorityWhenRenderingIndexPage()
     {
-        $sidebar = $this->createSidebar();
-        $sidebar->add(new NavigationGroup('other', [new NavigationItem('Other', 'Other')], 0));
+        $sidebar = $this->createSidebar()->add(new NavigationGroup('other', [new NavigationItem('Other', 'Other')], 0));
 
         $this->renderData->setPage(new DocumentationPage('index'));
         $this->assertSame('other', $this->getActiveGroupKey($sidebar));
@@ -179,8 +178,7 @@ class DocumentationSidebarGetActiveGroupUnitTest extends UnitTestCase
 
     public function testGetActiveGroupReturnsExplicitlySetIndexPageGroupWhenRenderingIndexPageRegardlessOfPriorities()
     {
-        $sidebar = $this->createSidebar();
-        $sidebar->add(new NavigationGroup('other', [new NavigationItem('Other', 'Other')], 0));
+        $sidebar = $this->createSidebar()->add(new NavigationGroup('other', [new NavigationItem('Other', 'Other')], 0));
 
         $this->renderData->setPage(new DocumentationPage('index', ['navigation.group' => 'usage']));
         $this->assertSame('usage', $this->getActiveGroupKey($sidebar));

--- a/packages/framework/tests/Unit/NavigationGroupTest.php
+++ b/packages/framework/tests/Unit/NavigationGroupTest.php
@@ -173,6 +173,20 @@ class NavigationGroupTest extends UnitTestCase
         $this->assertSame($group, $group->add([new NavigationItem(new Route(new MarkdownPage()), 'Bar')]));
     }
 
+    public function testNormalizeGroupKeyCreatesSlugs()
+    {
+        $this->assertSame('foo-bar', NavigationGroup::normalizeGroupKey('Foo Bar'));
+        $this->assertSame('foo-bar', NavigationGroup::normalizeGroupKey('foo bar'));
+        $this->assertSame('foo-bar', NavigationGroup::normalizeGroupKey('foo_bar'));
+        $this->assertSame('foo-bar', NavigationGroup::normalizeGroupKey('foo-bar'));
+        $this->assertSame('foo-bar', NavigationGroup::normalizeGroupKey(' foo bar '));
+    }
+
+    public function testNormalizeGroupKeyReturnsNullForNull()
+    {
+        $this->assertNull(NavigationGroup::normalizeGroupKey(null));
+    }
+
     protected function createNavigationItems(): array
     {
         return [

--- a/packages/framework/tests/Unit/NavigationGroupTest.php
+++ b/packages/framework/tests/Unit/NavigationGroupTest.php
@@ -182,11 +182,6 @@ class NavigationGroupTest extends UnitTestCase
         $this->assertSame('foo-bar', NavigationGroup::normalizeGroupKey(' foo bar '));
     }
 
-    public function testNormalizeGroupKeyReturnsNullForNull()
-    {
-        $this->assertNull(NavigationGroup::normalizeGroupKey(null));
-    }
-
     protected function createNavigationItems(): array
     {
         return [

--- a/packages/framework/tests/Unit/NavigationGroupTest.php
+++ b/packages/framework/tests/Unit/NavigationGroupTest.php
@@ -114,26 +114,6 @@ class NavigationGroupTest extends UnitTestCase
         $this->assertSame($group, $group->add([]));
     }
 
-    public function testAddingAnItemWithAGroupKeyKeepsTheSetGroupKey()
-    {
-        $group = new NavigationGroup('Foo');
-        $child = new NavigationItem(new Route(new MarkdownPage()), 'Child', group: 'bar');
-
-        $group->add($child);
-
-        $this->assertSame('bar', $child->getGroupKey());
-    }
-
-    public function testAddingAnItemWithNoGroupKeyDoesNotModifyGroupIdentifier()
-    {
-        $group = new NavigationGroup('Foo');
-        $child = new NavigationItem(new Route(new MarkdownPage()), 'Bar');
-
-        $group->add($child);
-
-        $this->assertNull($child->getGroupKey());
-    }
-
     public function testGetPriorityUsesDefaultPriority()
     {
         $this->assertSame(999, (new NavigationGroup('Foo'))->getPriority());

--- a/packages/framework/tests/Unit/NavigationItemTest.php
+++ b/packages/framework/tests/Unit/NavigationItemTest.php
@@ -44,7 +44,6 @@ class NavigationItemTest extends UnitTestCase
         $this->assertInstanceOf(NavigationItem::class, new NavigationItem('foo', 'Test'));
         $this->assertInstanceOf(NavigationItem::class, new NavigationItem(new Route(new MarkdownPage()), 'Test'));
         $this->assertInstanceOf(NavigationItem::class, new NavigationItem(new Route(new MarkdownPage()), 'Test', 500));
-        $this->assertInstanceOf(NavigationItem::class, new NavigationItem(new Route(new MarkdownPage()), 'Test', 500, 'foo'));
     }
 
     public function testIsInstanceOfNavigationElement()

--- a/packages/framework/tests/Unit/NavigationItemTest.php
+++ b/packages/framework/tests/Unit/NavigationItemTest.php
@@ -113,12 +113,6 @@ class NavigationItemTest extends UnitTestCase
         $this->assertSame(500, $NavigationItem->getPriority());
     }
 
-    public function testGetGroup()
-    {
-        $NavigationItem = new NavigationItem(new Route(new InMemoryPage('foo')), 'Page', 500);
-        $this->assertNull($NavigationItem->getGroupKey());
-    }
-
     public function testFromRoute()
     {
         $page = new MarkdownPage();
@@ -162,7 +156,6 @@ class NavigationItemTest extends UnitTestCase
         $this->assertEquals($route, $item->getPage()->getRoute());
         $this->assertSame('404.html', $item->getLink());
         $this->assertSame('404.html', (string) $item);
-        $this->assertNull($item->getGroupKey());
     }
 
     public function testForIndexRoute()
@@ -176,7 +169,6 @@ class NavigationItemTest extends UnitTestCase
         $this->assertEquals($route, $item->getPage()->getRoute());
         $this->assertSame('index.html', $item->getLink());
         $this->assertSame('index.html', (string) $item);
-        $this->assertNull($item->getGroupKey());
     }
 
     public function testCreateWithLabels()
@@ -313,32 +305,6 @@ class NavigationItemTest extends UnitTestCase
         ]));
         $this->assertFalse(NavigationItem::create('foo', 'bar')->isActive());
         $this->assertFalse(NavigationItem::create('https://example.com', 'bar')->isActive());
-    }
-
-    public function testGetGroupWithNoGroup()
-    {
-        $this->assertNull((new NavigationItem(new Route(new MarkdownPage()), 'Test', 500))->getGroupKey());
-    }
-
-    public function testGetGroupWithGroup()
-    {
-        $this->assertSame('foo', (new NavigationItem(new Route(new MarkdownPage()), 'Test', 500, 'foo'))->getGroupKey());
-    }
-
-    public function testGetGroupFromRouteWithGroup()
-    {
-        $this->assertSame('foo', NavigationItem::create(new Route(new MarkdownPage(matter: ['navigation.group' => 'foo'])))->getGroupKey());
-    }
-
-    public function testGetGroupCreateWithGroup()
-    {
-        $this->assertSame('foo', NavigationItem::create(new Route(new MarkdownPage(matter: ['navigation.group' => 'foo'])), 'foo')->getGroupKey());
-    }
-
-    public function testGroupKeysAreNormalized()
-    {
-        $item = new NavigationItem(new Route(new MarkdownPage()), 'Test', 500, 'Foo Bar');
-        $this->assertSame('foo-bar', $item->getGroupKey());
     }
 
     public function testNormalizeGroupKeyCreatesSlugs()

--- a/packages/framework/tests/Unit/NavigationItemTest.php
+++ b/packages/framework/tests/Unit/NavigationItemTest.php
@@ -305,18 +305,4 @@ class NavigationItemTest extends UnitTestCase
         $this->assertFalse(NavigationItem::create('foo', 'bar')->isActive());
         $this->assertFalse(NavigationItem::create('https://example.com', 'bar')->isActive());
     }
-
-    public function testNormalizeGroupKeyCreatesSlugs()
-    {
-        $this->assertSame('foo-bar', NavigationItem::normalizeGroupKey('Foo Bar'));
-        $this->assertSame('foo-bar', NavigationItem::normalizeGroupKey('foo bar'));
-        $this->assertSame('foo-bar', NavigationItem::normalizeGroupKey('foo_bar'));
-        $this->assertSame('foo-bar', NavigationItem::normalizeGroupKey('foo-bar'));
-        $this->assertSame('foo-bar', NavigationItem::normalizeGroupKey(' foo bar '));
-    }
-
-    public function testNormalizeGroupKeyReturnsNullForNull()
-    {
-        $this->assertNull(NavigationItem::normalizeGroupKey(null));
-    }
 }


### PR DESCRIPTION
Targets https://github.com/hydephp/develop/pull/1568.

> Do we actually need this? We should just care if it's physically stored in a group. Adding the group key here doesn't magically make it appear in the group, it needs to be added to the group's items array, so why should we care about the key here? 