### PR TITLE
Skip sitemap generation when there is no valid base URL

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -18,6 +18,7 @@ This serves two purposes:
 
 ### Changed
 - The `features` array in the `config/hyde.php` configuration file is now an array of `Feature` enums in https://github.com/hydephp/develop/pull/1650
+- Sitemap generation will now be skipped if a base URL is not set, as Google now will not index sitemaps without a base URL in https://github.com/hydephp/develop/pull/1660
 
 ### Deprecated
 - Deprecated the static `Features` flag methods used in the configuration files in https://github.com/hydephp/develop/pull/1650 and will be removed in HydePHP v2.0

--- a/packages/framework/src/Framework/Actions/PostBuildTasks/GenerateSitemap.php
+++ b/packages/framework/src/Framework/Actions/PostBuildTasks/GenerateSitemap.php
@@ -21,6 +21,10 @@ class GenerateSitemap extends PostBuildTask
 
     public function handle(): void
     {
+        if (blank(Hyde::url()) || str_starts_with(Hyde::url(), 'http://localhost')) {
+            $this->skip('Cannot generate sitemap without a valid base URL');
+        }
+
         $this->path = Hyde::sitePath('sitemap.xml');
 
         $this->needsParentDirectory($this->path);

--- a/packages/framework/tests/Feature/Services/BuildTaskServiceTest.php
+++ b/packages/framework/tests/Feature/Services/BuildTaskServiceTest.php
@@ -30,6 +30,8 @@ class BuildTaskServiceTest extends TestCase
      */
     public function testBuildCommandCanRunBuildTasks()
     {
+        config(['hyde.url' => 'https://example.com']);
+
         $this->artisan('build')
             ->expectsOutputToContain('Removing all files from build directory')
             ->expectsOutputToContain('Generating sitemap')


### PR DESCRIPTION
Before, this would fall back to a relative URL, but these no longer validate by Google and will not be indexed. It feels a bit dramatic to have an exception be thrown when building test sites locally so instead we just skip the build, but with a helpful message.

![image](https://github.com/hydephp/develop/assets/95144705/dd9b52ea-3778-4789-909a-eaa614ba9d10)

Technically this can be seen as a breaking change, as this results in a sitemap file not being generated. But the end result in both cases is the same. Before this change we in this scenario when missing a base URL we get a sitemap that cannot be indexed, and after this change we don't generate a sitemap at all. In both cases, Google will not index the site using the sitemap. In the new case, we at least provide a notice to the user. I think this better follows the principle of least astonishment and thus I believe this justifies targeting HydePHP v1.6 instead of v2.0.

The reason we consider localhost to be a non-valid URL is a tradeoff between users wanting to see what the sitemap looks locally, and when building for production in a CI where they forgot to configure an environment variable. I think the latter weights more heavily here. We could also add a `--force` flag to the `build:sitemap` command, but I don't think the complexity is warranted.