### PR TITLE
[2.x] Refactor features class to simplify it and extract an enum

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -15,6 +15,7 @@ This serves two purposes:
 
 ### Changed
 - **Breaking:** The internals of the navigation system has been rewritten into a new Navigation API. This change is breaking for custom navigation implementations. For more information, see below.
+- **Breaking:** The `hyde.features` configuration format has changed to use Enums instead of static method calls. For more information, see below.
 - Minor: Navigation menu items are now no longer filtered by duplicates (meaning two items with the same label can now exist in the same menu) in https://github.com/hydephp/develop/pull/1573
 - Minor: Due to changes in the navigation system, it is possible that existing configuration files will need to be adjusted in order for menus to look the same (in terms of ordering etc.)
 - Minor: The documentation article component now supports disabling the semantic rendering using a falsy value in https://github.com/hydephp/develop/pull/1566
@@ -70,6 +71,55 @@ The following configuration entries have been updated:
 -  Changed configuration option `docs.table_of_contents` to `docs.sidebar.table_of_contents` in https://github.com/hydephp/develop/pull/1584
 -  Upgrade path: Move the `table_of_contents` option's array in the `config/docs.php` file into the `sidebar` array in the same file.
 
+### Features configuration changes
+
+The `hyde.features` configuration format has changed to use Enums instead of static method calls. This change is breaking as it will require you to update your `config/hyde.php` file.
+
+#### Instead of
+
+```php
+// filepath: config/hyde.php
+
+'features' => [
+    // Page Modules
+    Features::htmlPages(),
+    Features::markdownPosts(),
+    Features::bladePages(),
+    Features::markdownPages(),
+    Features::documentationPages(),
+    
+    // Frontend Features
+    Features::darkmode(),
+    Features::documentationSearch(),
+    
+    // Integrations
+    Features::torchlight(),
+],
+```
+
+#### Use instead
+
+```php
+// filepath: config/hyde.php
+
+'features' => [
+    // Page Modules
+    Feature::HtmlPages,
+    Feature::MarkdownPosts,
+    Feature::BladePages,
+    Feature::MarkdownPages,
+    Feature::DocumentationPages,
+
+    // Frontend Features
+    Feature::Darkmode,
+    Feature::DocumentationSearch,
+
+    // Integrations
+    Feature::Torchlight,
+],
+```
+
+Of course, if you have disabled any of the features, do not include them in the new array.
 
 ## General impact
 

--- a/config/hyde.php
+++ b/config/hyde.php
@@ -23,8 +23,8 @@
 */
 
 use Hyde\Facades\Author;
-use Hyde\Facades\Features;
 use Hyde\Facades\Meta;
