### PR TITLE
Honour front matter navigation groups set in front matter regardless of subdirectory setting

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -15,7 +15,7 @@ This serves two purposes:
 - You can now specify which path to open when using the `--open` option in the serve command in https://github.com/hydephp/develop/pull/1694
 
 ### Changed
-- for changes in existing functionality.
+- When a navigation group is set in front matter, it will now be used regardless of the subdirectory configuration in https://github.com/hydephp/develop/pull/1703 (fixes https://github.com/hydephp/develop/issues/1515)
 
 ### Deprecated
 - for soon-to-be removed features.
@@ -24,7 +24,7 @@ This serves two purposes:
 - for now removed features.
 
 ### Fixed
-- for any bug fixes.
+- Fixed explicitly set front matter navigation group behavior being dependent on subdirectory configuration, fixing https://github.com/hydephp/develop/issues/1515 in https://github.com/hydephp/develop/pull/1703
 
 ### Security
 - in case of vulnerabilities.

--- a/packages/framework/src/Framework/Factories/NavigationDataFactory.php
+++ b/packages/framework/src/Framework/Factories/NavigationDataFactory.php
@@ -84,10 +84,6 @@ class NavigationDataFactory extends Concerns\PageDataFactory implements Navigati
             return $this->getSubdirectoryName();
         }
 
-        if ($this->matter->has('navigation.group')) {
-            return $this->getMatter('navigation.group');
-        }
-
         return $this->searchForGroupInFrontMatter() ?? $this->defaultGroup();
     }
 

--- a/packages/framework/src/Framework/Factories/NavigationDataFactory.php
+++ b/packages/framework/src/Framework/Factories/NavigationDataFactory.php
@@ -84,6 +84,10 @@ class NavigationDataFactory extends Concerns\PageDataFactory implements Navigati
             return $this->getSubdirectoryName();
         }
 
+        if ($this->matter->has('navigation.group')) {
+            return $this->getMatter('navigation.group');
+        }
+
         return $this->searchForGroupInFrontMatter() ?? $this->defaultGroup();
     }
 

--- a/packages/framework/src/Framework/Features/Navigation/NavigationMenu.php
+++ b/packages/framework/src/Framework/Features/Navigation/NavigationMenu.php
@@ -11,6 +11,8 @@ use BadMethodCallException;
 
 class NavigationMenu extends BaseNavigationMenu
 {
+    private bool $hasDropdowns;
+
     protected function generate(): void
     {
         parent::generate();
@@ -74,7 +76,7 @@ class NavigationMenu extends BaseNavigationMenu
 
     protected function hasGroupExplicitlySetInFrontMatter(): bool
     {
-        return $this->items->contains(function (NavItem $item): bool {
+        return $this->hasDropdowns ??= $this->items->contains(function (NavItem $item): bool {
             return $item->getGroup() !== null && $item->destination !== (string) DocumentationPage::home();
         });
     }

--- a/packages/framework/src/Framework/Features/Navigation/NavigationMenu.php
+++ b/packages/framework/src/Framework/Features/Navigation/NavigationMenu.php
@@ -69,7 +69,7 @@ class NavigationMenu extends BaseNavigationMenu
 
     protected function dropdownsEnabled(): bool
     {
-        return Config::getString('hyde.navigation.subdirectories', 'hidden') === 'dropdown' || $this->hasGroupExplicitlySetInFrontMatter();
+        return (Config::getString('hyde.navigation.subdirectories', 'hidden') === 'dropdown') || $this->hasGroupExplicitlySetInFrontMatter();
     }
 
     protected function hasGroupExplicitlySetInFrontMatter(): bool

--- a/packages/framework/src/Framework/Features/Navigation/NavigationMenu.php
+++ b/packages/framework/src/Framework/Features/Navigation/NavigationMenu.php
@@ -75,7 +75,7 @@ class NavigationMenu extends BaseNavigationMenu
     protected function hasGroupExplicitlySetInFrontMatter(): bool
     {
         return $this->items->contains(function (NavItem $item): bool {
-            return $item->getGroup() !== null;
+            return $item->getGroup() !== null && $item->destination !== (string) DocumentationPage::home();
         });
     }
 }

--- a/packages/framework/src/Framework/Features/Navigation/NavigationMenu.php
+++ b/packages/framework/src/Framework/Features/Navigation/NavigationMenu.php
@@ -71,4 +71,11 @@ class NavigationMenu extends BaseNavigationMenu
     {
         return Config::getString('hyde.navigation.subdirectories', 'hidden') === 'dropdown';
     }
+
+    protected function hasGroupExplicitlySetInFrontMatter(): bool
+    {
+        return $this->items->contains(function (NavItem $item): bool {
+            return $item->getGroup() !== null;
+        });
+    }
 }

--- a/packages/framework/src/Framework/Features/Navigation/NavigationMenu.php
+++ b/packages/framework/src/Framework/Features/Navigation/NavigationMenu.php
@@ -69,7 +69,7 @@ class NavigationMenu extends BaseNavigationMenu
 
     protected function dropdownsEnabled(): bool
     {
-        return Config::getString('hyde.navigation.subdirectories', 'hidden') === 'dropdown';
+        return Config::getString('hyde.navigation.subdirectories', 'hidden') === 'dropdown' || $this->hasGroupExplicitlySetInFrontMatter();
     }
 
     protected function hasGroupExplicitlySetInFrontMatter(): bool

--- a/packages/framework/src/Framework/Features/Navigation/NavigationMenu.php
+++ b/packages/framework/src/Framework/Features/Navigation/NavigationMenu.php
@@ -77,7 +77,7 @@ class NavigationMenu extends BaseNavigationMenu
     private function hasGroupExplicitlySetInFrontMatter(): bool
     {
         return $this->hasDropdowns ??= $this->items->contains(function (NavItem $item): bool {
-            return $item->getGroup() !== null && $item->destination !== (string) DocumentationPage::home();
+            return ($item->getGroup() !== null) && ($item->destination !== (string) DocumentationPage::home());
         });
     }
 }

--- a/packages/framework/src/Framework/Features/Navigation/NavigationMenu.php
+++ b/packages/framework/src/Framework/Features/Navigation/NavigationMenu.php
@@ -74,7 +74,7 @@ class NavigationMenu extends BaseNavigationMenu
         return (Config::getString('hyde.navigation.subdirectories', 'hidden') === 'dropdown') || $this->hasGroupExplicitlySetInFrontMatter();
     }
 
