### PR TITLE
[2.x] Includes facade improvements

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -29,7 +29,7 @@ This serves two purposes:
 - Media asset files are now copied using the new build task instead of the deprecated `BuildService::transferMediaAssets()` method.
 - Calling the `Include::path()` method will no longer create the includes directory in https://github.com/hydephp/develop/pull/1707
 - Calling the `DataCollection` methods will no longer create the data collections directory in https://github.com/hydephp/develop/pull/1732
-- Markdown includes are now converted to HTML using the custom HydePHP Markdown service, meaning they now support full GFM spec and custom Hyde features like colored blockquotes and code block filepath labels.
+- Markdown includes are now converted to HTML using the custom HydePHP Markdown service, meaning they now support full GFM spec and custom Hyde features like colored blockquotes and code block filepath labels in https://github.com/hydephp/develop/pull/1738
 
 ### Deprecated
 - for soon-to-be removed features.

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -24,6 +24,7 @@ This serves two purposes:
 - Minor: The documentation article component now supports disabling the semantic rendering using a falsy value in https://github.com/hydephp/develop/pull/1566
 - Minor: Changed the default build task message to make it more concise in https://github.com/hydephp/develop/pull/1659
 - Minor: Data collection files are now validated for syntax errors during discovery in https://github.com/hydephp/develop/pull/1732
+- Minor: Methods in the `Includes` facade now return `HtmlString` objects instead of `string` in https://github.com/hydephp/develop/pull/1738. For more information, see below.
 - The `hasFeature` method on the Hyde facade and HydeKernel now only accepts a Feature enum value instead of a string for its parameter.
 - Changed how the documentation search is generated, to be an `InMemoryPage` instead of a post-build task.
 - Media asset files are now copied using the new build task instead of the deprecated `BuildService::transferMediaAssets()` method.
@@ -222,6 +223,25 @@ For example, if you triggered the media transfer with a build service method cal
 
 (new TransferMediaAssets())->run();
 ```
+
+### Includes facade changes
+
+The following methods in the `Includes` facade now return `HtmlString` objects instead of `string`:
+
+- `Includes::html()`
+- `Includes::blade()`
+- `Includes::markdown()`
+
+- This means that you no longer need to use `{!! !!}` to render the output of these methods in Blade templates, instead just use `{{ }}`.
+- If you have used the return value of these methods in custom code, you may need to adjust your code to work with the new return type.
+
+For more information, see the RFC that proposed this change: https://github.com/hydephp/develop/issues/1734
+The RFC was implemented in https://github.com/hydephp/develop/pull/1738
+
+#### Remember to escape output if necessary
+
+**Note:** Remember that this means that includes are **no longer escaped** by default, so make sure to escape the output if necessary, for example if the content is user-generated.
+- (Use `{{ e(Includes::html('foo')) }}` instead of `{{ Includes::html('foo') }}` to escape the output, matching the previous behavior.)
 
 ### DataCollection API changes
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -30,6 +30,7 @@ This serves two purposes:
 - Calling the `Include::path()` method will no longer create the includes directory in https://github.com/hydephp/develop/pull/1707
 - Calling the `DataCollection` methods will no longer create the data collections directory in https://github.com/hydephp/develop/pull/1732
 - Markdown includes are now converted to HTML using the custom HydePHP Markdown service, meaning they now support full GFM spec and custom Hyde features like colored blockquotes and code block filepath labels in https://github.com/hydephp/develop/pull/1738
+- Markdown returned from includes are now trimmed of trailing whitespace and newlines in https://github.com/hydephp/develop/pull/1738
 
 ### Deprecated
 - for soon-to-be removed features.

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -25,6 +25,7 @@ This serves two purposes:
 - Minor: Changed the default build task message to make it more concise in https://github.com/hydephp/develop/pull/1659
 - Minor: Data collection files are now validated for syntax errors during discovery in https://github.com/hydephp/develop/pull/1732
 - Minor: Methods in the `Includes` facade now return `HtmlString` objects instead of `string` in https://github.com/hydephp/develop/pull/1738. For more information, see below.
+- Minor: `Includes::path()` and  `Includes::get()` methods now normalizes paths to be basenames to match the behaviour of the other include methods in https://github.com/hydephp/develop/pull/1738. This means that nested directories are no longer supported, as you should use a data collection for that.
 - The `hasFeature` method on the Hyde facade and HydeKernel now only accepts a Feature enum value instead of a string for its parameter.
 - Changed how the documentation search is generated, to be an `InMemoryPage` instead of a post-build task.
 - Media asset files are now copied using the new build task instead of the deprecated `BuildService::transferMediaAssets()` method.

--- a/docs/digging-deeper/helpers.md
+++ b/docs/digging-deeper/helpers.md
@@ -73,7 +73,15 @@ Includes::markdown('example') === Includes::markdown('example.md');
 
 All methods will return `null` if the file does not exist.
 However, you can supply a default value as the second argument to be used instead.
-Remember that Markdown and Blade defaults will still be rendered to HTML.
+Remember that Markdown and Blade defaults will also be rendered to HTML.
+
+Includes are particularly useful in Blade views, as you can echo them directly. You do not need to import the namespace, as it is already aliased.
+
+```blade
+<footer>
+    {{ Includes::markdown('footer.md') }}
+</footer>
+```
 
 ```php
 use Hyde\Support\Includes;

--- a/packages/framework/src/Support/Includes.php
+++ b/packages/framework/src/Support/Includes.php
@@ -90,11 +90,13 @@ class Includes
             if ($default === null) {
                 return null;
             } else {
-                return new HtmlString(trim(Markdown::render($default, MarkdownDocument::class)));
+                $markdown = $default;
+                return new HtmlString(trim(Markdown::render($markdown, MarkdownDocument::class)));
             }
         }
 
