### PR TITLE
Add a skip feature to build tasks

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -14,6 +14,7 @@ This serves two purposes:
 - Added a `Hyde::route()` helper to the `Hyde` facade in https://github.com/hydephp/develop/pull/1591
 - Added new global helper functions (`asset()`, `route()`, `url()`) in https://github.com/hydephp/develop/pull/1592
 - Added a new `Feature` enum to improve the `Features` facade in https://github.com/hydephp/develop/pull/1650
+- Added a helper to `->skip()` build tasks in https://github.com/hydephp/develop/pull/1656
 
 ### Changed
 - The `features` array in the `config/hyde.php` configuration file is now an array of `Feature` enums in https://github.com/hydephp/develop/pull/1650

--- a/docs/advanced-features/build-tasks.md
+++ b/docs/advanced-features/build-tasks.md
@@ -176,6 +176,8 @@ public function handle(): void
 
 ### Skipping tasks
 
+>info This feature was added in HydePHP v1.6.0
+
 If you for some reason need to skip the task during its execution, you can call the `skip()` method.
 
 ```php

--- a/docs/advanced-features/build-tasks.md
+++ b/docs/advanced-features/build-tasks.md
@@ -173,3 +173,20 @@ public function handle(): void
     $this->output->writeln('This is a line of text');
 }
 ```
+
+### Skipping tasks
+
+If you for some reason need to skip the task during its execution, you can call the `skip()` method.
+
+```php
+public function handle(): void
+{
+    if ($this->someCondition() !== true) {
+        $this->skip('Some condition was not met');
+        
+        // The task will not be executed past this point
+    }
+}
+```
+
+This will then halt the execution of the task, and display a notice with the message you provided to the console.

--- a/packages/framework/src/Framework/Features/BuildTasks/BuildTask.php
+++ b/packages/framework/src/Framework/Features/BuildTasks/BuildTask.php
@@ -57,7 +57,7 @@ abstract class BuildTask
                 $this->writeln("<error>{$exception->getMessage()}</error>");
             }
 
-           $this->exitCode = $exception->getCode();
+            $this->exitCode = $exception->getCode();
         }
 
         $this->write("\n");

--- a/packages/framework/src/Framework/Features/BuildTasks/BuildTask.php
+++ b/packages/framework/src/Framework/Features/BuildTasks/BuildTask.php
@@ -84,6 +84,12 @@ abstract class BuildTask
         $this->output?->writeln($message);
     }
 
+    /** Write a fluent message to the output that the task is skipping. */
+    public function skip(string $reason): void
+    {
+        throw new BuildTaskSkippedException($reason);
+    }
+
     /** Write a fluent message to the output that the task created the specified file. */
     public function createdSiteFile(string $path): static
     {

--- a/packages/framework/src/Framework/Features/BuildTasks/BuildTask.php
+++ b/packages/framework/src/Framework/Features/BuildTasks/BuildTask.php
@@ -95,9 +95,9 @@ abstract class BuildTask
      *
      * @throws \Hyde\Framework\Features\BuildTasks\BuildTaskSkippedException
      */
-    public function skip(string $reason = null): void
+    public function skip(string $reason = 'Task was skipped'): void
     {
-        throw new BuildTaskSkippedException($reason ?? 'Task was skipped');
+        throw new BuildTaskSkippedException($reason);
     }
 
     /** Write a fluent message to the output that the task created the specified file. */

--- a/packages/framework/src/Framework/Features/BuildTasks/BuildTask.php
+++ b/packages/framework/src/Framework/Features/BuildTasks/BuildTask.php
@@ -52,11 +52,12 @@ abstract class BuildTask
             if ($exception instanceof BuildTaskSkippedException) {
                 $this->writeln('<bg=yellow>Skipped</>');
                 $this->writeln("<fg=gray> > {$exception->getMessage()}</>");
+            } else {
+                $this->writeln('<error>Failed</error>');
+                $this->writeln("<error>{$exception->getMessage()}</error>");
             }
 
-            $this->writeln('<error>Failed</error>');
-            $this->writeln("<error>{$exception->getMessage()}</error>");
-            $this->exitCode = $exception->getCode();
+           $this->exitCode = $exception->getCode();
         }
 
         $this->write("\n");

--- a/packages/framework/src/Framework/Features/BuildTasks/BuildTask.php
+++ b/packages/framework/src/Framework/Features/BuildTasks/BuildTask.php
@@ -84,7 +84,11 @@ abstract class BuildTask
         $this->output?->writeln($message);
     }
 
