### PR TITLE
Deferrable config option proof of concept

### DIFF
--- a/config/docs.php
+++ b/config/docs.php
@@ -27,7 +27,7 @@ return [
 
     'sidebar' => [
         // The title in the sidebar header
-        'header' => defer(fn () => config('hyde.name').' Docs'),
+        'header' => defer(fn (\Illuminate\Config\Repository $config): string => $config->get('hyde.name').' Docs'),
 
         // When using a grouped sidebar, should the groups be collapsible?
         'collapsible' => true,

--- a/config/docs.php
+++ b/config/docs.php
@@ -1,5 +1,7 @@
 <?php
 
+use function Hyde\Config\defer;
+
 /*
 |--------------------------------------------------------------------------
 | Documentation Module Settings
@@ -25,7 +27,7 @@ return [
 
     'sidebar' => [
         // The title in the sidebar header
-        'header' => env('SITE_NAME', 'HydePHP').' Docs',
+        'header' => defer(fn () => config('hyde.name').' Docs'),
 
         // When using a grouped sidebar, should the groups be collapsible?
         'collapsible' => true,

--- a/packages/framework/src/Facades/Config.php
+++ b/packages/framework/src/Facades/Config.php
@@ -4,7 +4,9 @@ declare(strict_types=1);
 
 namespace Hyde\Facades;
 
+use Closure;
 use TypeError;
+use Hyde\Support\Internal\DeferredOption;
 
 use function sprintf;
 use function gettype;
@@ -55,6 +57,14 @@ class Config extends \Illuminate\Support\Facades\Config
         }
 
         return (string) self::validated($value, 'string', $key);
+    }
+
+    /**
+     * @experimental Defer resolving a configuration value until after the application has been created.
+     */
+    public static function defer(Closure $option): DeferredOption
+    {
+        return new DeferredOption($option);
     }
 
     protected static function validated(mixed $value, string $type, string $key): mixed

--- a/packages/framework/src/Foundation/Internal/LoadConfiguration.php
+++ b/packages/framework/src/Foundation/Internal/LoadConfiguration.php
@@ -102,7 +102,7 @@ class LoadConfiguration extends BaseLoadConfiguration
             }
 
             if ($value instanceof DeferredOption) {
-                $repository->set($key, $value());
+                $repository->set($key, $value($repository));
             }
         }
     }

--- a/packages/framework/src/Support/Internal/DeferredOption.php
+++ b/packages/framework/src/Support/Internal/DeferredOption.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Hyde\Support\Internal;
+
+use Closure;
+
+class DeferredOption
+{
+    protected Closure $closure;
+
+    public function __construct(Closure $closure)
+    {
+        $this->closure = $closure;
+    }
+
+    public function __invoke(): mixed
+    {
+        return $this->closure->__invoke();
+    }
+}

--- a/packages/framework/src/Support/Internal/DeferredOption.php
+++ b/packages/framework/src/Support/Internal/DeferredOption.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Hyde\Support\Internal;
 
 use Closure;
+use Illuminate\Config\Repository;
 
 class DeferredOption
 {
@@ -15,8 +16,8 @@ class DeferredOption
         $this->closure = $closure;
     }
 
-    public function __invoke(): mixed
+    public function __invoke(Repository $config): mixed
     {
-        return $this->closure->__invoke();
+        return $this->closure->__invoke($config);
     }
 }

--- a/packages/framework/src/helpers.php
+++ b/packages/framework/src/helpers.php
@@ -178,3 +178,17 @@ namespace Hyde {
         }
     }
 }
+
+namespace Hyde\Config {
+    use Closure;
+    use Hyde\Support\Internal\DeferredOption;
+
+    use function function_exists;
+
+    if (! function_exists('\Hyde\Config\defer')) {
+        function defer(Closure $closure): DeferredOption
+        {
+            return new DeferredOption($closure);
+        }
+    }
+}


### PR DESCRIPTION
```php
'header' => defer(fn () => config('hyde.name').' Docs'),
'header' => defer(fn ($config) => "{$config['hyde.name']} Docs"),
'header' => defer(fn (\Illuminate\Config\Repository $config): string => "{$config->get('hyde.name')} Docs"),
```