### PR TITLE
[2.x] Update the `route` helper function to throw if the route does not exist

### DIFF
--- a/packages/framework/src/helpers.php
+++ b/packages/framework/src/helpers.php
@@ -44,7 +44,7 @@ namespace {
              */
             function route(string $key): ?Hyde\Support\Models\Route
             {
-                return hyde()->route($key);
+                return hyde()->routes()->getRoute($key);
             }
         }
 

--- a/packages/framework/tests/Feature/HelpersTest.php
+++ b/packages/framework/tests/Feature/HelpersTest.php
@@ -142,13 +142,9 @@ class HelpersTest extends TestCase
     /** @covers ::route */
     public function testRouteFunctionWithInvalidRoute()
     {
-        $this->assertNull(route('foo'));
-    }
+        $this->expectException(\Hyde\Framework\Exceptions\RouteNotFoundException::class);
 
-    /** @covers ::route */
-    public function testRouteFunctionReturnsNullForNonExistentRoute()
-    {
-        $this->assertNull(route('nonexistent'));
+        route('invalid');
     }
 
     /** @covers ::url */


### PR DESCRIPTION
Fixes https://github.com/hydephp/develop/issues/1731