### PR TITLE
[2.x] Support automatic navigation priorities by prefixing a number in filenames

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -10,6 +10,7 @@ This serves two purposes:
 2. At release time, you can move the Unreleased section changes into a new release version section.
 
 ### Added
+- You can now specify navigation priorities by adding a numeric prefix to the source file names in https://github.com/hydephp/develop/pull/1709
 - Added a new `\Hyde\Framework\Actions\PreBuildTasks\TransferMediaAssets` build task handle media assets transfers for site builds.
 - The `\Hyde\Facades\Features` class is no longer marked as internal, and is now thus part of the public API.
 

--- a/docs/digging-deeper/navigation.md
+++ b/docs/digging-deeper/navigation.md
@@ -327,6 +327,30 @@ Here are some things to keep in mind, especially if you mix numerical prefix ord
    - For example: `_pages/01-home.md` and `_pages/01_home.md` are both valid.
 3. The leading zeroes are optional, so `_pages/1-home.md` is also valid.
 
+### Using numerical prefix ordering in subdirectories
+
+The numerical prefix ordering feature works great when using the automatic subdirectory-based grouping for navigation menu dropdowns and documentation sidebar categories.
+
+This integration has two main features to consider:
+1. You can use numerical prefixes in subdirectories to control the order of dropdowns.
+2. The ordering within a subdirectory works independently of its siblings, so you can start from one in each subdirectory.
+
+Here is an example structure of how you may want to organize a documentation site:
+
+```shell
+_docs/
+  01-getting-started/
+    01-installation.md
+    02-requirements.md
+    03-configuration.md
+  02-usage/
+    01-quick-start.md
+    02-advanced-usage.md
+  03-features/
+    01-feature-1.md
+    02-feature-2.md
+```
+
 ### Customization
 
 You can disable this feature by setting the `numerical_page_ordering` setting to `false` in the `hyde.php` config file. Hyde will then no longer extract the priority and will no longer strip the prefix from the route key.

--- a/docs/digging-deeper/navigation.md
+++ b/docs/digging-deeper/navigation.md
@@ -306,18 +306,26 @@ HydePHP v2 introduces a new feature that allows navigation items to be ordered b
 This is a great way to control the ordering of pages in both the primary navigation menu and the documentation sidebar, 
 as your file structure will match the order of the pages in the navigation menus.
 
-For example, the following will have the same order in the navigation menu as well as the file structure (assuming you sort files by name):
+For example, the following will have the same order in the navigation menu as in a file explorer:
 
-```
+```shell
 _pages/