-    protected function hasGroupExplicitlySetInFrontMatter(): bool
+    private function hasGroupExplicitlySetInFrontMatter(): bool
     {
         return $this->hasDropdowns ??= $this->items->contains(function (NavItem $item): bool {
             return $item->getGroup() !== null && $item->destination !== (string) DocumentationPage::home();

--- a/packages/framework/tests/Feature/NavigationMenuTest.php
+++ b/packages/framework/tests/Feature/NavigationMenuTest.php
@@ -383,4 +383,39 @@ class NavigationMenuTest extends TestCase
 
         $this->assertSame(['Foo', 'Bar', 'Baz'], $dropdowns[0]->getItems()->pluck('label')->toArray());
     }
+
+    public function testHasDropdownsReturnsTrueWhenGroupIsExplicitlySetInFrontMatter()
+    {
+        config(['hyde.navigation.subdirectories' => 'hidden']);
+        $page = new MarkdownPage('foo', matter: ['navigation.group' => 'test-group']);
+
+        Routes::addRoute($page->getRoute());
+        $menu = NavigationMenu::create();
+
+        $this->assertTrue($menu->hasDropdowns());
+    }
+
+    public function testGetDropdownsReturnsCorrectArrayWhenGroupIsExplicitlySetInFrontMatter()
+    {
+        config(['hyde.navigation.subdirectories' => 'hidden']);
+
+        Routes::addRoute((new MarkdownPage('foo', matter: ['navigation.group' => 'test-group']))->getRoute());
+        $menu = NavigationMenu::create();
+        $this->assertCount(1, $menu->getDropdowns());
+
+        $this->assertEquals([
+            DropdownNavItem::fromArray('test-group', [
+                NavItem::fromRoute((new MarkdownPage('foo'))->getRoute()),
+            ]),
+        ], $menu->getDropdowns());
+    }
+
+    public function testHasDropdownsReturnsFalseWhenGroupIsNotExplicitlySetInFrontMatter()
+    {
+        config(['hyde.navigation.subdirectories' => 'hidden']);
+
+        Routes::addRoute((new MarkdownPage('foo'))->getRoute());
+        $menu = NavigationMenu::create();
+        $this->assertFalse($menu->hasDropdowns());
+    }
 }

--- a/packages/framework/tests/Feature/NavigationMenuTest.php
+++ b/packages/framework/tests/Feature/NavigationMenuTest.php
@@ -387,12 +387,10 @@ class NavigationMenuTest extends TestCase
     public function testHasDropdownsReturnsTrueWhenGroupIsExplicitlySetInFrontMatter()
     {
         config(['hyde.navigation.subdirectories' => 'hidden']);
-        $page = new MarkdownPage('foo', matter: ['navigation.group' => 'test-group']);
 
-        Routes::addRoute($page->getRoute());
-        $menu = NavigationMenu::create();
+        Routes::addRoute((new MarkdownPage('foo', matter: ['navigation.group' => 'test-group']))->getRoute());
 
-        $this->assertTrue($menu->hasDropdowns());
+        $this->assertTrue(NavigationMenu::create()->hasDropdowns());
     }
 
     public function testGetDropdownsReturnsCorrectArrayWhenGroupIsExplicitlySetInFrontMatter()
@@ -400,6 +398,7 @@ class NavigationMenuTest extends TestCase
         config(['hyde.navigation.subdirectories' => 'hidden']);
 
         Routes::addRoute((new MarkdownPage('foo', matter: ['navigation.group' => 'test-group']))->getRoute());
+
         $menu = NavigationMenu::create();
         $this->assertCount(1, $menu->getDropdowns());
 

--- a/packages/framework/tests/Unit/NavigationDataFactoryUnitTest.php
+++ b/packages/framework/tests/Unit/NavigationDataFactoryUnitTest.php
@@ -146,6 +146,36 @@ class NavigationDataFactoryUnitTest extends UnitTestCase
         $this->assertSame(502, $factory->makePriority());
     }
 
