### PR TITLE
.gitattributes: substitute CRLF only in text files

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,4 +1,4 @@
-* text eol=lf
+* text=auto eol=lf
 
 *.blade.php diff=html
 *.css diff=css


### PR DESCRIPTION
Changing CRLF to LF makes sense for text files, but not images, where doing so can lead to file corruption. This commit tells Git to ignore binary files and only do the substitution in plain text files.

Fixes hydephp/hyde#239.