### PR TITLE
Fix issues with the sitemap and RSS feed generator commands

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -25,6 +25,7 @@ This serves two purposes:
 - for now removed features.
 
 ### Fixed
+- Fixed a bug where the sitemap and RSS feed generator commands did not work when the `_site/` directory was not present in https://github.com/hydephp/develop/pull/1654
 - Realtime Compiler: Fixed responsive dashboard table issue in https://github.com/hydephp/develop/pull/1595
 
 ### Security

--- a/packages/framework/src/Framework/Actions/PostBuildTasks/GenerateRssFeed.php
+++ b/packages/framework/src/Framework/Actions/PostBuildTasks/GenerateRssFeed.php
@@ -23,6 +23,8 @@ class GenerateRssFeed extends PostBuildTask
     {
         $this->path = Hyde::sitePath(RssFeedGenerator::getFilename());
 
+        $this->needsParentDirectory($this->path);
+
         file_put_contents($this->path, RssFeedGenerator::make());
     }
 

--- a/packages/framework/src/Framework/Actions/PostBuildTasks/GenerateRssFeed.php
+++ b/packages/framework/src/Framework/Actions/PostBuildTasks/GenerateRssFeed.php
@@ -20,10 +20,7 @@ class GenerateRssFeed extends PostBuildTask
     {
         $this->path = Hyde::sitePath(RssFeedGenerator::getFilename());
 
-        file_put_contents(
-            $this->path,
-            RssFeedGenerator::make()
-        );
+        file_put_contents($this->path, RssFeedGenerator::make());
     }
 
     public function printFinishMessage(): void

--- a/packages/framework/src/Framework/Actions/PostBuildTasks/GenerateRssFeed.php
+++ b/packages/framework/src/Framework/Actions/PostBuildTasks/GenerateRssFeed.php
@@ -8,23 +8,26 @@ use Hyde\Hyde;
 use Hyde\Framework\Features\BuildTasks\PostBuildTask;
 use Hyde\Framework\Features\XmlGenerators\RssFeedGenerator;
 
-use function Hyde\path_join;
 use function file_put_contents;
 
 class GenerateRssFeed extends PostBuildTask
 {
     public static string $message = 'Generating RSS feed';
 
+    protected string $path;
+
     public function handle(): void
     {
+        $this->path = Hyde::sitePath(RssFeedGenerator::getFilename());
+
         file_put_contents(
-            Hyde::sitePath(RssFeedGenerator::getFilename()),
+            $this->path,
             RssFeedGenerator::make()
         );
     }
 
     public function printFinishMessage(): void
     {
-        $this->createdSiteFile(path_join(Hyde::getOutputDirectory(), RssFeedGenerator::getFilename()))->withExecutionTime();
+        $this->createdSiteFile($this->path)->withExecutionTime();
     }
 }

--- a/packages/framework/src/Framework/Actions/PostBuildTasks/GenerateRssFeed.php
+++ b/packages/framework/src/Framework/Actions/PostBuildTasks/GenerateRssFeed.php
@@ -6,12 +6,15 @@ namespace Hyde\Framework\Actions\PostBuildTasks;
 
 use Hyde\Hyde;
 use Hyde\Framework\Features\BuildTasks\PostBuildTask;
+use Hyde\Framework\Concerns\InteractsWithDirectories;
 use Hyde\Framework\Features\XmlGenerators\RssFeedGenerator;
 
 use function file_put_contents;
 
 class GenerateRssFeed extends PostBuildTask
 {
+    use InteractsWithDirectories;
+
     public static string $message = 'Generating RSS feed';
 
     protected string $path;

--- a/packages/framework/src/Framework/Actions/PostBuildTasks/GenerateRssFeed.php
+++ b/packages/framework/src/Framework/Actions/PostBuildTasks/GenerateRssFeed.php
@@ -8,6 +8,7 @@ use Hyde\Hyde;
 use Hyde\Framework\Features\BuildTasks\PostBuildTask;
 use Hyde\Framework\Features\XmlGenerators\RssFeedGenerator;
 
+use function Hyde\path_join;
 use function file_put_contents;
 
 class GenerateRssFeed extends PostBuildTask
@@ -24,6 +25,6 @@ class GenerateRssFeed extends PostBuildTask
 
     public function printFinishMessage(): void
     {
-        $this->createdSiteFile(Hyde::getOutputDirectory().'/'.RssFeedGenerator::getFilename())->withExecutionTime();
+        $this->createdSiteFile(path_join(Hyde::getOutputDirectory(), RssFeedGenerator::getFilename()))->withExecutionTime();
     }
 }

--- a/packages/framework/src/Framework/Actions/PostBuildTasks/GenerateRssFeed.php
+++ b/packages/framework/src/Framework/Actions/PostBuildTasks/GenerateRssFeed.php
@@ -24,6 +24,6 @@ class GenerateRssFeed extends PostBuildTask
 
     public function printFinishMessage(): void
     {
-        $this->createdSiteFile('_site/'.RssFeedGenerator::getFilename())->withExecutionTime();
+        $this->createdSiteFile(Hyde::getOutputDirectory().'/'.RssFeedGenerator::getFilename())->withExecutionTime();
     }
 }