-    /** Write a fluent message to the output that the task is skipping. */
+    /**
+     * Write a fluent message to the output that the task is skipping.
+     *
+     * @throws \Hyde\Framework\Features\BuildTasks\BuildTaskSkippedException
+     */
     public function skip(string $reason): void
     {
         throw new BuildTaskSkippedException($reason);

--- a/packages/framework/src/Framework/Features/BuildTasks/BuildTask.php
+++ b/packages/framework/src/Framework/Features/BuildTasks/BuildTask.php
@@ -49,6 +49,11 @@ abstract class BuildTask
             $this->handle();
             $this->printFinishMessage();
         } catch (Throwable $exception) {
+            if ($exception instanceof BuildTaskSkippedException) {
+                $this->writeln('<bg=yellow>Skipped</>');
+                $this->writeln("<fg=gray> > {$exception->getMessage()}</>");
+            }
+
             $this->writeln('<error>Failed</error>');
             $this->writeln("<error>{$exception->getMessage()}</error>");
             $this->exitCode = $exception->getCode();

--- a/packages/framework/src/Framework/Features/BuildTasks/BuildTask.php
+++ b/packages/framework/src/Framework/Features/BuildTasks/BuildTask.php
@@ -95,9 +95,9 @@ abstract class BuildTask
      *
      * @throws \Hyde\Framework\Features\BuildTasks\BuildTaskSkippedException
      */
-    public function skip(string $reason): void
+    public function skip(string $reason = null): void
     {
-        throw new BuildTaskSkippedException($reason);
+        throw new BuildTaskSkippedException($reason ?? 'Task was skipped');
     }
 
     /** Write a fluent message to the output that the task created the specified file. */

--- a/packages/framework/src/Framework/Features/BuildTasks/BuildTask.php
+++ b/packages/framework/src/Framework/Features/BuildTasks/BuildTask.php
@@ -91,7 +91,7 @@ abstract class BuildTask
     }
 
     /**
-     * Write a fluent message to the output that the task is skipping.
+     * Write a fluent message to the output that the task is skipping and halt the execution.
      *
      * @throws \Hyde\Framework\Features\BuildTasks\BuildTaskSkippedException
      */

--- a/packages/framework/src/Framework/Features/BuildTasks/BuildTaskSkippedException.php
+++ b/packages/framework/src/Framework/Features/BuildTasks/BuildTaskSkippedException.php
@@ -4,7 +4,9 @@ declare(strict_types=1);
 
 namespace Hyde\Framework\Features\BuildTasks;
 
-class BuildTaskSkippedException
+use RuntimeException;
+
+class BuildTaskSkippedException extends RuntimeException
 {
     //
 }

--- a/packages/framework/src/Framework/Features/BuildTasks/BuildTaskSkippedException.php
+++ b/packages/framework/src/Framework/Features/BuildTasks/BuildTaskSkippedException.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Hyde\Framework\Features\BuildTasks;
+
+class BuildTaskSkippedException
+{
+    //
+}

--- a/packages/framework/src/Framework/Features/BuildTasks/BuildTaskSkippedException.php
+++ b/packages/framework/src/Framework/Features/BuildTasks/BuildTaskSkippedException.php
@@ -8,5 +8,8 @@ use RuntimeException;
 
 class BuildTaskSkippedException extends RuntimeException
 {
-    //
+    public function __construct(string $message = 'Task was skipped', int $code = 0)
+    {
+        parent::__construct($message, $code);
+    }
 }

--- a/packages/framework/tests/Unit/BuildTaskSkippedExceptionTest.php
+++ b/packages/framework/tests/Unit/BuildTaskSkippedExceptionTest.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Hyde\Framework\Testing\Unit;
+
+use Hyde\Framework\Features\BuildTasks\BuildTaskSkippedException;
+use Hyde\Testing\UnitTestCase;
+
+/**
+ * @covers \Hyde\Framework\Features\BuildTasks\BuildTaskSkippedException
+ */
+class BuildTaskSkippedExceptionTest extends UnitTestCase
+{
+    public function testItCanBeInstantiated()
+    {
+        $exception = new BuildTaskSkippedException();
+
+        $this->assertInstanceOf(BuildTaskSkippedException::class, $exception);
+    }
+
+    public function testItThrowsAnExceptionWithDefaultMessage()
+    {
+        $this->expectException(BuildTaskSkippedException::class);
+        $this->expectExceptionMessage('Task was skipped');
+
+        throw new BuildTaskSkippedException();
+    }
+
+    public function testItThrowsAnExceptionWithCustomMessage()
+    {
+        $this->expectException(BuildTaskSkippedException::class);
+        $this->expectExceptionMessage('Custom message');
+
+        throw new BuildTaskSkippedException('Custom message');
+    }
+
+    public function testDefaultExceptionCode()
+    {
+        $exception = new BuildTaskSkippedException();
+
+        $this->assertSame(0, $exception->getCode());
+    }
+
+    public function testCustomExceptionCode()
+    {
+        $exception = new BuildTaskSkippedException('Custom message', 123);
+
+        $this->assertSame(123, $exception->getCode());
+    }
+}

