### PR TITLE
Add a JSON output format option to the route list command

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -13,6 +13,7 @@ This serves two purposes:
 - Added support for using HTML comments to create Markdown code block filepath labels in https://github.com/hydephp/develop/pull/1693
 - Added a config option to disable the theme toggle buttons to automatically use browser settings in https://github.com/hydephp/develop/pull/1697
 - You can now specify which path to open when using the `--open` option in the serve command in https://github.com/hydephp/develop/pull/1694
+- Added a `--format=json` option to the `route:list` command in https://github.com/hydephp/develop/pull/1724
 
 ### Changed
 - When a navigation group is set in front matter, it will now be used regardless of the subdirectory configuration in https://github.com/hydephp/develop/pull/1703 (fixes https://github.com/hydephp/develop/issues/1515)

--- a/packages/framework/src/Console/Commands/RouteListCommand.php
+++ b/packages/framework/src/Console/Commands/RouteListCommand.php
@@ -31,6 +31,8 @@ class RouteListCommand extends Command
         if ($this->option('format') === 'txt') {
             $this->table($this->makeHeader($routes), $routes);
         } elseif ($this->option('format') === 'json') {
+            // Disable ANSI formatting
+            $this->output->setDecorated(false);
             $this->line(json_encode($routes, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES));
         } else {
             $this->error("Invalid format provided. Only 'txt' and 'json' are supported.");

--- a/packages/framework/src/Console/Commands/RouteListCommand.php
+++ b/packages/framework/src/Console/Commands/RouteListCommand.php
@@ -29,6 +29,10 @@ class RouteListCommand extends Command
 
         if ($this->option('format') === 'txt') {
             $this->table($this->makeHeader($routes), $routes);
+        } else {
+            $this->error("Invalid format provided. Only 'txt' is supported.");
+
+            return Command::FAILURE;
         }
 
         return Command::SUCCESS;

--- a/packages/framework/src/Console/Commands/RouteListCommand.php
+++ b/packages/framework/src/Console/Commands/RouteListCommand.php
@@ -28,15 +28,11 @@ class RouteListCommand extends Command
     {
         $routes = $this->generate();
 
-        if ($this->option('format') === 'txt') {
-            $this->table($this->makeHeader($routes), $routes);
-        } elseif ($this->option('format') === 'json') {
-            $this->writeRaw(json_encode($routes, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES));
-        } else {
-            return $this->fail("Invalid format provided. Only 'txt' and 'json' are supported.");
-        }
-
-        return Command::SUCCESS;
+        return match ($this->option('format')) {
+            'txt' => $this->table($this->makeHeader($routes), $routes) ?? Command::SUCCESS,
+            'json' => $this->writeRaw(json_encode($routes, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES)) ?? Command::SUCCESS,
+            default => $this->fail("Invalid format provided. Only 'txt' and 'json' are supported."),
+        };
     }
 
     /** @return array<integer, array<string, string>>  */

--- a/packages/framework/src/Console/Commands/RouteListCommand.php
+++ b/packages/framework/src/Console/Commands/RouteListCommand.php
@@ -31,9 +31,7 @@ class RouteListCommand extends Command
         if ($this->option('format') === 'txt') {
             $this->table($this->makeHeader($routes), $routes);
         } elseif ($this->option('format') === 'json') {
-            // Disable ANSI formatting
-            $this->output->setDecorated(false);
-            $this->output->writeln(json_encode($routes, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES));
+            $this->writeRaw(json_encode($routes, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES));
         } else {
             $this->error("Invalid format provided. Only 'txt' and 'json' are supported.");
 
@@ -53,5 +51,12 @@ class RouteListCommand extends Command
     protected function makeHeader(array $routes): array
     {
         return array_map(Hyde::makeTitle(...), array_keys($routes[0]));
+    }
+
+    /** Write a message without ANSI formatting */
+    protected function writeRaw(string $message): void
+    {
+        $this->output->setDecorated(false);
+        $this->output->writeln($message);
     }
 }

--- a/packages/framework/src/Console/Commands/RouteListCommand.php
+++ b/packages/framework/src/Console/Commands/RouteListCommand.php
@@ -33,9 +33,7 @@ class RouteListCommand extends Command
         } elseif ($this->option('format') === 'json') {
             $this->writeRaw(json_encode($routes, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES));
         } else {
-            $this->error("Invalid format provided. Only 'txt' and 'json' are supported.");
-
-            return Command::FAILURE;
+            return $this->fail("Invalid format provided. Only 'txt' and 'json' are supported.");
         }
 
         return Command::SUCCESS;