-        return new HtmlString(trim(Markdown::render(Filesystem::get($path), MarkdownDocument::class)));
+        $markdown = Filesystem::get($path);
+        return new HtmlString(trim(Markdown::render($markdown, MarkdownDocument::class)));
     }
 
     /**

--- a/packages/framework/src/Support/Includes.php
+++ b/packages/framework/src/Support/Includes.php
@@ -91,7 +91,6 @@ class Includes
                 return null;
             } else {
                 $markdown = $default;
-                return new HtmlString(trim(Markdown::render($markdown, MarkdownDocument::class)));
             }
         } else {
             $markdown = Filesystem::get($path);

--- a/packages/framework/src/Support/Includes.php
+++ b/packages/framework/src/Support/Includes.php
@@ -87,7 +87,7 @@ class Includes
         $path = static::normalizePath($filename, '.md');
         $contents = static::getFileContents($path);
 
-        if (! Filesystem::exists($path)) {
+        if ($contents === null) {
             return $default === null ? null : static::renderMarkdown($default);
         }
 

--- a/packages/framework/src/Support/Includes.php
+++ b/packages/framework/src/Support/Includes.php
@@ -87,16 +87,10 @@ class Includes
         $path = static::normalizePath($filename, '.md');
 
         if (! Filesystem::exists($path)) {
-            if ($default === null) {
-                return null;
-            } else {
-                $contents = null;
-            }
-        } else {
-            $contents = Filesystem::get($path);
+            return $default === null ? null : static::renderMarkdown($default);
         }
 
-        return static::renderMarkdown($contents ?? $default);
+        return static::renderMarkdown(Filesystem::get($path));
     }
 
     /**

--- a/packages/framework/src/Support/Includes.php
+++ b/packages/framework/src/Support/Includes.php
@@ -86,14 +86,13 @@ class Includes
     {
         $path = static::normalizePath($filename, '.md');
 
-        if (! Filesystem::exists($path)) {
+        if (Filesystem::exists($path)) {
+            $markdown = Filesystem::get($path);
+        } else {
             if ($default === null) {
                 return null;
             }
-
             $markdown = $default;
-        } else {
-            $markdown = Filesystem::get($path);
         }
 
         return new HtmlString(trim(Markdown::render($markdown, MarkdownDocument::class)));

--- a/packages/framework/src/Support/Includes.php
+++ b/packages/framework/src/Support/Includes.php
@@ -87,10 +87,10 @@ class Includes
         $path = static::normalizePath($filename, '.md');
 
         if (! Filesystem::exists($path)) {
-            return $default === null ? null : new HtmlString(trim(Markdown::render($default, MarkdownDocument::class)));
+            return $default === null ? null : static::renderMarkdown($default);
         }
 
-        return new HtmlString(trim(Markdown::render(Filesystem::get($path), MarkdownDocument::class)));
+        return static::renderMarkdown(Filesystem::get($path));
     }
 
     /**
@@ -114,5 +114,10 @@ class Includes
     protected static function normalizePath(string $filename, string $extension): string
     {
         return static::path(basename($filename, $extension).$extension);
+    }
+
+    protected static function renderMarkdown(string $markdown): HtmlString
+    {
+        return new HtmlString(trim(Markdown::render($markdown, MarkdownDocument::class)));
     }
 }

--- a/packages/framework/src/Support/Includes.php
+++ b/packages/framework/src/Support/Includes.php
@@ -87,11 +87,7 @@ class Includes
         $path = static::normalizePath($filename, '.md');
 
         if (! Filesystem::exists($path)) {
-            if ($default === null) {
-                return null;
-            } else {
-                return new HtmlString(trim(Markdown::render($default, MarkdownDocument::class)));
-            }
+            return $default === null ? null : new HtmlString(trim(Markdown::render($default, MarkdownDocument::class)));
         }
 
         return new HtmlString(trim(Markdown::render(Filesystem::get($path), MarkdownDocument::class)));

--- a/packages/framework/src/Support/Includes.php
+++ b/packages/framework/src/Support/Includes.php
@@ -96,7 +96,7 @@ class Includes
     protected static function getInclude(callable $method, string $extension, ?string $default, string $filename): ?HtmlString
     {
         $path = static::normalizePath($filename, $extension);
-        $contents = static::getFileContents($path);
+        $contents = static::getFileContents(static::path($path));
 
         if ($contents === null && $default === null) {
             return null;
@@ -112,11 +112,11 @@ class Includes
 
     protected static function getFileContents(string $path): ?string
     {
-        if (! Filesystem::exists(static::path($path))) {
+        if (! Filesystem::exists($path)) {
             return null;
         }
 
-        return Filesystem::get(static::path($path));
+        return Filesystem::get($path);
     }
 
     protected static function renderHtml(string $html): HtmlString

--- a/packages/framework/src/Support/Includes.php
+++ b/packages/framework/src/Support/Includes.php
@@ -112,11 +112,13 @@ class Includes
 
     protected static function getFileContents(string $path): ?string
     {
-        if (! Filesystem::exists(static::path($path))) {
+        $path = static::path($path);
+
+        if (! Filesystem::exists($path)) {
             return null;
         }
 
-        return Filesystem::get(static::path($path));
+        return Filesystem::get($path);
     }
 
     protected static function renderHtml(string $html): HtmlString

--- a/packages/framework/src/Support/Includes.php
+++ b/packages/framework/src/Support/Includes.php
@@ -90,9 +90,8 @@ class Includes
         if ($contents === null) {
             if ($default === null) {
                 return null;
-            } else {
-                $contents = $default;
             }
+            $contents = $default;
         }
 
         return static::renderMarkdown($contents);

--- a/packages/framework/src/Support/Includes.php
+++ b/packages/framework/src/Support/Includes.php
@@ -90,9 +90,14 @@ class Includes
             $markdown = Filesystem::get($path);
         } else {
             if ($default === null) {
-                return null;
+                $markdown = null;
+            } else {
+                $markdown = $default;
             }
-            $markdown = $default;
+        }
+
+        if ($markdown === null) {
+            return null;
         }
 
         return new HtmlString(trim(Markdown::render($markdown, MarkdownDocument::class)));

--- a/packages/framework/src/Support/Includes.php
+++ b/packages/framework/src/Support/Includes.php
@@ -89,8 +89,9 @@ class Includes
         if (! Filesystem::exists($path)) {
             if ($default === null) {
                 return null;
+            } else {
+                $contents = null;
             }
-            $contents = null;
         } else {
             $contents = Filesystem::get($path);
         }

--- a/packages/framework/src/Support/Includes.php
+++ b/packages/framework/src/Support/Includes.php
@@ -48,14 +48,7 @@ class Includes
      */
     public static function get(string $filename, ?string $default = null): ?string
     {
-        $path = static::path(static::normalizePath($filename));
-        $contents = static::getFileContents($path);
-
-        if ($contents === null && $default === null) {
-            return null;
-        }
-
-        return $contents ?? $default;
+        return static::getInclude([static::class, 'getRaw'], $filename, $default);
     }
 
     /**

--- a/packages/framework/src/Support/Includes.php
+++ b/packages/framework/src/Support/Includes.php
@@ -94,7 +94,7 @@ class Includes
         return static::getInclude([static::class, 'renderMarkdown'], $filename, $default, '.md');
     }
 
-    protected static function getInclude(callable $method, string $filename, ?string $default, string $extension = ''): ?HtmlString
+    protected static function getInclude(callable $method, string $filename, ?string $default, string $extension = ''): HtmlString|null
     {
         $path = static::normalizePath($filename, $extension);
         $contents = static::getFileContents(static::path($path));

--- a/packages/framework/src/Support/Includes.php
+++ b/packages/framework/src/Support/Includes.php
@@ -6,6 +6,7 @@ namespace Hyde\Support;
 
 use Hyde\Hyde;
 use Hyde\Facades\Filesystem;
+use Illuminate\Support\HtmlString;
 use Hyde\Markdown\Models\MarkdownDocument;
 use Hyde\Markdown\Models\Markdown;
 use Illuminate\Support\Facades\Blade;
@@ -61,17 +62,17 @@ class Includes
      *
      * @param  string  $filename  The name of the partial file, with or without the extension.
      * @param  string|null  $default  The default value to return if the partial is not found.
-     * @return string|null The raw contents of the partial file, or the default value if not found.
+     * @return HtmlString|null The contents of the partial file, or the default value if not found.
      */
-    public static function html(string $filename, ?string $default = null): ?string
+    public static function html(string $filename, ?string $default = null): ?HtmlString
     {
         $path = static::normalizePath($filename, '.html');
 
         if (! Filesystem::exists($path)) {
-            return $default === null ? null : $default;
+            return $default === null ? null : new HtmlString($default);
         }
 
-        return Filesystem::get($path);
+        return new HtmlString(Filesystem::get($path));
     }
 
     /**
@@ -79,17 +80,17 @@ class Includes
      *
      * @param  string  $filename  The name of the partial file, with or without the extension.
      * @param  string|null  $default  The default value to return if the partial is not found.
-     * @return string|null The rendered contents of the partial file, or the default value if not found.
+     * @return HtmlString|null The rendered contents of the partial file, or the default value if not found.
      */
-    public static function markdown(string $filename, ?string $default = null): ?string
+    public static function markdown(string $filename, ?string $default = null): ?HtmlString
     {
         $path = static::normalizePath($filename, '.md');
 
         if (! Filesystem::exists($path)) {
-            return $default === null ? null : trim(Markdown::render($default, MarkdownDocument::class));
+            return $default === null ? null : new HtmlString(trim(Markdown::render($default, MarkdownDocument::class)));
         }
 
-        return trim(Markdown::render(Filesystem::get($path), MarkdownDocument::class));
+        return new HtmlString(trim(Markdown::render(Filesystem::get($path), MarkdownDocument::class)));
     }
 
     /**
@@ -97,17 +98,17 @@ class Includes
      *
      * @param  string  $filename  The name of the partial file, with or without the extension.
      * @param  string|null  $default  The default value to return if the partial is not found.
-     * @return string|null The rendered contents of the partial file, or the default value if not found.
+     * @return HtmlString|null The rendered contents of the partial file, or the default value if not found.
      */
-    public static function blade(string $filename, ?string $default = null): ?string
+    public static function blade(string $filename, ?string $default = null): ?HtmlString
     {
         $path = static::normalizePath($filename, '.blade.php');
 
         if (! Filesystem::exists($path)) {
-            return $default === null ? null : Blade::render($default);
+            return $default === null ? null : new HtmlString(Blade::render($default));
         }
 
-        return Blade::render(Filesystem::get($path));
+        return new HtmlString(Blade::render(Filesystem::get($path)));
     }
 
     protected static function normalizePath(string $filename, string $extension): string