-  01-home.md # Gets priority 1, putting it first
-  02-about.md # Gets priority 2, putting it second
-  03-contact.md # Gets priority 3, putting it third
+  01-home.md # Gets priority 1, putting it first (will be saved to _site/index.html)
+  02-about.md # Gets priority 2, putting it second (will be saved to _site/about.html)
+  03-contact.md # Gets priority 3, putting it third (will be saved to _site/contact.html)
 ```
 
 Hyde will then parse the number from the filename and use it as the priority for the page in the navigation menus.
 
->info Remember, that while Hyde in general retains the source file names when creating route keys and thus output file names, Hyde will in this case strip the numerical prefix from the route key so your URLs will not contain the numerical prefix.
+### Keep in mind
+
+Here are some things to keep in mind, especially if you mix numerical prefix ordering with other ordering methods:
+
+1. The numerical prefix will still be part of the page identifier, but it will be stripped from the route key.
+   - For example: `_pages/01-home.md` will have the route key `home` and the page identifier `01-home`.
+2. You can delimit the numerical prefix with either a dash or an underscore.
+   - For example: `_pages/01-home.md` and `_pages/01_home.md` are both valid.
+3. The leading zeroes are optional, so `_pages/1-home.md` is also valid.
 
 ### Customization
 

--- a/docs/digging-deeper/navigation.md
+++ b/docs/digging-deeper/navigation.md
@@ -300,6 +300,37 @@ Here are some things to keep in mind when using dropdown menus, regardless of th
 - Dropdowns take priority over standard items. So if you have a dropdown with the key `about` and a page with the key `about`, the dropdown will be created, and the page won't be in the menu.
   - For example: With this file structure: `_pages/foo.md`, `_pages/foo/bar.md`, `_pages/foo/baz.md`, the link to `foo` will be lost.
 
+## Numerical Prefix Navigation Ordering
+
+HydePHP v2 introduces a new feature that allows navigation items to be ordered based on a numerical prefix in the filename.
+This is a great way to control the ordering of pages in both the primary navigation menu and the documentation sidebar, 
+as your file structure will match the order of the pages in the navigation menus.
+
+For example, the following will have the same order in the navigation menu as well as the file structure (assuming you sort files by name):
+
+```
+_pages/
+  01-home.md # Gets priority 1, putting it first
+  02-about.md # Gets priority 2, putting it second
+  03-contact.md # Gets priority 3, putting it third
+```
+
+Hyde will then parse the number from the filename and use it as the priority for the page in the navigation menus.
+
+>info Remember, that while Hyde in general retains the source file names when creating route keys and thus output file names, Hyde will in this case strip the numerical prefix from the route key so your URLs will not contain the numerical prefix.
+
+### Customization
+
+You can disable this feature by setting the `numerical_page_ordering` setting to `false` in the `hyde.php` config file. Hyde will then no longer extract the priority and will no longer strip the prefix from the route key.
+
+```php
+// filepath config/hyde.php
+
+'numerical_page_ordering' => false,
+```
+
+While it's not recommended, as you lose out on the convenience of the automatic ordering, any front matter priority settings will override the numerical prefix ordering if you for some reason need to.
+
 ## Digging Deeper into the internals
 
 While not required to know, you may find it interesting to learn more about how the navigation is handled internally. Here is a high level overview,

--- a/docs/digging-deeper/navigation.md
+++ b/docs/digging-deeper/navigation.md
@@ -298,12 +298,12 @@ For example: `_docs/getting-started/installation.md` will be placed in a group c
 
 Here are some things to keep in mind when using dropdown menus, regardless of the configuration:
 - Dropdowns take priority over standard items. So if you have a dropdown with the key `about` and a page with the key `about`, the dropdown will be created, and the page won't be in the menu.
-  - For example: With this file structure: `_pages/foo.md`, `_pages/foo/bar.md`, `_pages/foo/baz.md`, the link to `foo` will be lost.
+    - For example: With this file structure: `_pages/foo.md`, `_pages/foo/bar.md`, `_pages/foo/baz.md`, the link to `foo` will be lost.
 
 ## Numerical Prefix Navigation Ordering
 
 HydePHP v2 introduces a new feature that allows navigation items to be ordered based on a numerical prefix in the filename.
-This is a great way to control the ordering of pages in both the primary navigation menu and the documentation sidebar, 
+This is a great way to control the ordering of pages in both the primary navigation menu and the documentation sidebar,
 as your file structure will match the order of the pages in the navigation menus.
 
 For example, the following will have the same order in the navigation menu as in a file explorer:
@@ -322,9 +322,9 @@ Hyde will then parse the number from the filename and use it as the priority for
 Here are some things to keep in mind, especially if you mix numerical prefix ordering with other ordering methods:
 
 1. The numerical prefix will still be part of the page identifier, but it will be stripped from the route key.
-   - For example: `_pages/01-home.md` will have the route key `home` and the page identifier `01-home`.
+    - For example: `_pages/01-home.md` will have the route key `home` and the page identifier `01-home`.
 2. You can delimit the numerical prefix with either a dash or an underscore.
-   - For example: `_pages/01-home.md` and `_pages/01_home.md` are both valid.
+    - For example: `_pages/01-home.md` and `_pages/01_home.md` are both valid.
 3. The leading zeroes are optional, so `_pages/1-home.md` is also valid.
 
 ### Using numerical prefix ordering in subdirectories

--- a/packages/framework/src/Framework/Factories/NavigationDataFactory.php
+++ b/packages/framework/src/Framework/Factories/NavigationDataFactory.php
@@ -251,7 +251,7 @@ class NavigationDataFactory extends Concerns\PageDataFactory implements Navigati
             return null;
         }
 
-        return null;
+        return FilenamePrefixNavigationHelper::splitNumberAndIdentifier($this->identifier)[0];
     }
 
     private function canUseSubdirectoryForGroups(): bool

--- a/packages/framework/src/Framework/Factories/NavigationDataFactory.php
+++ b/packages/framework/src/Framework/Factories/NavigationDataFactory.php
@@ -97,6 +97,7 @@ class NavigationDataFactory extends Concerns\PageDataFactory implements Navigati
     {
         return $this->searchForPriorityInFrontMatter()
             ?? $this->searchForPriorityInConfigs()
+            ?? $this->checkFilePrefixForOrder()
             ?? NavigationMenu::LAST;
     }
 
@@ -237,6 +238,11 @@ class NavigationDataFactory extends Concerns\PageDataFactory implements Navigati
         }
 
         return $config[$pageKey] ?? null;
+    }
+
+    private function checkFilePrefixForOrder(): ?int
+    {
+        return null;
     }
 
     private function canUseSubdirectoryForGroups(): bool

--- a/packages/framework/src/Framework/Factories/NavigationDataFactory.php
+++ b/packages/framework/src/Framework/Factories/NavigationDataFactory.php
@@ -247,6 +247,10 @@ class NavigationDataFactory extends Concerns\PageDataFactory implements Navigati
             return null;
         }
 
+        if (! FilenamePrefixNavigationHelper::isIdentifierNumbered($this->identifier)) {
+            return null;
+        }
+
         return null;
     }
 

--- a/packages/framework/src/Framework/Factories/NavigationDataFactory.php
+++ b/packages/framework/src/Framework/Factories/NavigationDataFactory.php
@@ -12,6 +12,7 @@ use Hyde\Markdown\Models\FrontMatter;
 use Hyde\Framework\Factories\Concerns\CoreDataObject;
 use Hyde\Framework\Features\Navigation\NavigationMenu;
 use Hyde\Markdown\Contracts\FrontMatter\SubSchemas\NavigationSchema;
+use Hyde\Framework\Features\Navigation\FilenamePrefixNavigationHelper;
 
 use function basename;
 use function array_flip;
@@ -242,6 +243,10 @@ class NavigationDataFactory extends Concerns\PageDataFactory implements Navigati
 
     private function checkFilePrefixForOrder(): ?int
     {
+        if (! FilenamePrefixNavigationHelper::enabled()) {
+            return null;
+        }
+
         return null;
     }
 

--- a/packages/framework/src/Framework/Features/Navigation/FilenamePrefixNavigationHelper.php
+++ b/packages/framework/src/Framework/Features/Navigation/FilenamePrefixNavigationHelper.php
@@ -57,7 +57,7 @@ class FilenamePrefixNavigationHelper
         $parts[0] = (int) $parts[0];
 
         if (isset($parentPath)) {
-            $parts[1] = $parentPath . '/' . $parts[1];
+            $parts[1] = $parentPath.'/'.$parts[1];
         }
 
         return $parts;

--- a/packages/framework/src/Framework/Features/Navigation/FilenamePrefixNavigationHelper.php
+++ b/packages/framework/src/Framework/Features/Navigation/FilenamePrefixNavigationHelper.php
@@ -68,17 +68,17 @@ class FilenamePrefixNavigationHelper
         return str_contains($identifier, '/');
     }
 
-    protected static function getCoreIdentifierPart(string $identifier): string
-    {
-        assert(self::isIdentifierNested($identifier));
-
-        return Str::afterLast($identifier, '/');
-    }
-
     protected static function getNestedIdentifierPrefix(string $identifier): string
     {
         assert(self::isIdentifierNested($identifier));
 
         return Str::beforeLast($identifier, '/');
+    }
+
+    protected static function getCoreIdentifierPart(string $identifier): string
+    {
+        assert(self::isIdentifierNested($identifier));
+
+        return Str::afterLast($identifier, '/');
     }
 }

--- a/packages/framework/src/Framework/Features/Navigation/FilenamePrefixNavigationHelper.php
+++ b/packages/framework/src/Framework/Features/Navigation/FilenamePrefixNavigationHelper.php
@@ -53,4 +53,11 @@ class FilenamePrefixNavigationHelper
     {
         return str_contains($identifier, '/');
     }
+
+    protected static function getCoreIdentifierPart(string $identifier): string
+    {
+        assert(self::isIdentifierNested($identifier));
+
+        return explode('/', $identifier)[1];
+    }
 }

--- a/packages/framework/src/Framework/Features/Navigation/FilenamePrefixNavigationHelper.php
+++ b/packages/framework/src/Framework/Features/Navigation/FilenamePrefixNavigationHelper.php
@@ -30,6 +30,10 @@ class FilenamePrefixNavigationHelper
      */
     public static function isIdentifierNumbered(string $identifier): bool
     {
+        if (self::isIdentifierNested($identifier)) {
+            $identifier = self::getCoreIdentifierPart($identifier);
+        }
+
         return preg_match('/^\d+-/', $identifier) === 1;
     }
 

--- a/packages/framework/src/Framework/Features/Navigation/FilenamePrefixNavigationHelper.php
+++ b/packages/framework/src/Framework/Features/Navigation/FilenamePrefixNavigationHelper.php
@@ -48,4 +48,9 @@ class FilenamePrefixNavigationHelper
 
         return $parts;
     }
+
+    protected static function isIdentifierNested(string $identifier): bool
+    {
+        return str_contains($identifier, '/');
+    }
 }

--- a/packages/framework/src/Framework/Features/Navigation/FilenamePrefixNavigationHelper.php
+++ b/packages/framework/src/Framework/Features/Navigation/FilenamePrefixNavigationHelper.php
@@ -60,4 +60,11 @@ class FilenamePrefixNavigationHelper
 
         return explode('/', $identifier)[1];
     }
+
+    protected static function getNestedIdentifierPrefix(string $identifier): string
+    {
+        assert(self::isIdentifierNested($identifier));
+
+        return explode('/', $identifier)[0];
+    }
 }

--- a/packages/framework/src/Framework/Features/Navigation/FilenamePrefixNavigationHelper.php
+++ b/packages/framework/src/Framework/Features/Navigation/FilenamePrefixNavigationHelper.php
@@ -55,6 +55,10 @@ class FilenamePrefixNavigationHelper
 
         $parts[0] = (int) $parts[0];
 
+        if (isset($parentPath)) {
+            $parts[1] = $parentPath . '/' . $parts[1];
+        }
+
         return $parts;
     }
 

--- a/packages/framework/src/Framework/Features/Navigation/FilenamePrefixNavigationHelper.php
+++ b/packages/framework/src/Framework/Features/Navigation/FilenamePrefixNavigationHelper.php
@@ -23,7 +23,7 @@ class FilenamePrefixNavigationHelper
      */
     public static function enabled(): bool
     {
-        return Config::getBool('hyde.filename_page_ordering', true);
+        return Config::getBool('hyde.numerical_page_ordering', true);
     }
 
     /**

--- a/packages/framework/src/Framework/Features/Navigation/FilenamePrefixNavigationHelper.php
+++ b/packages/framework/src/Framework/Features/Navigation/FilenamePrefixNavigationHelper.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Hyde\Framework\Features\Navigation;
 
 use Hyde\Facades\Config;
+use Illuminate\Support\Str;
 
 use function assert;
 use function explode;
@@ -71,13 +72,13 @@ class FilenamePrefixNavigationHelper
     {
         assert(self::isIdentifierNested($identifier));
 
-        return explode('/', $identifier)[1];
+        return Str::afterLast($identifier, '/');
     }
 
     protected static function getNestedIdentifierPrefix(string $identifier): string
     {
         assert(self::isIdentifierNested($identifier));
 
-        return explode('/', $identifier)[0];
+        return Str::beforeLast($identifier, '/');
     }
 }

--- a/packages/framework/src/Framework/Features/Navigation/FilenamePrefixNavigationHelper.php
+++ b/packages/framework/src/Framework/Features/Navigation/FilenamePrefixNavigationHelper.php
@@ -44,6 +44,11 @@ class FilenamePrefixNavigationHelper
      */
     public static function splitNumberAndIdentifier(string $identifier): array
     {
+        if (self::isIdentifierNested($identifier)) {
+            $parentPath = self::getNestedIdentifierPrefix($identifier);
+            $identifier = self::getCoreIdentifierPart($identifier);
+        }
+
         assert(self::isIdentifierNumbered($identifier));
 
         $parts = explode('-', $identifier, 2);

--- a/packages/framework/src/Pages/DocumentationPage.php
+++ b/packages/framework/src/Pages/DocumentationPage.php
@@ -70,7 +70,7 @@ class DocumentationPage extends BaseMarkdownPage
     public function getRouteKey(): string
     {
         return Config::getBool('docs.flattened_output_paths', true)
-            ? unslash(static::outputDirectory().'/'.basename($this->identifier))
+            ? unslash(static::outputDirectory().'/'.basename(parent::getRouteKey()))
             : parent::getRouteKey();
     }
 

--- a/packages/framework/tests/Feature/FilenamePrefixNavigationPriorityTest.php
+++ b/packages/framework/tests/Feature/FilenamePrefixNavigationPriorityTest.php
@@ -102,7 +102,7 @@ class FilenamePrefixNavigationPriorityTest extends TestCase
 
     public function test_fixtureFlatMain_ordering()
     {
-        $pages = $this->setUpFixture($this->fixtureFlatMain());
+        $this->setUpFixture($this->fixtureFlatMain());
 
         $this->assertOrder(['home', 'about', 'contact']);
     }

--- a/packages/framework/tests/Feature/FilenamePrefixNavigationPriorityTest.php
+++ b/packages/framework/tests/Feature/FilenamePrefixNavigationPriorityTest.php
@@ -147,6 +147,7 @@ class FilenamePrefixNavigationPriorityTest extends TestCase
     protected function assertOrder(array $expected): void
     {
         $menu = NavigationMenuGenerator::handle(MainNavigationMenu::class);
+
         $actual = $menu->getItems()->mapWithKeys(function (NavigationItem|NavigationGroup $item, int $key): array {
             if ($item instanceof NavigationGroup) {
                 return [$item->getGroupKey() => $item->getItems()->map(function (NavigationItem $item): string {

--- a/packages/framework/tests/Feature/FilenamePrefixNavigationPriorityTest.php
+++ b/packages/framework/tests/Feature/FilenamePrefixNavigationPriorityTest.php
@@ -304,7 +304,7 @@ class FilenamePrefixNavigationPriorityTestingHelper
 
     protected function setupFixtureItem(string $class, string $file): void
     {
-        $page = new $class(basename($file, '.md'), [], $this->generateMarkdown($file));
+        $page = new $class(Str::before($file, '.'), [], $this->generateMarkdown($file));
         Hyde::pages()->addPage($page);
         Hyde::routes()->addRoute($page->getRoute());
     }
@@ -313,7 +313,7 @@ class FilenamePrefixNavigationPriorityTestingHelper
     {
         foreach ($files as $file) {
             $group = str($key)->after('-');
-            $page = new $class($group.'/'.basename($file, '.md'), [], $this->generateMarkdown($file));
+            $page = new $class($group.'/'.Str::before($file, '.'), [], $this->generateMarkdown($file));
             Hyde::pages()->addPage($page);
             Hyde::routes()->addRoute($page->getRoute());
         }

--- a/packages/framework/tests/Feature/FilenamePrefixNavigationPriorityTest.php
+++ b/packages/framework/tests/Feature/FilenamePrefixNavigationPriorityTest.php
@@ -9,6 +9,7 @@ use Hyde\Facades\Config;
 use Hyde\Testing\TestCase;
 use Hyde\Pages\MarkdownPage;
 use Hyde\Framework\Features\Navigation\NavigationItem;
+use Hyde\Framework\Features\Navigation\NavigationGroup;
 use Hyde\Framework\Features\Navigation\MainNavigationMenu;
 use Hyde\Framework\Features\Navigation\NavigationMenuGenerator;
 
@@ -144,7 +145,10 @@ class FilenamePrefixNavigationPriorityTest extends TestCase
     protected function assertOrder(array $expected): void
     {
         $menu = NavigationMenuGenerator::handle(MainNavigationMenu::class);
-        $actual = $menu->getItems()->map(function (NavigationItem $item) {
+        $actual = $menu->getItems()->map(function (NavigationItem|NavigationGroup $item) {
+            if ($item instanceof NavigationGroup) {
+                return $item->getItems()->map(fn ($item) => $item->getPage()->getRouteKey())->all();
+            }
             return $item->getPage()->getRouteKey();
         })->all();
 

--- a/packages/framework/tests/Feature/FilenamePrefixNavigationPriorityTest.php
+++ b/packages/framework/tests/Feature/FilenamePrefixNavigationPriorityTest.php
@@ -240,7 +240,7 @@ class FilenamePrefixNavigationPriorityTest extends TestCase
         ];
     }
 
-    public function fixtureFileExtensions(): array
+    protected function fixtureFileExtensions(): array
     {
         return [
             '01-foo.md',

--- a/packages/framework/tests/Feature/FilenamePrefixNavigationPriorityTest.php
+++ b/packages/framework/tests/Feature/FilenamePrefixNavigationPriorityTest.php
@@ -115,7 +115,7 @@ class FilenamePrefixNavigationPriorityTest extends TestCase
         $this->assertOrder(['home', 'about', 'contact']);
     }
 
-    protected function setUpFixture(array $files): array
+    protected function setUpFixture(array $files): self
     {
         foreach ($files as $file) {
             $page = new MarkdownPage(basename($file, '.md'), markdown: '# '.str($file)->after('-')->before('.')->ucfirst()."\n\nHello, world!\n");
@@ -123,7 +123,7 @@ class FilenamePrefixNavigationPriorityTest extends TestCase
             Hyde::routes()->addRoute($page->getRoute());
         }
 
-        return MarkdownPage::all()->all();
+        return $this;
     }
 
     /** @param array<string> $expected */

--- a/packages/framework/tests/Feature/FilenamePrefixNavigationPriorityTest.php
+++ b/packages/framework/tests/Feature/FilenamePrefixNavigationPriorityTest.php
@@ -151,6 +151,7 @@ class FilenamePrefixNavigationPriorityTest extends TestCase
             if ($item instanceof NavigationGroup) {
                 return $item->getItems()->map(fn ($item) => $item->getPage()->getRouteKey())->all();
             }
+
             return $item->getPage()->getRouteKey();
         })->all();
 

--- a/packages/framework/tests/Feature/FilenamePrefixNavigationPriorityTest.php
+++ b/packages/framework/tests/Feature/FilenamePrefixNavigationPriorityTest.php
@@ -90,7 +90,9 @@ class FilenamePrefixNavigationPriorityTest extends TestCase
     protected function setUpFixture(array $files): array
     {
         foreach ($files as $file) {
-            Hyde::pages()->addPage(new MarkdownPage(basename($file, '.md'), markdown: '# '.str($file)->after('-')->before('.')->ucfirst()."\n\nHello, world!\n"));
+            $page = new MarkdownPage(basename($file, '.md'), markdown: '# '.str($file)->after('-')->before('.')->ucfirst()."\n\nHello, world!\n");
+            Hyde::pages()->addPage($page);
+            Hyde::routes()->addRoute($page->getRoute());
         }
 
         return MarkdownPage::all()->all();

--- a/packages/framework/tests/Feature/FilenamePrefixNavigationPriorityTest.php
+++ b/packages/framework/tests/Feature/FilenamePrefixNavigationPriorityTest.php
@@ -22,6 +22,8 @@ use Hyde\Framework\Features\Navigation\NavigationMenuGenerator;
  * @covers \Hyde\Framework\Features\Navigation\MainNavigationMenu
  * @covers \Hyde\Framework\Features\Navigation\DocumentationSidebar
  * @covers \Hyde\Support\Models\RouteKey // Todo: Update the unit test for this class.
+ *
+ * Todo: Add test to ensure explicitly set priority overrides filename prefix.
  */
 class FilenamePrefixNavigationPriorityTest extends TestCase
 {

--- a/packages/framework/tests/Feature/FilenamePrefixNavigationPriorityTest.php
+++ b/packages/framework/tests/Feature/FilenamePrefixNavigationPriorityTest.php
@@ -103,6 +103,8 @@ class FilenamePrefixNavigationPriorityTest extends TestCase
     public function test_fixtureFlatMain_ordering()
     {
         $pages = $this->setUpFixture($this->fixtureFlatMain());
+
+        $this->assertOrder($pages, ['home', 'about', 'contact']);
     }
 
     protected function setUpFixture(array $files): array

--- a/packages/framework/tests/Feature/FilenamePrefixNavigationPriorityTest.php
+++ b/packages/framework/tests/Feature/FilenamePrefixNavigationPriorityTest.php
@@ -8,6 +8,9 @@ use Hyde\Hyde;
 use Hyde\Facades\Config;
 use Hyde\Testing\TestCase;
 use Hyde\Pages\MarkdownPage;
+use Hyde\Framework\Features\Navigation\NavigationItem;
+use Hyde\Framework\Features\Navigation\MainNavigationMenu;
+use Hyde\Framework\Features\Navigation\NavigationMenuGenerator;
 
 /**
  * High level test for the feature that allows navigation items to be sorted by filename prefix.
@@ -111,6 +114,18 @@ class FilenamePrefixNavigationPriorityTest extends TestCase
         }
 
         return MarkdownPage::all()->all();
+    }
+
+    /**
+     * @param array<\Hyde\Pages\Concerns\HydePage> $pages
+     * @param array<string> $expected
+     */
+    protected function assertOrder(array $pages, array $expected): void
+    {
+        $menu = NavigationMenuGenerator::handle(MainNavigationMenu::class);
+        $actual = $menu->getItems()->map(fn (NavigationItem $item) => $item->getPage()->getRouteKey())->all();
+
+        $this->assertSame($expected, $actual);
     }
 
     protected function fixtureFlatMain(): array

--- a/packages/framework/tests/Feature/FilenamePrefixNavigationPriorityTest.php
+++ b/packages/framework/tests/Feature/FilenamePrefixNavigationPriorityTest.php
@@ -156,12 +156,11 @@ class FilenamePrefixNavigationPriorityTest extends TestCase
     {
         $this->setUpSidebarFixture($this->fixtureGroupedSidebar());
 
-        $this->assertSidebarOrder(['other' => ['readme', 'installation', 'getting-started'],
-        'introduction' => [
-            'general', 'resources', 'requirements',
-        ], 'advanced' => [
-            'features', 'extensions', 'configuration',
-        ]]);
+        $this->assertSidebarOrder([
+            'other' => ['readme', 'installation', 'getting-started'],
+            'introduction' => ['general', 'resources', 'requirements'],
+            'advanced' => ['features', 'extensions', 'configuration'],
+        ]);
     }
 
     protected function setUpSidebarFixture(array $files): self

--- a/packages/framework/tests/Feature/FilenamePrefixNavigationPriorityTest.php
+++ b/packages/framework/tests/Feature/FilenamePrefixNavigationPriorityTest.php
@@ -149,7 +149,9 @@ class FilenamePrefixNavigationPriorityTest extends TestCase
         $menu = NavigationMenuGenerator::handle(MainNavigationMenu::class);
         $actual = $menu->getItems()->mapWithKeys(function (NavigationItem|NavigationGroup $item, int $key) {
             if ($item instanceof NavigationGroup) {
-                return [$item->getGroupKey() => $item->getItems()->map(fn ($item) => $item->getPage()->getRouteKey())->all()];
+                return [$item->getGroupKey() => $item->getItems()->map(function ($item) {
+                    return $item->getPage()->getRouteKey();
+                })->all()];
             }
 
             return [$key => $item->getPage()->getRouteKey()];

--- a/packages/framework/tests/Feature/FilenamePrefixNavigationPriorityTest.php
+++ b/packages/framework/tests/Feature/FilenamePrefixNavigationPriorityTest.php
@@ -104,7 +104,7 @@ class FilenamePrefixNavigationPriorityTest extends TestCase
     {
         $pages = $this->setUpFixture($this->fixtureFlatMain());
 
-        $this->assertOrder($pages, ['home', 'about', 'contact']);
+        $this->assertOrder(['home', 'about', 'contact']);
     }
 
     protected function setUpFixture(array $files): array
@@ -119,10 +119,9 @@ class FilenamePrefixNavigationPriorityTest extends TestCase
     }
 
     /**
-     * @param array<\Hyde\Pages\Concerns\HydePage> $pages
      * @param array<string> $expected
      */
-    protected function assertOrder(array $pages, array $expected): void
+    protected function assertOrder(array $expected): void
     {
         $menu = NavigationMenuGenerator::handle(MainNavigationMenu::class);
         $actual = $menu->getItems()->map(fn (NavigationItem $item) => $item->getPage()->getRouteKey())->all();

--- a/packages/framework/tests/Feature/FilenamePrefixNavigationPriorityTest.php
+++ b/packages/framework/tests/Feature/FilenamePrefixNavigationPriorityTest.php
@@ -25,6 +25,8 @@ use Hyde\Framework\Features\Navigation\NavigationMenuGenerator;
  * @covers \Hyde\Framework\Factories\NavigationDataFactory // Todo: Update the unit test for this class.
  * @covers \Hyde\Support\Models\RouteKey // Todo: Update the unit test for this class.
  *
+ * @see \Hyde\Framework\Testing\Unit\FilenamePrefixNavigationPriorityUnitTest
+ *
  * Todo: Add test to ensure explicitly set priority overrides filename prefix.
  */
 class FilenamePrefixNavigationPriorityTest extends TestCase

--- a/packages/framework/tests/Feature/FilenamePrefixNavigationPriorityTest.php
+++ b/packages/framework/tests/Feature/FilenamePrefixNavigationPriorityTest.php
@@ -157,7 +157,7 @@ class FilenamePrefixNavigationPriorityTest extends TestCase
         $this->setUpSidebarFixture($this->fixtureGroupedSidebar());
 
         $this->assertSidebarOrder(['readme', 'installation', 'getting-started', 'introduction' => [
-            'features', 'extensions', 'configuration',
+            'general', 'resources', 'requirements',
         ], 'advanced' => [
             'features', 'extensions', 'configuration',
         ]]);
@@ -254,9 +254,9 @@ class FilenamePrefixNavigationPriorityTest extends TestCase
             '02-installation.md',
             '03-getting-started.md',
             '04-introduction' => [
-                '01-features.md',
-                '02-extensions.md',
-                '03-configuration.md',
+                '01-general.md',
+                '02-resources.md',
+                '03-requirements.md',
             ],
             '05-advanced' => [
                 '01-features.md',

--- a/packages/framework/tests/Feature/FilenamePrefixNavigationPriorityTest.php
+++ b/packages/framework/tests/Feature/FilenamePrefixNavigationPriorityTest.php
@@ -7,6 +7,7 @@ namespace Hyde\Framework\Testing\Feature;
 use Hyde\Hyde;
 use Hyde\Facades\Config;
 use Hyde\Testing\TestCase;
+use Illuminate\Support\Str;
 use Hyde\Pages\MarkdownPage;
 use Hyde\Framework\Features\Navigation\NavigationItem;
 use Hyde\Framework\Features\Navigation\NavigationGroup;
@@ -150,7 +151,7 @@ class FilenamePrefixNavigationPriorityTest extends TestCase
         $actual = $menu->getItems()->mapWithKeys(function (NavigationItem|NavigationGroup $item, int $key) {
             if ($item instanceof NavigationGroup) {
                 return [$item->getGroupKey() => $item->getItems()->map(function ($item) {
-                    return $item->getPage()->getRouteKey();
+                    return Str::afterLast($item->getPage()->getRouteKey(), '/');
                 })->all()];
             }
 

--- a/packages/framework/tests/Feature/FilenamePrefixNavigationPriorityTest.php
+++ b/packages/framework/tests/Feature/FilenamePrefixNavigationPriorityTest.php
@@ -156,7 +156,8 @@ class FilenamePrefixNavigationPriorityTest extends TestCase
     {
         $this->setUpSidebarFixture($this->fixtureGroupedSidebar());
 
-        $this->assertSidebarOrder(['readme', 'installation', 'getting-started', 'introduction' => [
+        $this->assertSidebarOrder(['other' => ['readme', 'installation', 'getting-started'],
+        'introduction' => [
             'general', 'resources', 'requirements',
         ], 'advanced' => [
             'features', 'extensions', 'configuration',

--- a/packages/framework/tests/Feature/FilenamePrefixNavigationPriorityTest.php
+++ b/packages/framework/tests/Feature/FilenamePrefixNavigationPriorityTest.php
@@ -118,9 +118,7 @@ class FilenamePrefixNavigationPriorityTest extends TestCase
         return MarkdownPage::all()->all();
     }
 
-    /**
-     * @param array<string> $expected
-     */
+    /** @param array<string> $expected */
     protected function assertOrder(array $expected): void
     {
         $menu = NavigationMenuGenerator::handle(MainNavigationMenu::class);

--- a/packages/framework/tests/Feature/FilenamePrefixNavigationPriorityTest.php
+++ b/packages/framework/tests/Feature/FilenamePrefixNavigationPriorityTest.php
@@ -82,6 +82,11 @@ class FilenamePrefixNavigationPriorityTest extends TestCase
         $this->assertSame("$identifier.html", $page->getOutputPath());
     }
 
+    public function test_fixtureFlatMain_ordering()
+    {
+        $pages = $this->setUpFixture($this->fixtureFlatMain());
+    }
+
     protected function setUpFixture(array $files): array
     {
         foreach ($files as $file) {

--- a/packages/framework/tests/Feature/FilenamePrefixNavigationPriorityTest.php
+++ b/packages/framework/tests/Feature/FilenamePrefixNavigationPriorityTest.php
@@ -123,6 +123,15 @@ class FilenamePrefixNavigationPriorityTest extends TestCase
         $this->assertOrder(['home', 'about', 'contact']);
     }
 
+    public function test_fixtureGroupedMain_ordering()
+    {
+        $this->setUpFixture($this->fixtureGroupedMain());
+
+        $this->assertOrder(['home', 'about', 'contact', 'api' => [
+            'readme', 'installation', 'getting-started',
+        ]]);
+    }
+
     protected function setUpFixture(array $files): self
     {
         foreach ($files as $key => $file) {

--- a/packages/framework/tests/Feature/FilenamePrefixNavigationPriorityTest.php
+++ b/packages/framework/tests/Feature/FilenamePrefixNavigationPriorityTest.php
@@ -85,7 +85,7 @@ class FilenamePrefixNavigationPriorityTest extends TestCase
     protected function setUpFixture(array $files): array
     {
         foreach ($files as $file) {
-            Hyde::pages()->addPage(new MarkdownPage(basename($file, '.md')));
+            Hyde::pages()->addPage(new MarkdownPage(basename($file, '.md'), markdown: '# '.str($file)->after('-')->before('.')->ucfirst()."\n\nHello, world!\n"));
         }
 
         return MarkdownPage::all()->all();

--- a/packages/framework/tests/Feature/FilenamePrefixNavigationPriorityTest.php
+++ b/packages/framework/tests/Feature/FilenamePrefixNavigationPriorityTest.php
@@ -142,6 +142,24 @@ class FilenamePrefixNavigationPriorityTest extends TestCase
         ]]);
     }
 
+    public function test_fixtureFlatSidebar_ordering()
+    {
+        $this->setUpFixture($this->fixtureFlatSidebar());
+
+        $this->assertOrder(['readme', 'installation', 'getting-started']);
+    }
+
+    public function test_fixtureGroupedSidebar_ordering()
+    {
+        $this->setUpFixture($this->fixtureGroupedSidebar());
+
+        $this->assertOrder(['readme', 'installation', 'getting-started', 'introduction' => [
+            'features', 'extensions', 'configuration',
+        ], 'advanced' => [
+            'features', 'extensions', 'configuration',
+        ]]);
+    }
+
     protected function setUpFixture(array $files): self
     {
         foreach ($files as $key => $file) {

--- a/packages/framework/tests/Feature/FilenamePrefixNavigationPriorityTest.php
+++ b/packages/framework/tests/Feature/FilenamePrefixNavigationPriorityTest.php
@@ -122,10 +122,19 @@ class FilenamePrefixNavigationPriorityTest extends TestCase
 
     protected function setUpFixture(array $files): self
     {
-        foreach ($files as $file) {
-            $page = new MarkdownPage(basename($file, '.md'), markdown: '# '.str($file)->after('-')->before('.')->ucfirst()."\n\nHello, world!\n");
-            Hyde::pages()->addPage($page);
-            Hyde::routes()->addRoute($page->getRoute());
+        foreach ($files as $key => $file) {
+            if (is_string($file)) {
+                $page = new MarkdownPage(basename($file, '.md'), markdown: '# '.str($file)->after('-')->before('.')->ucfirst()."\n\nHello, world!\n");
+                Hyde::pages()->addPage($page);
+                Hyde::routes()->addRoute($page->getRoute());
+            } else {
+                foreach ($file as $child) {
+                    $group = str($key)->after('-');
+                    $page = new MarkdownPage($group.'/'.basename($child, '.md'), markdown: '# '.str($child)->after('-')->before('.')->ucfirst()."\n\nHello, world!\n");
+                    Hyde::pages()->addPage($page);
+                    Hyde::routes()->addRoute($page->getRoute());
+                }
+            }
         }
 
         return $this;

--- a/packages/framework/tests/Feature/FilenamePrefixNavigationPriorityTest.php
+++ b/packages/framework/tests/Feature/FilenamePrefixNavigationPriorityTest.php
@@ -89,6 +89,7 @@ class FilenamePrefixNavigationPriorityTest extends TestCase
 
     protected function setUpFixture(array $files): array
     {
+        // Todo: Replace kernel with mock class
         $this->withoutDefaultPages();
 
         foreach ($files as $file) {

--- a/packages/framework/tests/Feature/FilenamePrefixNavigationPriorityTest.php
+++ b/packages/framework/tests/Feature/FilenamePrefixNavigationPriorityTest.php
@@ -132,6 +132,16 @@ class FilenamePrefixNavigationPriorityTest extends TestCase
         ]]);
     }
 
+    public function test_fixtureGroupedMain_reverse_ordering()
+    {
+        // Also a sanity check but for the inner group as well.
+        $this->setUpFixture($this->arrayReverseRecursive($this->fixtureGroupedMain()));
+
+        $this->assertOrder(['home', 'about', 'contact', 'api' => [
+            'readme', 'installation', 'getting-started',
+        ]]);
+    }
+
     protected function setUpFixture(array $files): self
     {
         foreach ($files as $key => $file) {

--- a/packages/framework/tests/Feature/FilenamePrefixNavigationPriorityTest.php
+++ b/packages/framework/tests/Feature/FilenamePrefixNavigationPriorityTest.php
@@ -84,7 +84,7 @@ class FilenamePrefixNavigationPriorityTest extends TestCase
 
     public function testSourceFilesDoNotHaveTheirNumericalPrefixTrimmedFromRouteKeysWhenFeatureIsDisabled()
     {
-        Config::set('hyde.filename_page_ordering', false);
+        Config::set('hyde.numerical_page_ordering', false);
 
         $this->file('_pages/01-home.md');
 

--- a/packages/framework/tests/Feature/FilenamePrefixNavigationPriorityTest.php
+++ b/packages/framework/tests/Feature/FilenamePrefixNavigationPriorityTest.php
@@ -113,7 +113,7 @@ class FilenamePrefixNavigationPriorityTest extends TestCase
         $this->assertSame("$identifier.html", $page->getOutputPath());
     }
 
-    public function test_fixtureFlatMain_ordering()
+    public function testFlatMainNavigationOrdering()
     {
         $this->setupFixture([
             '01-home.md',
@@ -124,7 +124,7 @@ class FilenamePrefixNavigationPriorityTest extends TestCase
         $this->assertOrder(['home', 'about', 'contact']);
     }
 
-    public function test_fixtureFlatMain_reverse_ordering()
+    public function testReverseOrderOfFlatMainNavigation()
     {
         // This is just a sanity check to make sure the helper is working, so we only need one of these.
         $this->setupFixture(array_reverse([
@@ -136,7 +136,7 @@ class FilenamePrefixNavigationPriorityTest extends TestCase
         $this->assertOrder(['home', 'about', 'contact']);
     }
 
-    public function test_fixtureGroupedMain_ordering()
+    public function testGroupedMainNavigationOrdering()
     {
         $this->setupFixture([
             '01-home.md',
@@ -154,7 +154,7 @@ class FilenamePrefixNavigationPriorityTest extends TestCase
         ]]);
     }
 
-    public function test_fixtureGroupedMain_reverse_ordering()
+    public function testReverseOrderOfGroupedMainNavigation()
     {
         // Also a sanity check but for the inner group as well.
         $this->setupFixture($this->arrayReverseRecursive([
@@ -173,7 +173,7 @@ class FilenamePrefixNavigationPriorityTest extends TestCase
         ]]);
     }
 
-    public function test_fixtureFlatSidebar_ordering()
+    public function testFlatSidebarNavigationOrdering()
     {
         $this->setUpSidebarFixture([
             '01-readme.md',
@@ -184,7 +184,7 @@ class FilenamePrefixNavigationPriorityTest extends TestCase
         $this->assertSidebarOrder(['readme', 'installation', 'getting-started']);
     }
 
-    public function test_fixtureGroupedSidebar_ordering()
+    public function testGroupedSidebarNavigationOrdering()
     {
         $this->setUpSidebarFixture([
             '01-readme.md',
@@ -209,7 +209,7 @@ class FilenamePrefixNavigationPriorityTest extends TestCase
         ]);
     }
 
-    public function test_fixturePrefixSyntaxes_ordering()
+    public function testDifferentPrefixSyntaxesOrdering()
     {
         $fixtures = [
             [
@@ -240,7 +240,7 @@ class FilenamePrefixNavigationPriorityTest extends TestCase
         }
     }
 
-    public function test_fixtureFileExtensions_ordering()
+    public function testOrderingWithDifferentFileExtensions()
     {
         $this->setupFixture([
             '01-foo.md',

--- a/packages/framework/tests/Feature/FilenamePrefixNavigationPriorityTest.php
+++ b/packages/framework/tests/Feature/FilenamePrefixNavigationPriorityTest.php
@@ -89,6 +89,8 @@ class FilenamePrefixNavigationPriorityTest extends TestCase
 
     protected function setUpFixture(array $files): array
     {
+        $this->withoutDefaultPages();
+
         foreach ($files as $file) {
             $page = new MarkdownPage(basename($file, '.md'), markdown: '# '.str($file)->after('-')->before('.')->ucfirst()."\n\nHello, world!\n");
             Hyde::pages()->addPage($page);

--- a/packages/framework/tests/Feature/FilenamePrefixNavigationPriorityTest.php
+++ b/packages/framework/tests/Feature/FilenamePrefixNavigationPriorityTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Hyde\Framework\Testing\Feature;
 
+use Hyde\Hyde;
 use Hyde\Facades\Config;
 use Hyde\Testing\TestCase;
 use Hyde\Pages\MarkdownPage;
@@ -84,7 +85,7 @@ class FilenamePrefixNavigationPriorityTest extends TestCase
     protected function setUpFixture(array $files): array
     {
         foreach ($files as $file) {
-            $this->file("_pages/$file");
+            Hyde::pages()->addPage(new MarkdownPage(basename($file, '.md')));
         }
 
         return MarkdownPage::all()->all();

--- a/packages/framework/tests/Feature/FilenamePrefixNavigationPriorityTest.php
+++ b/packages/framework/tests/Feature/FilenamePrefixNavigationPriorityTest.php
@@ -144,7 +144,9 @@ class FilenamePrefixNavigationPriorityTest extends TestCase
     protected function assertOrder(array $expected): void
     {
         $menu = NavigationMenuGenerator::handle(MainNavigationMenu::class);
-        $actual = $menu->getItems()->map(fn (NavigationItem $item) => $item->getPage()->getRouteKey())->all();
+        $actual = $menu->getItems()->map(function (NavigationItem $item) {
+            return $item->getPage()->getRouteKey();
+        })->all();
 
         $this->assertSame($expected, $actual);
     }

--- a/packages/framework/tests/Feature/FilenamePrefixNavigationPriorityTest.php
+++ b/packages/framework/tests/Feature/FilenamePrefixNavigationPriorityTest.php
@@ -107,6 +107,14 @@ class FilenamePrefixNavigationPriorityTest extends TestCase
         $this->assertOrder(['home', 'about', 'contact']);
     }
 
+    public function test_fixtureFlatMain_reverse_ordering()
+    {
+        // This is just a sanity check to make sure the helper is working, so we only need one of these.
+        $this->setUpFixture(array_reverse($this->fixtureFlatMain()));
+
+        $this->assertOrder(['home', 'about', 'contact']);
+    }
+
     protected function setUpFixture(array $files): array
     {
         foreach ($files as $file) {

--- a/packages/framework/tests/Feature/FilenamePrefixNavigationPriorityTest.php
+++ b/packages/framework/tests/Feature/FilenamePrefixNavigationPriorityTest.php
@@ -7,7 +7,6 @@ namespace Hyde\Framework\Testing\Feature;
 use Hyde\Hyde;
 use Hyde\Facades\Config;
 use Hyde\Testing\TestCase;
-use Illuminate\Support\Str;
 use Hyde\Pages\MarkdownPage;
 use Hyde\Framework\Features\Navigation\NavigationItem;
 use Hyde\Framework\Features\Navigation\NavigationGroup;
@@ -151,7 +150,7 @@ class FilenamePrefixNavigationPriorityTest extends TestCase
         $actual = $menu->getItems()->mapWithKeys(function (NavigationItem|NavigationGroup $item, int $key) {
             if ($item instanceof NavigationGroup) {
                 return [$item->getGroupKey() => $item->getItems()->map(function ($item) {
-                    return Str::afterLast($item->getPage()->getRouteKey(), '/');
+                    return basename($item->getPage()->getRouteKey());
                 })->all()];
             }
 

--- a/packages/framework/tests/Feature/FilenamePrefixNavigationPriorityTest.php
+++ b/packages/framework/tests/Feature/FilenamePrefixNavigationPriorityTest.php
@@ -147,9 +147,9 @@ class FilenamePrefixNavigationPriorityTest extends TestCase
     protected function assertOrder(array $expected): void
     {
         $menu = NavigationMenuGenerator::handle(MainNavigationMenu::class);
-        $actual = $menu->getItems()->mapWithKeys(function (NavigationItem|NavigationGroup $item, int $key) {
+        $actual = $menu->getItems()->mapWithKeys(function (NavigationItem|NavigationGroup $item, int $key): array {
             if ($item instanceof NavigationGroup) {
-                return [$item->getGroupKey() => $item->getItems()->map(function ($item) {
+                return [$item->getGroupKey() => $item->getItems()->map(function (NavigationItem $item): string {
                     return basename($item->getPage()->getRouteKey());
                 })->all()];
             }

--- a/packages/framework/tests/Feature/FilenamePrefixNavigationPriorityTest.php
+++ b/packages/framework/tests/Feature/FilenamePrefixNavigationPriorityTest.php
@@ -21,6 +21,7 @@ use Hyde\Framework\Features\Navigation\NavigationMenuGenerator;
  * @covers \Hyde\Framework\Features\Navigation\FilenamePrefixNavigationHelper
  * @covers \Hyde\Framework\Features\Navigation\MainNavigationMenu
  * @covers \Hyde\Framework\Features\Navigation\DocumentationSidebar
+ * @covers \Hyde\Framework\Factories\NavigationDataFactory // Todo: Update the unit test for this class.
  * @covers \Hyde\Support\Models\RouteKey // Todo: Update the unit test for this class.
  *
  * Todo: Add test to ensure explicitly set priority overrides filename prefix.

--- a/packages/framework/tests/Feature/FilenamePrefixNavigationPriorityTest.php
+++ b/packages/framework/tests/Feature/FilenamePrefixNavigationPriorityTest.php
@@ -115,7 +115,11 @@ class FilenamePrefixNavigationPriorityTest extends TestCase
 
     public function test_fixtureFlatMain_ordering()
     {
-        $this->setupFixture($this->fixtureFlatMain());
+        $this->setupFixture([
+            '01-home.md',
+            '02-about.md',
+            '03-contact.md',
+        ]);
 
         $this->assertOrder(['home', 'about', 'contact']);
     }
@@ -123,14 +127,27 @@ class FilenamePrefixNavigationPriorityTest extends TestCase
     public function test_fixtureFlatMain_reverse_ordering()
     {
         // This is just a sanity check to make sure the helper is working, so we only need one of these.
-        $this->setupFixture(array_reverse($this->fixtureFlatMain()));
+        $this->setupFixture(array_reverse([
+            '01-home.md',
+            '02-about.md',
+            '03-contact.md',
+        ]));
 
         $this->assertOrder(['home', 'about', 'contact']);
     }
 
     public function test_fixtureGroupedMain_ordering()
     {
-        $this->setupFixture($this->fixtureGroupedMain());
+        $this->setupFixture([
+            '01-home.md',
+            '02-about.md',
+            '03-contact.md',
+            '04-api' => [
+                '01-readme.md',
+                '02-installation.md',
+                '03-getting-started.md',
+            ],
+        ]);
 
         $this->assertOrder(['home', 'about', 'contact', 'api' => [
             'readme', 'installation', 'getting-started',
@@ -140,7 +157,16 @@ class FilenamePrefixNavigationPriorityTest extends TestCase
     public function test_fixtureGroupedMain_reverse_ordering()
     {
         // Also a sanity check but for the inner group as well.
-        $this->setupFixture($this->arrayReverseRecursive($this->fixtureGroupedMain()));
+        $this->setupFixture($this->arrayReverseRecursive([
+            '01-home.md',
+            '02-about.md',
+            '03-contact.md',
+            '04-api' => [
+                '01-readme.md',
+                '02-installation.md',
+                '03-getting-started.md',
+            ],
+        ]));
 
         $this->assertOrder(['home', 'about', 'contact', 'api' => [
             'readme', 'installation', 'getting-started',
@@ -149,14 +175,32 @@ class FilenamePrefixNavigationPriorityTest extends TestCase
 
     public function test_fixtureFlatSidebar_ordering()
     {
-        $this->setUpSidebarFixture($this->fixtureFlatSidebar());
+        $this->setUpSidebarFixture([
+            '01-readme.md',
+            '02-installation.md',
+            '03-getting-started.md',
+        ]);
 
         $this->assertSidebarOrder(['readme', 'installation', 'getting-started']);
     }
 
     public function test_fixtureGroupedSidebar_ordering()
     {
-        $this->setUpSidebarFixture($this->fixtureGroupedSidebar());
+        $this->setUpSidebarFixture([
+            '01-readme.md',
+            '02-installation.md',
+            '03-getting-started.md',
+            '04-introduction' => [
+                '01-general.md',
+                '02-resources.md',
+                '03-requirements.md',
+            ],
+            '05-advanced' => [
+                '01-features.md',
+                '02-extensions.md',
+                '03-configuration.md',
+            ],
+        ]);
 
         $this->assertSidebarOrder([
             'other' => ['readme', 'installation', 'getting-started'],
@@ -167,13 +211,29 @@ class FilenamePrefixNavigationPriorityTest extends TestCase
 
     public function test_fixturePrefixSyntaxes_ordering()
     {
-        foreach ($this->fixturePrefixSyntaxes() as $fixture) {
+        $fixtures = [
+            [
+                '1-foo.md',
+                '2-bar.md',
+                '3-baz.md',
+            ], [
+                '01-foo.md',
+                '02-bar.md',
+                '03-baz.md',
+            ], [
+                '001-foo.md',
+                '002-bar.md',
+                '003-baz.md',
+            ],
+        ];
+
+        foreach ($fixtures as $fixture) {
             $this->setupFixture($fixture);
 
             $this->assertOrder(['foo', 'bar', 'baz']);
         }
 
-        foreach ($this->fixturePrefixSyntaxes() as $fixture) {
+        foreach ($fixtures as $fixture) {
             $this->setupFixture(array_reverse($fixture));
 
             $this->assertOrder(['foo', 'bar', 'baz']);
@@ -182,7 +242,11 @@ class FilenamePrefixNavigationPriorityTest extends TestCase
 
     public function test_fixtureFileExtensions_ordering()
     {
-        $this->setupFixture($this->fixtureFileExtensions());
+        $this->setupFixture([
+            '01-foo.md',
+            '02-bar.html',
+            '03-baz.blade.php',
+        ]);
 
         $this->assertOrder(['foo', 'bar', 'baz']);
     }
@@ -209,85 +273,6 @@ class FilenamePrefixNavigationPriorityTest extends TestCase
         $actual = $this->helper->createComparisonFormat($sidebar);
 
         $this->assertSame($expected, $actual);
-    }
-
-    protected function fixtureFlatMain(): array
-    {
-        return [
-            '01-home.md',
-            '02-about.md',
-            '03-contact.md',
-        ];
-    }
-
-    protected function fixtureGroupedMain(): array
-    {
-        return [
-            '01-home.md',
-            '02-about.md',
-            '03-contact.md',
-            '04-api' => [
-                '01-readme.md',
-                '02-installation.md',
-                '03-getting-started.md',
-            ],
-        ];
-    }
-
-    protected function fixtureFlatSidebar(): array
-    {
-        return [
-            '01-readme.md',
-            '02-installation.md',
-            '03-getting-started.md',
-        ];
-    }
-
-    protected function fixtureGroupedSidebar(): array
-    {
-        return [
-            '01-readme.md',
-            '02-installation.md',
-            '03-getting-started.md',
-            '04-introduction' => [
-                '01-general.md',
-                '02-resources.md',
-                '03-requirements.md',
-            ],
-            '05-advanced' => [
-                '01-features.md',
-                '02-extensions.md',
-                '03-configuration.md',
-            ],
-        ];
-    }
-
-    protected function fixturePrefixSyntaxes(): array
-    {
-        return [
-            [
-                '1-foo.md',
-                '2-bar.md',
-                '3-baz.md',
-            ], [
-                '01-foo.md',
-                '02-bar.md',
-                '03-baz.md',
-            ], [
-                '001-foo.md',
-                '002-bar.md',
-                '003-baz.md',
-            ],
-        ];
-    }
-
-    protected function fixtureFileExtensions(): array
-    {
-        return [
-            '01-foo.md',
-            '02-bar.html',
-            '03-baz.blade.php',
-        ];
     }
 
     protected function arrayReverseRecursive(array $array): array

--- a/packages/framework/tests/Feature/FilenamePrefixNavigationPriorityTest.php
+++ b/packages/framework/tests/Feature/FilenamePrefixNavigationPriorityTest.php
@@ -81,6 +81,15 @@ class FilenamePrefixNavigationPriorityTest extends TestCase
         $this->assertSame("$identifier.html", $page->getOutputPath());
     }
 
+    protected function setUpFixture(array $files): array
+    {
+        foreach ($files as $file) {
+            $this->file("_pages/$file");
+        }
+
+        return MarkdownPage::all()->all();
+    }
+
     protected function fixtureFlatMain(): array
     {
         return [

--- a/packages/framework/tests/Feature/FilenamePrefixNavigationPriorityTest.php
+++ b/packages/framework/tests/Feature/FilenamePrefixNavigationPriorityTest.php
@@ -248,4 +248,17 @@ class FilenamePrefixNavigationPriorityTest extends TestCase
             '03-baz.blade.php',
         ];
     }
+
+    protected function arrayReverseRecursive(array $array): array
+    {
+        $reversed = array_reverse($array);
+
+        foreach ($reversed as $key => $value) {
+            if (is_array($value)) {
+                $reversed[$key] = $this->arrayReverseRecursive($value);
+            }
+        }
+
+        return $reversed;
+    }
 }

--- a/packages/framework/tests/Feature/FilenamePrefixNavigationPriorityTest.php
+++ b/packages/framework/tests/Feature/FilenamePrefixNavigationPriorityTest.php
@@ -22,6 +22,21 @@ use Hyde\Pages\MarkdownPage;
  */
 class FilenamePrefixNavigationPriorityTest extends TestCase
 {
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        // Todo: Replace kernel with mock class
+        $this->withoutDefaultPages();
+    }
+
+    protected function tearDown(): void
+    {
+        $this->restoreDefaultPages();
+
+        parent::tearDown();
+    }
+
     public function testSourceFilesHaveTheirNumericalPrefixTrimmedFromRouteKeys()
     {
         $this->file('_pages/01-home.md');
@@ -89,9 +104,6 @@ class FilenamePrefixNavigationPriorityTest extends TestCase
 
     protected function setUpFixture(array $files): array
     {
-        // Todo: Replace kernel with mock class
-        $this->withoutDefaultPages();
-
         foreach ($files as $file) {
             $page = new MarkdownPage(basename($file, '.md'), markdown: '# '.str($file)->after('-')->before('.')->ucfirst()."\n\nHello, world!\n");
             Hyde::pages()->addPage($page);

--- a/packages/framework/tests/Feature/FilenamePrefixNavigationPriorityTest.php
+++ b/packages/framework/tests/Feature/FilenamePrefixNavigationPriorityTest.php
@@ -32,6 +32,8 @@ class FilenamePrefixNavigationPriorityTest extends TestCase
     {
         parent::setUp();
 
+        Config::set('hyde.navigation.subdirectories', 'dropdown');
+
         // Todo: Replace kernel with mock class
         $this->withoutDefaultPages();
     }

--- a/packages/framework/tests/Feature/FilenamePrefixNavigationPriorityTest.php
+++ b/packages/framework/tests/Feature/FilenamePrefixNavigationPriorityTest.php
@@ -165,6 +165,28 @@ class FilenamePrefixNavigationPriorityTest extends TestCase
         ]);
     }
 
+    public function test_fixturePrefixSyntaxes_ordering()
+    {
+        foreach ($this->fixturePrefixSyntaxes() as $fixture) {
+            $this->setupFixture($fixture);
+
+            $this->assertOrder(['foo', 'bar', 'baz']);
+        }
+
+        foreach ($this->fixturePrefixSyntaxes() as $fixture) {
+            $this->setupFixture(array_reverse($fixture));
+
+            $this->assertOrder(['foo', 'bar', 'baz']);
+        }
+    }
+
+    public function test_fixtureFileExtensions_ordering()
+    {
+        $this->setupFixture($this->fixtureFileExtensions());
+
+        $this->assertOrder(['foo', 'bar', 'baz']);
+    }
+
     protected function setUpSidebarFixture(array $files): self
     {
         return $this->setupFixture($files, sidebar: true);

--- a/packages/framework/tests/Feature/FilenamePrefixNavigationPriorityTest.php
+++ b/packages/framework/tests/Feature/FilenamePrefixNavigationPriorityTest.php
@@ -147,12 +147,12 @@ class FilenamePrefixNavigationPriorityTest extends TestCase
     protected function assertOrder(array $expected): void
     {
         $menu = NavigationMenuGenerator::handle(MainNavigationMenu::class);
-        $actual = $menu->getItems()->map(function (NavigationItem|NavigationGroup $item) {
+        $actual = $menu->getItems()->mapWithKeys(function (NavigationItem|NavigationGroup $item, int $key) {
             if ($item instanceof NavigationGroup) {
-                return $item->getItems()->map(fn ($item) => $item->getPage()->getRouteKey())->all();
+                return [$item->getGroupKey() => $item->getItems()->map(fn ($item) => $item->getPage()->getRouteKey())->all()];
             }
 
-            return $item->getPage()->getRouteKey();
+            return [$key => $item->getPage()->getRouteKey()];
         })->all();
 
         $this->assertSame($expected, $actual);

--- a/packages/framework/tests/Feature/Services/SitemapServiceTest.php
+++ b/packages/framework/tests/Feature/Services/SitemapServiceTest.php
@@ -30,7 +30,7 @@ class SitemapServiceTest extends TestCase
         copy(Hyde::vendorPath('resources/views/homepages/welcome.blade.php'), Hyde::path('_pages/index.blade.php'));
         copy(Hyde::vendorPath('resources/views/pages/404.blade.php'), Hyde::path('_pages/404.blade.php'));
 
-        Config::set(['hyde.filename_page_ordering' => false]);
+        Config::set(['hyde.numerical_page_ordering' => false]);
     }
 
     public function testServiceInstantiatesXmlElement()

--- a/packages/framework/tests/Unit/FilenamePrefixNavigationPriorityUnitTest.php
+++ b/packages/framework/tests/Unit/FilenamePrefixNavigationPriorityUnitTest.php
@@ -9,6 +9,8 @@ use Hyde\Framework\Features\Navigation\FilenamePrefixNavigationHelper;
 
 /**
  * @covers \Hyde\Framework\Features\Navigation\FilenamePrefixNavigationHelper
+ *
+ * @see \Hyde\Framework\Testing\Feature\FilenamePrefixNavigationPriorityTest
  */
 class FilenamePrefixNavigationPriorityUnitTest extends UnitTestCase
 {

--- a/packages/framework/tests/Unit/FilenamePrefixNavigationPriorityUnitTest.php
+++ b/packages/framework/tests/Unit/FilenamePrefixNavigationPriorityUnitTest.php
@@ -84,4 +84,25 @@ class FilenamePrefixNavigationPriorityUnitTest extends UnitTestCase
         $this->assertSame([2, 'foo/about.md'], FilenamePrefixNavigationHelper::splitNumberAndIdentifier('foo/02-about.md'));
         $this->assertSame([3, 'foo/contact.md'], FilenamePrefixNavigationHelper::splitNumberAndIdentifier('foo/03-contact.md'));
     }
+
+    public function testIdentifiersForDeeplyNestedPagesWithNumericalPrefixesAreDetected()
+    {
+        $this->assertTrue(FilenamePrefixNavigationHelper::isIdentifierNumbered('foo/bar/01-home.md'));
+        $this->assertTrue(FilenamePrefixNavigationHelper::isIdentifierNumbered('foo/bar/02-about.md'));
+        $this->assertTrue(FilenamePrefixNavigationHelper::isIdentifierNumbered('foo/bar/03-contact.md'));
+    }
+
+    public function testIdentifiersForDeeplyNestedPagesWithoutNumericalPrefixesAreNotDetected()
+    {
+        $this->assertFalse(FilenamePrefixNavigationHelper::isIdentifierNumbered('foo/bar/home.md'));
+        $this->assertFalse(FilenamePrefixNavigationHelper::isIdentifierNumbered('foo/bar/about.md'));
+        $this->assertFalse(FilenamePrefixNavigationHelper::isIdentifierNumbered('foo/bar/contact.md'));
+    }
+
+    public function testSplitNumberAndIdentifierForDeeplyNestedPages()
+    {
+        $this->assertSame([1, 'foo/bar/home.md'], FilenamePrefixNavigationHelper::splitNumberAndIdentifier('foo/bar/01-home.md'));
+        $this->assertSame([2, 'foo/bar/about.md'], FilenamePrefixNavigationHelper::splitNumberAndIdentifier('foo/bar/02-about.md'));
+        $this->assertSame([3, 'foo/bar/contact.md'], FilenamePrefixNavigationHelper::splitNumberAndIdentifier('foo/bar/03-contact.md'));
+    }
 }

--- a/packages/framework/tests/Unit/FilenamePrefixNavigationPriorityUnitTest.php
+++ b/packages/framework/tests/Unit/FilenamePrefixNavigationPriorityUnitTest.php
@@ -63,4 +63,25 @@ class FilenamePrefixNavigationPriorityUnitTest extends UnitTestCase
 
         FilenamePrefixNavigationHelper::splitNumberAndIdentifier('home.md');
     }
+
+    public function testIdentifiersForNestedPagesWithNumericalPrefixesAreDetected()
+    {
+        $this->assertTrue(FilenamePrefixNavigationHelper::isIdentifierNumbered('foo/01-home.md'));
+        $this->assertTrue(FilenamePrefixNavigationHelper::isIdentifierNumbered('foo/02-about.md'));
+        $this->assertTrue(FilenamePrefixNavigationHelper::isIdentifierNumbered('foo/03-contact.md'));
+    }
+
+    public function testIdentifiersForNestedPagesWithoutNumericalPrefixesAreNotDetected()
+    {
+        $this->assertFalse(FilenamePrefixNavigationHelper::isIdentifierNumbered('foo/home.md'));
+        $this->assertFalse(FilenamePrefixNavigationHelper::isIdentifierNumbered('foo/about.md'));
+        $this->assertFalse(FilenamePrefixNavigationHelper::isIdentifierNumbered('foo/contact.md'));
+    }
+
+    public function testSplitNumberAndIdentifierForNestedPages()
+    {
+        $this->assertSame([1, 'foo/home.md'], FilenamePrefixNavigationHelper::splitNumberAndIdentifier('foo/01-home.md'));
+        $this->assertSame([2, 'foo/about.md'], FilenamePrefixNavigationHelper::splitNumberAndIdentifier('foo/02-about.md'));
+        $this->assertSame([3, 'foo/contact.md'], FilenamePrefixNavigationHelper::splitNumberAndIdentifier('foo/03-contact.md'));
+    }
 }

--- a/packages/framework/tests/Unit/FilenamePrefixNavigationPriorityUnitTest.php
+++ b/packages/framework/tests/Unit/FilenamePrefixNavigationPriorityUnitTest.php
@@ -23,7 +23,7 @@ class FilenamePrefixNavigationPriorityUnitTest extends UnitTestCase
 
     public function testEnabledReturnsFalseWhenDisabled()
     {
-        self::mockConfig(['hyde.filename_page_ordering' => false]);
+        self::mockConfig(['hyde.numerical_page_ordering' => false]);
 
         $this->assertFalse(FilenamePrefixNavigationHelper::enabled());
     }


### PR DESCRIPTION
Fixes https://github.com/hydephp/develop/issues/1646

> When source filed are numbered like so (or using the most common convention)
> 
> ```
> 1_foo.md
> 2_bar.md
> 3_baz.md
> ```
> 
> That order should be used for their navigation priorities.
> 
> This makes large sites much cleaner as local file systems match the order of the results. Of course it should be possible to disable this as well.