+    public function testMakeGroupUsesFrontMatterGroupIfSet()
+    {
+        $frontMatter = new FrontMatter(['navigation.group' => 'Test Group']);
+        $coreDataObject = new CoreDataObject($frontMatter, new Markdown(), MarkdownPage::class, 'test.md', '', '', '');
+        $factory = new NavigationConfigTestClass($coreDataObject);
+
+        $this->assertSame('Test Group', $factory->makeGroup());
+    }
+
+    public function testMakeGroupUsesFrontMatterGroupIfSetRegardlessOfSubdirectoryConfiguration()
+    {
+        self::mockConfig(['hyde.navigation.subdirectories' => 'hidden']);
+
+        $frontMatter = new FrontMatter(['navigation.group' => 'Test Group']);
+        $coreDataObject = new CoreDataObject($frontMatter, new Markdown(), MarkdownPage::class, 'test.md', '', '', '');
+        $factory = new NavigationConfigTestClass($coreDataObject);
+
+        $this->assertSame('Test Group', $factory->makeGroup());
+    }
+
+    public function testMakeGroupDefaultsToNullIfFrontMatterGroupNotSetAndSubdirectoriesNotUsed()
+    {
+        self::mockConfig(['hyde.navigation.subdirectories' => 'hidden']);
+
+        $coreDataObject = new CoreDataObject(new FrontMatter(), new Markdown(), MarkdownPage::class, 'test.md', '', '', '');
+        $factory = new NavigationConfigTestClass($coreDataObject);
+
+        $this->assertNull($factory->makeGroup());
+    }
+
     protected function makeCoreDataObject(string $identifier = '', string $routeKey = '', string $pageClass = MarkdownPage::class): CoreDataObject
     {
         return new CoreDataObject(new FrontMatter(), new Markdown(), $pageClass, $identifier, '', '', $routeKey);
@@ -162,5 +192,10 @@ class NavigationConfigTestClass extends NavigationDataFactory
     public function makePriority(): int
     {
         return parent::makePriority();
+    }
+
+    public function makeGroup(): ?string
+    {
+        return parent::makeGroup();
     }
 }


### PR DESCRIPTION
This pull request fixes #1515, which concerns the inconsistency in navigation group behavior when setting navigation groups for standard pages in front matter alongside the dropdown subdirectory setting in the configuration file.

Using the following in `_pages/page.md` will now cause the page to be put in the appropriate dropdown regardless of the `hyde.navigation.subdirectories` setting. This better follows the principle of least astonishment as setting the front matter is an explicit instruction to HydePHP.

```markdown
---
navigation.group: My Group
---