--- a/packages/framework/src/Support/Includes.php
+++ b/packages/framework/src/Support/Includes.php
@@ -66,14 +66,7 @@ class Includes
      */
     public static function html(string $filename, ?string $default = null): ?HtmlString
     {
-        $path = static::normalizePath($filename, '.html');
-        $contents = static::getFileContents($path);
-
-        if ($contents === null && $default === null) {
-            return null;
-        }
-
-        return static::renderHtml($contents ?? $default);
+        return static::getInclude($filename, '.html', $default, 'renderHtml');
     }
 
     /**
@@ -85,14 +78,7 @@ class Includes
      */
     public static function markdown(string $filename, ?string $default = null): ?HtmlString
     {
-        $path = static::normalizePath($filename, '.md');
-        $contents = static::getFileContents($path);
-
-        if ($contents === null && $default === null) {
-            return null;
-        }
-
-        return static::renderMarkdown($contents ?? $default);
+        return static::getInclude($filename, '.md', $default, 'renderMarkdown');
     }
 
     /**
@@ -104,14 +90,7 @@ class Includes
      */
     public static function blade(string $filename, ?string $default = null): ?HtmlString
     {
-        $path = static::normalizePath($filename, '.blade.php');
-        $contents = static::getFileContents($path);
-
-        if ($contents === null && $default === null) {
-            return null;
-        }
-
-        return static::renderBlade($contents ?? $default);
+        return static::getInclude($filename, '.blade.php', $default, 'renderBlade');
     }
 
     protected static function normalizePath(string $filename, string $extension): string
@@ -141,5 +120,17 @@ class Includes
         }
 
         return Filesystem::get($path);
+    }
+
+    protected static function getInclude(string $filename, string $extension, ?string $default, string $method): ?HtmlString
+    {
+        $path = static::normalizePath($filename, $extension);
+        $contents = static::getFileContents($path);
+
+        if ($contents === null && $default === null) {
+            return null;
+        }
+
+        return static::$method($contents ?? $default);
     }
 }

--- a/packages/framework/src/Support/Includes.php
+++ b/packages/framework/src/Support/Includes.php
@@ -88,12 +88,10 @@ class Includes
 
         if (Filesystem::exists($path)) {
             $markdown = Filesystem::get($path);
+        } elseif ($default === null) {
+            $markdown = null;
         } else {
-            if ($default === null) {
-                $markdown = null;
-            } else {
-                $markdown = $default;
-            }
+            $markdown = $default;
         }
 
         if ($markdown === null) {

--- a/packages/framework/src/Support/Includes.php
+++ b/packages/framework/src/Support/Includes.php
@@ -54,7 +54,7 @@ class Includes
             return $default;
         }
 
-        return Filesystem::get($path);
+        return static::getFileContents($path);
     }
 
     /**
@@ -72,7 +72,7 @@ class Includes
             return $default === null ? null : static::renderHtml($default);
         }
 
-        return static::renderHtml(Filesystem::get($path));
+        return static::renderHtml(static::getFileContents($path));
     }
 
     /**
@@ -90,7 +90,7 @@ class Includes
             return $default === null ? null : static::renderMarkdown($default);
         }
 
-        return static::renderMarkdown(Filesystem::get($path));
+        return static::renderMarkdown(static::getFileContents($path));
     }
 
     /**
@@ -108,7 +108,7 @@ class Includes
             return $default === null ? null : static::renderBlade($default);
         }
 
-        return static::renderBlade(Filesystem::get($path));
+        return static::renderBlade(static::getFileContents($path));
     }
 
     protected static function normalizePath(string $filename, string $extension): string
@@ -129,5 +129,10 @@ class Includes
     protected static function renderBlade(string $blade): HtmlString
     {
         return new HtmlString(Blade::render($blade));
+    }
+
+    protected static function getFileContents(string $path): string
+    {
+        return Filesystem::get($path);
     }
 }

--- a/packages/framework/src/Support/Includes.php
+++ b/packages/framework/src/Support/Includes.php
@@ -66,7 +66,7 @@ class Includes
      */
     public static function html(string $filename, ?string $default = null): ?HtmlString
     {
-        return static::getInclude('renderHtml', '.html', $default, $filename);
+        return static::getInclude([static::class, 'renderHtml'], '.html', $default, $filename);
     }
 
     /**
@@ -78,7 +78,7 @@ class Includes
      */
     public static function markdown(string $filename, ?string $default = null): ?HtmlString
     {
-        return static::getInclude('renderMarkdown', '.md', $default, $filename);
+        return static::getInclude([static::class, 'renderMarkdown'], '.md', $default, $filename);
     }
 
     /**
@@ -90,7 +90,7 @@ class Includes
      */
     public static function blade(string $filename, ?string $default = null): ?HtmlString
     {
-        return static::getInclude('renderBlade', '.blade.php', $default, $filename);
+        return static::getInclude([static::class, 'renderBlade'], '.blade.php', $default, $filename);
     }
 
     protected static function normalizePath(string $filename, string $extension): string
@@ -122,7 +122,7 @@ class Includes
         return Filesystem::get($path);
     }
 
-    protected static function getInclude(string $method, string $extension, ?string $default, string $filename): ?HtmlString
+    protected static function getInclude(callable $method, string $extension, ?string $default, string $filename): ?HtmlString
     {
         $path = static::normalizePath($filename, $extension);
         $contents = static::getFileContents($path);
@@ -131,6 +131,6 @@ class Includes
             return null;
         }
 
-        return static::$method($contents ?? $default);
+        return $method($contents ?? $default);
     }
 }

--- a/packages/framework/src/Support/Includes.php
+++ b/packages/framework/src/Support/Includes.php
@@ -86,13 +86,14 @@ class Includes
     {
         $path = static::normalizePath($filename, '.md');
 
-        if (Filesystem::exists($path)) {
-            $markdown = Filesystem::get($path);
-        } else {
+        if (! Filesystem::exists($path)) {
             if ($default === null) {
                 return null;
             }
+
             $markdown = $default;
+        } else {
+            $markdown = Filesystem::get($path);
         }
 
         return new HtmlString(trim(Markdown::render($markdown, MarkdownDocument::class)));

--- a/packages/framework/src/Support/Includes.php
+++ b/packages/framework/src/Support/Includes.php
@@ -89,7 +89,7 @@ class Includes
         return static::getInclude([static::class, 'renderMarkdown'], $filename, $default, '.md');
     }
 
-    /** @param callable(string): (\Illuminate\Support\HtmlString|string|null) $method */
+    /** @param callable(string): (\Illuminate\Support\HtmlString|string) $method */
     protected static function getInclude(callable $method, string $filename, ?string $default, string $extension = ''): HtmlString|string|null
     {
         $path = static::normalizePath($filename, $extension);

--- a/packages/framework/src/Support/Includes.php
+++ b/packages/framework/src/Support/Includes.php
@@ -120,6 +120,11 @@ class Includes
         return Filesystem::get($path);
     }
 
+    protected static function getRaw(string $contents): string
+    {
+        return $contents;
+    }
+
     protected static function renderHtml(string $html): HtmlString
     {
         return new HtmlString($html);

--- a/packages/framework/src/Support/Includes.php
+++ b/packages/framework/src/Support/Includes.php
@@ -105,10 +105,10 @@ class Includes
         $path = static::normalizePath($filename, '.blade.php');
 
         if (! Filesystem::exists($path)) {
-            return $default === null ? null : new HtmlString(Blade::render($default));
+            return $default === null ? null : static::renderBlade($default);
         }
 
-        return new HtmlString(Blade::render(Filesystem::get($path)));
+        return static::renderBlade(Filesystem::get($path));
     }
 
     protected static function normalizePath(string $filename, string $extension): string
@@ -119,5 +119,10 @@ class Includes
     protected static function renderMarkdown(string $markdown): HtmlString
     {
         return new HtmlString(trim(Markdown::render($markdown, MarkdownDocument::class)));
+    }
+
+    protected static function renderBlade(string $blade): HtmlString
+    {
+        return new HtmlString(Blade::render($blade));
     }
 }

