### PR TITLE
Use late static bindings to support overriding data collections file finding

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -16,6 +16,8 @@ This serves two purposes:
 
 ### Changed
 - When a navigation group is set in front matter, it will now be used regardless of the subdirectory configuration in https://github.com/hydephp/develop/pull/1703 (fixes https://github.com/hydephp/develop/issues/1515)
+- Use late static bindings to support overriding data collections file finding in https://github.com/hydephp/develop/pull/1717 (fixes https://github.com/hydephp/develop/issues/1716)
+
 
 ### Deprecated
 - for soon-to-be removed features.
@@ -25,6 +27,7 @@ This serves two purposes:
 
 ### Fixed
 - Fixed explicitly set front matter navigation group behavior being dependent on subdirectory configuration, fixing https://github.com/hydephp/develop/issues/1515 in https://github.com/hydephp/develop/pull/1703
+- Fixed DataCollections file finding method not being able to be overriden https://github.com/hydephp/develop/issues/1716 in https://github.com/hydephp/develop/pull/1717
 
 ### Security
 - in case of vulnerabilities.

--- a/packages/framework/src/Support/DataCollections.php
+++ b/packages/framework/src/Support/DataCollections.php
@@ -51,7 +51,7 @@ class DataCollections extends Collection
     {
         static::needsDirectory(static::$sourceDirectory);
 
-        return new static(DataCollections::findFiles($name, 'md')->mapWithKeys(function (string $file): array {
+        return new static(static::findFiles($name, 'md')->mapWithKeys(function (string $file): array {
             return [static::makeIdentifier($file) => MarkdownFileParser::parse($file)];
         }));
     }
@@ -67,7 +67,7 @@ class DataCollections extends Collection
     {
         static::needsDirectory(static::$sourceDirectory);
 
-        return new static(DataCollections::findFiles($name, ['yaml', 'yml'])->mapWithKeys(function (string $file): array {
+        return new static(static::findFiles($name, ['yaml', 'yml'])->mapWithKeys(function (string $file): array {
             return [static::makeIdentifier($file) => MarkdownFileParser::parse($file)->matter()];
         }));
     }
@@ -83,7 +83,7 @@ class DataCollections extends Collection
     {
         static::needsDirectory(static::$sourceDirectory);
 
-        return new static(DataCollections::findFiles($name, 'json')->mapWithKeys(function (string $file) use ($asArray): array {
+        return new static(static::findFiles($name, 'json')->mapWithKeys(function (string $file) use ($asArray): array {
             return [static::makeIdentifier($file) => json_decode(Filesystem::get($file), $asArray)];
         }));
     }


### PR DESCRIPTION
Fixes https://github.com/hydephp/develop/issues/1716 by calling `static` instead of the class self reference.

This fix can be released in a patch release since protected methods are generally not supported by our BC promise.