--- a/packages/framework/src/Framework/Actions/PostBuildTasks/GenerateSitemap.php
+++ b/packages/framework/src/Framework/Actions/PostBuildTasks/GenerateSitemap.php
@@ -20,10 +20,7 @@ class GenerateSitemap extends PostBuildTask
     {
         $this->path = Hyde::sitePath('sitemap.xml');
 
-        file_put_contents(
-            $this->path,
-            SitemapGenerator::make()
-        );
+        file_put_contents($this->path, SitemapGenerator::make());
     }
 
     public function printFinishMessage(): void

--- a/packages/framework/src/Framework/Actions/PostBuildTasks/GenerateSitemap.php
+++ b/packages/framework/src/Framework/Actions/PostBuildTasks/GenerateSitemap.php
@@ -6,12 +6,15 @@ namespace Hyde\Framework\Actions\PostBuildTasks;
 
 use Hyde\Hyde;
 use Hyde\Framework\Features\BuildTasks\PostBuildTask;
+use Hyde\Framework\Concerns\InteractsWithDirectories;
 use Hyde\Framework\Features\XmlGenerators\SitemapGenerator;
 
 use function file_put_contents;
 
 class GenerateSitemap extends PostBuildTask
 {
+    use InteractsWithDirectories;
+
     public static string $message = 'Generating sitemap';
 
     protected string $path;

--- a/packages/framework/src/Framework/Actions/PostBuildTasks/GenerateSitemap.php
+++ b/packages/framework/src/Framework/Actions/PostBuildTasks/GenerateSitemap.php
@@ -24,6 +24,6 @@ class GenerateSitemap extends PostBuildTask
 
     public function printFinishMessage(): void
     {
-        $this->createdSiteFile('_site/sitemap.xml')->withExecutionTime();
+        $this->createdSiteFile(Hyde::getOutputDirectory().'/sitemap.xml')->withExecutionTime();
     }
 }

--- a/packages/framework/src/Framework/Actions/PostBuildTasks/GenerateSitemap.php
+++ b/packages/framework/src/Framework/Actions/PostBuildTasks/GenerateSitemap.php
@@ -8,6 +8,7 @@ use Hyde\Hyde;
 use Hyde\Framework\Features\BuildTasks\PostBuildTask;
 use Hyde\Framework\Features\XmlGenerators\SitemapGenerator;
 
+use function Hyde\path_join;
 use function file_put_contents;
 
 class GenerateSitemap extends PostBuildTask
@@ -24,6 +25,6 @@ class GenerateSitemap extends PostBuildTask
 
     public function printFinishMessage(): void
     {
-        $this->createdSiteFile(Hyde::getOutputDirectory().'/sitemap.xml')->withExecutionTime();
+        $this->createdSiteFile(path_join(Hyde::getOutputDirectory(), 'sitemap.xml'))->withExecutionTime();
     }
 }

--- a/packages/framework/src/Framework/Actions/PostBuildTasks/GenerateSitemap.php
+++ b/packages/framework/src/Framework/Actions/PostBuildTasks/GenerateSitemap.php
@@ -8,23 +8,26 @@ use Hyde\Hyde;
 use Hyde\Framework\Features\BuildTasks\PostBuildTask;
 use Hyde\Framework\Features\XmlGenerators\SitemapGenerator;
 
-use function Hyde\path_join;
 use function file_put_contents;
 
 class GenerateSitemap extends PostBuildTask
 {
     public static string $message = 'Generating sitemap';
 
+    protected string $path;
+
     public function handle(): void
     {
+        $this->path = Hyde::sitePath('sitemap.xml');
+
         file_put_contents(
-            Hyde::sitePath('sitemap.xml'),
+            $this->path,
             SitemapGenerator::make()
         );
     }
 
     public function printFinishMessage(): void
     {
-        $this->createdSiteFile(path_join(Hyde::getOutputDirectory(), 'sitemap.xml'))->withExecutionTime();
+        $this->createdSiteFile($this->path)->withExecutionTime();
     }
 }

--- a/packages/framework/src/Framework/Actions/PostBuildTasks/GenerateSitemap.php
+++ b/packages/framework/src/Framework/Actions/PostBuildTasks/GenerateSitemap.php
@@ -23,6 +23,8 @@ class GenerateSitemap extends PostBuildTask
     {
         $this->path = Hyde::sitePath('sitemap.xml');
 
+        $this->needsParentDirectory($this->path);
+
         file_put_contents($this->path, SitemapGenerator::make());
     }
 


### PR DESCRIPTION
Fixes a bug where the sitemap and RSS feed generator commands did not work when the `_site/` directory was not present, and adds some cleanups to the commands.