--- a/packages/framework/src/Support/Includes.php
+++ b/packages/framework/src/Support/Includes.php
@@ -49,12 +49,13 @@ class Includes
     public static function get(string $filename, ?string $default = null): ?string
     {
         $path = static::path(static::normalizePath($filename));
+        $contents = static::getFileContents($path);
 
-        if (! Filesystem::exists($path)) {
-            return $default;
+        if ($contents === null && $default === null) {
+            return null;
         }
 
-        return static::getFileContents($path);
+        return $contents ?? $default;
     }
 
     /**

--- a/packages/framework/src/Support/Includes.php
+++ b/packages/framework/src/Support/Includes.php
@@ -87,7 +87,11 @@ class Includes
         $path = static::normalizePath($filename, '.md');
 
         if (! Filesystem::exists($path)) {
-            return $default === null ? null : new HtmlString(trim(Markdown::render($default, MarkdownDocument::class)));
+            if ($default === null) {
+                return null;
+            } else {
+                return new HtmlString(trim(Markdown::render($default, MarkdownDocument::class)));
+            }
         }
 
         return new HtmlString(trim(Markdown::render(Filesystem::get($path), MarkdownDocument::class)));

--- a/packages/framework/src/Support/Includes.php
+++ b/packages/framework/src/Support/Includes.php
@@ -70,18 +70,6 @@ class Includes
     }
 
     /**
-     * Get the rendered Markdown of a partial file in the includes directory.
-     *
-     * @param  string  $filename  The name of the partial file, with or without the extension.
-     * @param  string|null  $default  The default value to return if the partial is not found.
-     * @return HtmlString|null The rendered contents of the partial file, or the default value if not found.
-     */
-    public static function markdown(string $filename, ?string $default = null): ?HtmlString
-    {
-        return static::getInclude([static::class, 'renderMarkdown'], '.md', $default, $filename);
-    }
-
-    /**
      * Get the rendered Blade of a partial file in the includes directory.
      *
      * @param  string  $filename  The name of the partial file, with or without the extension.
@@ -93,33 +81,16 @@ class Includes
         return static::getInclude([static::class, 'renderBlade'], '.blade.php', $default, $filename);
     }
 
-    protected static function normalizePath(string $filename, string $extension): string
+    /**
+     * Get the rendered Markdown of a partial file in the includes directory.
+     *
+     * @param  string  $filename  The name of the partial file, with or without the extension.
+     * @param  string|null  $default  The default value to return if the partial is not found.
+     * @return HtmlString|null The rendered contents of the partial file, or the default value if not found.
+     */
+    public static function markdown(string $filename, ?string $default = null): ?HtmlString
     {
-        return static::path(basename($filename, $extension).$extension);
-    }
-
-    protected static function renderHtml(string $html): HtmlString
-    {
-        return new HtmlString($html);
-    }
-
-    protected static function renderMarkdown(string $markdown): HtmlString
-    {
-        return new HtmlString(trim(Markdown::render($markdown, MarkdownDocument::class)));
-    }
-
-    protected static function renderBlade(string $blade): HtmlString
-    {
-        return new HtmlString(Blade::render($blade));
-    }
-
-    protected static function getFileContents(string $path): ?string
-    {
-        if (! Filesystem::exists($path)) {
-            return null;
-        }
-
-        return Filesystem::get($path);
+        return static::getInclude([static::class, 'renderMarkdown'], '.md', $default, $filename);
     }
 
     protected static function getInclude(callable $method, string $extension, ?string $default, string $filename): ?HtmlString
@@ -132,5 +103,34 @@ class Includes
         }
 
         return $method($contents ?? $default);
+    }
+
+    protected static function normalizePath(string $filename, string $extension): string
+    {
+        return static::path(basename($filename, $extension).$extension);
+    }
+
+    protected static function getFileContents(string $path): ?string
+    {
+        if (! Filesystem::exists($path)) {
+            return null;
+        }
+
+        return Filesystem::get($path);
+    }
+
+    protected static function renderHtml(string $html): HtmlString
+    {
+        return new HtmlString($html);
+    }
+
+    protected static function renderBlade(string $blade): HtmlString
+    {
+        return new HtmlString(Blade::render($blade));
+    }
+
+    protected static function renderMarkdown(string $markdown): HtmlString
+    {
+        return new HtmlString(trim(Markdown::render($markdown, MarkdownDocument::class)));
     }
 }

--- a/packages/framework/src/Support/Includes.php
+++ b/packages/framework/src/Support/Includes.php
@@ -93,9 +93,10 @@ class Includes
                 $markdown = $default;
                 return new HtmlString(trim(Markdown::render($markdown, MarkdownDocument::class)));
             }
+        } else {
+            $markdown = Filesystem::get($path);
         }
 
-        $markdown = Filesystem::get($path);
         return new HtmlString(trim(Markdown::render($markdown, MarkdownDocument::class)));
     }
 

--- a/packages/framework/src/Support/Includes.php
+++ b/packages/framework/src/Support/Includes.php
@@ -91,11 +91,7 @@ class Includes
             return null;
         }
 
