### PR TITLE
Fix undefined array key exception for empty Markdown pages

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -1129,7 +1129,7 @@
                 "illuminate/view": "^10.0",
                 "league/commonmark": "^2.2",
                 "php": "^8.1",
-                "spatie/yaml-front-matter": "^2.0.7",
+                "spatie/yaml-front-matter": "^2.0.9",
                 "symfony/yaml": "^6.0",
                 "torchlight/torchlight-commonmark": "^0.5.5"
             },
@@ -4429,16 +4429,16 @@
         },
         {
             "name": "spatie/yaml-front-matter",
-            "version": "2.0.8",
+            "version": "2.0.9",
             "source": {
                 "type": "git",
                 "url": "https://github.com/spatie/yaml-front-matter.git",
-                "reference": "f2f1f749a405fafc9d6337067c92c062d51a581c"
+                "reference": "cbe67e1cdd0a29a96d74ccab9400fe663e078392"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/spatie/yaml-front-matter/zipball/f2f1f749a405fafc9d6337067c92c062d51a581c",
-                "reference": "f2f1f749a405fafc9d6337067c92c062d51a581c",
+                "url": "https://api.github.com/repos/spatie/yaml-front-matter/zipball/cbe67e1cdd0a29a96d74ccab9400fe663e078392",
+                "reference": "cbe67e1cdd0a29a96d74ccab9400fe663e078392",
                 "shasum": ""
             },
             "require": {
@@ -4475,7 +4475,7 @@
                 "yaml"
             ],
             "support": {
-                "source": "https://github.com/spatie/yaml-front-matter/tree/2.0.8"
+                "source": "https://github.com/spatie/yaml-front-matter/tree/2.0.9"
             },
             "funding": [
                 {
@@ -4487,7 +4487,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2023-12-04T10:02:52+00:00"
+            "time": "2024-06-13T10:20:51+00:00"
         },
         {
             "name": "symfony/console",

--- a/packages/framework/composer.json
+++ b/packages/framework/composer.json
@@ -27,7 +27,7 @@
         "illuminate/view": "^10.0",
         "symfony/yaml": "^6.0",
         "league/commonmark": "^2.2",
-        "spatie/yaml-front-matter": "^2.0.7",
+        "spatie/yaml-front-matter": "^2.0.9",
         "torchlight/torchlight-commonmark": "^0.5.5"
     },
     "suggest": {

--- a/packages/framework/tests/Feature/MarkdownFileParserTest.php
+++ b/packages/framework/tests/Feature/MarkdownFileParserTest.php
@@ -84,4 +84,19 @@ class MarkdownFileParserTest extends UnitTestCase
         $this->assertSame('Mr. Hyde', $post->matter('author'));
         $this->assertSame('blog', $post->matter('category'));
     }
+
+    public function testCanParseMarkdownFileWithFrontMatterAndNoMarkdownBody()
+    {
+        file_put_contents(Hyde::path('_posts/test-post.md'), "---\nfoo: bar\n---");
+
+        $document = MarkdownFileParser::parse('_posts/test-post.md');
+
+        $this->assertInstanceOf(MarkdownDocument::class, $document);
+        $this->assertEquals('', $document->markdown);
+        $this->assertSame('', $document->markdown->body());
+
+        $this->assertEquals(FrontMatter::fromArray([
+            'foo' => 'bar',
+        ]), $document->matter);
+    }
 }


### PR DESCRIPTION
Bumps the front matter parser to use https://github.com/spatie/yaml-front-matter/pull/41, thus fixing https://github.com/hydephp/develop/issues/1705. Also adds a test to proof it.