@@ -58,5 +56,12 @@ class RouteListCommand extends Command
     {
         $this->output->setDecorated(false);
         $this->output->writeln($message);
+    }
+
+    protected function fail(string $message): int
+    {
+        $this->error($message);
+
+        return Command::FAILURE;
     }
 }

--- a/packages/framework/src/Console/Commands/RouteListCommand.php
+++ b/packages/framework/src/Console/Commands/RouteListCommand.php
@@ -18,7 +18,7 @@ use function array_values;
 class RouteListCommand extends Command
 {
     /** @var string */
-    protected $signature = 'route:list';
+    protected $signature = 'route:list {--format=txt : The output format (txt)}';
 
     /** @var string */
     protected $description = 'Display all the registered routes';

--- a/packages/framework/src/Console/Commands/RouteListCommand.php
+++ b/packages/framework/src/Console/Commands/RouteListCommand.php
@@ -10,6 +10,7 @@ use Hyde\Support\Internal\RouteListItem;
 
 use function array_map;
 use function array_keys;
+use function json_encode;
 use function array_values;
 
 /**
@@ -18,7 +19,7 @@ use function array_values;
 class RouteListCommand extends Command
 {
     /** @var string */
-    protected $signature = 'route:list {--format=txt : The output format (txt)}';
+    protected $signature = 'route:list {--format=txt : The output format (txt or json)}';
 
     /** @var string */
     protected $description = 'Display all the registered routes';
@@ -29,8 +30,10 @@ class RouteListCommand extends Command
 
         if ($this->option('format') === 'txt') {
             $this->table($this->makeHeader($routes), $routes);
+        } elseif ($this->option('format') === 'json') {
+            $this->line(json_encode($routes, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES));
         } else {
-            $this->error("Invalid format provided. Only 'txt' is supported.");
+            $this->error("Invalid format provided. Only 'txt' and 'json' are supported.");
 
             return Command::FAILURE;
         }

--- a/packages/framework/src/Console/Commands/RouteListCommand.php
+++ b/packages/framework/src/Console/Commands/RouteListCommand.php
@@ -33,7 +33,7 @@ class RouteListCommand extends Command
         } elseif ($this->option('format') === 'json') {
             // Disable ANSI formatting
             $this->output->setDecorated(false);
-            $this->line(json_encode($routes, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES));
+            $this->output->writeln(json_encode($routes, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES));
         } else {
             $this->error("Invalid format provided. Only 'txt' and 'json' are supported.");
 

--- a/packages/framework/src/Console/Commands/RouteListCommand.php
+++ b/packages/framework/src/Console/Commands/RouteListCommand.php
@@ -31,7 +31,7 @@ class RouteListCommand extends Command
         return match ($this->option('format')) {
             'txt' => $this->table($this->makeHeader($routes), $routes) ?? Command::SUCCESS,
             'json' => $this->writeRaw(json_encode($routes, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES)) ?? Command::SUCCESS,
-            default => $this->fail("Invalid format provided. Only 'txt' and 'json' are supported."),
+            default => $this->error("Invalid format provided. Only 'txt' and 'json' are supported.") ?? Command::FAILURE,
         };
     }
 
@@ -52,12 +52,5 @@ class RouteListCommand extends Command
     {
         $this->output->setDecorated(false);
         $this->output->writeln($message);
-    }
-
-    protected function fail(string $message): int
-    {
-        $this->error($message);
-
-        return Command::FAILURE;
     }
 }