-        if ($contents === null) {
-            $contents = $default;
-        }
-
-        return static::renderMarkdown($contents);
+        return static::renderMarkdown($contents ?? $default);
     }
 
     /**

--- a/packages/framework/src/Support/Includes.php
+++ b/packages/framework/src/Support/Includes.php
@@ -105,7 +105,7 @@ class Includes
         return $method($contents ?? $default);
     }
 
-    protected static function normalizePath(string $filename, string $extension): string
+    protected static function normalizePath(string $filename, string $extension = ''): string
     {
         return static::path(basename($filename, $extension).$extension);
     }

--- a/packages/framework/src/Support/Includes.php
+++ b/packages/framework/src/Support/Includes.php
@@ -94,7 +94,7 @@ class Includes
         return static::getInclude([static::class, 'renderMarkdown'], $filename, $default, '.md');
     }
 
-    protected static function getInclude(callable $method, string $filename, ?string $default, string $extension): ?HtmlString
+    protected static function getInclude(callable $method, string $filename, ?string $default, string $extension = ''): ?HtmlString
     {
         $path = static::normalizePath($filename, $extension);
         $contents = static::getFileContents(static::path($path));

--- a/packages/framework/src/Support/Includes.php
+++ b/packages/framework/src/Support/Includes.php
@@ -43,7 +43,7 @@ class Includes
      *
      * @param  string  $filename  The name of the partial file, including the extension.
      * @param  string|null  $default  The default value to return if the partial is not found.
-     * @return string|null The contents of the partial file, or the default value if not found.
+     * @return string|null The raw contents of the partial file, or the default value if not found.
      */
     public static function get(string $filename, ?string $default = null): ?string
     {

--- a/packages/framework/src/Support/Includes.php
+++ b/packages/framework/src/Support/Includes.php
@@ -36,9 +36,9 @@ class Includes
     {
         if ($filename === null) {
             return Hyde::path(static::$includesDirectory);
-        } else {
-            return Hyde::path(static::$includesDirectory.'/'.static::normalizePath($filename));
         }
+
+        return Hyde::path(static::$includesDirectory.'/'.static::normalizePath($filename));
     }
 
     /**

--- a/packages/framework/src/Support/Includes.php
+++ b/packages/framework/src/Support/Includes.php
@@ -89,9 +89,9 @@ class Includes
         if (! Filesystem::exists($path)) {
             if ($default === null) {
                 return null;
+            } else {
+                $markdown = $default;
             }
-
-            $markdown = $default;
         } else {
             $markdown = Filesystem::get($path);
         }

--- a/packages/framework/src/Support/Includes.php
+++ b/packages/framework/src/Support/Includes.php
@@ -67,7 +67,7 @@ class Includes
      */
     public static function html(string $filename, ?string $default = null): ?HtmlString
     {
-        return static::getInclude([static::class, 'renderHtml'], '.html', $default, $filename);
+        return static::getInclude([static::class, 'renderHtml'], $filename, $default, '.html');
     }
 
     /**
@@ -79,7 +79,7 @@ class Includes
      */
     public static function blade(string $filename, ?string $default = null): ?HtmlString
     {
-        return static::getInclude([static::class, 'renderBlade'], '.blade.php', $default, $filename);
+        return static::getInclude([static::class, 'renderBlade'], $filename, $default, '.blade.php');
     }
 
     /**
@@ -91,10 +91,10 @@ class Includes
      */
     public static function markdown(string $filename, ?string $default = null): ?HtmlString
     {
-        return static::getInclude([static::class, 'renderMarkdown'], '.md', $default, $filename);
+        return static::getInclude([static::class, 'renderMarkdown'], $filename, $default, '.md');
     }
 
-    protected static function getInclude(callable $method, string $extension, ?string $default, string $filename): ?HtmlString
+    protected static function getInclude(callable $method, string $filename, ?string $default, string $extension): ?HtmlString
     {
         $path = static::normalizePath($filename, $extension);
         $contents = static::getFileContents(static::path($path));

--- a/packages/framework/src/Support/Includes.php
+++ b/packages/framework/src/Support/Includes.php
@@ -94,7 +94,7 @@ class Includes
         return static::getInclude([static::class, 'renderMarkdown'], $filename, $default, '.md');
     }
 
-    protected static function getInclude(callable $method, string $filename, ?string $default, string $extension = ''): HtmlString|null
+    protected static function getInclude(callable $method, string $filename, ?string $default, string $extension = ''): HtmlString|string|null
     {
         $path = static::normalizePath($filename, $extension);
         $contents = static::getFileContents(static::path($path));

--- a/packages/framework/src/Support/Includes.php
+++ b/packages/framework/src/Support/Includes.php
@@ -88,10 +88,12 @@ class Includes
 
         if (Filesystem::exists($path)) {
             $markdown = Filesystem::get($path);
-        } elseif ($default === null) {
-            $markdown = null;
         } else {
-            $markdown = $default;
+            if ($default === null) {
+                $markdown = null;
+            } else {
+                $markdown = $default;
+            }
         }
 
         if ($markdown === null) {

--- a/packages/framework/src/Support/Includes.php
+++ b/packages/framework/src/Support/Includes.php
@@ -87,10 +87,16 @@ class Includes
         $path = static::normalizePath($filename, '.md');
 
         if (! Filesystem::exists($path)) {
-            return $default === null ? null : static::renderMarkdown($default);
+            if ($default === null) {
+                return null;
+            } else {
+                $contents = null;
+            }
+        } else {
+            $contents = Filesystem::get($path);
         }
 
-        return static::renderMarkdown(Filesystem::get($path));
+        return static::renderMarkdown($contents ?? $default);
     }
 
     /**

--- a/packages/framework/src/Support/Includes.php
+++ b/packages/framework/src/Support/Includes.php
@@ -88,7 +88,11 @@ class Includes
         $contents = static::getFileContents($path);
 
         if ($contents === null) {
-            return $default === null ? null : static::renderMarkdown($default);
+            if ($default === null) {
+                return null;
+            } else {
+                return static::renderMarkdown($default);
+            }
         }
 
         return static::renderMarkdown($contents);

--- a/packages/framework/src/Support/Includes.php
+++ b/packages/framework/src/Support/Includes.php
@@ -84,7 +84,8 @@ class Includes
      */
     public static function markdown(string $filename, ?string $default = null): ?HtmlString
     {
-        $contents = static::getFileContents(static::normalizePath($filename, '.md'));
+        $path = static::normalizePath($filename, '.md');
+        $contents = static::getFileContents($path);
 
         if ($contents === null && $default === null) {
             return null;

--- a/packages/framework/src/Support/Includes.php
+++ b/packages/framework/src/Support/Includes.php
@@ -89,9 +89,9 @@ class Includes
         if (! Filesystem::exists($path)) {
             if ($default === null) {
                 return null;
-            } else {
-                $markdown = $default;
             }
+
+            $markdown = $default;
         } else {
             $markdown = Filesystem::get($path);
         }

--- a/packages/framework/src/Support/Includes.php
+++ b/packages/framework/src/Support/Includes.php
@@ -84,8 +84,7 @@ class Includes
      */
     public static function markdown(string $filename, ?string $default = null): ?HtmlString
     {
-        $path = static::normalizePath($filename, '.md');
-        $contents = static::getFileContents($path);
+        $contents = static::getFileContents(static::normalizePath($filename, '.md'));
 
         if ($contents === null && $default === null) {
             return null;

--- a/packages/framework/src/Support/Includes.php
+++ b/packages/framework/src/Support/Includes.php
@@ -36,7 +36,7 @@ class Includes
     {
         return $filename === null
             ? Hyde::path(static::$includesDirectory)
-            : Hyde::path(static::$includesDirectory.'/'.$filename);
+            : Hyde::path(static::$includesDirectory.'/'.static::normalizePath($filename));
     }
 
     /**
@@ -48,7 +48,7 @@ class Includes
      */
     public static function get(string $filename, ?string $default = null): ?string
     {
-        $path = static::path($filename);
+        $path = static::path(static::normalizePath($filename));
 
         if (! Filesystem::exists($path)) {
             return $default;

--- a/packages/framework/src/Support/Includes.php
+++ b/packages/framework/src/Support/Includes.php
@@ -69,10 +69,10 @@ class Includes
         $path = static::normalizePath($filename, '.html');
 
         if (! Filesystem::exists($path)) {
-            return $default === null ? null : new HtmlString($default);
+            return $default === null ? null : static::renderHtml($default);
         }
 
-        return new HtmlString(Filesystem::get($path));
+        return static::renderHtml(Filesystem::get($path));
     }
 
     /**
@@ -114,6 +114,11 @@ class Includes
     protected static function normalizePath(string $filename, string $extension): string
     {
         return static::path(basename($filename, $extension).$extension);
+    }
+
+    protected static function renderHtml(string $html): HtmlString
+    {
+        return new HtmlString($html);
     }
 
     protected static function renderMarkdown(string $markdown): HtmlString

--- a/packages/framework/src/Support/Includes.php
+++ b/packages/framework/src/Support/Includes.php
@@ -87,6 +87,7 @@ class Includes
         return static::getInclude([static::class, 'renderMarkdown'], $filename, $default, '.md');
     }
 
+    /** @param callable(string): \Illuminate\Support\HtmlString|string|null $method */
     protected static function getInclude(callable $method, string $filename, ?string $default, string $extension = ''): HtmlString|string|null
     {
         $path = static::normalizePath($filename, $extension);

--- a/packages/framework/src/Support/Includes.php
+++ b/packages/framework/src/Support/Includes.php
@@ -93,10 +93,9 @@ class Includes
                 $markdown = $default;
                 return new HtmlString(trim(Markdown::render($markdown, MarkdownDocument::class)));
             }
-        } else {
-            $markdown = Filesystem::get($path);
         }
 
+        $markdown = Filesystem::get($path);
         return new HtmlString(trim(Markdown::render($markdown, MarkdownDocument::class)));
     }
 

--- a/packages/framework/src/Support/Includes.php
+++ b/packages/framework/src/Support/Includes.php
@@ -67,12 +67,13 @@ class Includes
     public static function html(string $filename, ?string $default = null): ?HtmlString
     {
         $path = static::normalizePath($filename, '.html');
+        $contents = static::getFileContents($path);
 
-        if (! Filesystem::exists($path)) {
-            return $default === null ? null : static::renderHtml($default);
+        if ($contents === null && $default === null) {
+            return null;
         }
 
-        return static::renderHtml(static::getFileContents($path));
+        return static::renderHtml($contents ?? $default);
     }
 
     /**
@@ -104,12 +105,13 @@ class Includes
     public static function blade(string $filename, ?string $default = null): ?HtmlString
     {
         $path = static::normalizePath($filename, '.blade.php');
+        $contents = static::getFileContents($path);
 
-        if (! Filesystem::exists($path)) {
-            return $default === null ? null : static::renderBlade($default);
+        if ($contents === null && $default === null) {
+            return null;
         }
 
-        return static::renderBlade(static::getFileContents($path));
+        return static::renderBlade($contents ?? $default);
     }
 
     protected static function normalizePath(string $filename, string $extension): string

--- a/packages/framework/src/Support/Includes.php
+++ b/packages/framework/src/Support/Includes.php
@@ -112,13 +112,11 @@ class Includes
 
     protected static function getFileContents(string $path): ?string
     {
-        $path = static::path($path);
-
-        if (! Filesystem::exists($path)) {
+        if (! Filesystem::exists(static::path($path))) {
             return null;
         }
 
-        return Filesystem::get($path);
+        return Filesystem::get(static::path($path));
     }
 
     protected static function renderHtml(string $html): HtmlString

--- a/packages/framework/src/Support/Includes.php
+++ b/packages/framework/src/Support/Includes.php
@@ -89,9 +89,8 @@ class Includes
         if (! Filesystem::exists($path)) {
             if ($default === null) {
                 return null;
-            } else {
-                $contents = null;
             }
+            $contents = null;
         } else {
             $contents = Filesystem::get($path);
         }

--- a/packages/framework/src/Support/Includes.php
+++ b/packages/framework/src/Support/Includes.php
@@ -87,7 +87,7 @@ class Includes
         return static::getInclude([static::class, 'renderMarkdown'], $filename, $default, '.md');
     }
 
-    /** @param callable(string): \Illuminate\Support\HtmlString|string|null $method */
+    /** @param callable(string): (\Illuminate\Support\HtmlString|string|null) $method */
     protected static function getInclude(callable $method, string $filename, ?string $default, string $extension = ''): HtmlString|string|null
     {
         $path = static::normalizePath($filename, $extension);

--- a/packages/framework/src/Support/Includes.php
+++ b/packages/framework/src/Support/Includes.php
@@ -85,12 +85,13 @@ class Includes
     public static function markdown(string $filename, ?string $default = null): ?HtmlString
     {
         $path = static::normalizePath($filename, '.md');
+        $contents = static::getFileContents($path);
 
         if (! Filesystem::exists($path)) {
             return $default === null ? null : static::renderMarkdown($default);
         }
 
-        return static::renderMarkdown(static::getFileContents($path));
+        return static::renderMarkdown($contents);
     }
 
     /**

--- a/packages/framework/src/Support/Includes.php
+++ b/packages/framework/src/Support/Includes.php
@@ -34,9 +34,11 @@ class Includes
      */
     public static function path(?string $filename = null): string
     {
-        return $filename === null
-            ? Hyde::path(static::$includesDirectory)
-            : Hyde::path(static::$includesDirectory.'/'.static::normalizePath($filename));
+        if ($filename === null) {
+            return Hyde::path(static::$includesDirectory);
+        } else {
+            return Hyde::path(static::$includesDirectory.'/'.static::normalizePath($filename));
+        }
     }
 
     /**

--- a/packages/framework/src/Support/Includes.php
+++ b/packages/framework/src/Support/Includes.php
@@ -91,7 +91,7 @@ class Includes
             if ($default === null) {
                 return null;
             } else {
-                return static::renderMarkdown($default);
+                $contents = $default;
             }
         }
 

--- a/packages/framework/src/Support/Includes.php
+++ b/packages/framework/src/Support/Includes.php
@@ -107,16 +107,16 @@ class Includes
 
     protected static function normalizePath(string $filename, string $extension = ''): string
     {
-        return static::path(basename($filename, $extension).$extension);
+        return basename($filename, $extension).$extension;
     }
 
     protected static function getFileContents(string $path): ?string
     {
-        if (! Filesystem::exists($path)) {
+        if (! Filesystem::exists(static::path($path))) {
             return null;
         }
 
-        return Filesystem::get($path);
+        return Filesystem::get(static::path($path));
     }
 
     protected static function renderHtml(string $html): HtmlString

--- a/packages/framework/src/Support/Includes.php
+++ b/packages/framework/src/Support/Includes.php
@@ -131,8 +131,12 @@ class Includes
         return new HtmlString(Blade::render($blade));
     }
 
-    protected static function getFileContents(string $path): string
+    protected static function getFileContents(string $path): ?string
     {
+        if (! Filesystem::exists($path)) {
+            return null;
+        }
+
         return Filesystem::get($path);
     }
 }

--- a/packages/framework/src/Support/Includes.php
+++ b/packages/framework/src/Support/Includes.php
@@ -90,13 +90,11 @@ class Includes
             if ($default === null) {
                 return null;
             } else {
-                $markdown = $default;
-                return new HtmlString(trim(Markdown::render($markdown, MarkdownDocument::class)));
+                return new HtmlString(trim(Markdown::render($default, MarkdownDocument::class)));
             }
         }
 
-        $markdown = Filesystem::get($path);
-        return new HtmlString(trim(Markdown::render($markdown, MarkdownDocument::class)));
+        return new HtmlString(trim(Markdown::render(Filesystem::get($path), MarkdownDocument::class)));
     }
 
     /**

--- a/packages/framework/src/Support/Includes.php
+++ b/packages/framework/src/Support/Includes.php
@@ -66,7 +66,7 @@ class Includes
      */
     public static function html(string $filename, ?string $default = null): ?HtmlString
     {
-        return static::getInclude($filename, '.html', $default, 'renderHtml');
+        return static::getInclude('renderHtml', '.html', $default, $filename);
     }
 
     /**
@@ -78,7 +78,7 @@ class Includes
      */
     public static function markdown(string $filename, ?string $default = null): ?HtmlString
     {
-        return static::getInclude($filename, '.md', $default, 'renderMarkdown');
+        return static::getInclude('renderMarkdown', '.md', $default, $filename);
     }
 
     /**
@@ -90,7 +90,7 @@ class Includes
      */
     public static function blade(string $filename, ?string $default = null): ?HtmlString
     {
-        return static::getInclude($filename, '.blade.php', $default, 'renderBlade');
+        return static::getInclude('renderBlade', '.blade.php', $default, $filename);
     }
 
     protected static function normalizePath(string $filename, string $extension): string
@@ -122,7 +122,7 @@ class Includes
         return Filesystem::get($path);
     }
 
-    protected static function getInclude(string $filename, string $extension, ?string $default, string $method): ?HtmlString
+    protected static function getInclude(string $method, string $extension, ?string $default, string $filename): ?HtmlString
     {
         $path = static::normalizePath($filename, $extension);
         $contents = static::getFileContents($path);

--- a/packages/framework/src/Support/Includes.php
+++ b/packages/framework/src/Support/Includes.php
@@ -10,6 +10,7 @@ use Hyde\Markdown\Models\MarkdownDocument;
 use Hyde\Markdown\Models\Markdown;
 use Illuminate\Support\Facades\Blade;
 
+use function trim;
 use function basename;
 
 /**
@@ -85,10 +86,10 @@ class Includes
         $path = static::normalizePath($filename, '.md');
 
         if (! Filesystem::exists($path)) {
-            return $default === null ? null : Markdown::render($default, MarkdownDocument::class);
+            return $default === null ? null : trim(Markdown::render($default, MarkdownDocument::class));
         }
 
-        return Markdown::render(Filesystem::get($path), MarkdownDocument::class);
+        return trim(Markdown::render(Filesystem::get($path), MarkdownDocument::class));
     }
 
     /**

--- a/packages/framework/src/Support/Includes.php
+++ b/packages/framework/src/Support/Includes.php
@@ -91,6 +91,7 @@ class Includes
                 return null;
             } else {
                 $markdown = $default;
+                return new HtmlString(trim(Markdown::render($markdown, MarkdownDocument::class)));
             }
         } else {
             $markdown = Filesystem::get($path);

--- a/packages/framework/src/Support/Includes.php
+++ b/packages/framework/src/Support/Includes.php
@@ -90,14 +90,9 @@ class Includes
             $markdown = Filesystem::get($path);
         } else {
             if ($default === null) {
-                $markdown = null;
-            } else {
-                $markdown = $default;
+                return null;
             }
-        }
-
-        if ($markdown === null) {
-            return null;
+            $markdown = $default;
         }
 
         return new HtmlString(trim(Markdown::render($markdown, MarkdownDocument::class)));

--- a/packages/framework/src/Support/Includes.php
+++ b/packages/framework/src/Support/Includes.php
@@ -87,10 +87,11 @@ class Includes
         $path = static::normalizePath($filename, '.md');
         $contents = static::getFileContents($path);
 
+        if ($contents === null && $default === null) {
+            return null;
+        }
+
         if ($contents === null) {
-            if ($default === null) {
-                return null;
-            }
             $contents = $default;
         }
 

--- a/packages/framework/src/Support/Includes.php
+++ b/packages/framework/src/Support/Includes.php
@@ -48,7 +48,7 @@ class Includes
      */
     public static function get(string $filename, ?string $default = null): ?string
     {
-        return static::getInclude([static::class, 'getRaw'], $filename, $default);
+        return static::getInclude(fn (string $contents): string => $contents, $filename, $default);
     }
 
     /**
@@ -112,11 +112,6 @@ class Includes
         }
 
         return Filesystem::get($path);
-    }
-
-    protected static function getRaw(string $contents): string
-    {
-        return $contents;
     }
 
     protected static function renderHtml(string $html): HtmlString

--- a/packages/framework/tests/Feature/IncludesFacadeTest.php
+++ b/packages/framework/tests/Feature/IncludesFacadeTest.php
@@ -77,7 +77,7 @@ class IncludesFacadeTest extends TestCase
 
     public function testMarkdownReturnsRenderedPartial()
     {
-        $expected = "<h1>foo bar</h1>\n";
+        $expected = '<h1>foo bar</h1>';
         file_put_contents(Hyde::path('resources/includes/foo.md'), '# foo bar');
         $this->assertSame($expected, Includes::markdown('foo.md'));
         Filesystem::unlink('resources/includes/foo.md');
@@ -86,7 +86,7 @@ class IncludesFacadeTest extends TestCase
     public function testMarkdownReturnsRenderedDefaultValueWhenNotFound()
     {
         $this->assertNull(Includes::markdown('foo.md'));
-        $this->assertSame("<h1>default</h1>\n", Includes::markdown('foo.md', '# default'));
+        $this->assertSame('<h1>default</h1>', Includes::markdown('foo.md', '# default'));
     }
 
     public function testMarkdownWithAndWithoutExtension()
@@ -122,7 +122,7 @@ class IncludesFacadeTest extends TestCase
         $this->file('resources/includes/without-torchlight.md', 'Syntax highlighted by torchlight.dev');
 
         $this->assertSame(
-            "<p>Syntax highlighted by torchlight.dev</p>\n",
+            '<p>Syntax highlighted by torchlight.dev</p>',
             Includes::markdown('without-torchlight.md')
         );
     }
@@ -186,7 +186,6 @@ class IncludesFacadeTest extends TestCase
         </tr>
         </tbody>
         </table>
-
         HTML;
 
         $this->file('resources/includes/advanced.md', $markdown);
@@ -244,12 +243,10 @@ class IncludesFacadeTest extends TestCase
         <h1>Rendered Blade</h1>
         <h1>Compiled Markdown</h1>
 
-
         // Without extension
         <h1>Literal HTML</h1>
         <h1>Rendered Blade</h1>
         <h1>Compiled Markdown</h1>
-
         HTML;
 
         $this->assertSame($expected, Blade::render($view));

--- a/packages/framework/tests/Feature/IncludesFacadeTest.php
+++ b/packages/framework/tests/Feature/IncludesFacadeTest.php
@@ -238,6 +238,11 @@ class IncludesFacadeTest extends TestCase
         {!! Includes::html('foo') !!}
         {!! Includes::blade('foo') !!}
         {!! Includes::markdown('foo') !!}
+        
+        // With escaped
+        {{ Includes::html('foo.html') }}
+        {{ Includes::blade('foo.blade.php') }}
+        {{ Includes::markdown('foo.md') }}
         BLADE;
 
         $expected = <<<'HTML'
@@ -250,6 +255,11 @@ class IncludesFacadeTest extends TestCase
         <h1>Literal HTML</h1>
         <h1>Rendered Blade</h1>
         <h1>Compiled Markdown</h1>
+
+        // With escaped
+        &lt;h1&gt;Literal HTML&lt;/h1&gt;
+        &lt;h1&gt;Rendered Blade&lt;/h1&gt;
+        &lt;h1&gt;Compiled Markdown&lt;/h1&gt;
         HTML;
 
         $this->assertSame($expected, Blade::render($view));

--- a/packages/framework/tests/Feature/IncludesFacadeTest.php
+++ b/packages/framework/tests/Feature/IncludesFacadeTest.php
@@ -223,33 +223,33 @@ class IncludesFacadeTest extends TestCase
         // Emulates the actual usage of the Includes facade from a Blade view.
 
         $this->file('resources/includes/foo.blade.php', '<h1>{{ "Rendered Blade" }}</h1>');
-        $this->file('resources/includes/foo.md', '# Compiled Markdown');
         $this->file('resources/includes/foo.html', '<h1>Literal HTML</h1>');
+        $this->file('resources/includes/foo.md', '# Compiled Markdown');
 
         $view = <<<'BLADE'
         // With extension
+        {!! Includes::html('foo.html') !!}
         {!! Includes::blade('foo.blade.php') !!}
         {!! Includes::markdown('foo.md') !!}
-        {!! Includes::html('foo.html') !!}
         
         // Without extension
+        {!! Includes::html('foo') !!}
         {!! Includes::blade('foo') !!}
         {!! Includes::markdown('foo') !!}
-        {!! Includes::html('foo') !!}
         BLADE;
 
         $expected = <<<'HTML'
         // With extension
+        <h1>Literal HTML</h1>
         <h1>Rendered Blade</h1>
         <h1>Compiled Markdown</h1>
 
-        <h1>Literal HTML</h1>
 
         // Without extension
+        <h1>Literal HTML</h1>
         <h1>Rendered Blade</h1>
         <h1>Compiled Markdown</h1>
 
-        <h1>Literal HTML</h1>
         HTML;
 
         $this->assertSame($expected, Blade::render($view));

--- a/packages/framework/tests/Feature/IncludesFacadeTest.php
+++ b/packages/framework/tests/Feature/IncludesFacadeTest.php
@@ -119,12 +119,15 @@ class IncludesFacadeTest extends TestCase
 
     public function testTorchlightAttributionIsNotInjectedToMarkdownPartials()
     {
-        $this->file('resources/includes/without-torchlight.md', 'Syntax highlighted by torchlight.dev');
+        $placeholder = 'Syntax highlighted by torchlight.dev';
+        $this->file('resources/includes/without-torchlight.md', $placeholder);
 
-        $this->assertSame(
-            '<p>Syntax highlighted by torchlight.dev</p>',
-            Includes::markdown('without-torchlight.md')
-        );
+        $rendered = Includes::markdown('without-torchlight.md');
+
+        $attribution = 'Syntax highlighting by <a href="https://torchlight.dev/" rel="noopener nofollow">Torchlight.dev</a>';
+
+        $this->assertStringNotContainsString($attribution, $rendered);
+        $this->assertSame("<p>$placeholder</p>", $rendered);
     }
 
     public function testAdvancedMarkdownDocumentIsCompiledToHtml()

--- a/packages/framework/tests/Unit/IncludesFacadeUnitTest.php
+++ b/packages/framework/tests/Unit/IncludesFacadeUnitTest.php
@@ -9,6 +9,7 @@ use Closure;
 use Hyde\Hyde;
 use Hyde\Support\Includes;
 use Hyde\Testing\UnitTestCase;
+use Illuminate\Support\HtmlString;
 use Illuminate\Support\Facades\Blade;
 use Illuminate\Filesystem\Filesystem;
 
@@ -82,7 +83,7 @@ class IncludesFacadeUnitTest extends UnitTestCase
             $filesystem->shouldReceive('get')->with($this->includesPath($filename))->andReturn($expected);
         });
 
-        $this->assertSame($expected, Includes::html($filename));
+        $this->assertHtmlStringIsSame($expected, Includes::html($filename));
     }
 
     public function testHtmlReturnsDefaultValueWhenNotFound()
@@ -95,7 +96,7 @@ class IncludesFacadeUnitTest extends UnitTestCase
         });
 
         $this->assertNull(Includes::html($filename));
-        $this->assertSame($default, Includes::html($filename, $default));
+        $this->assertHtmlStringIsSame($default, Includes::html($filename, $default));
     }
 
     public function testHtmlWithAndWithoutExtension()
@@ -108,7 +109,7 @@ class IncludesFacadeUnitTest extends UnitTestCase
             $filesystem->shouldReceive('get')->with($this->includesPath($filename))->andReturn($content);
         });
 
-        $this->assertSame(Includes::html('foo.html'), Includes::html('foo'));
+        $this->assertHtmlStringIsSame(Includes::html('foo.html'), Includes::html('foo'));
     }
 
     public function testMarkdownReturnsRenderedPartial()
@@ -123,7 +124,7 @@ class IncludesFacadeUnitTest extends UnitTestCase
             $filesystem->shouldReceive('get')->with($this->includesPath($filename))->andReturn($content);
         });
 
-        $this->assertSame($expected, Includes::markdown($filename));
+        $this->assertHtmlStringIsSame($expected, Includes::markdown($filename));
     }
 
     public function testMarkdownReturnsRenderedDefaultValueWhenNotFound()
@@ -137,7 +138,7 @@ class IncludesFacadeUnitTest extends UnitTestCase
         });
 
         $this->assertNull(Includes::markdown($filename));
-        $this->assertSame($expected, Includes::markdown($filename, $default));
+        $this->assertHtmlStringIsSame($expected, Includes::markdown($filename, $default));
     }
 
     public function testMarkdownWithAndWithoutExtension()
@@ -152,9 +153,9 @@ class IncludesFacadeUnitTest extends UnitTestCase
             $filesystem->shouldReceive('get')->with($this->includesPath($filename))->andReturn($content);
         });
 
-        $this->assertSame($expected, Includes::markdown('foo.md'));
-        $this->assertSame(Includes::markdown('foo.md'), Includes::markdown('foo'));
-        $this->assertSame(Includes::markdown('foo.md'), Includes::markdown('foo.md'));
+        $this->assertHtmlStringIsSame($expected, Includes::markdown('foo.md'));
+        $this->assertHtmlStringIsSame(Includes::markdown('foo.md'), Includes::markdown('foo'));
+        $this->assertHtmlStringIsSame(Includes::markdown('foo.md'), Includes::markdown('foo.md'));
     }
 
     public function testBladeReturnsRenderedPartial()
@@ -171,7 +172,7 @@ class IncludesFacadeUnitTest extends UnitTestCase
             Blade::shouldReceive('render')->with($content)->andReturn($expected);
         });
 
-        $this->assertSame($expected, Includes::blade($filename));
+        $this->assertHtmlStringIsSame($expected, Includes::blade($filename));
     }
 
     public function testBladeWithAndWithoutExtension()
@@ -187,7 +188,7 @@ class IncludesFacadeUnitTest extends UnitTestCase
             Blade::shouldReceive('render')->with($content)->andReturn($expected);
         });
 
-        $this->assertSame(Includes::blade('foo.blade.php'), Includes::blade('foo'));
+        $this->assertHtmlStringIsSame(Includes::blade('foo.blade.php'), Includes::blade('foo'));
     }
 
     public function testBladeReturnsDefaultValueWhenNotFound()
@@ -203,7 +204,7 @@ class IncludesFacadeUnitTest extends UnitTestCase
         });
 
         $this->assertNull(Includes::blade($filename));
-        $this->assertSame($expected, Includes::blade($filename, $default));
+        $this->assertHtmlStringIsSame($expected, Includes::blade($filename, $default));
     }
 
     protected function mockFilesystem(Closure $config): void
@@ -218,5 +219,11 @@ class IncludesFacadeUnitTest extends UnitTestCase
     protected function includesPath(string $filename): string
     {
         return Hyde::path('resources/includes/'.$filename);
+    }
+
+    protected function assertHtmlStringIsSame(string|HtmlString $expected, mixed $actual): void
+    {
+        $this->assertInstanceOf(HtmlString::class, $actual);
+        $this->assertSame((string) $expected, $actual->toHtml());
     }
 }

--- a/packages/framework/tests/Unit/IncludesFacadeUnitTest.php
+++ b/packages/framework/tests/Unit/IncludesFacadeUnitTest.php
@@ -114,7 +114,7 @@ class IncludesFacadeUnitTest extends UnitTestCase
     public function testMarkdownReturnsRenderedPartial()
     {
         $filename = 'foo.md';
-        $expected = "<h1>foo bar</h1>\n";
+        $expected = '<h1>foo bar</h1>';
 
         $this->mockFilesystem(function ($filesystem) use ($filename) {
             $content = '# foo bar';
@@ -130,7 +130,7 @@ class IncludesFacadeUnitTest extends UnitTestCase
     {
         $filename = 'foo.md';
         $default = '# default';
-        $expected = "<h1>default</h1>\n";
+        $expected = '<h1>default</h1>';
 
         $this->mockFilesystem(function ($filesystem) use ($filename) {
             $filesystem->shouldReceive('exists')->with($this->includesPath($filename))->andReturn(false);
@@ -142,7 +142,7 @@ class IncludesFacadeUnitTest extends UnitTestCase
 
     public function testMarkdownWithAndWithoutExtension()
     {
-        $expected = "<h1>foo bar</h1>\n";
+        $expected = '<h1>foo bar</h1>';
 
         $this->mockFilesystem(function ($filesystem) {
             $content = '# foo bar';

--- a/packages/framework/tests/Unit/IncludesFacadeUnitTest.php
+++ b/packages/framework/tests/Unit/IncludesFacadeUnitTest.php
@@ -47,6 +47,11 @@ class IncludesFacadeUnitTest extends UnitTestCase
         $this->assertSame(Hyde::path('resources/includes/partial.html'), Includes::path('partial.html'));
     }
 
+    public function testPathNormalizesNestedIdentifiers()
+    {
+        $this->assertSame(Hyde::path('resources/includes/partial.html'), Includes::path('foo/partial.html'));
+    }
+
     public function testGetReturnsPartial()
     {
         $filename = 'foo.txt';
@@ -71,6 +76,20 @@ class IncludesFacadeUnitTest extends UnitTestCase
 
         $this->assertNull(Includes::get($filename));
         $this->assertSame($default, Includes::get($filename, $default));
+    }
+
+    public function testGetNormalizesNestedIdentifiers()
+    {
+        $filename = 'foo/bar.txt';
+        $normalized = 'bar.txt';
+        $expected = 'foo bar';
+
+        $this->mockFilesystem(function ($filesystem) use ($expected, $normalized) {
+            $filesystem->shouldReceive('exists')->with($this->includesPath($normalized))->andReturn(true);
+            $filesystem->shouldReceive('get')->with($this->includesPath($normalized))->andReturn($expected);
+        });
+
+        $this->assertSame($expected, Includes::get($filename));
     }
 
     public function testHtmlReturnsRenderedPartial()


### PR DESCRIPTION
- [x] Methods in the `Includes` facade now return `HtmlString` objects instead of `string`
    - Fixes https://github.com/hydephp/develop/issues/1734
- [x] Markdown includes are now converted to HTML using the custom HydePHP Markdown service, meaning they now support full GFM spec and custom Hyde features like colored blockquotes and code block filepath labels 
- [x] Markdown returned from includes are now trimmed of trailing whitespace and newlines 
- [x] The `Includes::path()` and `Includes::get()` methods now normalizes paths to be basenames to match the behaviour of the other include method.
    - This means that nested directories are no longer supported, as you should use a data collection for that.


### Includes facade changes

The following methods in the `Includes` facade now return `HtmlString` objects instead of `string`:

- `Includes::html()`
- `Includes::blade()`
- `Includes::markdown()`

Notes:

- This means that you no longer need to use `{!! !!}` to render the output of these methods in Blade templates, instead just use `{{ }}`.
- If you have used the return value of these methods in custom code, you may need to adjust your code to work with the new return type.


For more information, see the RFC that proposed this change: https://github.com/hydephp/develop/issues/1734
The RFC was implemented in https://github.com/hydephp/develop/pull/1738

#### Remember to escape output if necessary

**Note:** Remember that this means that includes are **no longer escaped** by default, so make sure to escape the output if necessary, for example if the content is user-generated.
- (Use `{{ e(Includes::html('foo')) }}` instead of `{{ Includes::html('foo') }}` to escape the output, matching the previous behavior.)