### PR TITLE
Add custom filepath label support for HTML comments

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -10,7 +10,7 @@ This serves two purposes:
 2. At release time, you can move the Unreleased section changes into a new release version section.
 
 ### Added
-- for new features.
+- Added support for using HTML comments to create Markdown code block filepath labels in https://github.com/hydephp/develop/pull/1693
 
 ### Changed
 - for changes in existing functionality.

--- a/packages/framework/src/Markdown/Processing/CodeblockFilepathProcessor.php
+++ b/packages/framework/src/Markdown/Processing/CodeblockFilepathProcessor.php
@@ -10,6 +10,7 @@ use Hyde\Markdown\Contracts\MarkdownPreProcessorContract;
 use Illuminate\Support\Facades\View;
 use Illuminate\Support\HtmlString;
 
+use function array_merge;
 use function preg_replace;
 use function str_contains;
 use function str_ireplace;
@@ -36,6 +37,8 @@ class CodeblockFilepathProcessor implements MarkdownPreProcessorContract, Markdo
         '/* filepath ',
         '# filepath: ',
         '# filepath ',
+        '<!-- filepath: ',
+        '<!-- filepath ',
     ];
 
     /**
@@ -52,7 +55,7 @@ class CodeblockFilepathProcessor implements MarkdownPreProcessorContract, Markdo
                 // We then replace these markers in the post-processor.
                 $lines[$index - 2] .= sprintf(
                     "\n<!-- HYDE[Filepath]%s -->",
-                    trim(str_ireplace(static::$patterns, '', $line))
+                    trim(str_ireplace(array_merge(static::$patterns, ['-->']), '', $line))
                 );
 
                 // Remove the original comment lines

--- a/packages/framework/tests/Feature/Services/Markdown/CodeblockFilepathProcessorTest.php
+++ b/packages/framework/tests/Feature/Services/Markdown/CodeblockFilepathProcessorTest.php
@@ -17,7 +17,7 @@ class CodeblockFilepathProcessorTest extends TestCase
         $markdown = "\n```php\n// filepath: foo.php\necho 'Hello World';\n```";
         $expected = "\n<!-- HYDE[Filepath]foo.php -->\n```php\necho 'Hello World';\n```";
 
-        $this->assertEquals($expected, CodeblockFilepathProcessor::preprocess($markdown));
+        $this->assertSame($expected, CodeblockFilepathProcessor::preprocess($markdown));
     }
 
     public function testPreprocessAcceptsMultipleFilepathFormats()
@@ -37,7 +37,7 @@ class CodeblockFilepathProcessorTest extends TestCase
             $markdown = "\n```php\n{$pattern}foo.php\necho 'Hello World';\n```";
             $expected = "\n<!-- HYDE[Filepath]foo.php -->\n```php\necho 'Hello World';\n```";
 
-            $this->assertEquals($expected, CodeblockFilepathProcessor::preprocess($markdown));
+            $this->assertSame($expected, CodeblockFilepathProcessor::preprocess($markdown));
         }
     }
 
@@ -54,7 +54,7 @@ class CodeblockFilepathProcessorTest extends TestCase
             $markdown = "\n```php\n{$pattern}foo.php\necho 'Hello World';\n```";
             $expected = "\n<!-- HYDE[Filepath]foo.php -->\n```php\necho 'Hello World';\n```";
 
-            $this->assertEquals($expected, CodeblockFilepathProcessor::preprocess($markdown));
+            $this->assertSame($expected, CodeblockFilepathProcessor::preprocess($markdown));
         }
     }
 
@@ -72,7 +72,7 @@ class CodeblockFilepathProcessorTest extends TestCase
             $markdown = "\n```$language\n// filepath: foo.$language\nfoo\n```";
             $expected = "\n<!-- HYDE[Filepath]foo.$language -->\n```$language\nfoo\n```";
 
-            $this->assertEquals($expected, CodeblockFilepathProcessor::preprocess($markdown));
+            $this->assertSame($expected, CodeblockFilepathProcessor::preprocess($markdown));
         }
     }
 

--- a/packages/framework/tests/Feature/Services/Markdown/CodeblockFilepathProcessorTest.php
+++ b/packages/framework/tests/Feature/Services/Markdown/CodeblockFilepathProcessorTest.php
@@ -74,8 +74,6 @@ class CodeblockFilepathProcessorTest extends TestCase
 
             $this->assertEquals($expected, CodeblockFilepathProcessor::preprocess($markdown));
         }
-
-        $this->assertEquals($expected, CodeblockFilepathProcessor::preprocess($markdown));
     }
 
     public function testPreprocessAcceptsMultipleInputBlocks()

--- a/packages/framework/tests/Feature/Services/Markdown/CodeblockFilepathProcessorTest.php
+++ b/packages/framework/tests/Feature/Services/Markdown/CodeblockFilepathProcessorTest.php
@@ -58,6 +58,44 @@ class CodeblockFilepathProcessorTest extends TestCase
         }
     }
 
+    public function testPreprocessCanUseHtmlComments()
+    {
+        $markdown = <<<'MD'
+        
+        ```html
+        <!-- filepath: foo.html -->
+        <p>Hello World</p>
+        ```
+        MD;
+
+        $expected = <<<'MD'
+
+        <!-- HYDE[Filepath]foo.html -->
+        ```html
+        <p>Hello World</p>
+        ```
+        MD;
+
+        $this->assertSame($expected, CodeblockFilepathProcessor::preprocess($markdown));
+    }
+
+    public function testPreprocessCanUseHtmlCommentsWithDifferentPatterns()
+    {
+        $patterns = [
+            '<!-- filepath: ',
+            '<!-- Filepath: ',
+            '<!-- FilePath: ',
+            '<!-- FILEPATH: ',
+        ];
+
+        foreach ($patterns as $pattern) {
+            $markdown = "\n```html\n{$pattern}foo.html\n<p>Hello World</p>\n```";
+            $expected = "\n<!-- HYDE[Filepath]foo.html -->\n```html\n<p>Hello World</p>\n```";
+
+            $this->assertSame($expected, CodeblockFilepathProcessor::preprocess($markdown));
+        }
+    }
+
     public function testPreprocessAcceptsMultipleLanguages()
     {
         $languages = [


### PR DESCRIPTION
Now supports this, and thus fixes https://github.com/hydephp/develop/issues/1564

```
<!-- filepath resources/includes/head.html -->
<!-- Custom HTML in the head -->
```

Also cleans up the related test