--- a/packages/framework/tests/Unit/BuildTaskUnitTest.php
+++ b/packages/framework/tests/Unit/BuildTaskUnitTest.php
@@ -186,13 +186,11 @@ class BuildTaskUnitTest extends UnitTestCase
 
     public function testTaskSkipping()
     {
-        $task = new BufferedTestBuildTask();
-
-        $task->mockHandle(function (BufferedTestBuildTask $task) {
-            $task->skip();
+        $task = tap(new BufferedTestBuildTask(), function (BufferedTestBuildTask $task) {
+            $task->mockHandle(function (BufferedTestBuildTask $task) {
+                $task->skip();
+            })->run();
         });
-
-        $task->run();
 
         $this->assertSame(0, $task->property('exitCode'));
         $this->assertSame('<bg=yellow>Skipped</>', $task->buffer[1]);
@@ -201,13 +199,11 @@ class BuildTaskUnitTest extends UnitTestCase
 
     public function testTaskSkippingWithCustomMessage()
     {
-        $task = new BufferedTestBuildTask();
-
-        $task->mockHandle(function (BufferedTestBuildTask $task) {
-            $task->skip('Custom reason');
+        $task = tap(new BufferedTestBuildTask(), function (BufferedTestBuildTask $task) {
+            $task->mockHandle(function (BufferedTestBuildTask $task) {
+                $task->skip('Custom reason');
+            })->run();
         });
-
-        $task->run();
 
         $this->assertSame(0, $task->property('exitCode'));
         $this->assertSame('<bg=yellow>Skipped</>', $task->buffer[1]);
@@ -278,9 +274,11 @@ class InspectableTestBuildTask extends BuildTask
         $this->mockedEndTime = $time;
     }
 
-    public function mockHandle(Closure $handle): void
+    public function mockHandle(Closure $handle): static
     {
         $this->mockHandle = $handle;
+
+        return $this;
     }
 
     protected function stopClock(): float

--- a/packages/framework/tests/Unit/BuildTaskUnitTest.php
+++ b/packages/framework/tests/Unit/BuildTaskUnitTest.php
@@ -184,6 +184,36 @@ class BuildTaskUnitTest extends UnitTestCase
         $this->assertSame(' in 1,234.56ms', $task->buffer[0]);
     }
 
+    public function testTaskSkipping()
+    {
+        $task = new BufferedTestBuildTask();
+
+        $task->mockHandle(function (BufferedTestBuildTask $task) {
+            $task->skip();
+        });
+
+        $task->run();
+
+        $this->assertSame(0, $task->property('exitCode'));
+        $this->assertSame('<bg=yellow>Skipped</>', $task->buffer[1]);
+        $this->assertSame('<fg=gray> > Task was skipped</>', $task->buffer[2]);
+    }
+
+    public function testTaskSkippingWithCustomMessage()
+    {
+        $task = new BufferedTestBuildTask();
+
+        $task->mockHandle(function (BufferedTestBuildTask $task) {
+            $task->skip('Custom reason');
+        });
+
+        $task->run();
+
+        $this->assertSame(0, $task->property('exitCode'));
+        $this->assertSame('<bg=yellow>Skipped</>', $task->buffer[1]);
+        $this->assertSame('<fg=gray> > Custom reason</>', $task->buffer[2]);
+    }
+
     public function testExceptionHandling()
     {
         $task = new BufferedTestBuildTask();
@@ -217,7 +247,7 @@ class InspectableTestBuildTask extends BuildTask
     public function handle(): void
     {
         if (isset($this->mockHandle)) {
-            ($this->mockHandle)();
+            ($this->mockHandle)($this);
         } else {
             $this->wasHandled = true;
         }


### PR DESCRIPTION
Designed to match the exception formatting but with less scary output

```php
if (blank(Hyde::url()) || str_starts_with(Hyde::url(), 'http://localhost')) {
    $this->skip('Cannot generate sitemap without a valid base URL');
}
```

![image](https://github.com/hydephp/develop/assets/95144705/4b4f4162-f730-4f31-b190-2db95eb0f28a)
