### PR TITLE
Introduce a new Feature enum to improve the Features facade

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -13,12 +13,13 @@ This serves two purposes:
 - Added a `@head` stack to the `head.blade.php` component in https://github.com/hydephp/develop/pull/1567
 - Added a `Hyde::route()` helper to the `Hyde` facade in https://github.com/hydephp/develop/pull/1591
 - Added new global helper functions (`asset()`, `route()`, `url()`) in https://github.com/hydephp/develop/pull/1592
+- Added a new `Feature` enum to improve the `Features` facade in https://github.com/hydephp/develop/pull/1650
 
 ### Changed
-- for changes in existing functionality.
+- The `features` array in the `config/hyde.php` configuration file is now an array of `Feature` enums in https://github.com/hydephp/develop/pull/1650
 
 ### Deprecated
-- for soon-to-be removed features.
+- Deprecated the static `Features` flag methods used in the configuration files in https://github.com/hydephp/develop/pull/1650 and will be removed in HydePHP v2.0
 
 ### Removed
 - for now removed features.
@@ -28,3 +29,31 @@ This serves two purposes:
 
 ### Security
 - in case of vulnerabilities.
+
+### Upgrade Path
+
+In order to prepare your project for HydePHP v2.0, you should update your `config/hyde.php` configuration file to use the new `Feature` enum for the `features` array.
+
+Your new config array should look like this:
+
+```php
+    use Hyde\Enums\Feature;
+    
+    'features' => [
+        // Page Modules
+        Feature::HtmlPages,
+        Feature::MarkdownPosts,
+        Feature::BladePages,
+        Feature::MarkdownPages,
+        Feature::DocumentationPages,
+
+        // Frontend Features
+        Feature::Darkmode,
+        Feature::DocumentationSearch,
+
+        // Integrations
+        Feature::Torchlight,
+    ],
+```
+
+If you need more help, you can see detailed upgrade instructions in the pull request https://github.com/hydephp/develop/pull/1650

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -37,8 +37,10 @@ In order to prepare your project for HydePHP v2.0, you should update your `confi
 Your new config array should look like this:
 
 ```php
+    // Make sure to import the new Feature enum at the top of the file 
     use Hyde\Enums\Feature;
     
