### PR TITLE
Update realtime compiler open flag to support specifying the page to open

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -11,6 +11,7 @@ This serves two purposes:
 
 ### Added
 - Added support for using HTML comments to create Markdown code block filepath labels in https://github.com/hydephp/develop/pull/1693
+- You can now specify which path to open when using the `--open` option in the serve command in https://github.com/hydephp/develop/pull/1694
 
 ### Changed
 - for changes in existing functionality.

--- a/packages/framework/src/Console/Commands/ServeCommand.php
+++ b/packages/framework/src/Console/Commands/ServeCommand.php
@@ -46,7 +46,7 @@ class ServeCommand extends Command
         $this->configureOutput();
         $this->printStartMessage();
 
-        if ($this->option('open')) {
+        if ($this->option('open') !== 'false') {
             $this->openInBrowser();
         }
 

--- a/packages/framework/src/Console/Commands/ServeCommand.php
+++ b/packages/framework/src/Console/Commands/ServeCommand.php
@@ -153,6 +153,7 @@ class ServeCommand extends Command
         };
 
         $command = sprintf('%s http://%s:%d', $binary, $this->getHostSelection(), $this->getPortSelection());
+        $command = rtrim($command, '/');
 
         $process = $binary ? Process::command($command)->run() : null;
 

--- a/packages/framework/src/Console/Commands/ServeCommand.php
+++ b/packages/framework/src/Console/Commands/ServeCommand.php
@@ -33,7 +33,7 @@ class ServeCommand extends Command
         {--dashboard= : Enable the realtime compiler dashboard. (Overrides config setting)}
         {--pretty-urls= : Enable pretty URLs. (Overrides config setting)}
         {--play-cdn= : Enable the Tailwind Play CDN. (Overrides config setting)}
-        {--open= : Open the site preview in the browser.}
+        {--open=false : Open the site preview in the browser.}
     ';
 
     /** @var string */

