### PR TITLE
Improve behaviour when a site URL is not explicitly set

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -18,6 +18,8 @@ This serves two purposes:
 ### Changed
 - When a navigation group is set in front matter, it will now be used regardless of the subdirectory configuration in https://github.com/hydephp/develop/pull/1703 (fixes https://github.com/hydephp/develop/issues/1515)
 - Use late static bindings to support overriding data collections file finding in https://github.com/hydephp/develop/pull/1717 (fixes https://github.com/hydephp/develop/issues/1716)
+- Method `Hyde::hasSiteUrl()` now returns false if the site URL is for localhost in https://github.com/hydephp/develop/pull/1726
+- Method `Hyde::url()` will now return a relative URL instead of throwing an exception when supplied a path even if the site URL is not set in https://github.com/hydephp/develop/pull/1726
 
 ### Deprecated
 - for soon-to-be removed features.

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -34,3 +34,17 @@ This serves two purposes:
 
 ### Security
 - in case of vulnerabilities.
+
+### Extra information
+
+This release contains changes to how HydePHP behaves when a site URL is not set by the user.
+
+These changes are made to reduce the chance of the default `localhost` value showing up in production environments.
+
+Most notably, HydePHP now considers that default site URL `localhost` to mean that a site URL is not set, as the user has not set it.
+This means that things like automatic canonical URLs will not be added, as Hyde won't know how to make them without a site URL. 
+The previous behaviour was that Hyde used `localhost` in canonical URLs, which is never useful in production environments.
+
+For this reason, we felt it worth it to make this change in a minor release, as it has a such large benefit for sites.
+
+You can read more about the details and design decisions of this change in the following pull request https://github.com/hydephp/develop/pull/1726.

--- a/packages/framework/src/Foundation/Kernel/Hyperlinks.php
+++ b/packages/framework/src/Foundation/Kernel/Hyperlinks.php
@@ -131,7 +131,7 @@ class Hyperlinks
     {
         $value = Config::getNullableString('hyde.url');
 
-        return ! blank($value);
+        return ! blank($value) && $value !== 'http://localhost';
     }
 
     /**

--- a/packages/framework/src/Foundation/Kernel/Hyperlinks.php
+++ b/packages/framework/src/Foundation/Kernel/Hyperlinks.php
@@ -129,7 +129,9 @@ class Hyperlinks
      */
     public function hasSiteUrl(): bool
     {
-        return ! blank(Config::getNullableString('hyde.url'));
+        $value = Config::getNullableString('hyde.url');
+
+        return ! blank($value);
     }
 
     /**

--- a/packages/framework/src/Foundation/Kernel/Hyperlinks.php
+++ b/packages/framework/src/Foundation/Kernel/Hyperlinks.php
@@ -126,6 +126,8 @@ class Hyperlinks
 
     /**
      * Check if a site base URL has been set in config (or .env).
+     *
+     * The default value is `http://localhost`, which is not considered a valid site URL.
      */
     public function hasSiteUrl(): bool
     {

--- a/packages/framework/src/Foundation/Kernel/Hyperlinks.php
+++ b/packages/framework/src/Foundation/Kernel/Hyperlinks.php
@@ -149,6 +149,13 @@ class Hyperlinks
             return rtrim(rtrim(Config::getString('hyde.url'), '/')."/$path", '/');
         }
 
+        // Since v1.7.0, we return the relative path even if the base URL is not set,
+        // as this is more likely to be the desired behavior the user's expecting.
+        if (! blank($path)) {
+            return $path;
+        }
+
+        // User is trying to get the base URL, but it's not set
         throw new BaseUrlNotSetException();
     }
 

--- a/packages/framework/src/Framework/Actions/PostBuildTasks/GenerateSitemap.php
+++ b/packages/framework/src/Framework/Actions/PostBuildTasks/GenerateSitemap.php
@@ -9,7 +9,6 @@ use Hyde\Framework\Features\BuildTasks\PostBuildTask;
 use Hyde\Framework\Concerns\InteractsWithDirectories;
 use Hyde\Framework\Features\XmlGenerators\SitemapGenerator;
 
-use function blank;
 use function file_put_contents;
 
 class GenerateSitemap extends PostBuildTask