--- a/packages/framework/src/Console/Commands/RouteListCommand.php
+++ b/packages/framework/src/Console/Commands/RouteListCommand.php
@@ -27,7 +27,9 @@ class RouteListCommand extends Command
     {
         $routes = $this->generate();
 
-        $this->table($this->makeHeader($routes), $routes);
+        if ($this->option('format') === 'txt') {
+            $this->table($this->makeHeader($routes), $routes);
+        }
 
         return Command::SUCCESS;
     }

--- a/packages/framework/tests/Feature/Commands/RouteListCommandTest.php
+++ b/packages/framework/tests/Feature/Commands/RouteListCommandTest.php
@@ -114,6 +114,13 @@ class RouteListCommandTest extends TestCase
             ]])->assertExitCode(0);
     }
 
+    public function testConsoleRouteListWithInvalidFormatOption()
+    {
+        $this->artisan('route:list --format=foo')
+            ->expectsOutput("Invalid format provided. Only 'txt' is supported.")
+            ->assertExitCode(1);
+    }
+
     protected function headers(): array
     {
         return ['Page Type', 'Source File', 'Output File', 'Route Key'];

--- a/packages/framework/tests/Feature/Commands/RouteListCommandTest.php
+++ b/packages/framework/tests/Feature/Commands/RouteListCommandTest.php
@@ -114,10 +114,30 @@ class RouteListCommandTest extends TestCase
             ]])->assertExitCode(0);
     }
 
+    public function testConsoleRouteListWithJsonFormatOption()
+    {
+        $this->artisan('route:list --format=json')
+            ->expectsOutput(json_encode([
+                [
+                    'page_type' => 'BladePage',
+                    'source_file' => '_pages/404.blade.php',
+                    'output_file' => '_site/404.html',
+                    'route_key' => '404',
+                ],
+                [
+                    'page_type' => 'BladePage',
+                    'source_file' => '_pages/index.blade.php',
+                    'output_file' => '_site/index.html',
+                    'route_key' => 'index',
+                ],
+            ], JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES))
+            ->assertExitCode(0);
+    }
+
     public function testConsoleRouteListWithInvalidFormatOption()
     {
         $this->artisan('route:list --format=foo')
-            ->expectsOutput("Invalid format provided. Only 'txt' is supported.")
+            ->expectsOutput("Invalid format provided. Only 'txt' and 'json' are supported.")
             ->assertExitCode(1);
     }
 

--- a/packages/framework/tests/Feature/Commands/RouteListCommandTest.php
+++ b/packages/framework/tests/Feature/Commands/RouteListCommandTest.php
@@ -98,6 +98,22 @@ class RouteListCommandTest extends TestCase
             ]])->assertExitCode(0);
     }
 
+    public function testConsoleRouteListWithTextFormatOption()
+    {
+        $this->artisan('route:list --format=txt')
+            ->expectsTable($this->headers(), [[
+                'BladePage',
+                '_pages/404.blade.php',
+                '_site/404.html',
+                '404',
+            ], [
+                'BladePage',
+                '_pages/index.blade.php',
+                '_site/index.html',
+                'index',
+            ]])->assertExitCode(0);
+    }
+
     protected function headers(): array
     {
         return ['Page Type', 'Source File', 'Output File', 'Route Key'];


### PR DESCRIPTION
Fixes https://github.com/hydephp/develop/issues/1715 and opens up for more formats in the future, trying to match how Symfony does it. 

Currently only the `json` format is added.

```json
[
    {
        "page_type": "BladePage",
        "source_file": "_pages/404.blade.php",
        "output_file": "_site/404.html",
        "route_key": "404"
    },
    {
        "page_type": "BladePage",
        "source_file": "_pages/index.blade.php",
        "output_file": "_site/index.html",
        "route_key": "index"
    }
]
```

Of course, the output of this can also be redirected into a file stream:

```bash
$ php hyde route:list --format=json > routes.json
```