--- a/packages/framework/src/Console/Commands/ServeCommand.php
+++ b/packages/framework/src/Console/Commands/ServeCommand.php
@@ -145,14 +145,14 @@ class ServeCommand extends Command
 
     protected function openInBrowser(): void
     {
-        $command = match (PHP_OS_FAMILY) {
+        $binary = match (PHP_OS_FAMILY) {
             'Windows' => 'start',
             'Darwin' => 'open',
             'Linux' => 'xdg-open',
             default => null
         };
 
-        $process = $command ? Process::command(sprintf('%s http://%s:%d', $command, $this->getHostSelection(), $this->getPortSelection()))->run() : null;
+        $process = $binary ? Process::command(sprintf('%s http://%s:%d', $binary, $this->getHostSelection(), $this->getPortSelection()))->run() : null;
 
         if (! $process || $process->failed()) {
             $this->warn('Unable to open the site preview in the browser on your system:');

--- a/packages/framework/src/Console/Commands/ServeCommand.php
+++ b/packages/framework/src/Console/Commands/ServeCommand.php
@@ -153,7 +153,7 @@ class ServeCommand extends Command
         };
 
         $command = sprintf('%s http://%s:%d', $binary, $this->getHostSelection(), $this->getPortSelection());
-        $command = rtrim($command, '/');
+        $command = rtrim("$command/$path", '/');
 
         $process = $binary ? Process::command($command)->run() : null;
 

--- a/packages/framework/src/Console/Commands/ServeCommand.php
+++ b/packages/framework/src/Console/Commands/ServeCommand.php
@@ -33,7 +33,7 @@ class ServeCommand extends Command
         {--dashboard= : Enable the realtime compiler dashboard. (Overrides config setting)}
         {--pretty-urls= : Enable pretty URLs. (Overrides config setting)}
         {--play-cdn= : Enable the Tailwind Play CDN. (Overrides config setting)}
-        {--open : Open the site preview in the browser.}
+        {--open= : Open the site preview in the browser.}
     ';
 
     /** @var string */

--- a/packages/framework/src/Console/Commands/ServeCommand.php
+++ b/packages/framework/src/Console/Commands/ServeCommand.php
@@ -47,7 +47,7 @@ class ServeCommand extends Command
         $this->printStartMessage();
 
         if ($this->option('open') !== 'false') {
-            $this->openInBrowser();
+            $this->openInBrowser((string) $this->option('open'));
         }
 
         $this->runServerProcess(sprintf('php -S %s:%d %s',
@@ -143,7 +143,7 @@ class ServeCommand extends Command
         return null;
     }
 
-    protected function openInBrowser(): void
+    protected function openInBrowser(string $path = '/'): void
     {
         $binary = match (PHP_OS_FAMILY) {
             'Windows' => 'start',

--- a/packages/framework/src/Console/Commands/ServeCommand.php
+++ b/packages/framework/src/Console/Commands/ServeCommand.php
@@ -152,7 +152,9 @@ class ServeCommand extends Command
             default => null
         };
 
-        $process = $binary ? Process::command(sprintf('%s http://%s:%d', $binary, $this->getHostSelection(), $this->getPortSelection()))->run() : null;
+        $command = sprintf('%s http://%s:%d', $binary, $this->getHostSelection(), $this->getPortSelection());
+
+        $process = $binary ? Process::command($command)->run() : null;
 
         if (! $process || $process->failed()) {
             $this->warn('Unable to open the site preview in the browser on your system:');

--- a/packages/framework/tests/Unit/ServeCommandOptionsUnitTest.php
+++ b/packages/framework/tests/Unit/ServeCommandOptionsUnitTest.php
@@ -223,28 +223,7 @@ class ServeCommandOptionsUnitTest extends UnitTestCase
     {
         HydeKernel::setInstance(new HydeKernel());
 
-        $command = new class(['open' => true]) extends ServeCommandMock
-        {
-            public bool $openInBrowserCalled = false;
-
-            // Void unrelated methods
-            protected function configureOutput(): void
-            {
-            }
-
-            protected function printStartMessage(): void
-            {
-            }
-
-            protected function runServerProcess(string $command): void
-            {
-            }
-
-            protected function openInBrowser(string $path = '/'): void
-            {
-                $this->openInBrowserCalled = true;
-            }
-        };
+        $command = $this->getOpenServeCommandMock(['open' => true]);
 
         $command->safeHandle();
 
@@ -255,28 +234,7 @@ class ServeCommandOptionsUnitTest extends UnitTestCase
     {
         HydeKernel::setInstance(new HydeKernel());
 
-        $command = new class(['open' => '']) extends ServeCommandMock
-        {
-            public bool $openInBrowserCalled = false;
-
-            // Void unrelated methods
-            protected function configureOutput(): void
-            {
-            }
-
-            protected function printStartMessage(): void
-            {
-            }
-
-            protected function runServerProcess(string $command): void
-            {
-            }
-
-            protected function openInBrowser(string $path = '/'): void
-            {
-                $this->openInBrowserCalled = true;
-            }
-        };
+        $command = $this->getOpenServeCommandMock(['open' => '']);
 
         $command->safeHandle();
 
@@ -287,28 +245,7 @@ class ServeCommandOptionsUnitTest extends UnitTestCase
     {
         HydeKernel::setInstance(new HydeKernel());
 
-        $command = new class(['open' => 'dashboard']) extends ServeCommandMock
-        {
-            public string $openInBrowserPath = '';
-
-            // Void unrelated methods
-            protected function configureOutput(): void
-            {
-            }
-
-            protected function printStartMessage(): void
-            {
-            }
-
-            protected function runServerProcess(string $command): void
-            {
-            }
-
-            protected function openInBrowser(string $path = '/'): void
-            {
-                $this->openInBrowserPath = $path;
-            }
-        };
+        $command = $this->getOpenServeCommandMock(['open' => 'dashboard']);
 
         $command->safeHandle();
 
@@ -394,6 +331,34 @@ class ServeCommandOptionsUnitTest extends UnitTestCase
     protected function getMock(array $options = []): ServeCommandMock
     {
         return new ServeCommandMock($options);
+    }
+
+    protected function getOpenServeCommandMock(array $arguments): ServeCommandMock
+    {
+        return new class($arguments) extends ServeCommandMock
+        {
+            public bool $openInBrowserCalled = false;
+            public string $openInBrowserPath = '';
+
+            // Void unrelated methods
+            protected function configureOutput(): void
+            {
+            }
+
+            protected function printStartMessage(): void
+            {
+            }
+
+            protected function runServerProcess(string $command): void
+            {
+            }
+
+            protected function openInBrowser(string $path = '/'): void
+            {
+                $this->openInBrowserCalled = true;
+                $this->openInBrowserPath = $path;
+            }
+        };
     }
 }
 

--- a/packages/framework/tests/Unit/ServeCommandOptionsUnitTest.php
+++ b/packages/framework/tests/Unit/ServeCommandOptionsUnitTest.php
@@ -28,6 +28,13 @@ class ServeCommandOptionsUnitTest extends UnitTestCase
         ]);
     }
 
+    protected function tearDown(): void
+    {
+        $this->addToAssertionCount(Mockery::getContainer()->mockery_getExpectationCount());
+
+        parent::tearDown();
+    }
+
     public function testGetHostSelection()
     {
         $this->assertSame('localhost', $this->getMock()->getHostSelection());

--- a/packages/framework/tests/Unit/ServeCommandOptionsUnitTest.php
+++ b/packages/framework/tests/Unit/ServeCommandOptionsUnitTest.php
@@ -7,6 +7,7 @@ namespace Hyde\Framework\Testing\Unit;
 use Mockery;
 use Hyde\Testing\UnitTestCase;
 use Hyde\Foundation\HydeKernel;
+use Illuminate\Process\Factory;
 use Illuminate\Console\OutputStyle;
 use Hyde\Console\Commands\ServeCommand;
 use Illuminate\Support\Facades\Process;
@@ -26,6 +27,9 @@ class ServeCommandOptionsUnitTest extends UnitTestCase
             'hyde.server.host' => 'localhost',
             'hyde.server.port' => 8080,
         ]);
+
+        Process::swap(new Factory());
+        Process::preventStrayProcesses();
     }
 
     protected function tearDown(): void

--- a/packages/framework/tests/Unit/ServeCommandOptionsUnitTest.php
+++ b/packages/framework/tests/Unit/ServeCommandOptionsUnitTest.php
@@ -227,7 +227,7 @@ class ServeCommandOptionsUnitTest extends UnitTestCase
             {
             }
 
-            protected function openInBrowser(): void
+            protected function openInBrowser(string $path = '/'): void
             {
                 $this->openInBrowserCalled = true;
             }
@@ -304,7 +304,7 @@ class ServeCommandOptionsUnitTest extends UnitTestCase
  * @method getEnvironmentVariables
  * @method parseEnvironmentOption(string $name)
  * @method checkArgvForOption(string $name)
- * @method openInBrowser()
+ * @method openInBrowser(string $path = '/')
  */
 class ServeCommandMock extends ServeCommand
 {

--- a/packages/framework/tests/Unit/ServeCommandOptionsUnitTest.php
+++ b/packages/framework/tests/Unit/ServeCommandOptionsUnitTest.php
@@ -253,11 +253,7 @@ class ServeCommandOptionsUnitTest extends UnitTestCase
         $command = $this->getMock(['--open' => true]);
         $command->setOutput($output);
 
-        $binary = match (PHP_OS_FAMILY) {
-            'Darwin' => 'open',
-            'Windows' => 'start',
-            default => 'xdg-open',
-        };
+        $binary = $this->getTestRunnerBinary();
 
         Process::shouldReceive('command')->once()->with("$binary http://localhost:8080")->andReturnSelf();
         Process::shouldReceive('run')->once()->andReturnSelf();
@@ -281,11 +277,7 @@ class ServeCommandOptionsUnitTest extends UnitTestCase
         $command = $this->getMock(['--open' => true]);
         $command->setOutput($output);
 
-        $binary = match (PHP_OS_FAMILY) {
-            'Darwin' => 'open',
-            'Windows' => 'start',
-            default => 'xdg-open',
-        };
+        $binary = $this->getTestRunnerBinary();
 
         Process::shouldReceive('command')->once()->with("$binary http://localhost:8080")->andReturnSelf();
         Process::shouldReceive('run')->once()->andReturnSelf();
@@ -297,6 +289,15 @@ class ServeCommandOptionsUnitTest extends UnitTestCase
         Mockery::close();
 
         $this->assertTrue(true);
+    }
+
+    protected function getTestRunnerBinary(): string
+    {
+        return match (PHP_OS_FAMILY) {
+            'Darwin' => 'open',
+            'Windows' => 'start',
+            default => 'xdg-open',
+        };
     }
 
     protected function getMock(array $options = []): ServeCommandMock

--- a/packages/framework/tests/Unit/ServeCommandOptionsUnitTest.php
+++ b/packages/framework/tests/Unit/ServeCommandOptionsUnitTest.php
@@ -32,6 +32,8 @@ class ServeCommandOptionsUnitTest extends UnitTestCase
     {
         $this->addToAssertionCount(Mockery::getContainer()->mockery_getExpectationCount());
 
+        Mockery::close();
+
         parent::tearDown();
     }
 
@@ -285,10 +287,6 @@ class ServeCommandOptionsUnitTest extends UnitTestCase
         Process::shouldReceive('errorOutput')->once()->andReturn("Missing suitable 'open' binary.");
 
         $command->openInBrowser();
-
-        Mockery::close();
-
-        $this->assertTrue(true);
     }
 
     protected function getTestRunnerBinary(): string


### PR DESCRIPTION
**Pull Request Description:**

This pull request aims to enhance the functionality of the new realtime compiler by introducing a `--open` flag. With this addition, users will have the ability to specify the page to open upon server startup. The default page will remain as 'index', ensuring backward compatibility, while the `--open` flag offers users the flexibility to easily navigate to a different page.

**Example Usage:**
```bash
php hyde serve --open=dashboard
```

Executing the command above will result in the server opening `localhost:8080/dashboard` instead of the default `localhost:8080`. This feature enhancement aims to streamline user experience by providing a convenient method to set the initial page when launching the server.

It fixes https://github.com/hydephp/develop/issues/1504