+use Hyde\Foundation\Concerns\Feature;
 
 return [
 
@@ -248,24 +248,23 @@ return [
     |
     | Some of Hyde's features are optional. Feel free to disable the features
     | you don't need by removing or commenting them out from this array.
-    | This config concept is directly inspired by Laravel Jetstream.
     |
     */
 
     'features' => [
         // Page Modules
-        Features::htmlPages(),
-        Features::markdownPosts(),
-        Features::bladePages(),
-        Features::markdownPages(),
-        Features::documentationPages(),
+        Feature::HtmlPages,
+        Feature::MarkdownPosts,
+        Feature::BladePages,
+        Feature::MarkdownPages,
+        Feature::DocumentationPages,
 
         // Frontend Features
-        Features::darkmode(),
-        Features::documentationSearch(),
+        Feature::Darkmode,
+        Feature::DocumentationSearch,
 
         // Integrations
-        Features::torchlight(),
+        Feature::Torchlight,
     ],
 
     /*

--- a/docs/creating-content/documentation-pages.md
+++ b/docs/creating-content/documentation-pages.md
@@ -290,12 +290,12 @@ that runs during the build command, and a frontend JavaScript plugin that adds t
 
 >info Tip: The HydeSearch plugin is what powers the search feature on this site! Why not [try it out](search)?
 
-The search feature is enabled by default. You can disable it by removing the `documentationSearch` from the Hyde `Features` config array.
+The search feature is enabled by default. You can disable it by removing the `DocumentationSearch` option from the Hyde `Features` config array.
 
 ```php
 // filepath: config/hyde.php
 'features' => [
-    Features::documentationSearch(), // [tl! --]
+    Feature::DocumentationSearch, // [tl! --]
 ],
 ```
 

--- a/packages/framework/config/hyde.php
+++ b/packages/framework/config/hyde.php
@@ -23,8 +23,8 @@
 */
 
 use Hyde\Facades\Author;
-use Hyde\Facades\Features;
 use Hyde\Facades\Meta;
+use Hyde\Foundation\Concerns\Feature;
 
 return [
 
@@ -248,24 +248,23 @@ return [
     |
     | Some of Hyde's features are optional. Feel free to disable the features
     | you don't need by removing or commenting them out from this array.
-    | This config concept is directly inspired by Laravel Jetstream.
     |
     */
 
     'features' => [
         // Page Modules
-        Features::htmlPages(),
-        Features::markdownPosts(),
-        Features::bladePages(),
-        Features::markdownPages(),
-        Features::documentationPages(),
+        Feature::HtmlPages,
+        Feature::MarkdownPosts,
+        Feature::BladePages,
+        Feature::MarkdownPages,
+        Feature::DocumentationPages,
 
         // Frontend Features
-        Features::darkmode(),
-        Features::documentationSearch(),
+        Feature::Darkmode,
+        Feature::DocumentationSearch,
 
         // Integrations
-        Features::torchlight(),
+        Feature::Torchlight,
     ],
 
     /*

--- a/packages/framework/src/Console/Commands/DebugCommand.php
+++ b/packages/framework/src/Console/Commands/DebugCommand.php
@@ -70,11 +70,11 @@ class DebugCommand extends Command
 
     protected function printEnabledFeatures(): void
     {
-        /** @var array<string, string> $features */
+        /** @var array<\Hyde\Foundation\Concerns\Feature> $features */
         $features = Config::getArray('hyde.features', []);
 
         foreach ($features as $feature) {
-            $this->line(" - $feature");
+            $this->line(" - $feature->name");
         }
     }
 }

--- a/packages/framework/src/Facades/Features.php
+++ b/packages/framework/src/Facades/Features.php
@@ -163,9 +163,7 @@ class Features implements SerializableContract
      */
     public static function mock(string|array $feature, bool $enabled = null): void
     {
-        $features = is_array($feature) ? $feature : [$feature => $enabled];
-
-        foreach ($features as $feature => $enabled) {
+        foreach (is_array($feature) ? $feature : [$feature => $enabled] as $feature => $enabled) {
             if ($enabled !== true) {
                 Hyde::features()->features = array_filter(Hyde::features()->features, fn (string $search): bool => $search !== $feature);
             } else {

--- a/packages/framework/src/Facades/Features.php
+++ b/packages/framework/src/Facades/Features.php
@@ -72,44 +72,44 @@ class Features implements SerializableContract
     // Configure features to be used in the config file.
     // =================================================
 
-    public static function htmlPages(): string
+    public static function htmlPages(): Feature
     {
-        return 'html-pages';
+        return Feature::HtmlPages;
     }
 
-    public static function bladePages(): string
+    public static function bladePages(): Feature
     {
-        return 'blade-pages';
+        return Feature::BladePages;
     }
 
-    public static function markdownPages(): string
+    public static function markdownPages(): Feature
     {
-        return 'markdown-pages';
+        return Feature::MarkdownPages;
     }
 
-    public static function markdownPosts(): string
+    public static function markdownPosts(): Feature
     {
-        return 'markdown-posts';
+        return Feature::MarkdownPosts;
     }
 
-    public static function documentationPages(): string
+    public static function documentationPages(): Feature
     {
-        return 'documentation-pages';
+        return Feature::DocumentationPages;
     }
 
-    public static function documentationSearch(): string
+    public static function documentationSearch(): Feature
     {
-        return 'documentation-search';
+        return Feature::DocumentationSearch;
     }
 
-    public static function darkmode(): string
+    public static function darkmode(): Feature
     {
-        return 'darkmode';
+        return Feature::Darkmode;
     }
 
-    public static function torchlight(): string
+    public static function torchlight(): Feature
     {
-        return 'torchlight';
+        return Feature::Torchlight;
     }
 
     // ================================================

--- a/packages/framework/src/Facades/Features.php
+++ b/packages/framework/src/Facades/Features.php
@@ -191,8 +191,8 @@ class Features implements SerializableContract
     public function toArray(): array
     {
         return collect(Feature::cases())
-            ->mapWithKeys(fn (Feature $case): array => [
-                $case->value => $this->features[$case->value],
+            ->mapWithKeys(fn (Feature $feature): array => [
+                $feature->value => $this->features[$feature->value],
             ])->toArray();
     }
 

--- a/packages/framework/src/Facades/Features.php
+++ b/packages/framework/src/Facades/Features.php
@@ -56,82 +56,38 @@ class Features implements SerializableContract
         return Hyde::features()->features;
     }
 
-    // =================================================
-    // Configure features to be used in the config file.
-    // =================================================
-
-    public static function htmlPages(): Feature
-    {
-        return Feature::HtmlPages;
-    }
-
-    public static function bladePages(): Feature
-    {
-        return Feature::BladePages;
-    }
-
-    public static function markdownPages(): Feature
-    {
-        return Feature::MarkdownPages;
-    }
-
-    public static function markdownPosts(): Feature
-    {
-        return Feature::MarkdownPosts;
-    }
-
-    public static function documentationPages(): Feature
-    {
-        return Feature::DocumentationPages;
-    }
-
-    public static function documentationSearch(): Feature
-    {
-        return Feature::DocumentationSearch;
-    }
-
-    public static function darkmode(): Feature
-    {
-        return Feature::Darkmode;
-    }
-
-    public static function torchlight(): Feature
-    {
-        return Feature::Torchlight;
-    }
-
     // ================================================
     // Determine if a given feature is enabled.
     // ================================================
 
     public static function hasHtmlPages(): bool
     {
-        return static::has(static::htmlPages());
+        return static::has(Feature::HtmlPages);
     }
 
     public static function hasBladePages(): bool
     {
-        return static::has(static::bladePages());
+        return static::has(Feature::BladePages);
     }
 
     public static function hasMarkdownPages(): bool
     {
-        return static::has(static::markdownPages());
+        return static::has(Feature::MarkdownPages);
     }
 
     public static function hasMarkdownPosts(): bool
     {
-        return static::has(static::markdownPosts());
+        return static::has(Feature::MarkdownPosts);
     }
 
     public static function hasDocumentationPages(): bool
     {
-        return static::has(static::documentationPages());
+        return static::has(Feature::DocumentationPages);
     }
 
     public static function hasDarkmode(): bool
     {
-        return static::has(static::darkmode());
+        return static::has(Feature::Darkmode);
     }
 
     // ====================================================
@@ -167,14 +123,14 @@ class Features implements SerializableContract
      */
     public static function hasTorchlight(): bool
     {
-        return static::has(static::torchlight())
+        return static::has(Feature::Torchlight)
             && (Config::getNullableString('torchlight.token') !== null)
             && (app('env') !== 'testing');
     }
 
     public static function hasDocumentationSearch(): bool
     {
-        return static::has(static::documentationSearch())
+        return static::has(Feature::DocumentationSearch)
             && static::hasDocumentationPages()
             && count(DocumentationPage::files()) > 0;
     }

--- a/packages/framework/src/Facades/Features.php
+++ b/packages/framework/src/Facades/Features.php
@@ -168,10 +168,9 @@ class Features implements SerializableContract
         foreach ($features as $feature => $enabled) {
             if ($enabled !== true) {
                 Hyde::features()->features = array_filter(Hyde::features()->features, fn (string $search): bool => $search !== $feature);
-                continue;
+            } else {
+                Hyde::features()->features[] = $feature;
             }
-
-            Hyde::features()->features[] = $feature;
         }
     }
 }

--- a/packages/framework/src/Facades/Features.php
+++ b/packages/framework/src/Facades/Features.php
@@ -41,7 +41,7 @@ class Features implements SerializableContract
     /**
      * Determine if the given specified is enabled.
      */
-    public static function has(string $feature): bool
+    public static function has(Feature $feature): bool
     {
         return in_array($feature, static::enabled());
     }

--- a/packages/framework/src/Facades/Features.php
+++ b/packages/framework/src/Facades/Features.php
@@ -7,6 +7,7 @@ namespace Hyde\Facades;
 use Hyde\Hyde;
 use Hyde\Pages\MarkdownPost;
 use Hyde\Pages\DocumentationPage;
+use Hyde\Foundation\Concerns\Feature;
 use Hyde\Support\Concerns\Serializable;
 use Hyde\Support\Contracts\SerializableContract;
 

--- a/packages/framework/src/Facades/Features.php
+++ b/packages/framework/src/Facades/Features.php
@@ -231,7 +231,7 @@ class Features implements SerializableContract
      *
      * @param  string|array<string, bool>  $feature
      */
-    public static function mock(string|array $feature, bool $enabled = true): void
+    public static function mock(string|array $feature, bool $enabled = null): void
     {
         $features = is_array($feature) ? $feature : [$feature => $enabled];
 

--- a/packages/framework/src/Facades/Features.php
+++ b/packages/framework/src/Facades/Features.php
@@ -194,12 +194,6 @@ class Features implements SerializableContract
             ])->toArray();
     }
 
-    /** @return array<Feature> */
-    protected static function getDefaultOptions(): array
-    {
-        return Feature::cases();
-    }
-
     protected function boot(): array
     {
         return array_map(fn (Feature $feature): string => $feature->value, $this->getConfiguredFeatures());
@@ -208,7 +202,7 @@ class Features implements SerializableContract
     /** @return array<Feature> */
     protected function getConfiguredFeatures(): array
     {
-        return Config::getArray('hyde.features', static::getDefaultOptions());
+        return Config::getArray('hyde.features', Feature::cases());
     }
 
     /**

--- a/packages/framework/src/Facades/Features.php
+++ b/packages/framework/src/Facades/Features.php
@@ -163,7 +163,7 @@ class Features implements SerializableContract
 
     /**
      * Torchlight is by default enabled automatically when an API token
-     * is set in the .env file but is disabled when running tests.
+     * is set in the `.env` file but is disabled when running tests.
      */
     public static function hasTorchlight(): bool
     {

--- a/packages/framework/src/Facades/Features.php
+++ b/packages/framework/src/Facades/Features.php
@@ -13,7 +13,6 @@ use Hyde\Support\Contracts\SerializableContract;
 use Illuminate\Support\Arr;
 
 use function is_array;
-use function array_map;
 use function array_filter;
 use function extension_loaded;
 use function in_array;
@@ -146,7 +145,7 @@ class Features implements SerializableContract
 
     protected function boot(): array
     {
-        return array_map(fn (Feature $feature): string => $feature->value, $this->getConfiguredFeatures());
+        return Arr::map($this->getConfiguredFeatures(), fn (Feature $feature): string => $feature->value);
     }
 
     /** @return array<Feature> */

--- a/packages/framework/src/Facades/Features.php
+++ b/packages/framework/src/Facades/Features.php
@@ -190,7 +190,10 @@ class Features implements SerializableContract
      */
     public function toArray(): array
     {
-        return $this->features;
+        return collect(Feature::cases())
+            ->mapWithKeys(fn (Feature $case): array => [
+                $case->value => $this->features[$case->value],
+            ])->toArray();
     }
 
     /** @return array<Feature> */

--- a/packages/framework/src/Facades/Features.php
+++ b/packages/framework/src/Facades/Features.php
@@ -164,10 +164,10 @@ class Features implements SerializableContract
     public static function mock(string|array $feature, bool $enabled = null): void
     {
         foreach (is_array($feature) ? $feature : [$feature => $enabled] as $feature => $enabled) {
-            if ($enabled !== true) {
-                Hyde::features()->features = array_filter(Hyde::features()->features, fn (string $search): bool => $search !== $feature);
-            } else {
+            if ($enabled === true) {
                 Hyde::features()->features[] = $feature;
+            } else {
+                Hyde::features()->features = array_filter(Hyde::features()->features, fn (string $search): bool => $search !== $feature);
             }
         }
     }

--- a/packages/framework/src/Facades/Features.php
+++ b/packages/framework/src/Facades/Features.php
@@ -206,21 +206,7 @@ class Features implements SerializableContract
     /** @return array<Feature> */
     protected static function getDefaultOptions(): array
     {
-        return [
-            // Page Modules
-            static::htmlPages(),
-            static::markdownPosts(),
-            static::bladePages(),
-            static::markdownPages(),
-            static::documentationPages(),
-
-            // Frontend Features
-            static::darkmode(),
-            static::documentationSearch(),
-
-            // Integrations
-            static::torchlight(),
-        ];
+        return Feature::cases();
     }
 
     protected function boot(): array

--- a/packages/framework/src/Facades/Features.php
+++ b/packages/framework/src/Facades/Features.php
@@ -29,6 +29,8 @@ class Features implements SerializableContract
     /**
      * The features that are enabled.
      *
+     * @todo Simplify internal state complexity
+     *
      * @var array<string, bool>
      */
     protected array $features = [];

--- a/packages/framework/src/Facades/Features.php
+++ b/packages/framework/src/Facades/Features.php
@@ -192,6 +192,7 @@ class Features implements SerializableContract
     {
         return collect(Feature::cases())
             ->mapWithKeys(fn (Feature $feature): array => [
+                // Todo: $feature->value => isset($this->features[$feature->value]),
                 $feature->value => $this->features[$feature->value],
             ])->toArray();
     }

--- a/packages/framework/src/Facades/Features.php
+++ b/packages/framework/src/Facades/Features.php
@@ -203,7 +203,7 @@ class Features implements SerializableContract
         return $this->features;
     }
 
-    /** @return array<string> */
+    /** @return array<Feature> */
     protected static function getDefaultOptions(): array
     {
         return [
@@ -244,7 +244,7 @@ class Features implements SerializableContract
         return $enabled;
     }
 
-    /** @return array<string> */
+    /** @return array<Feature> */
     protected function getConfiguredFeatures(): array
     {
         return Config::getArray('hyde.features', static::getDefaultOptions());

--- a/packages/framework/src/Facades/Features.php
+++ b/packages/framework/src/Facades/Features.php
@@ -53,19 +53,7 @@ class Features implements SerializableContract
      */
     public static function enabled(): array
     {
-        return array_keys(array_filter(Hyde::features()->getFeatures()));
-    }
-
-    /**
-     * Get all features and their status.
-     *
-     * @deprecated This method might not actually provide value, as it's not interesting information to have.
-     *
-     * @return array<string, bool>
-     */
-    public static function getFeatures(): array
-    {
-        return Hyde::features()->toArray();
+        return array_keys(array_filter(Hyde::features()->toArray()));
     }
 
     // =================================================

--- a/packages/framework/src/Facades/Features.php
+++ b/packages/framework/src/Facades/Features.php
@@ -35,7 +35,7 @@ class Features implements SerializableContract
 
     public function __construct()
     {
-        $this->features = $this->boot();
+        $this->features = $this->getConfiguredFeatures();
     }
 
     /**
@@ -141,11 +141,6 @@ class Features implements SerializableContract
         return Arr::mapWithKeys(Feature::cases(), fn (Feature $feature): array => [
             $feature->value => static::has($feature),
         ]);
-    }
-
-    protected function boot(): array
-    {
-        return $this->getConfiguredFeatures();
     }
 
     /** @return array<Feature> */

--- a/packages/framework/src/Facades/Features.php
+++ b/packages/framework/src/Facades/Features.php
@@ -56,10 +56,6 @@ class Features implements SerializableContract
         return Hyde::features()->features;
     }
 
-    // ================================================
-    // Determine if a given feature is enabled.
-    // ================================================
-
     public static function hasHtmlPages(): bool
     {
         return static::has(Feature::HtmlPages);
@@ -89,11 +85,6 @@ class Features implements SerializableContract
     {
         return static::has(Feature::Darkmode);
     }
-
-    // ====================================================
-    // Dynamic features that in addition to being enabled
-    // in the config file, require preconditions to be met.
-    // ====================================================
 
     /**
      * Can a sitemap be generated?

--- a/packages/framework/src/Facades/Features.php
+++ b/packages/framework/src/Facades/Features.php
@@ -145,7 +145,9 @@ class Features implements SerializableContract
 
     protected function boot(): array
     {
-        return Arr::map($this->getConfiguredFeatures(), fn (Feature $feature): string => $feature->value);
+        return Arr::map($this->getConfiguredFeatures(), function (Feature $feature): string {
+            return $feature->value;
+        });
     }
 
     /** @return array<Feature> */

--- a/packages/framework/src/Facades/Features.php
+++ b/packages/framework/src/Facades/Features.php
@@ -128,6 +128,9 @@ class Features implements SerializableContract
             && (app('env') !== 'testing');
     }
 
+    /**
+     * Should documentation search be enabled?
+     */
     public static function hasDocumentationSearch(): bool
     {
         return static::has(Feature::DocumentationSearch)

--- a/packages/framework/src/Facades/Features.php
+++ b/packages/framework/src/Facades/Features.php
@@ -29,7 +29,7 @@ class Features implements SerializableContract
     /**
      * The features that are enabled.
      *
-     * @var array<Feature>
+     * @var array<\Hyde\Foundation\Concerns\Feature>
      */
     protected array $features = [];
 

--- a/packages/framework/src/Facades/Features.php
+++ b/packages/framework/src/Facades/Features.php
@@ -164,10 +164,10 @@ class Features implements SerializableContract
     public static function mock(string|array $feature, bool $enabled = null): void
     {
         foreach (is_array($feature) ? $feature : [$feature => $enabled] as $feature => $enabled) {
-            if ($enabled === true) {
-                Hyde::features()->features[] = $feature;
-            } else {
+            if ($enabled !== true) {
                 Hyde::features()->features = array_filter(Hyde::features()->features, fn (string $search): bool => $search !== $feature);
+            } else {
+                Hyde::features()->features[] = $feature;
             }
         }
     }

--- a/packages/framework/src/Facades/Features.php
+++ b/packages/framework/src/Facades/Features.php
@@ -35,7 +35,7 @@ class Features implements SerializableContract
 
     public function __construct()
     {
-        $this->features = $this->getConfiguredFeatures();
+        $this->features = Config::getArray('hyde.features', Feature::cases());
     }
 
     /**
@@ -141,12 +141,6 @@ class Features implements SerializableContract
         return Arr::mapWithKeys(Feature::cases(), fn (Feature $feature): array => [
             $feature->value => static::has($feature),
         ]);
-    }
-
-    /** @return array<Feature> */
-    protected function getConfiguredFeatures(): array
-    {
-        return Config::getArray('hyde.features', Feature::cases());
     }
 
     /**

--- a/packages/framework/src/Facades/Features.php
+++ b/packages/framework/src/Facades/Features.php
@@ -192,8 +192,7 @@ class Features implements SerializableContract
     {
         return collect(Feature::cases())
             ->mapWithKeys(fn (Feature $feature): array => [
-                // Todo: $feature->value => isset($this->features[$feature->value]),
-                $feature->value => $this->features[$feature->value],
+                 $feature->value => isset($this->features[$feature->value]),
             ])->toArray();
     }
 

--- a/packages/framework/src/Facades/Features.php
+++ b/packages/framework/src/Facades/Features.php
@@ -231,13 +231,13 @@ class Features implements SerializableContract
 
         // Set all default features to false
         foreach ($options as $feature) {
-            $enabled[$feature] = false;
+            $enabled[$feature->value] = false;
         }
 
         // Set all features to true if they are enabled in the config file
         foreach ($this->getConfiguredFeatures() as $feature) {
             if (in_array($feature, $options)) {
-                $enabled[$feature] = true;
+                $enabled[$feature->value] = true;
             }
         }
 

--- a/packages/framework/src/Facades/Features.php
+++ b/packages/framework/src/Facades/Features.php
@@ -10,6 +10,7 @@ use Hyde\Pages\DocumentationPage;
 use Hyde\Foundation\Concerns\Feature;
 use Hyde\Support\Concerns\Serializable;
 use Hyde\Support\Contracts\SerializableContract;
+use Illuminate\Support\Arr;
 
 use function is_array;
 use function array_map;
@@ -138,10 +139,9 @@ class Features implements SerializableContract
      */
     public function toArray(): array
     {
-        return collect(Feature::cases())
-            ->mapWithKeys(fn (Feature $feature): array => [
-                $feature->value => in_array($feature->value, $this->features),
-            ])->toArray();
+        return Arr::mapWithKeys(Feature::cases(), fn (Feature $feature): array => [
+            $feature->value => in_array($feature->value, $this->features),
+        ]);
     }
 
     protected function boot(): array

--- a/packages/framework/src/Facades/Features.php
+++ b/packages/framework/src/Facades/Features.php
@@ -118,6 +118,16 @@ class Features implements SerializableContract
     }
 
     /**
+     * Should documentation search be enabled?
+     */
+    public static function hasDocumentationSearch(): bool
+    {
+        return static::has(Feature::DocumentationSearch)
+            && static::hasDocumentationPages()
+            && count(DocumentationPage::files()) > 0;
+    }
+
+    /**
      * Torchlight is by default enabled automatically when an API token
      * is set in the `.env` file but is disabled when running tests.
      */
@@ -126,16 +136,6 @@ class Features implements SerializableContract
         return static::has(Feature::Torchlight)
             && (Config::getNullableString('torchlight.token') !== null)
             && (app('env') !== 'testing');
-    }
-
-    /**
-     * Should documentation search be enabled?
-     */
-    public static function hasDocumentationSearch(): bool
-    {
-        return static::has(Feature::DocumentationSearch)
-            && static::hasDocumentationPages()
-            && count(DocumentationPage::files()) > 0;
     }
 
     /**

--- a/packages/framework/src/Facades/Features.php
+++ b/packages/framework/src/Facades/Features.php
@@ -43,7 +43,7 @@ class Features implements SerializableContract
      */
     public static function has(Feature $feature): bool
     {
-        return in_array($feature, static::enabled());
+        return in_array($feature->value, static::enabled());
     }
 
     /**

--- a/packages/framework/src/Foundation/Concerns/Feature.php
+++ b/packages/framework/src/Foundation/Concerns/Feature.php
@@ -7,6 +7,8 @@ namespace Hyde\Foundation\Concerns;
 /**
  * A configurable feature that belongs to the Features class.
  *
+ * @see \Hyde\Facades\Features
+ *
  * @experimental This class may change significantly before its release.
  */
 enum Feature

--- a/packages/framework/src/Foundation/Concerns/Feature.php
+++ b/packages/framework/src/Foundation/Concerns/Feature.php
@@ -5,6 +5,8 @@ declare(strict_types=1);
 namespace Hyde\Foundation\Concerns;
 
 /**
+ * A configurable feature that belongs to the Features class.
+ *
  * @experimental This class may change significantly before its release.
  */
 enum Feature

--- a/packages/framework/src/Foundation/Concerns/Feature.php
+++ b/packages/framework/src/Foundation/Concerns/Feature.php
@@ -13,5 +13,17 @@ namespace Hyde\Foundation\Concerns;
  */
 enum Feature
 {
-    //
+    // Page Modules
+    case HtmlPages;
+    case MarkdownPosts;
+    case BladePages;
+    case MarkdownPages;
+    case DocumentationPages;
+
+    // Frontend Features
+    case Darkmode;
+    case DocumentationSearch;
+
+    // Integrations
+    case Torchlight;
 }

--- a/packages/framework/src/Foundation/Concerns/Feature.php
+++ b/packages/framework/src/Foundation/Concerns/Feature.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Hyde\Foundation\Concerns;
+
+enum Feature
+{
+    //
+}

--- a/packages/framework/src/Foundation/Concerns/Feature.php
+++ b/packages/framework/src/Foundation/Concerns/Feature.php
@@ -11,19 +11,19 @@ namespace Hyde\Foundation\Concerns;
  *
  * @experimental This class may change significantly before its release.
  */
-enum Feature
+enum Feature: string
 {
     // Page Modules
-    case HtmlPages;
-    case MarkdownPosts;
-    case BladePages;
-    case MarkdownPages;
-    case DocumentationPages;
+    case HtmlPages = 'html-pages';
+    case MarkdownPosts = 'markdown-posts';
+    case BladePages = 'blade-pages';
+    case MarkdownPages = 'markdown-pages';
+    case DocumentationPages = 'documentation-pages';
 
     // Frontend Features
-    case Darkmode;
-    case DocumentationSearch;
+    case Darkmode = 'darkmode';
+    case DocumentationSearch = 'documentation-search';
 
     // Integrations
-    case Torchlight;
+    case Torchlight = 'torchlight';
 }

--- a/packages/framework/src/Foundation/Concerns/Feature.php
+++ b/packages/framework/src/Foundation/Concerns/Feature.php
@@ -4,6 +4,9 @@ declare(strict_types=1);
 
 namespace Hyde\Foundation\Concerns;
 
+/**
+ * @experimental This class may change significantly before its release.
+ */
 enum Feature
 {
     //

--- a/packages/framework/src/Foundation/HydeKernel.php
+++ b/packages/framework/src/Foundation/HydeKernel.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Hyde\Foundation;
 
 use Hyde\Facades\Features;
+use Hyde\Foundation\Concerns\Feature;
 use Hyde\Foundation\Kernel\Filesystem;
 use Hyde\Foundation\Kernel\Hyperlinks;
 use Hyde\Foundation\Kernel\FileCollection;
@@ -91,9 +92,9 @@ class HydeKernel implements SerializableContract
         return $this->features ??= new Features();
     }
 
-    public function hasFeature(string $feature): bool
+    public function hasFeature(Feature|string $feature): bool
     {
-        return Features::has($feature);
+        return Features::has($feature instanceof Feature ? $feature : Feature::from($feature));
     }
 
     /** @inheritDoc */

--- a/packages/framework/src/Framework/Services/ValidationService.php
+++ b/packages/framework/src/Framework/Services/ValidationService.php
@@ -10,6 +10,7 @@ use Hyde\Facades\Features;
 use Hyde\Pages\BladePage;
 use Hyde\Pages\MarkdownPage;
 use Hyde\Pages\DocumentationPage;
+use Hyde\Foundation\Concerns\Feature;
 use Hyde\Support\Models\ValidationResult as Result;
 
 use function count;
@@ -121,7 +122,7 @@ class ValidationService
 
     public function check_a_torchlight_api_token_is_set(Result $result): Result
     {
-        if (! Features::has(Features::torchlight())) {
+        if (! Features::has(Feature::Torchlight)) {
             return $result->skip('Check a Torchlight API token is set')
                 ->withTip('Torchlight is an API for code syntax highlighting. You can enable it in the Hyde config.');
         }

--- a/packages/framework/src/Hyde.php
+++ b/packages/framework/src/Hyde.php
@@ -6,6 +6,7 @@ namespace Hyde;
 
 use Hyde\Facades\Features;
 use Hyde\Foundation\HydeKernel;
+use Hyde\Foundation\Concerns\Feature;
 use Hyde\Foundation\Kernel\FileCollection;
 use Hyde\Foundation\Kernel\Filesystem;
 use Hyde\Foundation\Kernel\PageCollection;
@@ -58,7 +59,7 @@ use JetBrains\PhpStorm\Pure;
  * @method static HydeKernel getInstance()
  * @method static Filesystem filesystem()
  * @method static array getRegisteredExtensions()
- * @method static bool hasFeature(string $feature)
+ * @method static bool hasFeature(Feature|string $feature)
  * @method static bool hasSiteUrl()
  * @method static void setInstance(HydeKernel $instance)
  * @method static void setBasePath(string $basePath)

--- a/packages/framework/tests/Feature/ConfigurableFeaturesTest.php
+++ b/packages/framework/tests/Feature/ConfigurableFeaturesTest.php
@@ -9,6 +9,8 @@ use Hyde\Facades\Features;
 use Hyde\Testing\TestCase;
 use Illuminate\Support\Facades\Config;
 
+use function config;
+
 /**
  * @covers \Hyde\Facades\Features
  */
@@ -95,6 +97,28 @@ class ConfigurableFeaturesTest extends TestCase
             'documentation-search' => false,
             'torchlight' => false,
         ], (new Features)->toArray());
+    }
+
+    public function testSerializedClassState()
+    {
+        config(['hyde.features' => [
+            Features::htmlPages(),
+            Features::markdownPosts(),
+            Features::bladePages(),
+        ]]);
+
+        $this->assertSame(<<<'JSON'
+        {
+            "html-pages": true,
+            "markdown-posts": true,
+            "blade-pages": true,
+            "markdown-pages": false,
+            "documentation-pages": false,
+            "darkmode": false,
+            "documentation-search": false,
+            "torchlight": false
+        }
+        JSON, (new Features)->toJson(JSON_PRETTY_PRINT));
     }
 
     public function testFeaturesCanBeMocked()

--- a/packages/framework/tests/Feature/ConfigurableFeaturesTest.php
+++ b/packages/framework/tests/Feature/ConfigurableFeaturesTest.php
@@ -77,18 +77,16 @@ class ConfigurableFeaturesTest extends TestCase
 
     public function testToArrayMethodContainsAllSettings()
     {
-        $array = (new Features)->toArray();
-
-        $this->assertArrayHasKey('html-pages', $array);
-        $this->assertArrayHasKey('markdown-posts', $array);
-        $this->assertArrayHasKey('blade-pages', $array);
-        $this->assertArrayHasKey('markdown-pages', $array);
-        $this->assertArrayHasKey('documentation-pages', $array);
-        $this->assertArrayHasKey('darkmode', $array);
-        $this->assertArrayHasKey('documentation-search', $array);
-        $this->assertArrayHasKey('torchlight', $array);
-
-        $this->assertCount(8, $array);
+        $this->assertSame([
+            'html-pages',
+            'markdown-posts',
+            'blade-pages',
+            'markdown-pages',
+            'documentation-pages',
+            'darkmode',
+            'documentation-search',
+            'torchlight',
+        ], array_keys((new Features)->toArray()));
     }
 
     public function testFeaturesCanBeMocked()

--- a/packages/framework/tests/Feature/ConfigurableFeaturesTest.php
+++ b/packages/framework/tests/Feature/ConfigurableFeaturesTest.php
@@ -63,30 +63,18 @@ class ConfigurableFeaturesTest extends TestCase
         $this->assertFalse(Features::hasSitemap());
     }
 
-    public function testToArrayMethodReturnsMethodArray()
-    {
-        $array = (new Features)->toArray();
-        $this->assertIsArray($array);
-        $this->assertNotEmpty($array);
-        foreach ($array as $feature => $enabled) {
-            $this->assertIsString($feature);
-            $this->assertIsBool($enabled);
-            $this->assertStringStartsNotWith('has', $feature);
-        }
-    }
-
     public function testToArrayMethodContainsAllSettings()
     {
         $this->assertSame([
-            'html-pages',
-            'markdown-posts',
-            'blade-pages',
-            'markdown-pages',
-            'documentation-pages',
-            'darkmode',
-            'documentation-search',
-            'torchlight',
-        ], array_keys((new Features)->toArray()));
+            'html-pages' => true,
+            'markdown-posts' => true,
+            'blade-pages' => true,
+            'markdown-pages' => true,
+            'documentation-pages' => true,
+            'darkmode' => true,
+            'documentation-search' => true,
+            'torchlight' => true,
+        ], (new Features)->toArray());
     }
 
     public function testFeaturesCanBeMocked()

--- a/packages/framework/tests/Feature/ConfigurableFeaturesTest.php
+++ b/packages/framework/tests/Feature/ConfigurableFeaturesTest.php
@@ -7,6 +7,7 @@ namespace Hyde\Framework\Testing\Feature;
 use Hyde\Hyde;
 use Hyde\Facades\Features;
 use Hyde\Testing\TestCase;
+use Hyde\Foundation\Concerns\Feature;
 use Illuminate\Support\Facades\Config;
 
 use function config;
@@ -82,9 +83,9 @@ class ConfigurableFeaturesTest extends TestCase
     public function testToArrayMethodContainsAllSettingsIncludingFalseValues()
     {
         config(['hyde.features' => [
-            Features::htmlPages(),
-            Features::markdownPosts(),
-            Features::bladePages(),
+            Feature::HtmlPages,
+            Feature::MarkdownPosts,
+            Feature::BladePages,
         ]]);
 
         $this->assertSame([
@@ -102,9 +103,9 @@ class ConfigurableFeaturesTest extends TestCase
     public function testSerializedClassState()
     {
         config(['hyde.features' => [
-            Features::htmlPages(),
-            Features::markdownPosts(),
-            Features::bladePages(),
+            Feature::HtmlPages,
+            Feature::MarkdownPosts,
+            Feature::BladePages,
         ]]);
 
         $this->assertSame(<<<'JSON'
@@ -168,9 +169,9 @@ class ConfigurableFeaturesTest extends TestCase
     public function testGetEnabledUsesConfiguredOptions()
     {
         config(['hyde.features' => [
-            Features::htmlPages(),
-            Features::markdownPosts(),
-            Features::bladePages(),
+            Feature::HtmlPages,
+            Feature::MarkdownPosts,
+            Feature::BladePages,
         ]]);
 
         $this->assertSame([
@@ -185,9 +186,9 @@ class ConfigurableFeaturesTest extends TestCase
         $this->expectException(\TypeError::class); // Todo: Consider if we should handle this again by ignoring it, or throw with a more specific message
 
         $config = [
-            Features::htmlPages(),
-            Features::markdownPosts(),
-            Features::bladePages(),
+            Feature::HtmlPages,
+            Feature::MarkdownPosts,
+            Feature::BladePages,
             'foo',
         ];
 

--- a/packages/framework/tests/Feature/ConfigurableFeaturesTest.php
+++ b/packages/framework/tests/Feature/ConfigurableFeaturesTest.php
@@ -137,20 +137,17 @@ class ConfigurableFeaturesTest extends TestCase
 
     public function testGetEnabledUsesConfiguredOptions()
     {
-        $config = [
+        config(['hyde.features' => [
             Features::htmlPages(),
             Features::markdownPosts(),
             Features::bladePages(),
-        ];
-        $expected = [
+        ]]);
+
+        $this->assertSame([
             'html-pages',
             'markdown-posts',
             'blade-pages',
-        ];
-
-        config(['hyde.features' => $config]);
-
-        $this->assertSame($expected, Features::enabled());
+        ], Features::enabled());
     }
 
     public function testCannotUseArbitraryValuesInEnabledOptions()

--- a/packages/framework/tests/Feature/ConfigurableFeaturesTest.php
+++ b/packages/framework/tests/Feature/ConfigurableFeaturesTest.php
@@ -123,7 +123,7 @@ class ConfigurableFeaturesTest extends TestCase
     {
         $default = $this->defaultOptions();
 
-        $this->assertSame($default, Features::getFeatures());
+        $this->assertSame($default, Features::enabled());
     }
 
     public function testGetEnabledUsesDefaultOptionsWhenConfigIsEmpty()
@@ -132,7 +132,7 @@ class ConfigurableFeaturesTest extends TestCase
 
         $default = $this->defaultOptions();
 
-        $this->assertSame($default, Features::getFeatures());
+        $this->assertSame($default, Features::enabled());
     }
 
     public function testGetEnabledUsesConfiguredOptions()
@@ -143,19 +143,14 @@ class ConfigurableFeaturesTest extends TestCase
             Features::bladePages(),
         ];
         $expected = [
-            Features::htmlPages()->value => true,
-            Features::markdownPosts()->value => true,
-            Features::bladePages()->value => true,
-            'markdown-pages' => false,
-            'documentation-pages' => false,
-            'darkmode' => false,
-            'documentation-search' => false,
-            'torchlight' => false,
+            'html-pages',
+            'markdown-posts',
+            'blade-pages',
         ];
 
         config(['hyde.features' => $config]);
 
-        $this->assertSame($expected, Features::getFeatures());
+        $this->assertSame($expected, Features::enabled());
     }
 
     public function testCannotUseArbitraryValuesInEnabledOptions()
@@ -179,14 +174,14 @@ class ConfigurableFeaturesTest extends TestCase
     protected function defaultOptions(): array
     {
         return [
-            'html-pages' => true,
-            'markdown-posts' => true,
-            'blade-pages' => true,
-            'markdown-pages' => true,
-            'documentation-pages' => true,
-            'darkmode' => true,
-            'documentation-search' => true,
-            'torchlight' => true,
+            'html-pages',
+            'markdown-posts',
+            'blade-pages',
+            'markdown-pages',
+            'documentation-pages',
+            'darkmode',
+            'documentation-search',
+            'torchlight',
         ];
     }
 

--- a/packages/framework/tests/Feature/ConfigurableFeaturesTest.php
+++ b/packages/framework/tests/Feature/ConfigurableFeaturesTest.php
@@ -143,9 +143,9 @@ class ConfigurableFeaturesTest extends TestCase
             Features::bladePages(),
         ];
         $expected = [
-            Features::htmlPages() => true,
-            Features::markdownPosts() => true,
-            Features::bladePages() => true,
+            Features::htmlPages()->value => true,
+            Features::markdownPosts()->value => true,
+            Features::bladePages()->value => true,
             'markdown-pages' => false,
             'documentation-pages' => false,
             'darkmode' => false,

--- a/packages/framework/tests/Feature/ConfigurableFeaturesTest.php
+++ b/packages/framework/tests/Feature/ConfigurableFeaturesTest.php
@@ -77,6 +77,26 @@ class ConfigurableFeaturesTest extends TestCase
         ], (new Features)->toArray());
     }
 
+    public function testToArrayMethodContainsAllSettingsIncludingFalseValues()
+    {
+        config(['hyde.features' => [
+            Features::htmlPages(),
+            Features::markdownPosts(),
+            Features::bladePages(),
+        ]]);
+
+        $this->assertSame([
+            'html-pages' => true,
+            'markdown-posts' => true,
+            'blade-pages' => true,
+            'markdown-pages' => false,
+            'documentation-pages' => false,
+            'darkmode' => false,
+            'documentation-search' => false,
+            'torchlight' => false,
+        ], (new Features)->toArray());
+    }
+
     public function testFeaturesCanBeMocked()
     {
         Features::mock('darkmode', true);

--- a/packages/framework/tests/Feature/ConfigurableFeaturesTest.php
+++ b/packages/framework/tests/Feature/ConfigurableFeaturesTest.php
@@ -182,6 +182,8 @@ class ConfigurableFeaturesTest extends TestCase
 
     public function testCannotUseArbitraryValuesInEnabledOptions()
     {
+        $this->expectException(\TypeError::class); // Todo: Consider if we should handle this again by ignoring it, or throw with a more specific message
+
         $config = [
             Features::htmlPages(),
             Features::markdownPosts(),

--- a/packages/framework/tests/Feature/DarkmodeFeatureTest.php
+++ b/packages/framework/tests/Feature/DarkmodeFeatureTest.php
@@ -7,11 +7,11 @@ namespace Hyde\Framework\Testing\Feature;
 use Hyde\Facades\Features;
 use Hyde\Pages\DocumentationPage;
 use Hyde\Testing\TestCase;
+use Hyde\Foundation\Concerns\Feature;
 use Illuminate\Support\Facades\Config;
 use Hyde\Framework\Features\Navigation\MainNavigationMenu;
 
 /**
- * @covers \Hyde\Facades\Features::darkmode
  * @covers \Hyde\Facades\Features::hasDarkmode
  */
 class DarkmodeFeatureTest extends TestCase
@@ -34,7 +34,7 @@ class DarkmodeFeatureTest extends TestCase
     public function testHasDarkmodeIsTrueWhenSet()
     {
         Config::set('hyde.features', [
-            Features::darkmode(),
+            Feature::Darkmode,
         ]);
 
         $this->assertTrue(Features::hasDarkmode());
@@ -43,9 +43,9 @@ class DarkmodeFeatureTest extends TestCase
     public function testLayoutHasToggleButtonAndScriptWhenEnabled()
     {
         Config::set('hyde.features', [
-            Features::markdownPages(),
-            Features::bladePages(),
-            Features::darkmode(),
+            Feature::MarkdownPages,
+            Feature::BladePages,
+            Feature::Darkmode,
         ]);
 
         app()->instance('navigation.main', new MainNavigationMenu());
@@ -63,8 +63,8 @@ class DarkmodeFeatureTest extends TestCase
     public function testDocumentationPageHasToggleButtonAndScriptWhenEnabled()
     {
         Config::set('hyde.features', [
-            Features::documentationPages(),
-            Features::darkmode(),
+            Feature::DocumentationPages,
+            Feature::Darkmode,
         ]);
 
         view()->share('page', new DocumentationPage());
@@ -82,8 +82,8 @@ class DarkmodeFeatureTest extends TestCase
     public function testDarkModeThemeButtonIsHiddenInLayoutsWhenDisabled()
     {
         Config::set('hyde.features', [
-            Features::markdownPages(),
-            Features::bladePages(),
+            Feature::MarkdownPages,
+            Feature::BladePages,
         ]);
 
         app()->instance('navigation.main', new MainNavigationMenu());
@@ -101,7 +101,7 @@ class DarkmodeFeatureTest extends TestCase
     public function testDarkModeThemeButtonIsHiddenInDocumentationPagesWhenDisabled()
     {
         Config::set('hyde.features', [
-            Features::documentationPages(),
+            Feature::DocumentationPages,
         ]);
 
         view()->share('page', new DocumentationPage());

--- a/packages/framework/tests/Feature/HydeKernelTest.php
+++ b/packages/framework/tests/Feature/HydeKernelTest.php
@@ -10,6 +10,7 @@ use Hyde\Facades\Features;
 use Hyde\Foundation\Facades\Pages;
 use Hyde\Foundation\Facades\Routes;
 use Hyde\Foundation\HydeKernel;
+use Hyde\Foundation\Concerns\Feature;
 use Hyde\Foundation\Kernel\Filesystem;
 use Hyde\Framework\HydeServiceProvider;
 use Hyde\Hyde;
@@ -76,7 +77,8 @@ class HydeKernelTest extends TestCase
 
     public function testHasFeatureHelperCallsMethodOnFeaturesClass()
     {
-        $this->assertSame(Features::has('foo'), Hyde::hasFeature('foo'));
+        $this->assertSame(Features::has(Feature::BladePages), Hyde::hasFeature(Feature::BladePages));
+        $this->assertSame(Features::has(Feature::BladePages), Hyde::hasFeature('blade-pages'));
     }
 
     public function testCurrentPageHelperReturnsCurrentPageName()

--- a/packages/framework/tests/Unit/ConfigFileTest.php
+++ b/packages/framework/tests/Unit/ConfigFileTest.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Hyde\Framework\Testing\Unit;
 
-use Hyde\Facades\Features;
+use Hyde\Foundation\Concerns\Feature;
 use Hyde\Foundation\HydeCoreExtension;
 use Hyde\Hyde;
 use Hyde\Pages\BladePage;
@@ -13,7 +13,6 @@ use Hyde\Pages\HtmlPage;
 use Hyde\Pages\MarkdownPage;
 use Hyde\Pages\MarkdownPost;
 use Hyde\Testing\UnitTestCase;
-use ReflectionClass;
 
 /**
  * @see \Hyde\Framework\Testing\Unit\HydeConfigFilesAreMatchingTest
@@ -79,7 +78,7 @@ class ConfigFileTest extends UnitTestCase
     public function testDefaultFeaturesArrayMatchesDefaultFeatures()
     {
         expect($this->getConfig('features'))
-            ->toBe((new ReflectionClass(Features::class))->getMethod('getDefaultOptions')->invoke(null));
+            ->toBe(Feature::cases());
     }
 
     protected function getConfig(string $option): mixed

--- a/packages/framework/tests/Unit/ConfigurableFeaturesUnitTest.php
+++ b/packages/framework/tests/Unit/ConfigurableFeaturesUnitTest.php
@@ -11,7 +11,7 @@ beforeEach(function () {
     $this->needsKernel();
 });
 
-test('expect has method returns false when feature is disabled', function (Feature $feature) {
+test('has feature method returns false when feature is disabled', function (Feature $feature) {
     $method = "has$feature->name";
 
     Config::set('hyde.features', []);
@@ -20,7 +20,7 @@ test('expect has method returns false when feature is disabled', function (Featu
     $this->assertFalse(Features::$method(), "Method '$method' should return false when feature is not enabled");
 })->with(Feature::cases())->covers(Hyde\Facades\Features::class);
 
-test('expect has method returns true when feature is enabled', function (Feature $feature) {
+test('has feature method returns true when feature is enabled', function (Feature $feature) {
     $method = "has$feature->name";
 
     Config::set('hyde.features', [$feature]);

--- a/packages/framework/tests/Unit/ConfigurableFeaturesUnitTest.php
+++ b/packages/framework/tests/Unit/ConfigurableFeaturesUnitTest.php
@@ -33,3 +33,9 @@ test('has feature method returns true when feature is enabled', function (Featur
         Feature::Torchlight,
     ]))
 )->covers(Hyde\Facades\Features::class);
+
+test('all enum cases have a features accessor', function (Feature $feature) {
+    $method = "has$feature->name";
+
+    $this->assertTrue(method_exists(Features::class, $method), "Method '$method' should exist on Features facade");
+})->with(Feature::cases())->covers(Hyde\Facades\Features::class);

--- a/packages/framework/tests/Unit/ConfigurableFeaturesUnitTest.php
+++ b/packages/framework/tests/Unit/ConfigurableFeaturesUnitTest.php
@@ -3,6 +3,7 @@
 declare(strict_types=1);
 
 use Hyde\Facades\Features;
+use Hyde\Foundation\Concerns\Feature;
 use Illuminate\Support\Facades\Config;
 
 beforeEach(function () {
@@ -10,28 +11,25 @@ beforeEach(function () {
     $this->needsKernel();
 });
 
-test('expect has method returns false when feature is disabled', function (string $method) {
+test('expect has method returns false when feature is disabled', function (Feature $feature) {
+    $method = "has$feature->name";
+
     Config::set('hyde.features', []);
     \Hyde\Foundation\HydeKernel::setInstance(new \Hyde\Foundation\HydeKernel());
 
     $this->assertFalse(Features::$method(), "Method '$method' should return false when feature is not enabled");
-})->with([
-    'hasHtmlPages',
-    'hasBladePages',
-    'hasMarkdownPages',
-    'hasMarkdownPosts',
-    'hasDocumentationPages',
-])->covers(Hyde\Facades\Features::class);
+})->with(Feature::cases())->covers(Hyde\Facades\Features::class);
 
-test('expect has method returns true when feature is enabled', function (string $method) {
-    Config::set('hyde.features', [str($method)->kebab()->replace('has-', '')->toString()]);
+test('expect has method returns true when feature is enabled', function (Feature $feature) {
+    $method = "has$feature->name";
+
+    Config::set('hyde.features', [$feature]);
     \Hyde\Foundation\HydeKernel::setInstance(new \Hyde\Foundation\HydeKernel());
 
     $this->assertTrue(Features::$method(), "Method '$method' should return true when feature is enabled");
-})->with([
-    'hasHtmlPages',
-    'hasBladePages',
-    'hasMarkdownPages',
-    'hasMarkdownPosts',
-    'hasDocumentationPages',
-])->covers(Hyde\Facades\Features::class);
+})->with(
+    collect(Feature::cases())->reject(fn (Feature $feature): bool => in_array($feature, [
+        Feature::DocumentationSearch,
+        Feature::Torchlight,
+    ]))
+)->covers(Hyde\Facades\Features::class);

--- a/packages/testing/src/ResetsApplication.php
+++ b/packages/testing/src/ResetsApplication.php
@@ -6,6 +6,7 @@ namespace Hyde\Testing;
 
 use Hyde\Facades\Filesystem;
 use Hyde\Hyde;
+use Hyde\Foundation\Concerns\Feature;
 
 trait ResetsApplication
 {
@@ -55,9 +56,7 @@ trait ResetsApplication
     {
         $features = config('hyde.features');
 
-        $flipped = array_flip($features);
-        unset($flipped['documentation-search']);
-        $features = array_flip($flipped);
+        $features = array_filter($features, fn (Feature $feature): bool => $feature !== Feature::DocumentationSearch);
 
         config(['hyde.features' => $features]);
     }
@@ -67,7 +66,7 @@ trait ResetsApplication
     {
         $features = config('hyde.features');
 
-        $features[] = 'documentation-search';
+        $features[] = Feature::DocumentationSearch;
 
         config(['hyde.features' => $features]);
     }


### PR DESCRIPTION
Follow up to https://github.com/hydephp/develop/pull/1647. Contains a highly breaking config change in c5484800f76f135a1269e53147fd247a9384b542

![windowlight-c251d105](https://github.com/hydephp/develop/assets/95144705/cbf6b029-0fbc-42b8-a0fe-30cddb387c7a)
