### PR TITLE
[2.x] Calling the `Include::path()` method will no longer create the directory

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -23,6 +23,8 @@ This serves two purposes:
 - The `hasFeature` method on the Hyde facade and HydeKernel now only accepts a Feature enum value instead of a string for its parameter.
 - Changed how the documentation search is generated, to be an `InMemoryPage` instead of a post-build task.
 - Media asset files are now copied using the new build task instead of the deprecated `BuildService::transferMediaAssets()` method.
+- Calling the `Include::path()` method will no longer create the includes directory in https://github.com/hydephp/develop/pull/1707
+
 
 ### Deprecated
 - for soon-to-be removed features.

--- a/packages/framework/src/Support/Includes.php
+++ b/packages/framework/src/Support/Includes.php
@@ -7,7 +7,6 @@ namespace Hyde\Support;
 use Hyde\Hyde;
 use Hyde\Markdown\Models\Markdown;
 use Illuminate\Support\Facades\Blade;
-use Hyde\Framework\Concerns\InteractsWithDirectories;
 
 use function basename;
 use function file_exists;
@@ -20,8 +19,6 @@ use function file_get_contents;
  */
 class Includes
 {
-    use InteractsWithDirectories;
-
     /**
      * @var string The directory where includes are stored.
      */
@@ -35,8 +32,6 @@ class Includes
      */
     public static function path(?string $filename = null): string
     {
-        static::needsDirectory(static::$includesDirectory);
-
         return $filename === null
             ? Hyde::path(static::$includesDirectory)
             : Hyde::path(static::$includesDirectory.'/'.$filename);

--- a/packages/framework/tests/Feature/IncludesFacadeTest.php
+++ b/packages/framework/tests/Feature/IncludesFacadeTest.php
@@ -15,6 +15,20 @@ use Illuminate\Support\Facades\File;
  */
 class IncludesFacadeTest extends TestCase
 {
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        File::makeDirectory(Includes::path(), recursive: true);
+    }
+
+    public function tearDown(): void
+    {
+        File::deleteDirectory(Includes::path());
+
+        parent::tearDown();
+    }
+
     public function testPathReturnsTheIncludesDirectory()
     {
         $this->assertSame(
@@ -29,14 +43,6 @@ class IncludesFacadeTest extends TestCase
             Hyde::path('resources/includes/partial.html'),
             Includes::path('partial.html')
         );
-    }
-
-    public function testPathCreatesDirectoryIfItDoesNotExist()
-    {
-        $path = Includes::path();
-        File::deleteDirectory($path);
-        $this->assertFalse(File::exists($path));
-        $this->assertTrue(File::exists(Includes::path()));
     }
 
     public function testGetReturnsPartial()

--- a/packages/framework/tests/Feature/IncludesFacadeTest.php
+++ b/packages/framework/tests/Feature/IncludesFacadeTest.php
@@ -8,7 +8,6 @@ use Hyde\Facades\Filesystem;
 use Hyde\Support\Includes;
 use Hyde\Hyde;
 use Hyde\Testing\TestCase;
-use Illuminate\Support\Facades\File;
 
 /**
  * @covers \Hyde\Support\Includes
@@ -19,14 +18,7 @@ class IncludesFacadeTest extends TestCase
     {
         parent::setUp();
 
-        File::makeDirectory(Includes::path(), recursive: true);
-    }
-
-    public function tearDown(): void
-    {
-        File::deleteDirectory(Includes::path());
-
-        parent::tearDown();
+        $this->directory('resources/includes');
     }
 
     public function testPathReturnsTheIncludesDirectory()


### PR DESCRIPTION
It feels weird that this creates the directory, and it violates the principle of least astonishment as it's surprising that this creates a directory when you just request the path. Fixes https://github.com/hydephp/develop/issues/1706