+    // Then replace your enabled features with the new Feature enum cases
     'features' => [
         // Page Modules
         Feature::HtmlPages,
@@ -56,4 +58,4 @@ Your new config array should look like this:
     ],
 ```
 
-If you need more help, you can see detailed upgrade instructions in the pull request https://github.com/hydephp/develop/pull/1650
+If you need more help, you can see detailed upgrade instructions with screenshots in the pull request https://github.com/hydephp/develop/pull/1650

--- a/config/hyde.php
+++ b/config/hyde.php
@@ -23,7 +23,7 @@
 */
 
 use Hyde\Facades\Author;
-use Hyde\Facades\Features;
+use Hyde\Enums\Feature;
 use Hyde\Facades\Meta;
 
 return [
@@ -254,18 +254,18 @@ return [
 
     'features' => [
         // Page Modules
-        Features::htmlPages(),
-        Features::markdownPosts(),
-        Features::bladePages(),
-        Features::markdownPages(),
-        Features::documentationPages(),
+        Feature::HtmlPages,
+        Feature::MarkdownPosts,
+        Feature::BladePages,
+        Feature::MarkdownPages,
+        Feature::DocumentationPages,
 
         // Frontend Features
-        Features::darkmode(),
-        Features::documentationSearch(),
+        Feature::Darkmode,
+        Feature::DocumentationSearch,
 
         // Integrations
-        Features::torchlight(),
+        Feature::Torchlight,
     ],
 
     /*

--- a/packages/framework/config/hyde.php
+++ b/packages/framework/config/hyde.php
@@ -23,7 +23,7 @@
 */
 
 use Hyde\Facades\Author;
-use Hyde\Facades\Features;
+use Hyde\Enums\Feature;
 use Hyde\Facades\Meta;
 
 return [
@@ -254,18 +254,18 @@ return [
 
     'features' => [
         // Page Modules
-        Features::htmlPages(),
-        Features::markdownPosts(),
-        Features::bladePages(),
-        Features::markdownPages(),
-        Features::documentationPages(),
+        Feature::HtmlPages,
+        Feature::MarkdownPosts,
+        Feature::BladePages,
+        Feature::MarkdownPages,
+        Feature::DocumentationPages,
 
         // Frontend Features
-        Features::darkmode(),
-        Features::documentationSearch(),
+        Feature::Darkmode,
+        Feature::DocumentationSearch,
 
         // Integrations
-        Features::torchlight(),
+        Feature::Torchlight,
     ],
 
     /*

--- a/packages/framework/src/Console/Commands/DebugCommand.php
+++ b/packages/framework/src/Console/Commands/DebugCommand.php
@@ -70,11 +70,11 @@ class DebugCommand extends Command
 
     protected function printEnabledFeatures(): void
     {
-        /** @var array<string, string> $features */
+        /** @var array<\Hyde\Enums\Feature> $features */
         $features = Config::getArray('hyde.features', []);
 
         foreach ($features as $feature) {
-            $this->line(" - $feature");
+            $this->line(" - $feature->name");
         }
     }
 }

--- a/packages/framework/src/Enums/Feature.php
+++ b/packages/framework/src/Enums/Feature.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Hyde\Enums;
 
 enum Feature

--- a/packages/framework/src/Enums/Feature.php
+++ b/packages/framework/src/Enums/Feature.php
@@ -9,7 +9,7 @@ namespace Hyde\Enums;
  *
  * @see \Hyde\Facades\Features
  */
-enum Feature
+enum Feature: string
 {
     //
 }

--- a/packages/framework/src/Enums/Feature.php
+++ b/packages/framework/src/Enums/Feature.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace Hyde\Enums;
+
+enum Feature
+{
+    //
+}

--- a/packages/framework/src/Enums/Feature.php
+++ b/packages/framework/src/Enums/Feature.php
@@ -4,6 +4,11 @@ declare(strict_types=1);
 
 namespace Hyde\Enums;
 
+/**
+ * A configurable feature that belongs to the Features class.
+ *
+ * @see \Hyde\Facades\Features
+ */
 enum Feature
 {
     //

--- a/packages/framework/src/Enums/Feature.php
+++ b/packages/framework/src/Enums/Feature.php
@@ -11,5 +11,17 @@ namespace Hyde\Enums;
  */
 enum Feature: string
 {
-    //
+    // Page Modules
+    case HtmlPages = 'html-pages';
+    case MarkdownPosts = 'markdown-posts';
+    case BladePages = 'blade-pages';
+    case MarkdownPages = 'markdown-pages';
+    case DocumentationPages = 'documentation-pages';
+
+    // Frontend Features
+    case Darkmode = 'darkmode';
+    case DocumentationSearch = 'documentation-search';
+
+    // Integrations
+    case Torchlight = 'torchlight';
 }

--- a/packages/framework/src/Facades/Features.php
+++ b/packages/framework/src/Facades/Features.php
@@ -40,7 +40,7 @@ class Features implements SerializableContract
     /**
      * Determine if the given specified is enabled.
      */
-    public static function enabled(string $feature): bool
+    public static function enabled(Feature|string $feature): bool
     {
         return static::resolveMockedInstance($feature) ?? in_array(
             $feature, Config::getArray('hyde.features', static::getDefaultOptions())

--- a/packages/framework/src/Facades/Features.php
+++ b/packages/framework/src/Facades/Features.php
@@ -103,41 +103,65 @@ class Features implements SerializableContract
     // Configure features to be used in the config file.
     // =================================================
 
+    /**
+     * @deprecated This method will be removed in v2.0. Please use `Feature::HtmlPages` instead.
+     */
     public static function htmlPages(): Feature
     {
         return Feature::HtmlPages;
     }
 
+    /**
+     * @deprecated This method will be removed in v2.0. Please use `Feature::BladePages` instead.
+     */
     public static function bladePages(): Feature
     {
         return Feature::BladePages;
     }
 
+    /**
+     * @deprecated This method will be removed in v2.0. Please use `Feature::MarkdownPages` instead.
+     */
     public static function markdownPages(): Feature
     {
         return Feature::MarkdownPages;
     }
 
+    /**
+     * @deprecated This method will be removed in v2.0. Please use `Feature::MarkdownPosts` instead.
+     */
     public static function markdownPosts(): Feature
     {
         return Feature::MarkdownPosts;
     }
 
+    /**
+     * @deprecated This method will be removed in v2.0. Please use `Feature::DocumentationPages` instead.
+     */
     public static function documentationPages(): Feature
     {
         return Feature::DocumentationPages;
     }
 
+    /**
+     * @deprecated This method will be removed in v2.0. Please use `Feature::DocumentationSearch` instead.
+     */
     public static function documentationSearch(): Feature
     {
         return Feature::DocumentationSearch;
     }
 
+    /**
+     * @deprecated This method will be removed in v2.0. Please use `Feature::Darkmode` instead.
+     */
     public static function darkmode(): Feature
     {
         return Feature::Darkmode;
     }
 
+    /**
+     * @deprecated This method will be removed in v2.0. Please use `Feature::Torchlight` instead.
+     */
     public static function torchlight(): Feature
     {
         return Feature::Torchlight;

--- a/packages/framework/src/Facades/Features.php
+++ b/packages/framework/src/Facades/Features.php
@@ -40,9 +40,9 @@ class Features implements SerializableContract
     /**
      * Determine if the given specified is enabled.
      */
-    public static function enabled(Feature|string $feature): bool
+    public static function enabled(Feature $feature): bool
     {
-        return static::resolveMockedInstance($feature) ?? in_array(
+        return static::resolveMockedInstance($feature->value) ?? in_array(
             $feature, Config::getArray('hyde.features', static::getDefaultOptions())
         );
     }

--- a/packages/framework/src/Facades/Features.php
+++ b/packages/framework/src/Facades/Features.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Hyde\Facades;
 
 use Hyde\Hyde;
+use Hyde\Enums\Feature;
 use Hyde\Pages\MarkdownPost;
 use Hyde\Pages\DocumentationPage;
 use Hyde\Support\Concerns\Serializable;
@@ -104,42 +105,42 @@ class Features implements SerializableContract
 
     public static function htmlPages(): string
     {
-        return 'html-pages';
+        return Feature::HtmlPages->value;
     }
 
     public static function bladePages(): string
     {
-        return 'blade-pages';
+        return Feature::BladePages->value;
     }
 
     public static function markdownPages(): string
     {
-        return 'markdown-pages';
+        return Feature::MarkdownPages->value;
     }
 
     public static function markdownPosts(): string
     {
-        return 'markdown-posts';
+        return Feature::MarkdownPosts->value;
     }
 
     public static function documentationPages(): string
     {
-        return 'documentation-pages';
+        return Feature::DocumentationPages->value;
     }
 
     public static function documentationSearch(): string
     {
-        return 'documentation-search';
+        return Feature::DocumentationSearch->value;
     }
 
     public static function darkmode(): string
     {
-        return 'darkmode';
+        return Feature::Darkmode->value;
     }
 
     public static function torchlight(): string
     {
-        return 'torchlight';
+        return Feature::Torchlight->value;
     }
 
     // ====================================================

--- a/packages/framework/src/Facades/Features.php
+++ b/packages/framework/src/Facades/Features.php
@@ -54,39 +54,39 @@ class Features implements SerializableContract
 
     public static function hasHtmlPages(): bool
     {
-        return static::enabled(static::htmlPages());
+        return static::enabled(Feature::HtmlPages);
     }
 
     public static function hasBladePages(): bool
     {
-        return static::enabled(static::bladePages());
+        return static::enabled(Feature::BladePages);
     }
 
     public static function hasMarkdownPages(): bool
     {
-        return static::enabled(static::markdownPages());
+        return static::enabled(Feature::MarkdownPages);
     }
 
     public static function hasMarkdownPosts(): bool
     {
-        return static::enabled(static::markdownPosts());
+        return static::enabled(Feature::MarkdownPosts);
     }
 
     public static function hasDocumentationPages(): bool
     {
-        return static::enabled(static::documentationPages());
+        return static::enabled(Feature::DocumentationPages);
     }
 
     public static function hasDocumentationSearch(): bool
     {
-        return static::enabled(static::documentationSearch())
+        return static::enabled(Feature::DocumentationSearch)
             && static::hasDocumentationPages()
             && count(DocumentationPage::files()) > 0;
     }
 
     public static function hasDarkmode(): bool
     {
-        return static::enabled(static::darkmode());
+        return static::enabled(Feature::Darkmode);
     }
 
     /**
@@ -95,7 +95,7 @@ class Features implements SerializableContract
      */
     public static function hasTorchlight(): bool
     {
-        return static::enabled(static::torchlight())
+        return static::enabled(Feature::Torchlight)
             && (Config::getNullableString('torchlight.token') !== null)
             && (app('env') !== 'testing');
     }
@@ -203,18 +203,18 @@ class Features implements SerializableContract
     {
         return [
             // Page Modules
-            static::htmlPages(),
-            static::markdownPosts(),
-            static::bladePages(),
-            static::markdownPages(),
-            static::documentationPages(),
+            Feature::HtmlPages,
+            Feature::MarkdownPosts,
+            Feature::BladePages,
+            Feature::MarkdownPages,
+            Feature::DocumentationPages,
 
             // Frontend Features
-            static::darkmode(),
-            static::documentationSearch(),
+            Feature::Darkmode,
+            Feature::DocumentationSearch,
 
             // Integrations
-            static::torchlight(),
+            Feature::Torchlight,
         ];
     }
 }

--- a/packages/framework/src/Facades/Features.php
+++ b/packages/framework/src/Facades/Features.php
@@ -104,72 +104,56 @@ class Features implements SerializableContract
     // Configure features to be used in the config file.
     // =================================================
 
-    /**
-     * @deprecated This method will be removed in v2.0. Please use `Feature::HtmlPages` instead.
-     */
+    /** @deprecated This method will be removed in v2.0. Please use `Feature::HtmlPages` instead. */
     #[Deprecated(reason: 'Replaced by the \Hyde\Enums\Feature::HtmlPages Enum case', replacement: 'Feature::HtmlPages', since: '1.6.0')]
     public static function htmlPages(): Feature
     {
         return Feature::HtmlPages;
     }
 
-    /**
-     * @deprecated This method will be removed in v2.0. Please use `Feature::BladePages` instead.
-     */
+    /** @deprecated This method will be removed in v2.0. Please use `Feature::BladePages` instead. */
     #[Deprecated(reason: 'Replaced by the \Hyde\Enums\Feature::BladePages Enum case', replacement: 'Feature::BladePages', since: '1.6.0')]
     public static function bladePages(): Feature
     {
         return Feature::BladePages;
     }
 
-    /**
-     * @deprecated This method will be removed in v2.0. Please use `Feature::MarkdownPages` instead.
-     */
+    /** @deprecated This method will be removed in v2.0. Please use `Feature::MarkdownPages` instead. */
     #[Deprecated(reason: 'Replaced by the \Hyde\Enums\Feature::MarkdownPages Enum case', replacement: 'Feature::MarkdownPages', since: '1.6.0')]
     public static function markdownPages(): Feature
     {
         return Feature::MarkdownPages;
     }
 
-    /**
-     * @deprecated This method will be removed in v2.0. Please use `Feature::MarkdownPosts` instead.
-     */
+    /** @deprecated This method will be removed in v2.0. Please use `Feature::MarkdownPosts` instead. */
     #[Deprecated(reason: 'Replaced by the \Hyde\Enums\Feature::MarkdownPosts Enum case', replacement: 'Feature::MarkdownPosts', since: '1.6.0')]
     public static function markdownPosts(): Feature
     {
         return Feature::MarkdownPosts;
     }
 
-    /**
-     * @deprecated This method will be removed in v2.0. Please use `Feature::DocumentationPages` instead.
-     */
+    /** @deprecated This method will be removed in v2.0. Please use `Feature::DocumentationPages` instead. */
     #[Deprecated(reason: 'Replaced by the \Hyde\Enums\Feature::DocumentationPages Enum case', replacement: 'Feature::DocumentationPages', since: '1.6.0')]
     public static function documentationPages(): Feature
     {
         return Feature::DocumentationPages;
     }
 
-    /**
-     * @deprecated This method will be removed in v2.0. Please use `Feature::DocumentationSearch` instead.
-     */
+    /** @deprecated This method will be removed in v2.0. Please use `Feature::DocumentationSearch` instead. */
     #[Deprecated(reason: 'Replaced by the \Hyde\Enums\Feature::DocumentationSearch Enum case', replacement: 'Feature::DocumentationSearch', since: '1.6.0')]
     public static function documentationSearch(): Feature
     {
         return Feature::DocumentationSearch;
     }
 
-    /**
-     * @deprecated This method will be removed in v2.0. Please use `Feature::Darkmode` instead.
-     */
+    /** @deprecated This method will be removed in v2.0. Please use `Feature::Darkmode` instead. */
     #[Deprecated(reason: 'Replaced by the \Hyde\Enums\Feature::Darkmode Enum case', replacement: 'Feature::Darkmode', since: '1.6.0')]
     public static function darkmode(): Feature
     {
         return Feature::Darkmode;
     }
 
-    /**
-     * @deprecated This method will be removed in v2.0. Please use `Feature::Torchlight` instead.
-     */
+    /** @deprecated This method will be removed in v2.0. Please use `Feature::Torchlight` instead. */
     #[Deprecated(reason: 'Replaced by the \Hyde\Enums\Feature::Torchlight Enum case', replacement: 'Feature::Torchlight', since: '1.6.0')]
     public static function torchlight(): Feature
     {

--- a/packages/framework/src/Facades/Features.php
+++ b/packages/framework/src/Facades/Features.php
@@ -103,44 +103,44 @@ class Features implements SerializableContract
     // Configure features to be used in the config file.
     // =================================================
 
-    public static function htmlPages(): string
+    public static function htmlPages(): Feature
     {
-        return Feature::HtmlPages->value;
+        return Feature::HtmlPages;
     }
 
-    public static function bladePages(): string
+    public static function bladePages(): Feature
     {
-        return Feature::BladePages->value;
+        return Feature::BladePages;
     }
 
-    public static function markdownPages(): string
+    public static function markdownPages(): Feature
     {
-        return Feature::MarkdownPages->value;
+        return Feature::MarkdownPages;
     }
 
-    public static function markdownPosts(): string
+    public static function markdownPosts(): Feature
     {
-        return Feature::MarkdownPosts->value;
+        return Feature::MarkdownPosts;
     }
 
-    public static function documentationPages(): string
+    public static function documentationPages(): Feature
     {
-        return Feature::DocumentationPages->value;
+        return Feature::DocumentationPages;
     }
 
-    public static function documentationSearch(): string
+    public static function documentationSearch(): Feature
     {
-        return Feature::DocumentationSearch->value;
+        return Feature::DocumentationSearch;
     }
 
-    public static function darkmode(): string
+    public static function darkmode(): Feature
     {
-        return Feature::Darkmode->value;
+        return Feature::Darkmode;
     }
 
-    public static function torchlight(): string
+    public static function torchlight(): Feature
     {
-        return Feature::Torchlight->value;
+        return Feature::Torchlight;
     }
 
     // ====================================================

--- a/packages/framework/src/Facades/Features.php
+++ b/packages/framework/src/Facades/Features.php
@@ -8,6 +8,7 @@ use Hyde\Hyde;
 use Hyde\Enums\Feature;
 use Hyde\Pages\MarkdownPost;
 use Hyde\Pages\DocumentationPage;
+use JetBrains\PhpStorm\Deprecated;
 use Hyde\Support\Concerns\Serializable;
 use Hyde\Support\Contracts\SerializableContract;
 use Hyde\Framework\Concerns\Internal\MockableFeatures;
@@ -106,6 +107,7 @@ class Features implements SerializableContract
     /**
      * @deprecated This method will be removed in v2.0. Please use `Feature::HtmlPages` instead.
      */
+    #[Deprecated(reason: 'Replaced by the \Hyde\Enums\Feature::HtmlPages Enum case', replacement: 'Feature::HtmlPages', since: '1.6.0')]
     public static function htmlPages(): Feature
     {
         return Feature::HtmlPages;
@@ -114,6 +116,7 @@ class Features implements SerializableContract
     /**
      * @deprecated This method will be removed in v2.0. Please use `Feature::BladePages` instead.
      */
+    #[Deprecated(reason: 'Replaced by the \Hyde\Enums\Feature::BladePages Enum case', replacement: 'Feature::BladePages', since: '1.6.0')]
     public static function bladePages(): Feature
     {
         return Feature::BladePages;
@@ -122,6 +125,7 @@ class Features implements SerializableContract
     /**
      * @deprecated This method will be removed in v2.0. Please use `Feature::MarkdownPages` instead.
      */
+    #[Deprecated(reason: 'Replaced by the \Hyde\Enums\Feature::MarkdownPages Enum case', replacement: 'Feature::MarkdownPages', since: '1.6.0')]
     public static function markdownPages(): Feature
     {
         return Feature::MarkdownPages;
@@ -130,6 +134,7 @@ class Features implements SerializableContract
     /**
      * @deprecated This method will be removed in v2.0. Please use `Feature::MarkdownPosts` instead.
      */
+    #[Deprecated(reason: 'Replaced by the \Hyde\Enums\Feature::MarkdownPosts Enum case', replacement: 'Feature::MarkdownPosts', since: '1.6.0')]
     public static function markdownPosts(): Feature
     {
         return Feature::MarkdownPosts;
@@ -138,6 +143,7 @@ class Features implements SerializableContract
     /**
      * @deprecated This method will be removed in v2.0. Please use `Feature::DocumentationPages` instead.
      */
+    #[Deprecated(reason: 'Replaced by the \Hyde\Enums\Feature::DocumentationPages Enum case', replacement: 'Feature::DocumentationPages', since: '1.6.0')]
     public static function documentationPages(): Feature
     {
         return Feature::DocumentationPages;
@@ -146,6 +152,7 @@ class Features implements SerializableContract
     /**
      * @deprecated This method will be removed in v2.0. Please use `Feature::DocumentationSearch` instead.
      */
+    #[Deprecated(reason: 'Replaced by the \Hyde\Enums\Feature::DocumentationSearch Enum case', replacement: 'Feature::DocumentationSearch', since: '1.6.0')]
     public static function documentationSearch(): Feature
     {
         return Feature::DocumentationSearch;
@@ -154,6 +161,7 @@ class Features implements SerializableContract
     /**
      * @deprecated This method will be removed in v2.0. Please use `Feature::Darkmode` instead.
      */
+    #[Deprecated(reason: 'Replaced by the \Hyde\Enums\Feature::Darkmode Enum case', replacement: 'Feature::Darkmode', since: '1.6.0')]
     public static function darkmode(): Feature
     {
         return Feature::Darkmode;
@@ -162,6 +170,7 @@ class Features implements SerializableContract
     /**
      * @deprecated This method will be removed in v2.0. Please use `Feature::Torchlight` instead.
      */
+    #[Deprecated(reason: 'Replaced by the \Hyde\Enums\Feature::Torchlight Enum case', replacement: 'Feature::Torchlight', since: '1.6.0')]
     public static function torchlight(): Feature
     {
         return Feature::Torchlight;

--- a/packages/framework/src/Foundation/HydeKernel.php
+++ b/packages/framework/src/Foundation/HydeKernel.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Hyde\Foundation;
 
+use Hyde\Enums\Feature;
 use Hyde\Facades\Features;
 use Hyde\Foundation\Kernel\Filesystem;
 use Hyde\Foundation\Kernel\Hyperlinks;
@@ -89,9 +90,9 @@ class HydeKernel implements SerializableContract
         return new Features;
     }
 
-    public function hasFeature(string $feature): bool
+    public function hasFeature(Feature|string $feature): bool
     {
-        return Features::enabled($feature);
+        return Features::enabled(is_string($feature) ? Feature::from($feature) : $feature);
     }
 
     /** @inheritDoc */

--- a/packages/framework/src/Framework/Concerns/Internal/MockableFeatures.php
+++ b/packages/framework/src/Framework/Concerns/Internal/MockableFeatures.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Hyde\Framework\Concerns\Internal;
 
+use Hyde\Enums\Feature;
+
 use function is_array;
 
 /**
@@ -30,8 +32,12 @@ trait MockableFeatures
         static::$mockedInstances[$feature] = $enabled;
     }
 
-    public static function resolveMockedInstance(string $feature): ?bool
+    public static function resolveMockedInstance(Feature|string $feature): ?bool
     {
+        if ($feature instanceof Feature) {
+            $feature = $feature->value;
+        }
+
         return static::$mockedInstances[$feature] ?? null;
     }
 

--- a/packages/framework/src/Framework/Services/ValidationService.php
+++ b/packages/framework/src/Framework/Services/ValidationService.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Hyde\Framework\Services;
 
 use Hyde\Hyde;
+use Hyde\Enums\Feature;
 use Hyde\Facades\Config;
 use Hyde\Facades\Features;
 use Hyde\Pages\BladePage;
@@ -121,7 +122,7 @@ class ValidationService
 
     public function check_a_torchlight_api_token_is_set(Result $result): Result
     {
-        if (! Features::enabled(Features::torchlight())) {
+        if (! Features::enabled(Feature::Torchlight)) {
             return $result->skip('Check a Torchlight API token is set')
                 ->withTip('Torchlight is an API for code syntax highlighting. You can enable it in the Hyde config.');
         }

--- a/packages/framework/src/Hyde.php
+++ b/packages/framework/src/Hyde.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Hyde;
 
+use Hyde\Enums\Feature;
 use Hyde\Facades\Features;
 use Hyde\Foundation\HydeKernel;
 use Hyde\Foundation\Kernel\FileCollection;
@@ -58,7 +59,7 @@ use JetBrains\PhpStorm\Pure;
  * @method static HydeKernel getInstance()
  * @method static Filesystem filesystem()
  * @method static array getRegisteredExtensions()
- * @method static bool hasFeature(string $feature)
+ * @method static bool hasFeature(Feature|string $feature)
  * @method static bool hasSiteUrl()
  * @method static void setInstance(HydeKernel $instance)
  * @method static void setBasePath(string $basePath)

--- a/packages/framework/tests/Feature/ConfigurableFeaturesTest.php
+++ b/packages/framework/tests/Feature/ConfigurableFeaturesTest.php
@@ -29,15 +29,13 @@ class ConfigurableFeaturesTest extends TestCase
     {
         $features = [];
         foreach (get_class_methods(Features::class) as $method) {
-            if (! str_starts_with($method, 'has') && $method !== 'enabled') {
-                $features[] = '\Hyde\Framework\Helpers\Features::'.$method.'()';
+            if (str_starts_with($method, 'has') && $method !== 'hasDocumentationSearch' && $method !== 'hasTorchlight') {
+                $features[] = $method;
             }
         }
 
-        Config::set('hyde.features', $features);
-
-        foreach ($features as $feature) {
-            $this->assertTrue(Features::enabled($feature), 'Method '.$feature.' should return true when feature is enabled');
+        foreach ($features as $method) {
+            $this->assertTrue(Features::$method(), 'Method '.$method.' should return true when feature is enabled');
         }
     }
 

--- a/packages/framework/tests/Feature/DarkmodeFeatureTest.php
+++ b/packages/framework/tests/Feature/DarkmodeFeatureTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Hyde\Framework\Testing\Feature;
 
+use Hyde\Enums\Feature;
 use Hyde\Facades\Features;
 use Hyde\Pages\DocumentationPage;
 use Hyde\Testing\TestCase;
@@ -30,7 +31,7 @@ class DarkmodeFeatureTest extends TestCase
         $this->assertFalse(Features::hasDarkmode());
 
         Config::set('hyde.features', [
-            Features::darkmode(),
+            Feature::Darkmode,
         ]);
 
         $this->assertTrue(Features::hasDarkmode());
@@ -39,9 +40,9 @@ class DarkmodeFeatureTest extends TestCase
     public function testLayoutHasToggleButtonAndScriptWhenEnabled()
     {
         Config::set('hyde.features', [
-            Features::markdownPages(),
-            Features::bladePages(),
-            Features::darkmode(),
+            Feature::MarkdownPages,
+            Feature::BladePages,
+            Feature::Darkmode,
         ]);
 
         $view = view('hyde::layouts/page')->with([
@@ -57,8 +58,8 @@ class DarkmodeFeatureTest extends TestCase
     public function testDocumentationPageHasToggleButtonAndScriptWhenEnabled()
     {
         Config::set('hyde.features', [
-            Features::documentationPages(),
-            Features::darkmode(),
+            Feature::DocumentationPages,
+            Feature::Darkmode,
         ]);
 
         view()->share('page', new DocumentationPage());
@@ -76,8 +77,8 @@ class DarkmodeFeatureTest extends TestCase
     public function testDarkModeThemeButtonIsHiddenInLayoutsWhenDisabled()
     {
         Config::set('hyde.features', [
-            Features::markdownPages(),
-            Features::bladePages(),
+            Feature::MarkdownPages,
+            Feature::BladePages,
         ]);
 
         $view = view('hyde::layouts/page')->with([
@@ -93,7 +94,7 @@ class DarkmodeFeatureTest extends TestCase
     public function testDarkModeThemeButtonIsHiddenInDocumentationPagesWhenDisabled()
     {
         Config::set('hyde.features', [
-            Features::documentationPages(),
+            Feature::DocumentationPages,
         ]);
 
         view()->share('page', new DocumentationPage());

--- a/packages/framework/tests/Feature/HydeKernelTest.php
+++ b/packages/framework/tests/Feature/HydeKernelTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Hyde\Framework\Testing\Feature;
 
 use Throwable;
+use Hyde\Enums\Feature;
 use Composer\InstalledVersions;
 use Hyde\Facades\Features;
 use Hyde\Foundation\Facades\Pages;
@@ -76,7 +77,8 @@ class HydeKernelTest extends TestCase
 
     public function testHasFeatureHelperCallsMethodOnFeaturesClass()
     {
-        $this->assertSame(Features::enabled('foo'), Hyde::hasFeature('foo'));
+        $this->assertSame(Features::enabled(Feature::BladePages), Hyde::hasFeature(Feature::BladePages));
+        $this->assertSame(Features::enabled(Feature::BladePages), Hyde::hasFeature('blade-pages'));
     }
 
     public function testCurrentPageHelperReturnsCurrentPageName()


### PR DESCRIPTION
## Abstract

Cherry picks some changes from https://github.com/hydephp/develop/pull/1647 and https://github.com/hydephp/develop/pull/1649 in order to make the v2 upgrade path smoother. See https://twitter.com/CodeWithCaen/status/1777647925939593341

## Upgrade Path

To upgrade to use the enum cases instead of the now deprecated static features methods, simply replace the following usages:

![diff](https://github.com/hydephp/develop/assets/95144705/50a223f4-c2b4-4dac-9664-918ba3a362c1)


### PhpStorm Automatic Refactors
If you are using PhpStorm, you can follow these steps to do it automatically


#### Step 1: Put your caret on one of the deprecated method calls in the `features` array in the `config/hyde.php` file
![1](https://github.com/hydephp/develop/assets/95144705/ad2dcd3b-92fd-498d-8f70-85e456ea7710)

#### Step 2: Run <kbd>Alt+Enter</kbd> to open the context menu
![2](https://github.com/hydephp/develop/assets/95144705/4f65d0c3-dd7e-44a7-b5c7-cb9cfd9d68d8)

#### Step 3: On the highlighted option, press <kbd>right arrow</kbd> to open the submenu and "Fix all deprecated problems in file"
![3](https://github.com/hydephp/develop/assets/95144705/ffb891bd-e790-4cff-9836-53261063ef45)

#### Step 4: Move the cursor to the added `Feature` class and open the context menu again
![4](https://github.com/hydephp/develop/assets/95144705/3f217144-6b1c-4d72-abc5-ea83563f8949)

#### Step 5: Select the "Import class" option
![5](https://github.com/hydephp/develop/assets/95144705/0eb0ce56-8e42-415a-9cb1-2574f6f4cd50)

#### Step 6: Done!
![6](https://github.com/hydephp/develop/assets/95144705/3fa18701-6af0-4638-94f4-509a5fd3e6a1)



