### PR TITLE
Move internal helper classes to new internal support namespace

### DIFF
--- a/packages/framework/src/Console/Commands/RouteListCommand.php
+++ b/packages/framework/src/Console/Commands/RouteListCommand.php
@@ -4,15 +4,15 @@ declare(strict_types=1);
 
 namespace Hyde\Console\Commands;
 
-use Hyde\Console\Concerns\Command;
 use Hyde\Hyde;
 use Hyde\Pages\InMemoryPage;
 use Hyde\Support\Models\Route;
-use Hyde\Support\Models\RouteList;
-use Hyde\Support\Models\RouteListItem;
+use Hyde\Console\Concerns\Command;
+use Hyde\Support\Internal\RouteList;
+use Hyde\Support\Internal\RouteListItem;
 
-use function file_exists;
 use function sprintf;
+use function file_exists;
 
 /**
  * Display the list of site routes.

--- a/packages/framework/src/Support/Internal/RouteList.php
+++ b/packages/framework/src/Support/Internal/RouteList.php
@@ -2,21 +2,20 @@
 
 declare(strict_types=1);
 
-namespace Hyde\Support\Models;
+namespace Hyde\Support\Internal;
 
 use Hyde\Hyde;
+use Hyde\Support\Models\Route;
 use Illuminate\Contracts\Support\Arrayable;
 
-use function array_keys;
-use function array_map;
 use function collect;
-use function str_replace;
 use function ucwords;
+use function array_map;
+use function array_keys;
+use function str_replace;
 
 /**
- * @internal This class is experimental and is subject to change.
- *
- * @experimental This class is experimental and is subject to change.
+ * @internal This class is internal and should not be depended on outside the HydePHP framework code.
  */
 class RouteList implements Arrayable
 {

--- a/packages/framework/src/Support/Internal/RouteListItem.php
+++ b/packages/framework/src/Support/Internal/RouteListItem.php
@@ -2,19 +2,18 @@
 
 declare(strict_types=1);
 
-namespace Hyde\Support\Models;
+namespace Hyde\Support\Internal;
 
 use Hyde\Hyde;
 use Hyde\Pages\InMemoryPage;
+use Hyde\Support\Models\Route;
 use Illuminate\Contracts\Support\Arrayable;
 
 use function class_basename;
 use function str_starts_with;
 
 /**
- * @internal This class is experimental and is subject to change.
- *
- * @experimental This class is experimental and is subject to change.
+ * @internal This class is internal and should not be depended on outside the HydePHP framework code.
  */
 class RouteListItem implements Arrayable
 {

--- a/packages/framework/tests/Feature/Commands/RouteListCommandTest.php
+++ b/packages/framework/tests/Feature/Commands/RouteListCommandTest.php
@@ -5,13 +5,13 @@ declare(strict_types=1);
 namespace Hyde\Framework\Testing\Feature\Commands;
 
 use Hyde\Hyde;
+use Hyde\Testing\TestCase;
 use Hyde\Pages\InMemoryPage;
 use Hyde\Support\Models\Route;
-use Hyde\Testing\TestCase;
 
 /**
  * @covers \Hyde\Console\Commands\RouteListCommand
- * @covers \Hyde\Support\Models\RouteListItem
+ * @covers \Hyde\Support\Internal\RouteListItem
  *
  * @see \Hyde\Framework\Testing\Feature\RouteListTest
  */

--- a/packages/framework/tests/Feature/RouteListTest.php
+++ b/packages/framework/tests/Feature/RouteListTest.php
@@ -5,14 +5,14 @@ declare(strict_types=1);
 namespace Hyde\Framework\Testing\Feature;
 
 use Hyde\Hyde;
+use Hyde\Testing\TestCase;
 use Hyde\Pages\InMemoryPage;
 use Hyde\Support\Models\Route;
-use Hyde\Support\Models\RouteList;
-use Hyde\Testing\TestCase;
+use Hyde\Support\Internal\RouteList;
 
 /**
- * @covers \Hyde\Support\Models\RouteList
- * @covers \Hyde\Support\Models\RouteListItem
+ * @covers \Hyde\Support\Internal\RouteList
+ * @covers \Hyde\Support\Internal\RouteListItem
  */
 class RouteListTest extends TestCase
 {


### PR DESCRIPTION
By placing experimental or internal classes within a dedicated namespace like Hyde\Support\Internal, we make it clear to other developers that these classes are not part of the stable public API. It also allows us to organize our codebase more effectively, making it easier to maintain and evolve over time. It also gives us more freedom to create more helper classes like this, without increasing the maintenance burden.