@@ -22,7 +21,7 @@ class GenerateSitemap extends PostBuildTask
 
     public function handle(): void
     {
-        if (blank(Hyde::url()) || str_starts_with(Hyde::url(), 'http://localhost')) {
+        if (! Hyde::hasSiteUrl()) {
             $this->skip('Cannot generate sitemap without a valid base URL');
         }
 

--- a/packages/framework/tests/Feature/Foundation/HyperlinksTest.php
+++ b/packages/framework/tests/Feature/Foundation/HyperlinksTest.php
@@ -56,7 +56,8 @@ class HyperlinksTest extends TestCase
 
     public function testAssetHelperReturnsQualifiedAbsoluteUriWhenRequestedAndSiteHasBaseUrl()
     {
-        $this->assertSame('http://localhost/media/test.jpg', $this->class->asset('test.jpg', true));
+        config(['hyde.url' => 'https://example.org']);
+        $this->assertSame('https://example.org/media/test.jpg', $this->class->asset('test.jpg', true));
     }
 
     public function testAssetHelperReturnsDefaultRelativePathWhenQualifiedAbsoluteUriIsRequestedButSiteHasNoBaseUrl()
@@ -65,8 +66,19 @@ class HyperlinksTest extends TestCase
         $this->assertSame('media/test.jpg', $this->class->asset('test.jpg', true));
     }
 
+    public function testAssetHelperReturnsDefaultRelativePathWhenQualifiedAbsoluteUriIsRequestedButSiteBaseUrlIsLocalhost()
+    {
+        $this->assertSame('media/test.jpg', $this->class->asset('test.jpg', true));
+    }
+
     public function testAssetHelperReturnsInputWhenQualifiedAbsoluteUriIsRequestedButImageIsAlreadyQualified()
     {
+        $this->assertSame('http://localhost/media/test.jpg', $this->class->asset('http://localhost/media/test.jpg', true));
+    }
+
+    public function testAssetHelperReturnsInputWhenQualifiedAbsoluteUriIsRequestedButImageIsAlreadyQualifiedRegardlessOfMatchingTheConfiguredUrl()
+    {
+        config(['hyde.url' => 'https://example.org']);
         $this->assertSame('http://localhost/media/test.jpg', $this->class->asset('http://localhost/media/test.jpg', true));
     }
 

--- a/packages/framework/tests/Feature/HelpersTest.php
+++ b/packages/framework/tests/Feature/HelpersTest.php
@@ -154,8 +154,15 @@ class HelpersTest extends TestCase
     public function testUrlFunctionWithoutBaseUrl()
     {
         $this->app['config']->set(['hyde.url' => null]);
+        $this->assertSame('foo', url('foo'));
+    }
+
+    /** @covers ::url */
+    public function testUrlFunctionWithoutBaseUrlOrPath()
+    {
+        $this->app['config']->set(['hyde.url' => null]);
         $this->expectException(\Hyde\Framework\Exceptions\BaseUrlNotSetException::class);
-        $this->assertNull(url('foo'));
+        $this->assertNull(url());
     }
 
     /** @covers ::url */

--- a/packages/framework/tests/Feature/HelpersTest.php
+++ b/packages/framework/tests/Feature/HelpersTest.php
@@ -77,7 +77,14 @@ class HelpersTest extends TestCase
     public function testAssetFunctionWithQualifiedUrl()
     {
         $this->assertSame(Hyde::asset('foo', true), asset('foo', true));
-        $this->assertSame('http://localhost/media/foo', asset('foo', true));
+        $this->assertSame('media/foo', asset('foo', true));
+    }
+
+    /** @covers ::asset */
+    public function testAssetFunctionWithQualifiedUrlAndSetBaseUrl()
+    {
+        $this->app['config']->set(['hyde.url' => 'https://example.com']);
+        $this->assertSame('https://example.com/media/foo', asset('foo', true));
     }
 
     /** @covers ::asset */
@@ -91,6 +98,13 @@ class HelpersTest extends TestCase
     public function testAssetFunctionWithQualifiedUrlAndNoBaseUrl()
     {
         $this->app['config']->set(['hyde.url' => null]);
+        $this->assertSame('media/foo', asset('foo', true));
+    }
+
+    /** @covers ::asset */
+    public function testAssetFunctionWithQualifiedUrlAndLocalhostBaseUrl()
+    {
+        $this->app['config']->set(['hyde.url' => 'http://localhost']);
         $this->assertSame('media/foo', asset('foo', true));
     }
 
@@ -146,8 +160,15 @@ class HelpersTest extends TestCase
     /** @covers ::url */
     public function testUrlFunctionWithBaseUrl()
     {
+        $this->app['config']->set(['hyde.url' => 'https://example.com']);
+        $this->assertSame('https://example.com/foo', url('foo'));
+    }
+
+    /** @covers ::url */
+    public function testUrlFunctionWithLocalhostBaseUrl()
+    {
         $this->app['config']->set(['hyde.url' => 'http://localhost']);
-        $this->assertSame('http://localhost/foo', url('foo'));
+        $this->assertSame('foo', url('foo'));
     }
 
     /** @covers ::url */
@@ -161,6 +182,14 @@ class HelpersTest extends TestCase
     public function testUrlFunctionWithoutBaseUrlOrPath()
     {
         $this->app['config']->set(['hyde.url' => null]);
+        $this->expectException(\Hyde\Framework\Exceptions\BaseUrlNotSetException::class);
+        $this->assertNull(url());
+    }
+
+    /** @covers ::url */
+    public function testUrlFunctionWithLocalhostBaseUrlButNoPath()
+    {
+        $this->app['config']->set(['hyde.url' => 'http://localhost']);
         $this->expectException(\Hyde\Framework\Exceptions\BaseUrlNotSetException::class);
         $this->assertNull(url());
     }

--- a/packages/framework/tests/Feature/SitesWithoutBaseUrlAreHandledGracefullyTest.php
+++ b/packages/framework/tests/Feature/SitesWithoutBaseUrlAreHandledGracefullyTest.php
@@ -6,8 +6,6 @@ namespace Hyde\Framework\Testing\Feature;
 
 use Hyde\Hyde;
 use Hyde\Testing\TestCase;
-use Hyde\Pages\HtmlPage;
-use Hyde\Pages\BladePage;
 use Hyde\Pages\MarkdownPage;
 use Hyde\Pages\MarkdownPost;
 use Hyde\Pages\DocumentationPage;
@@ -27,63 +25,45 @@ use Hyde\Pages\DocumentationPage;
  */
 class SitesWithoutBaseUrlAreHandledGracefullyTest extends TestCase
 {
-    /**
-     * @dataProvider pageClassProvider
-     */
-    public function testLocalhostLinksAreNotAddedToCompiledHtmlWhenBaseUrlIsNull(string $class): void
-    {
-        config(['hyde.url' => null]);
-
-        $html = $this->getHtml($class);
-
-        $this->assertStringNotContainsString('http://localhost', $html);
-    }
-
-    /**
-     * @dataProvider pageClassProvider
-     */
-    public function testLocalhostLinksAreNotAddedToCompiledHtmlWhenBaseUrlIsNotSet(string $class): void
-    {
-        config(['hyde.url' => '']);
-
-        $html = $this->getHtml($class);
-
-        $this->assertStringNotContainsString('http://localhost', $html);
-    }
-
-    /**
-     * @dataProvider pageClassProvider
-     */
-    public function testLocalhostLinksAreNotAddedToCompiledHtmlWhenBaseUrlIsSetToLocalhost(string $class): void
-    {
-        config(['hyde.url' => 'http://localhost']);
-
-        $html = $this->getHtml($class);
-
-        $this->assertStringNotContainsString('http://localhost', $html);
-    }
-
-    /**
-     * @dataProvider pageClassProvider
-     */
-    public function testSiteUrlLinksAreAddedToCompiledHtmlWhenBaseUrlIsSetToValidUrl(string $class): void
-    {
-        config(['hyde.url' => 'https://example.com']);
-
-        $html = $this->getHtml($class);
-
-        $this->assertStringNotContainsString('http://localhost', $html);
-    }
-
     public static function pageClassProvider(): array
     {
         return [
-            // [HtmlPage::class],
-            // [BladePage::class],
             [MarkdownPage::class],
             [MarkdownPost::class],
             [DocumentationPage::class],
         ];
+    }
+
+    /** @dataProvider pageClassProvider */
+    public function testLocalhostLinksAreNotAddedToCompiledHtmlWhenBaseUrlIsNull(string $class)
+    {
+        config(['hyde.url' => null]);
+
+        $this->assertStringNotContainsString('http://localhost', $this->getHtml($class));
+    }
+
+    /** @dataProvider pageClassProvider */
+    public function testLocalhostLinksAreNotAddedToCompiledHtmlWhenBaseUrlIsNotSet(string $class)
+    {
+        config(['hyde.url' => '']);
+
+        $this->assertStringNotContainsString('http://localhost', $this->getHtml($class));
+    }
+
+    /** @dataProvider pageClassProvider */
+    public function testLocalhostLinksAreNotAddedToCompiledHtmlWhenBaseUrlIsSetToLocalhost(string $class)
+    {
+        config(['hyde.url' => 'http://localhost']);
+
+        $this->assertStringNotContainsString('http://localhost', $this->getHtml($class));
+    }
+
+    /** @dataProvider pageClassProvider */
+    public function testSiteUrlLinksAreAddedToCompiledHtmlWhenBaseUrlIsSetToValidUrl(string $class)
+    {
+        config(['hyde.url' => 'https://example.com']);
+
+        $this->assertStringNotContainsString('http://localhost', $this->getHtml($class));
     }
 
     protected function getHtml(string $class): string

--- a/packages/framework/tests/Feature/SitesWithoutBaseUrlAreHandledGracefullyTest.php
+++ b/packages/framework/tests/Feature/SitesWithoutBaseUrlAreHandledGracefullyTest.php
@@ -63,6 +63,18 @@ class SitesWithoutBaseUrlAreHandledGracefullyTest extends TestCase
         $this->assertStringNotContainsString('http://localhost', $html);
     }
 
+    /**
+     * @dataProvider pageClassProvider
+     */
+    public function testSiteUrlLinksAreAddedToCompiledHtmlWhenBaseUrlIsSetToValidUrl(string $class): void
+    {
+        config(['hyde.url' => 'https://example.com']);
+
+        $html = $this->getHtml($class);
+
+        $this->assertStringNotContainsString('http://localhost', $html);
+    }
+
     public static function pageClassProvider(): array
     {
         return [

--- a/packages/framework/tests/Feature/SitesWithoutBaseUrlAreHandledGracefullyTest.php
+++ b/packages/framework/tests/Feature/SitesWithoutBaseUrlAreHandledGracefullyTest.php
@@ -6,7 +6,11 @@ namespace Hyde\Framework\Testing\Feature;
 
 use Hyde\Hyde;
 use Hyde\Testing\TestCase;
+use Hyde\Pages\HtmlPage;
+use Hyde\Pages\BladePage;
+use Hyde\Pages\MarkdownPage;
 use Hyde\Pages\MarkdownPost;
+use Hyde\Pages\DocumentationPage;
 
 /**
  * High level test to ensure that sites without a base URL are handled gracefully.
@@ -23,31 +27,51 @@ use Hyde\Pages\MarkdownPost;
  */
 class SitesWithoutBaseUrlAreHandledGracefullyTest extends TestCase
 {
-    public function testLocalhostLinksAreNotAddedToCompiledHtmlWhenBaseUrlIsNull(): void
+    /**
+     * @dataProvider pageClassProvider
+     */
+    public function testLocalhostLinksAreNotAddedToCompiledHtmlWhenBaseUrlIsNull(string $class): void
     {
         config(['hyde.url' => null]);
 
-        $html = $this->getHtml(MarkdownPost::class);
+        $html = $this->getHtml($class);
 
         $this->assertStringNotContainsString('http://localhost', $html);
     }
 
-    public function testLocalhostLinksAreNotAddedToCompiledHtmlWhenBaseUrlIsNotSet(): void
+    /**
+     * @dataProvider pageClassProvider
+     */
+    public function testLocalhostLinksAreNotAddedToCompiledHtmlWhenBaseUrlIsNotSet(string $class): void
     {
         config(['hyde.url' => '']);
 
-        $html = $this->getHtml(MarkdownPost::class);
+        $html = $this->getHtml($class);
 
         $this->assertStringNotContainsString('http://localhost', $html);
     }
 
-    public function testLocalhostLinksAreNotAddedToCompiledHtmlWhenBaseUrlIsSetToLocalhost(): void
+    /**
+     * @dataProvider pageClassProvider
+     */
+    public function testLocalhostLinksAreNotAddedToCompiledHtmlWhenBaseUrlIsSetToLocalhost(string $class): void
     {
         config(['hyde.url' => 'http://localhost']);
 
-        $html = $this->getHtml(MarkdownPost::class);
+        $html = $this->getHtml($class);
 
         $this->assertStringNotContainsString('http://localhost', $html);
+    }
+
+    public static function pageClassProvider(): array
+    {
+        return [
+            // [HtmlPage::class],
+            // [BladePage::class],
+            [MarkdownPage::class],
+            [MarkdownPost::class],
+            [DocumentationPage::class],
+        ];
     }
 
     protected function getHtml(string $class): string

--- a/packages/framework/tests/Feature/SitesWithoutBaseUrlAreHandledGracefullyTest.php
+++ b/packages/framework/tests/Feature/SitesWithoutBaseUrlAreHandledGracefullyTest.php
@@ -23,7 +23,25 @@ use Hyde\Pages\MarkdownPost;
  */
 class SitesWithoutBaseUrlAreHandledGracefullyTest extends TestCase
 {
+    public function testLocalhostLinksAreNotAddedToCompiledHtmlWhenBaseUrlIsNull(): void
+    {
+        config(['hyde.url' => null]);
+
+        $html = $this->getHtml(MarkdownPost::class);
+
+        $this->assertStringNotContainsString('http://localhost', $html);
+    }
+
     public function testLocalhostLinksAreNotAddedToCompiledHtmlWhenBaseUrlIsNotSet(): void
+    {
+        config(['hyde.url' => '']);
+
+        $html = $this->getHtml(MarkdownPost::class);
+
+        $this->assertStringNotContainsString('http://localhost', $html);
+    }
+
+    public function testLocalhostLinksAreNotAddedToCompiledHtmlWhenBaseUrlIsSetToLocalhost(): void
     {
         config(['hyde.url' => 'http://localhost']);
 

--- a/packages/framework/tests/Feature/SitesWithoutBaseUrlAreHandledGracefullyTest.php
+++ b/packages/framework/tests/Feature/SitesWithoutBaseUrlAreHandledGracefullyTest.php
@@ -4,7 +4,9 @@ declare(strict_types=1);
 
 namespace Hyde\Framework\Testing\Feature;
 
+use Hyde\Hyde;
 use Hyde\Testing\TestCase;
+use Hyde\Pages\MarkdownPost;
 
 /**
  * High level test to ensure that sites without a base URL are handled gracefully.
@@ -21,5 +23,21 @@ use Hyde\Testing\TestCase;
  */
 class SitesWithoutBaseUrlAreHandledGracefullyTest extends TestCase
 {
-    //
+    public function testLocalhostLinksAreNotAddedToCompiledHtmlWhenBaseUrlIsNotSet(): void
+    {
+        config(['hyde.url' => 'http://localhost']);
+
+        $html = $this->getHtml(MarkdownPost::class);
+
+        $this->assertStringNotContainsString('http://localhost', $html);
+    }
+
+    protected function getHtml(string $class): string
+    {
+        $page = new $class('foo');
+
+        Hyde::shareViewData($page);
+
+        return $page->compile();
+    }
 }

--- a/packages/framework/tests/Feature/SitesWithoutBaseUrlAreHandledGracefullyTest.php
+++ b/packages/framework/tests/Feature/SitesWithoutBaseUrlAreHandledGracefullyTest.php
@@ -9,6 +9,14 @@ use Hyde\Testing\TestCase;
 /**
  * High level test to ensure that sites without a base URL are handled gracefully.
  *
+ * For example: In case a user forgot to set a base URL, we don't want their site
+ * to have localhost links in the compiled HTML output since that would break
+ * things when deployed to production. So we fall back to relative links.
+ *
+ * Some things like sitemaps and RSS feeds cannot be generated without a base URL,
+ * as their schemas generally do not allow relative URLs. In those cases, we
+ * don't generate files at all, and we don't add any links to them either.
+ *
  * @coversNothing This test is not testing a specific class, but a general feature of the framework.
  */
 class SitesWithoutBaseUrlAreHandledGracefullyTest extends TestCase

--- a/packages/framework/tests/Feature/SitesWithoutBaseUrlAreHandledGracefullyTest.php
+++ b/packages/framework/tests/Feature/SitesWithoutBaseUrlAreHandledGracefullyTest.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Hyde\Framework\Testing\Feature;
+
+use Hyde\Testing\TestCase;
+
+/**
+ * High level test to ensure that sites without a base URL are handled gracefully.
+ *
+ * @coversNothing This test is not testing a specific class, but a general feature of the framework.
+ */
+class SitesWithoutBaseUrlAreHandledGracefullyTest extends TestCase
+{
+    //
+}

--- a/packages/framework/tests/Feature/Views/MetadataViewTest.php
+++ b/packages/framework/tests/Feature/Views/MetadataViewTest.php
@@ -25,7 +25,7 @@ class MetadataViewTest extends TestCase
     {
         parent::setUp();
 
-        config(['hyde.url' => 'http://localhost']);
+        config(['hyde.url' => 'https://example.com']);
         config(['hyde.enable_cache_busting' => false]);
     }
 
@@ -79,7 +79,7 @@ class MetadataViewTest extends TestCase
             '<meta charset="utf-8">',
             '<meta name="viewport" content="width=device-width, initial-scale=1">',
             '<meta id="meta-color-scheme" name="color-scheme" content="light">',
-            '<link rel="sitemap" href="http://localhost/sitemap.xml" type="application/xml" title="Sitemap">',
+            '<link rel="sitemap" href="https://example.com/sitemap.xml" type="application/xml" title="Sitemap">',
             '<meta name="generator" content="HydePHP v'.HydeKernel::VERSION.'">',
             '<meta property="og:site_name" content="HydePHP">',
         ];
@@ -93,7 +93,7 @@ class MetadataViewTest extends TestCase
         $assertions = $this->assertSee('test', array_merge($this->getDefaultTags(), [
             '<title>HydePHP - Test</title>',
             '<link rel="stylesheet" href="media/app.css">',
-            '<link rel="canonical" href="http://localhost/test.html">',
+            '<link rel="canonical" href="https://example.com/test.html">',
             '<meta name="twitter:title" content="HydePHP - Test">',
             '<meta property="og:title" content="HydePHP - Test">',
         ]));
@@ -109,7 +109,7 @@ class MetadataViewTest extends TestCase
         $assertions = $this->assertSee('test', array_merge($this->getDefaultTags(), [
             '<title>HydePHP - Test</title>',
             '<link rel="stylesheet" href="media/app.css">',
-            '<link rel="canonical" href="http://localhost/test.html">',
+            '<link rel="canonical" href="https://example.com/test.html">',
             '<meta name="twitter:title" content="HydePHP - Test">',
             '<meta property="og:title" content="HydePHP - Test">',
         ]));
@@ -125,7 +125,7 @@ class MetadataViewTest extends TestCase
         $assertions = $this->assertSee('docs/test', array_merge($this->getDefaultTags(), [
             '<title>HydePHP - Test</title>',
             '<link rel="stylesheet" href="../media/app.css">',
-            '<link rel="canonical" href="http://localhost/docs/test.html">',
+            '<link rel="canonical" href="https://example.com/docs/test.html">',
             '<meta name="twitter:title" content="HydePHP - Test">',
             '<meta property="og:title" content="HydePHP - Test">',
         ]));
@@ -140,16 +140,16 @@ class MetadataViewTest extends TestCase
 
         $assertions = $this->assertSee('posts/test', array_merge($this->getDefaultTags(), [
             '<title>HydePHP - Test</title>',
-            '<link rel="alternate" href="http://localhost/feed.xml" type="application/rss+xml" title="HydePHP RSS Feed">',
+            '<link rel="alternate" href="https://example.com/feed.xml" type="application/rss+xml" title="HydePHP RSS Feed">',
             '<link rel="stylesheet" href="../media/app.css">',
-            '<link rel="canonical" href="http://localhost/posts/test.html">',
+            '<link rel="canonical" href="https://example.com/posts/test.html">',
             '<meta name="twitter:title" content="HydePHP - Test">',
-            '<meta name="url" content="http://localhost/posts/test.html">',
+            '<meta name="url" content="https://example.com/posts/test.html">',
             '<meta property="og:title" content="HydePHP - Test">',
-            '<meta property="og:url" content="http://localhost/posts/test.html">',
+            '<meta property="og:url" content="https://example.com/posts/test.html">',
             '<meta property="og:type" content="article">',
             '<meta itemprop="identifier" content="test">',
-            '<meta itemprop="url" content="http://localhost/posts/test.html">',
+            '<meta itemprop="url" content="https://example.com/posts/test.html">',
         ]));
 
         $this->assertAllTagsWereCovered('posts/test', $assertions);
@@ -177,25 +177,92 @@ class MetadataViewTest extends TestCase
 
         $assertions = $this->assertSee('posts/test', array_merge($this->getDefaultTags(), [
             '<title>HydePHP - My title</title>',
-            '<link rel="alternate" href="http://localhost/feed.xml" type="application/rss+xml" title="HydePHP RSS Feed">',
+            '<link rel="alternate" href="https://example.com/feed.xml" type="application/rss+xml" title="HydePHP RSS Feed">',
             '<link rel="stylesheet" href="../media/app.css">',
-            '<link rel="canonical" href="http://localhost/posts/test.html">',
+            '<link rel="canonical" href="https://example.com/posts/test.html">',
             '<meta name="twitter:title" content="HydePHP - My title">',
             '<meta name="description" content="My description">',
             '<meta name="author" content="Mr. Hyde">',
             '<meta name="keywords" content="My category">',
-            '<meta name="url" content="http://localhost/posts/test.html">',
+            '<meta name="url" content="https://example.com/posts/test.html">',
             '<meta property="og:title" content="HydePHP - My title">',
-            '<meta property="og:url" content="http://localhost/posts/test.html">',
+            '<meta property="og:url" content="https://example.com/posts/test.html">',
             '<meta property="og:type" content="article">',
             '<meta property="og:article:published_time" content="2022-01-01T00:00:00+00:00">',
             '<meta property="og:image" content="../media/image.jpg">',
             '<meta itemprop="identifier" content="test">',
-            '<meta itemprop="url" content="http://localhost/posts/test.html">',
+            '<meta itemprop="url" content="https://example.com/posts/test.html">',
             '<meta itemprop="url" content="../media/image.jpg">',
             '<meta itemprop="contentUrl" content="../media/image.jpg">',
         ]));
 
         $this->assertAllTagsWereCovered('posts/test', $assertions);
+    }
+
+    public function testCanonicalUrlTagsAreNotAddedWhenCanonicalUrlIsNotSet()
+    {
+        config(['hyde.url' => 'http://localhost']);
+
+        $this->file('_posts/test.md', <<<'MARKDOWN'
+            ---
+            title: "My title"
+            description: "My description"
+            category: "My category"
+            date: "2022-01-01"
+            author: "Mr. Hyde"
+            image: image.jpg
+            ---
+
+            ## Hello World
+
+            Lorem Ipsum Dolor Amet.
+            MARKDOWN
+        );
+        $this->build('_posts/test.md');
+
+        $assertions = $this->assertSee('posts/test', [
+            '<meta charset="utf-8">',
+            '<meta name="viewport" content="width=device-width, initial-scale=1">',
+            '<meta id="meta-color-scheme" name="color-scheme" content="light">',
+            '<meta name="generator" content="HydePHP v'.HydeKernel::VERSION.'">',
+            '<meta property="og:site_name" content="HydePHP">',
+            '<title>HydePHP - My title</title>',
+            '<link rel="stylesheet" href="../media/app.css">',
+            '<meta name="twitter:title" content="HydePHP - My title">',
+            '<meta name="description" content="My description">',
+            '<meta name="author" content="Mr. Hyde">',
+            '<meta name="keywords" content="My category">',
+            '<meta property="og:title" content="HydePHP - My title">',
+            '<meta property="og:type" content="article">',
+            '<meta property="og:article:published_time" content="2022-01-01T00:00:00+00:00">',
+            '<meta property="og:image" content="../media/image.jpg">',
+            '<meta itemprop="identifier" content="test">',
+            '<meta itemprop="url" content="../media/image.jpg">',
+            '<meta itemprop="contentUrl" content="../media/image.jpg">',
+
+            // '<link rel="sitemap" href="http://localhost/sitemap.xml" type="application/xml" title="Sitemap">',
+            // '<link rel="alternate" href="http://localhost/feed.xml" type="application/rss+xml" title="HydePHP RSS Feed">',
+            // '<link rel="canonical" href="http://localhost/posts/test.html">',
+            // '<meta name="url" content="http://localhost/posts/test.html">',
+            // '<meta property="og:url" content="http://localhost/posts/test.html">',
+            // '<meta itemprop="url" content="http://localhost/posts/test.html">',
+        ]);
+
+        $this->assertAllTagsWereCovered('posts/test', $assertions);
+
+        $dontSee = [
+            '<link rel="sitemap"',
+            '<link rel="alternate"',
+            '<link rel="canonical"',
+            '<meta name="url"',
+            '<meta property="og:url"',
+            '<meta itemprop="url" content="http',
+        ];
+
+        $contents = file_get_contents(Hyde::path('_site/posts/test.html'));
+
+        foreach ($dontSee as $text) {
+            $this->assertStringNotContainsString($text, $contents);
+        }
     }
 }

--- a/packages/framework/tests/Unit/Foundation/HyperlinksUrlPathHelpersTest.php
+++ b/packages/framework/tests/Unit/Foundation/HyperlinksUrlPathHelpersTest.php
@@ -112,6 +112,26 @@ class HyperlinksUrlPathHelpersTest extends TestCase
         $this->assertSame('foo/bar', $this->class->url('foo/bar.html'));
     }
 
+    public function testHelperFallsBackToRelativeLinksWhenSiteUrlIsSetToLocalhost()
+    {
+        config(['hyde.url' => 'http://localhost']);
+
+        $this->assertSame('index.html', $this->class->url('index.html'));
+        $this->assertSame('foo.html', $this->class->url('foo.html'));
+        $this->assertSame('foo/bar.html', $this->class->url('foo/bar.html'));
+        $this->assertSame('docs/index.html', $this->class->url('docs/index.html'));
+    }
+
+    public function testHelperFallsBackToPrettyRelativeLinksWhenSiteUrlIsSetToLocalhostAndPrettyUrlsAreEnabled()
+    {
+        config(['hyde.url' => 'http://localhost', 'hyde.pretty_urls' => true]);
+
+        $this->assertSame('/', $this->class->url('index.html'));
+        $this->assertSame('foo', $this->class->url('foo.html'));
+        $this->assertSame('docs/', $this->class->url('docs/index.html'));
+        $this->assertSame('foo/bar', $this->class->url('foo/bar.html'));
+    }
+
     public function testHelperReturnsExpectedStringWhenSiteUrlIsSet()
     {
         config(['hyde.url' => 'https://example.com']);

--- a/packages/framework/tests/Unit/Foundation/HyperlinksUrlPathHelpersTest.php
+++ b/packages/framework/tests/Unit/Foundation/HyperlinksUrlPathHelpersTest.php
@@ -92,6 +92,26 @@ class HyperlinksUrlPathHelpersTest extends TestCase
         $this->class->url();
     }
 
+    public function testHelperFallsBackToRelativeLinksWhenNoSiteUrlIsSet()
+    {
+        config(['hyde.url' => '']);
+
+        $this->assertSame('index.html', $this->class->url('index.html'));
+        $this->assertSame('foo.html', $this->class->url('foo.html'));
+        $this->assertSame('foo/bar.html', $this->class->url('foo/bar.html'));
+        $this->assertSame('docs/index.html', $this->class->url('docs/index.html'));
+    }
+
+    public function testHelperFallsBackToPrettyRelativeLinksWhenNoSiteUrlIsSetAndPrettyUrlsAreEnabled()
+    {
+        config(['hyde.url' => '', 'hyde.pretty_urls' => true]);
+
+        $this->assertSame('/', $this->class->url('index.html'));
+        $this->assertSame('foo', $this->class->url('foo.html'));
+        $this->assertSame('docs/', $this->class->url('docs/index.html'));
+        $this->assertSame('foo/bar', $this->class->url('foo/bar.html'));
+    }
+
     public function testHelperReturnsExpectedStringWhenSiteUrlIsSet()
     {
         config(['hyde.url' => 'https://example.com']);


### PR DESCRIPTION
## Abstract

We're getting some issues by Hyde using `localhost` as the default site URL. Initially, this PR will target the 1.x branch because I consider these things to be bugs that should be fixed in v1, however, there may be side effects of this: primarily that output HTML will change - but I do not think anyone will depend on those undesired effects before this patch, since localhost is never desired in production. This will resolve https://github.com/hydephp/develop/issues/1720

Expanding on the reasoning behind allowing this in 1.x: Since v1 is LTS, I don't want to leave those users hanging with what is in my opinion a bug, that localhost links can "leak" through production. And I think the only way to fix this is by changing some logic which could have side effects. But I think I am okay with that tradeoff as it stands now, especially since I think any possible usages that may be affected probably don't actually desire the logic we have now.

## Major changes

### Method `Hyde::hasSiteUrl()` now returns false if URL is localhost

This better matches the documented method description of "Check if a site base URL has been set in config (or .env).", as this value is `localhost` by default and thus not set by the user.

### Method `Hyde::url()` now resolves relative paths instead of throwing

We now return the relative path even if the base URL is not set, as this is more likely to be the desired behavior the user's expecting. If the user is trying to get the base URL, but it's not set, we throw the exception.

