### PR TITLE
[2.x] Even smarter sitemap generation

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -27,6 +27,7 @@ This serves two purposes:
 - Minor: Data collection files are now validated for syntax errors during discovery in https://github.com/hydephp/develop/pull/1732
 - Minor: Methods in the `Includes` facade now return `HtmlString` objects instead of `string` in https://github.com/hydephp/develop/pull/1738. For more information, see below.
 - Minor: `Includes::path()` and  `Includes::get()` methods now normalizes paths to be basenames to match the behaviour of the other include methods in https://github.com/hydephp/develop/pull/1738. This means that nested directories are no longer supported, as you should use a data collection for that.
+- Minor: The `processing_time_ms` attribute in the `sitemap.xml` file has now been removed in https://github.com/hydephp/develop/pull/1744
 - Improved the sitemap data generation to be even smarter in https://github.com/hydephp/develop/pull/1744
 - The `hasFeature` method on the Hyde facade and HydeKernel now only accepts a Feature enum value instead of a string for its parameter.
 - Changed how the documentation search is generated, to be an `InMemoryPage` instead of a post-build task.

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -28,8 +28,7 @@ This serves two purposes:
 - Minor: Methods in the `Includes` facade now return `HtmlString` objects instead of `string` in https://github.com/hydephp/develop/pull/1738. For more information, see below.
 - Minor: `Includes::path()` and  `Includes::get()` methods now normalizes paths to be basenames to match the behaviour of the other include methods in https://github.com/hydephp/develop/pull/1738. This means that nested directories are no longer supported, as you should use a data collection for that.
 - Minor: The `processing_time_ms` attribute in the `sitemap.xml` file has now been removed in https://github.com/hydephp/develop/pull/1744
-- Improved sitemap generation to be smarter and more dynamic in https://github.com/hydephp/develop/pull/1744
-- Improved the sitemap data generation to be even smarter in https://github.com/hydephp/develop/pull/1744
+- Improved the sitemap data generation to be smarter and more dynamic in https://github.com/hydephp/develop/pull/1744
 - The `hasFeature` method on the Hyde facade and HydeKernel now only accepts a Feature enum value instead of a string for its parameter.
 - Changed how the documentation search is generated, to be an `InMemoryPage` instead of a post-build task.
 - Media asset files are now copied using the new build task instead of the deprecated `BuildService::transferMediaAssets()` method.

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -28,6 +28,7 @@ This serves two purposes:
 - Minor: Methods in the `Includes` facade now return `HtmlString` objects instead of `string` in https://github.com/hydephp/develop/pull/1738. For more information, see below.
 - Minor: `Includes::path()` and  `Includes::get()` methods now normalizes paths to be basenames to match the behaviour of the other include methods in https://github.com/hydephp/develop/pull/1738. This means that nested directories are no longer supported, as you should use a data collection for that.
 - Minor: The `processing_time_ms` attribute in the `sitemap.xml` file has now been removed in https://github.com/hydephp/develop/pull/1744
+- Improved sitemap generation to be smarter and more dynamic in https://github.com/hydephp/develop/pull/1744
 - Improved the sitemap data generation to be even smarter in https://github.com/hydephp/develop/pull/1744
 - The `hasFeature` method on the Hyde facade and HydeKernel now only accepts a Feature enum value instead of a string for its parameter.
 - Changed how the documentation search is generated, to be an `InMemoryPage` instead of a post-build task.

--- a/packages/framework/src/Framework/Features/XmlGenerators/SitemapGenerator.php
+++ b/packages/framework/src/Framework/Features/XmlGenerators/SitemapGenerator.php
@@ -14,13 +14,13 @@ use Hyde\Pages\MarkdownPage;
 use Hyde\Pages\MarkdownPost;
 use Hyde\Facades\Filesystem;
 use Hyde\Support\Models\Route;
+use Illuminate\Support\Carbon;
 use Hyde\Pages\DocumentationPage;
 use Hyde\Foundation\Facades\Routes;
 
 use function blank;
 use function in_array;
 use function date;
-use function time;
 use function str_starts_with;
 
 /**
@@ -63,7 +63,7 @@ class SitemapGenerator extends BaseXmlGenerator
         $timestamp = @Filesystem::lastModified($file);
 
         if (! $timestamp) {
-            $timestamp = time();
+            $timestamp = Carbon::now()->timestamp;
         }
 
         return date('c', $timestamp);

--- a/packages/framework/src/Framework/Features/XmlGenerators/SitemapGenerator.php
+++ b/packages/framework/src/Framework/Features/XmlGenerators/SitemapGenerator.php
@@ -103,10 +103,6 @@ class SitemapGenerator extends BaseXmlGenerator
             return 'daily';
         }
 
-        if (in_array($pageClass, [MarkdownPost::class, InMemoryPage::class, HtmlPage::class])) {
-            return 'weekly';
-        }
-
         return 'weekly';
     }
 

--- a/packages/framework/src/Framework/Features/XmlGenerators/SitemapGenerator.php
+++ b/packages/framework/src/Framework/Features/XmlGenerators/SitemapGenerator.php
@@ -72,10 +72,10 @@ class SitemapGenerator extends BaseXmlGenerator
             if ($identifier === 'index') {
                 $priority = 1;
             }
+        }
 
-            if ($identifier === '404') {
-                $priority = 0.5;
-            }
+        if ($identifier === '404') {
+            $priority = 0.5;
         }
 
         if ($pageClass === DocumentationPage::class) {

--- a/packages/framework/src/Framework/Features/XmlGenerators/SitemapGenerator.php
+++ b/packages/framework/src/Framework/Features/XmlGenerators/SitemapGenerator.php
@@ -60,13 +60,7 @@ class SitemapGenerator extends BaseXmlGenerator
 
     protected function getLastModDate(string $file): string
     {
-        $timestamp = @Filesystem::lastModified($file);
-
-        if (! $timestamp) {
-            $timestamp = Carbon::now()->timestamp;
-        }
-
-        return date('c', $timestamp);
+        return date('c', @Filesystem::lastModified($file) ?: Carbon::now()->timestamp);
     }
 
     protected function getPriority(string $pageClass, string $identifier): string

--- a/packages/framework/src/Framework/Features/XmlGenerators/SitemapGenerator.php
+++ b/packages/framework/src/Framework/Features/XmlGenerators/SitemapGenerator.php
@@ -93,17 +93,20 @@ class SitemapGenerator extends BaseXmlGenerator
         return (string) $priority;
     }
 
+    /** Intelligently find a good change frequency for the given page based on assumptions about the site structure. */
     protected function getChangeFrequency(string $pageClass, string $identifier): string
     {
-        if ($identifier === '404') {
-            return 'monthly';
-        }
+        $frequency = 'weekly';
 
         if (in_array($pageClass, [BladePage::class, MarkdownPage::class, DocumentationPage::class])) {
-            return 'daily';
+            $frequency = 'daily';
         }
 
-        return 'weekly';
+        if ($identifier === '404') {
+            $frequency = 'monthly';
+        }
+
+        return $frequency;
     }
 
     protected function resolveRouteLink(Route $route): string

--- a/packages/framework/src/Framework/Features/XmlGenerators/SitemapGenerator.php
+++ b/packages/framework/src/Framework/Features/XmlGenerators/SitemapGenerator.php
@@ -61,9 +61,11 @@ class SitemapGenerator extends BaseXmlGenerator
     protected function getLastModDate(string $file): string
     {
         $timestamp = @Filesystem::lastModified($file);
+
         if (! $timestamp) {
             $timestamp = time();
         }
+
         return date('c', $timestamp);
     }
 

--- a/packages/framework/src/Framework/Features/XmlGenerators/SitemapGenerator.php
+++ b/packages/framework/src/Framework/Features/XmlGenerators/SitemapGenerator.php
@@ -107,8 +107,8 @@ class SitemapGenerator extends BaseXmlGenerator
             // to using relative links instead of using localhost links.
 
             return $route->getLink();
-        } else {
-            return Hyde::url($route->getOutputPath());
         }
+
+        return Hyde::url($route->getOutputPath());
     }
 }

--- a/packages/framework/src/Framework/Features/XmlGenerators/SitemapGenerator.php
+++ b/packages/framework/src/Framework/Features/XmlGenerators/SitemapGenerator.php
@@ -52,6 +52,11 @@ class SitemapGenerator extends BaseXmlGenerator
         $this->addChild($urlItem, 'priority', $this->generatePriority(...$this->getRouteInformation($route)));
     }
 
+    protected function resolveRouteLink(Route $route): string
+    {
+        return Hyde::url($route->getOutputPath());
+    }
+
     protected function getLastModDate(string $file): string
     {
         return date('c', @Filesystem::lastModified($file) ?: Carbon::now()->timestamp);
@@ -95,11 +100,6 @@ class SitemapGenerator extends BaseXmlGenerator
         }
 
         return $frequency;
-    }
-
-    protected function resolveRouteLink(Route $route): string
-    {
-        return Hyde::url($route->getOutputPath());
     }
 
     /** @return array{class-string<\Hyde\Pages\Concerns\HydePage>, string} */

--- a/packages/framework/src/Framework/Features/XmlGenerators/SitemapGenerator.php
+++ b/packages/framework/src/Framework/Features/XmlGenerators/SitemapGenerator.php
@@ -91,6 +91,7 @@ class SitemapGenerator extends BaseXmlGenerator
 
     /**
      * @param  class-string<\Hyde\Pages\Concerns\HydePage>  $pageClass
+     * @return 'always'|'hourly'|'daily '|'weekly'|'monthly'|'yearly'|'never'
      */
     protected function generateChangeFrequency(string $pageClass, string $identifier): string
     {

--- a/packages/framework/src/Framework/Features/XmlGenerators/SitemapGenerator.php
+++ b/packages/framework/src/Framework/Features/XmlGenerators/SitemapGenerator.php
@@ -57,37 +57,29 @@ class SitemapGenerator extends BaseXmlGenerator
         return date('c', @Filesystem::lastModified($file) ?: Carbon::now()->timestamp);
     }
 
-    /** Intelligently find a good priority for the given page based on assumptions about the site structure. */
     protected function generatePriority(string $pageClass, string $identifier): string
     {
-        // The default priority, unless we find a better match.
         $priority = 0.5;
 
         if (in_array($pageClass, [BladePage::class, MarkdownPage::class, DocumentationPage::class])) {
-            // These pages are usually high up in the site hierarchy, so they get a higher priority.
             $priority = 0.9;
 
             if ($identifier === 'index') {
-                // The homepage is the most important page, so it gets the highest priority.
                 $priority = 1;
             }
         }
 
         if (in_array($pageClass, [MarkdownPost::class, InMemoryPage::class, HtmlPage::class])) {
-            // Posts are usually less important than normal pages as there may be many of them.
-            // We group in InMemoryPages and HtmlPages here since we don't have much context for them.
             $priority = 0.75;
         }
 
         if ($identifier === '404') {
-            // 404 pages are rarely important to index, so they get a lower priority.
             $priority = 0.25;
         }
 
         return (string) $priority;
     }
 
-    /** Intelligently find a good change frequency for the given page based on assumptions about the site structure. */
     protected function generateChangeFrequency(string $pageClass, string $identifier): string
     {
         $frequency = 'weekly';

--- a/packages/framework/src/Framework/Features/XmlGenerators/SitemapGenerator.php
+++ b/packages/framework/src/Framework/Features/XmlGenerators/SitemapGenerator.php
@@ -12,12 +12,12 @@ use Hyde\Facades\Config;
 use Hyde\Pages\BladePage;
 use Hyde\Pages\MarkdownPage;
 use Hyde\Pages\MarkdownPost;
+use Hyde\Facades\Filesystem;
 use Hyde\Support\Models\Route;
 use Hyde\Pages\DocumentationPage;
 use Hyde\Foundation\Facades\Routes;
 
 use function blank;
-use function filemtime;
 use function in_array;
 use function date;
 use function time;
@@ -60,7 +60,7 @@ class SitemapGenerator extends BaseXmlGenerator
 
     protected function getLastModDate(string $file): string
     {
-        $timestamp = @filemtime($file);
+        $timestamp = @Filesystem::lastModified($file);
         if (! $timestamp) {
             $timestamp = time();
         }

--- a/packages/framework/src/Framework/Features/XmlGenerators/SitemapGenerator.php
+++ b/packages/framework/src/Framework/Features/XmlGenerators/SitemapGenerator.php
@@ -42,8 +42,6 @@ class SitemapGenerator extends BaseXmlGenerator
 
     public function getXml(): string
     {
-        $this->xmlElement->addAttribute('processing_time_ms', $this->getFormattedProcessingTime());
-
         return parent::getXml();
     }
 
@@ -120,11 +118,5 @@ class SitemapGenerator extends BaseXmlGenerator
         } else {
             return Hyde::url($route->getOutputPath());
         }
-    }
-
-    /** @return numeric-string */
-    protected function getFormattedProcessingTime(): string
-    {
-        return (string) $this->getExecutionTimeInMs();
     }
 }

--- a/packages/framework/src/Framework/Features/XmlGenerators/SitemapGenerator.php
+++ b/packages/framework/src/Framework/Features/XmlGenerators/SitemapGenerator.php
@@ -101,6 +101,8 @@ class SitemapGenerator extends BaseXmlGenerator
         $baseUrl = Config::getNullableString('hyde.url');
 
         if (blank($baseUrl) || str_starts_with($baseUrl, 'http://localhost')) {
+            // TODO: This does not seem to be reachable from the actual commands, and should be removed.
+
             // While the sitemap spec requires a full URL, we rather fall back
             // to using relative links instead of using localhost links.
 

--- a/packages/framework/src/Framework/Features/XmlGenerators/SitemapGenerator.php
+++ b/packages/framework/src/Framework/Features/XmlGenerators/SitemapGenerator.php
@@ -37,11 +37,6 @@ class SitemapGenerator extends BaseXmlGenerator
         return $this;
     }
 
-    public function getXml(): string
-    {
-        return parent::getXml();
-    }
-
     protected function constructBaseElement(): void
     {
         $this->xmlElement = new SimpleXMLElement('<?xml version="1.0" encoding="UTF-8"?><urlset xmlns="https://www.sitemaps.org/schemas/sitemap/0.9"></urlset>');

--- a/packages/framework/src/Framework/Features/XmlGenerators/SitemapGenerator.php
+++ b/packages/framework/src/Framework/Features/XmlGenerators/SitemapGenerator.php
@@ -62,7 +62,9 @@ class SitemapGenerator extends BaseXmlGenerator
         return date('c', @Filesystem::lastModified($file) ?: Carbon::now()->timestamp);
     }
 
-    /** @param class-string<\Hyde\Pages\Concerns\HydePage> $pageClass */
+    /**
+     * @param  class-string<\Hyde\Pages\Concerns\HydePage>  $pageClass
+     */
     protected function generatePriority(string $pageClass, string $identifier): string
     {
         $priority = 0.5;
@@ -86,7 +88,9 @@ class SitemapGenerator extends BaseXmlGenerator
         return (string) $priority;
     }
 
-    /** @param class-string<\Hyde\Pages\Concerns\HydePage> $pageClass */
+    /**
+     * @param  class-string<\Hyde\Pages\Concerns\HydePage>  $pageClass
+     */
     protected function generateChangeFrequency(string $pageClass, string $identifier): string
     {
         $frequency = 'weekly';

--- a/packages/framework/src/Framework/Features/XmlGenerators/SitemapGenerator.php
+++ b/packages/framework/src/Framework/Features/XmlGenerators/SitemapGenerator.php
@@ -48,8 +48,8 @@ class SitemapGenerator extends BaseXmlGenerator
 
         $this->addChild($urlItem, 'loc', $this->resolveRouteLink($route));
         $this->addChild($urlItem, 'lastmod', $this->getLastModDate($route->getSourcePath()));
-        $this->addChild($urlItem, 'changefreq', $this->generateChangeFrequency($route->getPageClass(), $route->getPage()->getIdentifier()));
-        $this->addChild($urlItem, 'priority', $this->generatePriority($route->getPageClass(), $route->getPage()->getIdentifier()));
+        $this->addChild($urlItem, 'changefreq', $this->generateChangeFrequency(...$this->getRouteInformation($route)));
+        $this->addChild($urlItem, 'priority', $this->generatePriority(...$this->getRouteInformation($route)));
     }
 
     protected function getLastModDate(string $file): string
@@ -98,5 +98,10 @@ class SitemapGenerator extends BaseXmlGenerator
     protected function resolveRouteLink(Route $route): string
     {
         return Hyde::url($route->getOutputPath());
+    }
+
+    protected function getRouteInformation(Route $route): array
+    {
+        return [$route->getPageClass(), $route->getPage()->getIdentifier()];
     }
 }

--- a/packages/framework/src/Framework/Features/XmlGenerators/SitemapGenerator.php
+++ b/packages/framework/src/Framework/Features/XmlGenerators/SitemapGenerator.php
@@ -18,10 +18,8 @@ use Illuminate\Support\Carbon;
 use Hyde\Pages\DocumentationPage;
 use Hyde\Foundation\Facades\Routes;
 
-use function blank;
 use function in_array;
 use function date;
-use function str_starts_with;
 
 /**
  * @see https://www.sitemaps.org/protocol.html
@@ -98,17 +96,6 @@ class SitemapGenerator extends BaseXmlGenerator
 
     protected function resolveRouteLink(Route $route): string
     {
-        $baseUrl = Config::getNullableString('hyde.url');
-
-        if (blank($baseUrl) || str_starts_with($baseUrl, 'http://localhost')) {
-            // TODO: This does not seem to be reachable from the actual commands, and should be removed.
-
-            // While the sitemap spec requires a full URL, we rather fall back
-            // to using relative links instead of using localhost links.
-
-            return $route->getLink();
-        }
-
         return Hyde::url($route->getOutputPath());
     }
 }

--- a/packages/framework/src/Framework/Features/XmlGenerators/SitemapGenerator.php
+++ b/packages/framework/src/Framework/Features/XmlGenerators/SitemapGenerator.php
@@ -64,6 +64,7 @@ class SitemapGenerator extends BaseXmlGenerator
 
     /**
      * @param  class-string<\Hyde\Pages\Concerns\HydePage>  $pageClass
+     * @return numeric-string
      */
     protected function generatePriority(string $pageClass, string $identifier): string
     {

--- a/packages/framework/src/Framework/Features/XmlGenerators/SitemapGenerator.php
+++ b/packages/framework/src/Framework/Features/XmlGenerators/SitemapGenerator.php
@@ -95,7 +95,19 @@ class SitemapGenerator extends BaseXmlGenerator
 
     protected function getChangeFrequency(string $pageClass, string $identifier): string
     {
-        return 'daily';
+        if ($identifier === '404') {
+            return 'monthly';
+        }
+
+        if (in_array($pageClass, [BladePage::class, MarkdownPage::class, DocumentationPage::class])) {
+            return 'daily';
+        }
+
+        if (in_array($pageClass, [MarkdownPost::class, InMemoryPage::class, HtmlPage::class])) {
+            return 'weekly';
+        }
+
+        return 'weekly';
     }
 
     protected function resolveRouteLink(Route $route): string

--- a/packages/framework/src/Framework/Features/XmlGenerators/SitemapGenerator.php
+++ b/packages/framework/src/Framework/Features/XmlGenerators/SitemapGenerator.php
@@ -60,11 +60,11 @@ class SitemapGenerator extends BaseXmlGenerator
 
     protected function getLastModDate(string $file): string
     {
-        if (@filemtime($file)) {
-            return date('c', @filemtime($file));
-        } else {
-            return date('c', time());
+        $timestamp = @filemtime($file);
+        if (! $timestamp) {
+            $timestamp = time();
         }
+        return date('c', $timestamp);
     }
 
     protected function getPriority(string $pageClass, string $identifier): string

--- a/packages/framework/src/Framework/Features/XmlGenerators/SitemapGenerator.php
+++ b/packages/framework/src/Framework/Features/XmlGenerators/SitemapGenerator.php
@@ -74,16 +74,16 @@ class SitemapGenerator extends BaseXmlGenerator
             }
         }
 
-        if ($identifier === '404') {
-            $priority = 0.5;
-        }
-
         if ($pageClass === DocumentationPage::class) {
             $priority = 0.9;
         }
 
         if ($pageClass === MarkdownPost::class) {
             $priority = 0.75;
+        }
+
+        if ($identifier === '404') {
+            $priority = 0.5;
         }
 
         return (string) $priority;

--- a/packages/framework/src/Framework/Features/XmlGenerators/SitemapGenerator.php
+++ b/packages/framework/src/Framework/Features/XmlGenerators/SitemapGenerator.php
@@ -8,7 +8,6 @@ namespace Hyde\Framework\Features\XmlGenerators;
 
 use Hyde\Hyde;
 use SimpleXMLElement;
-use Hyde\Facades\Config;
 use Hyde\Pages\HtmlPage;
 use Hyde\Pages\BladePage;
 use Hyde\Pages\MarkdownPage;
@@ -50,12 +49,7 @@ class SitemapGenerator extends BaseXmlGenerator
         $this->addChild($urlItem, 'loc', $this->resolveRouteLink($route));
         $this->addChild($urlItem, 'lastmod', $this->getLastModDate($route->getSourcePath()));
         $this->addChild($urlItem, 'changefreq', $this->getChangeFrequency($route->getPageClass(), $route->getPage()->getIdentifier()));
-
-        if (Config::getBool('hyde.sitemap.dynamic_priority', true)) {
-            $this->addChild($urlItem, 'priority', $this->getPriority(
-                $route->getPageClass(), $route->getPage()->getIdentifier()
-            ));
-        }
+        $this->addChild($urlItem, 'priority', $this->getPriority($route->getPageClass(), $route->getPage()->getIdentifier()));
     }
 
     protected function getLastModDate(string $file): string

--- a/packages/framework/src/Framework/Features/XmlGenerators/SitemapGenerator.php
+++ b/packages/framework/src/Framework/Features/XmlGenerators/SitemapGenerator.php
@@ -57,6 +57,7 @@ class SitemapGenerator extends BaseXmlGenerator
         return date('c', @Filesystem::lastModified($file) ?: Carbon::now()->timestamp);
     }
 
+    /** @param class-string<\Hyde\Pages\Concerns\HydePage> $pageClass */
     protected function generatePriority(string $pageClass, string $identifier): string
     {
         $priority = 0.5;
@@ -80,6 +81,7 @@ class SitemapGenerator extends BaseXmlGenerator
         return (string) $priority;
     }
 
+    /** @param class-string<\Hyde\Pages\Concerns\HydePage> $pageClass */
     protected function generateChangeFrequency(string $pageClass, string $identifier): string
     {
         $frequency = 'weekly';
@@ -100,6 +102,7 @@ class SitemapGenerator extends BaseXmlGenerator
         return Hyde::url($route->getOutputPath());
     }
 
+    /** @return array{class-string<\Hyde\Pages\Concerns\HydePage>, string} */
     protected function getRouteInformation(Route $route): array
     {
         return [$route->getPageClass(), $route->getPage()->getIdentifier()];

--- a/packages/framework/src/Framework/Features/XmlGenerators/SitemapGenerator.php
+++ b/packages/framework/src/Framework/Features/XmlGenerators/SitemapGenerator.php
@@ -84,7 +84,7 @@ class SitemapGenerator extends BaseXmlGenerator
 
         if ($identifier === '404') {
             // 404 pages are rarely important to index, so they get a lower priority.
-            $priority = 0.5;
+            $priority = 0.25;
         }
 
         return (string) $priority;

--- a/packages/framework/src/Framework/Features/XmlGenerators/SitemapGenerator.php
+++ b/packages/framework/src/Framework/Features/XmlGenerators/SitemapGenerator.php
@@ -9,10 +9,12 @@ namespace Hyde\Framework\Features\XmlGenerators;
 use Hyde\Hyde;
 use SimpleXMLElement;
 use Hyde\Facades\Config;
+use Hyde\Pages\HtmlPage;
 use Hyde\Pages\BladePage;
 use Hyde\Pages\MarkdownPage;
 use Hyde\Pages\MarkdownPost;
 use Hyde\Facades\Filesystem;
+use Hyde\Pages\InMemoryPage;
 use Hyde\Support\Models\Route;
 use Illuminate\Support\Carbon;
 use Hyde\Pages\DocumentationPage;
@@ -77,8 +79,9 @@ class SitemapGenerator extends BaseXmlGenerator
             }
         }
 
-        if ($pageClass === MarkdownPost::class) {
-            // Posts are usually less important than pages as there may be many of them.
+        if (in_array($pageClass, [MarkdownPost::class, InMemoryPage::class, HtmlPage::class])) {
+            // Posts are usually less important than normal pages as there may be many of them.
+            // We group in InMemoryPages and HtmlPages here since we don't have much context for them.
             $priority = 0.75;
         }
 

--- a/packages/framework/src/Framework/Features/XmlGenerators/SitemapGenerator.php
+++ b/packages/framework/src/Framework/Features/XmlGenerators/SitemapGenerator.php
@@ -61,28 +61,34 @@ class SitemapGenerator extends BaseXmlGenerator
         return date('c', @Filesystem::lastModified($file) ?: Carbon::now()->timestamp);
     }
 
+    /** Intelligently find a good priority for the given page based on assumptions about the site structure. */
     protected function getPriority(string $pageClass, string $identifier): string
     {
         // The default priority, unless we find a better match.
         $priority = 0.5;
 
         if (in_array($pageClass, [BladePage::class, MarkdownPage::class])) {
+            // These pages are usually high up in the site hierarchy, so they get a higher priority.
             $priority = 0.9;
 
             if ($identifier === 'index') {
+                // The homepage is the most important page, so it gets the highest priority.
                 $priority = 1;
             }
         }
 
         if ($pageClass === DocumentationPage::class) {
+            // If a site has documentation pages, they are usually important as well.
             $priority = 0.9;
         }
 
         if ($pageClass === MarkdownPost::class) {
+            // Posts are usually less important than pages as there may be many of them.
             $priority = 0.75;
         }
 
         if ($identifier === '404') {
+            // 404 pages are rarely important to index, so they get a lower priority.
             $priority = 0.5;
         }
 

--- a/packages/framework/src/Framework/Features/XmlGenerators/SitemapGenerator.php
+++ b/packages/framework/src/Framework/Features/XmlGenerators/SitemapGenerator.php
@@ -15,7 +15,6 @@ use Hyde\Pages\MarkdownPost;
 use Hyde\Support\Models\Route;
 use Hyde\Pages\DocumentationPage;
 use Hyde\Foundation\Facades\Routes;
-use Hyde\Framework\Concerns\TracksExecutionTime;
 
 use function blank;
 use function filemtime;
@@ -29,8 +28,6 @@ use function str_starts_with;
  */
 class SitemapGenerator extends BaseXmlGenerator
 {
-    use TracksExecutionTime;
-
     public function generate(): static
     {
         Routes::all()->each(function (Route $route): void {
@@ -47,8 +44,6 @@ class SitemapGenerator extends BaseXmlGenerator
 
     protected function constructBaseElement(): void
     {
-        $this->startClock();
-
         $this->xmlElement = new SimpleXMLElement('<?xml version="1.0" encoding="UTF-8"?><urlset xmlns="https://www.sitemaps.org/schemas/sitemap/0.9"></urlset>');
         $this->xmlElement->addAttribute('generator', 'HydePHP '.Hyde::version());
     }

--- a/packages/framework/src/Framework/Features/XmlGenerators/SitemapGenerator.php
+++ b/packages/framework/src/Framework/Features/XmlGenerators/SitemapGenerator.php
@@ -60,7 +60,11 @@ class SitemapGenerator extends BaseXmlGenerator
 
     protected function getLastModDate(string $file): string
     {
-        return date('c', @filemtime($file) ?: time());
+        if (@filemtime($file)) {
+            return date('c', @filemtime($file));
+        } else {
+            return date('c', time());
+        }
     }
 
     protected function getPriority(string $pageClass, string $identifier): string

--- a/packages/framework/src/Framework/Features/XmlGenerators/SitemapGenerator.php
+++ b/packages/framework/src/Framework/Features/XmlGenerators/SitemapGenerator.php
@@ -48,8 +48,8 @@ class SitemapGenerator extends BaseXmlGenerator
 
         $this->addChild($urlItem, 'loc', $this->resolveRouteLink($route));
         $this->addChild($urlItem, 'lastmod', $this->getLastModDate($route->getSourcePath()));
-        $this->addChild($urlItem, 'changefreq', $this->getChangeFrequency($route->getPageClass(), $route->getPage()->getIdentifier()));
-        $this->addChild($urlItem, 'priority', $this->getPriority($route->getPageClass(), $route->getPage()->getIdentifier()));
+        $this->addChild($urlItem, 'changefreq', $this->generateChangeFrequency($route->getPageClass(), $route->getPage()->getIdentifier()));
+        $this->addChild($urlItem, 'priority', $this->generatePriority($route->getPageClass(), $route->getPage()->getIdentifier()));
     }
 
     protected function getLastModDate(string $file): string
@@ -58,7 +58,7 @@ class SitemapGenerator extends BaseXmlGenerator
     }
 
     /** Intelligently find a good priority for the given page based on assumptions about the site structure. */
-    protected function getPriority(string $pageClass, string $identifier): string
+    protected function generatePriority(string $pageClass, string $identifier): string
     {
         // The default priority, unless we find a better match.
         $priority = 0.5;
@@ -88,7 +88,7 @@ class SitemapGenerator extends BaseXmlGenerator
     }
 
     /** Intelligently find a good change frequency for the given page based on assumptions about the site structure. */
-    protected function getChangeFrequency(string $pageClass, string $identifier): string
+    protected function generateChangeFrequency(string $pageClass, string $identifier): string
     {
         $frequency = 'weekly';
 

--- a/packages/framework/src/Framework/Features/XmlGenerators/SitemapGenerator.php
+++ b/packages/framework/src/Framework/Features/XmlGenerators/SitemapGenerator.php
@@ -67,7 +67,7 @@ class SitemapGenerator extends BaseXmlGenerator
         // The default priority, unless we find a better match.
         $priority = 0.5;
 
-        if (in_array($pageClass, [BladePage::class, MarkdownPage::class])) {
+        if (in_array($pageClass, [BladePage::class, MarkdownPage::class, DocumentationPage::class])) {
             // These pages are usually high up in the site hierarchy, so they get a higher priority.
             $priority = 0.9;
 
@@ -75,11 +75,6 @@ class SitemapGenerator extends BaseXmlGenerator
                 // The homepage is the most important page, so it gets the highest priority.
                 $priority = 1;
             }
-        }
-
-        if ($pageClass === DocumentationPage::class) {
-            // If a site has documentation pages, they are usually important as well.
-            $priority = 0.9;
         }
 
         if ($pageClass === MarkdownPost::class) {

--- a/packages/framework/tests/Feature/Commands/BuildSitemapCommandTest.php
+++ b/packages/framework/tests/Feature/Commands/BuildSitemapCommandTest.php
@@ -21,7 +21,12 @@ class BuildSitemapCommandTest extends TestCase
 
         $this->assertFileDoesNotExist(Hyde::path('_site/sitemap.xml'));
 
-        $this->artisan('build:sitemap')->assertExitCode(0);
+        $this->artisan('build:sitemap')
+            ->expectsOutputToContain('Generating sitemap...')
+            ->doesntExpectOutputToContain('Skipped')
+            ->expectsOutputToContain(' > Created _site/sitemap.xml')
+            ->assertExitCode(0);
+
         $this->assertFileExists(Hyde::path('_site/sitemap.xml'));
 
         Filesystem::unlink('_site/sitemap.xml');
@@ -33,7 +38,12 @@ class BuildSitemapCommandTest extends TestCase
 
         $this->assertFileDoesNotExist(Hyde::path('_site/sitemap.xml'));
 
-        $this->artisan('build:sitemap')->assertExitCode(0);
+        $this->artisan('build:sitemap')
+            ->expectsOutputToContain('Generating sitemap...')
+            ->expectsOutputToContain('Skipped')
+            ->expectsOutput(' > Cannot generate sitemap without a valid base URL')
+            ->assertExitCode(0);
+
         $this->assertFileDoesNotExist(Hyde::path('_site/sitemap.xml'));
     }
 }

--- a/packages/framework/tests/Feature/Commands/BuildSitemapCommandTest.php
+++ b/packages/framework/tests/Feature/Commands/BuildSitemapCommandTest.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Hyde\Framework\Testing\Feature\Commands;
 
-use Hyde\Facades\Filesystem;
 use Hyde\Hyde;
 use Hyde\Testing\TestCase;
 
@@ -18,6 +17,8 @@ class BuildSitemapCommandTest extends TestCase
     {
         config(['hyde.url' => 'https://example.com']);
 
+        $this->cleanUpWhenDone('_site/sitemap.xml');
+
         $this->assertFileDoesNotExist(Hyde::path('_site/sitemap.xml'));
 
         $this->artisan('build:sitemap')
@@ -27,8 +28,6 @@ class BuildSitemapCommandTest extends TestCase
             ->assertExitCode(0);
 
         $this->assertFileExists(Hyde::path('_site/sitemap.xml'));
-
-        Filesystem::unlink('_site/sitemap.xml');
     }
 
     public function testSitemapIsNotGeneratedWhenConditionsAreNotMet()

--- a/packages/framework/tests/Feature/Commands/BuildSitemapCommandTest.php
+++ b/packages/framework/tests/Feature/Commands/BuildSitemapCommandTest.php
@@ -17,7 +17,6 @@ class BuildSitemapCommandTest extends TestCase
     public function testSitemapIsGeneratedWhenConditionsAreMet()
     {
         config(['hyde.url' => 'https://example.com']);
-        // config(['hyde.generate_sitemap' => true]); This is only applied when calling the main build command. If the user calls this command directly, it will always generate the sitemap as long as the URL is set.
 
         $this->assertFileDoesNotExist(Hyde::path('_site/sitemap.xml'));
 

--- a/packages/framework/tests/Feature/SitemapFeatureTest.php
+++ b/packages/framework/tests/Feature/SitemapFeatureTest.php
@@ -43,15 +43,13 @@ class SitemapFeatureTest extends TestCase
 
         $this->assertFileExists('_site/sitemap.xml');
 
-        $expected = '<?xml version="1.0" encoding="UTF-8"?>'."\n".$this->stripFormatting($this->expected())."\n";
+        $expected = '<?xml version="1.0" encoding="UTF-8"?>'."\n".$this->stripFormatting($this->expected(Hyde::version()))."\n";
         $actual = file_get_contents('_site/sitemap.xml');
         $this->assertSame($expected, $actual);
     }
 
-    protected function expected(): string
+    protected function expected(string $version): string
     {
-        $version = Hyde::version();
-
         return <<<XML
         <urlset xmlns="https://www.sitemaps.org/schemas/sitemap/0.9" generator="HydePHP $version">
             <url>

--- a/packages/framework/tests/Feature/SitemapFeatureTest.php
+++ b/packages/framework/tests/Feature/SitemapFeatureTest.php
@@ -48,6 +48,18 @@ class SitemapFeatureTest extends TestCase
         );
     }
 
+    protected function setUpBroadSiteStructure(): void
+    {
+        $this->file('_pages/about.md', "# About\n\nThis is the about page.");
+        $this->file('_pages/contact.html', '<h1>Contact</h1><p>This is the contact page.</p>');
+        $this->file('_posts/hello-world.md', "# Hello, World!\n\nThis is the first post.");
+        $this->file('_posts/second-post.md', "# Second Post\n\nThis is the second post.");
+        $this->file('_docs/index.md', "# Documentation\n\nThis is the documentation index.");
+        $this->file('_docs/installation.md', "# Installation\n\nThis is the installation guide.");
+        $this->file('_docs/usage.md', "# Usage\n\nThis is the usage guide.");
+        $this->file('_docs/404.md', "# 404\n\nThis is the 404 page.");
+    }
+
     protected function expected(string $version): string
     {
         return <<<XML
@@ -126,18 +138,6 @@ class SitemapFeatureTest extends TestCase
             </url>
         </urlset>
         XML;
-    }
-
-    protected function setUpBroadSiteStructure(): void
-    {
-        $this->file('_pages/about.md', "# About\n\nThis is the about page.");
-        $this->file('_pages/contact.html', '<h1>Contact</h1><p>This is the contact page.</p>');
-        $this->file('_posts/hello-world.md', "# Hello, World!\n\nThis is the first post.");
-        $this->file('_posts/second-post.md', "# Second Post\n\nThis is the second post.");
-        $this->file('_docs/index.md', "# Documentation\n\nThis is the documentation index.");
-        $this->file('_docs/installation.md', "# Installation\n\nThis is the installation guide.");
-        $this->file('_docs/usage.md', "# Usage\n\nThis is the usage guide.");
-        $this->file('_docs/404.md', "# 404\n\nThis is the 404 page.");
     }
 
     protected function stripFormatting(string $xml): string

--- a/packages/framework/tests/Feature/SitemapFeatureTest.php
+++ b/packages/framework/tests/Feature/SitemapFeatureTest.php
@@ -110,7 +110,7 @@ class SitemapFeatureTest extends TestCase
                 <loc>https://example.com/docs/index.html</loc>
                 <lastmod>2024-01-01T12:00:00+00:00</lastmod>
                 <changefreq>daily</changefreq>
-                <priority>0.9</priority>
+                <priority>1</priority>
             </url>
             <url>
                 <loc>https://example.com/docs/installation.html</loc>

--- a/packages/framework/tests/Feature/SitemapFeatureTest.php
+++ b/packages/framework/tests/Feature/SitemapFeatureTest.php
@@ -147,7 +147,6 @@ class SitemapFeatureTest extends TestCase
 
     protected function expandLines(string $xml): string
     {
-        // Expand the XML to make it easier to read in the test output.
         return str_replace('><', ">\n<", $xml);
     }
 

--- a/packages/framework/tests/Feature/SitemapFeatureTest.php
+++ b/packages/framework/tests/Feature/SitemapFeatureTest.php
@@ -9,6 +9,8 @@ use Hyde\Testing\TestCase;
 /**
  * High level test of the sitemap generation feature.
  *
+ * It contains a setup that covers all code paths, proving 100% coverage in actual usage.
+ *
  * @see \Hyde\Framework\Testing\Feature\Services\SitemapServiceTest
  * @see \Hyde\Framework\Testing\Feature\Commands\BuildSitemapCommandTest
  *

--- a/packages/framework/tests/Feature/SitemapFeatureTest.php
+++ b/packages/framework/tests/Feature/SitemapFeatureTest.php
@@ -30,8 +30,9 @@ class SitemapFeatureTest extends TestCase
             ->assertExitCode(0);
 
         $this->assertFileExists('_site/sitemap.xml');
-        // TODO: Fix dynamic data in comparison 
-        $this->assertFileEqualsString('<?xml version="1.0" encoding="UTF-8"?>'."\n".$this->stripFormatting($this->expected()), '_site/sitemap.xml');
+        // TODO: Fix dynamic data in comparison
+        $expected = '<?xml version="1.0" encoding="UTF-8"?>'."\n".$this->stripFormatting($this->expected());
+        $this->assertFileEqualsString($expected, '_site/sitemap.xml');
     }
 
     protected function expected(): string

--- a/packages/framework/tests/Feature/SitemapFeatureTest.php
+++ b/packages/framework/tests/Feature/SitemapFeatureTest.php
@@ -22,6 +22,10 @@ class SitemapFeatureTest extends TestCase
     {
         $this->setUpBroadSiteStructure();
         $this->withSiteUrl();
+
+        $this->artisan('build:sitemap')
+            ->expectsOutputToContain('Created _site/sitemap.xml')
+            ->assertExitCode(0);
     }
 
     protected function setUpBroadSiteStructure(): void

--- a/packages/framework/tests/Feature/SitemapFeatureTest.php
+++ b/packages/framework/tests/Feature/SitemapFeatureTest.php
@@ -9,6 +9,7 @@ use Hyde\Hyde;
 use Hyde\Testing\TestCase;
 use Illuminate\Support\Carbon;
 use Illuminate\Support\Facades\File;
+use Illuminate\Filesystem\Filesystem;
 
 /**
  * High level test of the sitemap generation feature.
@@ -28,7 +29,7 @@ class SitemapFeatureTest extends TestCase
     {
         Carbon::setTestNow('2024-01-01 12:00:00');
 
-        $filesystem = Mockery::mock(\Illuminate\Filesystem\Filesystem::class)->makePartial();
+        $filesystem = Mockery::mock(Filesystem::class)->makePartial();
         $filesystem->shouldReceive('lastModified')->andReturn(Carbon::now()->timestamp);
         File::swap($filesystem);
 

--- a/packages/framework/tests/Feature/SitemapFeatureTest.php
+++ b/packages/framework/tests/Feature/SitemapFeatureTest.php
@@ -23,6 +23,8 @@ class SitemapFeatureTest extends TestCase
 {
     public function testTheSitemapFeature()
     {
+        $this->markTestSkipped('This test is not yet complete.');
+
         Carbon::setTestNow('2024-01-01 12:00:00');
 
         $this->cleanUpWhenDone('_site/sitemap.xml');

--- a/packages/framework/tests/Feature/SitemapFeatureTest.php
+++ b/packages/framework/tests/Feature/SitemapFeatureTest.php
@@ -44,8 +44,7 @@ class SitemapFeatureTest extends TestCase
         $this->assertFileExists('_site/sitemap.xml');
 
         $expected =  '<?xml version="1.0" encoding="UTF-8"?>'."\n{$this->stripFormatting($this->expected(Hyde::version()))}\n";
-        $actual = file_get_contents('_site/sitemap.xml');
-        $this->assertSame($expected, $actual);
+        $this->assertSame($expected, file_get_contents('_site/sitemap.xml'));
     }
 
     protected function expected(string $version): string

--- a/packages/framework/tests/Feature/SitemapFeatureTest.php
+++ b/packages/framework/tests/Feature/SitemapFeatureTest.php
@@ -32,7 +32,8 @@ class SitemapFeatureTest extends TestCase
         $this->assertFileExists('_site/sitemap.xml');
         // TODO: Fix dynamic data in comparison
         $expected = '<?xml version="1.0" encoding="UTF-8"?>'."\n".$this->stripFormatting($this->expected());
-        $this->assertSame($expected, file_get_contents('_site/sitemap.xml'));
+        $actual = file_get_contents('_site/sitemap.xml');
+        $this->assertSame($expected, $actual);
     }
 
     protected function expected(): string

--- a/packages/framework/tests/Feature/SitemapFeatureTest.php
+++ b/packages/framework/tests/Feature/SitemapFeatureTest.php
@@ -22,6 +22,7 @@ class SitemapFeatureTest extends TestCase
 {
     public function testTheSitemapFeature()
     {
+        $this->cleanUpWhenDone('_site/sitemap.xml');
         $this->setUpBroadSiteStructure();
         $this->withSiteUrl();
 

--- a/packages/framework/tests/Feature/SitemapFeatureTest.php
+++ b/packages/framework/tests/Feature/SitemapFeatureTest.php
@@ -30,6 +30,7 @@ class SitemapFeatureTest extends TestCase
             ->assertExitCode(0);
 
         $this->assertFileExists('_site/sitemap.xml');
+        // TODO: Fix dynamic data in comparison 
         $this->assertFileEqualsString('<?xml version="1.0" encoding="UTF-8"?>'."\n".$this->stripFormatting($this->expected()), '_site/sitemap.xml');
     }
 

--- a/packages/framework/tests/Feature/SitemapFeatureTest.php
+++ b/packages/framework/tests/Feature/SitemapFeatureTest.php
@@ -42,7 +42,7 @@ class SitemapFeatureTest extends TestCase
 
         $this->assertFileExists('_site/sitemap.xml');
 
-        $this->assertSame(
+        $this->assertSameXml(
             '<?xml version="1.0" encoding="UTF-8"?>'."\n{$this->stripFormatting($this->expected(Hyde::version()))}\n",
             file_get_contents('_site/sitemap.xml')
         );
@@ -143,5 +143,10 @@ class SitemapFeatureTest extends TestCase
     protected function stripFormatting(string $xml): string
     {
         return implode('', array_map('trim', explode("\n", $xml)));
+    }
+
+    protected function assertSameXml(string $expected, string $actual): void
+    {
+        $this->assertSame($expected, $actual);
     }
 }

--- a/packages/framework/tests/Feature/SitemapFeatureTest.php
+++ b/packages/framework/tests/Feature/SitemapFeatureTest.php
@@ -26,6 +26,8 @@ class SitemapFeatureTest extends TestCase
         $this->artisan('build:sitemap')
             ->expectsOutputToContain('Created _site/sitemap.xml')
             ->assertExitCode(0);
+
+        $this->assertFileExists('_site/sitemap.xml');
     }
 
     protected function setUpBroadSiteStructure(): void

--- a/packages/framework/tests/Feature/SitemapFeatureTest.php
+++ b/packages/framework/tests/Feature/SitemapFeatureTest.php
@@ -32,7 +32,7 @@ class SitemapFeatureTest extends TestCase
         $this->assertFileExists('_site/sitemap.xml');
         // TODO: Fix dynamic data in comparison
         $expected = '<?xml version="1.0" encoding="UTF-8"?>'."\n".$this->stripFormatting($this->expected());
-        $this->assertFileEqualsString($expected, '_site/sitemap.xml');
+        $this->assertSame($expected, file_get_contents('_site/sitemap.xml'));
     }
 
     protected function expected(): string

--- a/packages/framework/tests/Feature/SitemapFeatureTest.php
+++ b/packages/framework/tests/Feature/SitemapFeatureTest.php
@@ -67,13 +67,13 @@ class SitemapFeatureTest extends TestCase
             <url>
                 <loc>https://example.com/contact.html</loc>
                 <lastmod>2024-01-01T12:00:00+00:00</lastmod>
-                <changefreq>daily</changefreq>
+                <changefreq>weekly</changefreq>
                 <priority>0.75</priority>
             </url>
             <url>
                 <loc>https://example.com/404.html</loc>
                 <lastmod>2024-01-01T12:00:00+00:00</lastmod>
-                <changefreq>daily</changefreq>
+                <changefreq>monthly</changefreq>
                 <priority>0.25</priority>
             </url>
             <url>
@@ -91,19 +91,19 @@ class SitemapFeatureTest extends TestCase
             <url>
                 <loc>https://example.com/posts/hello-world.html</loc>
                 <lastmod>2024-01-01T12:00:00+00:00</lastmod>
-                <changefreq>daily</changefreq>
+                <changefreq>weekly</changefreq>
                 <priority>0.75</priority>
             </url>
             <url>
                 <loc>https://example.com/posts/second-post.html</loc>
                 <lastmod>2024-01-01T12:00:00+00:00</lastmod>
-                <changefreq>daily</changefreq>
+                <changefreq>weekly</changefreq>
                 <priority>0.75</priority>
             </url>
             <url>
                 <loc>https://example.com/docs/404.html</loc>
                 <lastmod>2024-01-01T12:00:00+00:00</lastmod>
-                <changefreq>daily</changefreq>
+                <changefreq>monthly</changefreq>
                 <priority>0.25</priority>
             </url>
             <url>
@@ -127,13 +127,13 @@ class SitemapFeatureTest extends TestCase
             <url>
                 <loc>https://example.com/docs/search.json</loc>
                 <lastmod>2024-01-01T12:00:00+00:00</lastmod>
-                <changefreq>daily</changefreq>
+                <changefreq>weekly</changefreq>
                 <priority>0.5</priority>
             </url>
             <url>
                 <loc>https://example.com/docs/search.html</loc>
                 <lastmod>2024-01-01T12:00:00+00:00</lastmod>
-                <changefreq>daily</changefreq>
+                <changefreq>weekly</changefreq>
                 <priority>0.5</priority>
             </url>
         </urlset>

--- a/packages/framework/tests/Feature/SitemapFeatureTest.php
+++ b/packages/framework/tests/Feature/SitemapFeatureTest.php
@@ -33,7 +33,7 @@ class SitemapFeatureTest extends TestCase
         // TODO: Fix dynamic data in comparison
         $expected = '<?xml version="1.0" encoding="UTF-8"?>'."\n".$this->stripFormatting($this->expected());
         $actual = file_get_contents('_site/sitemap.xml');
-        $this->assertSame($expected, $actual);
+        $this->assertSame($this->stripDynamicData($expected), $this->stripDynamicData($actual));
     }
 
     protected function expected(): string
@@ -131,5 +131,10 @@ class SitemapFeatureTest extends TestCase
     protected function stripFormatting(string $xml): string
     {
         return str_replace("\n", '', $xml);
+    }
+
+    protected function stripDynamicData(string $string): string
+    {
+        return $string;
     }
 }

--- a/packages/framework/tests/Feature/SitemapFeatureTest.php
+++ b/packages/framework/tests/Feature/SitemapFeatureTest.php
@@ -21,6 +21,7 @@ class SitemapFeatureTest extends TestCase
     public function testTheSitemapFeature()
     {
         $this->setUpBroadSiteStructure();
+        $this->withSiteUrl();
     }
 
     protected function setUpBroadSiteStructure(): void

--- a/packages/framework/tests/Feature/SitemapFeatureTest.php
+++ b/packages/framework/tests/Feature/SitemapFeatureTest.php
@@ -28,6 +28,15 @@ class SitemapFeatureTest extends TestCase
             ->assertExitCode(0);
 
         $this->assertFileExists('_site/sitemap.xml');
+        $this->assertFileEqualsString($this->expected(), '_site/sitemap.xml');
+    }
+
+    protected function expected(): string
+    {
+        return <<<XML
+        <?xml version="1.0" encoding="UTF-8"?>
+        TODO
+        XML;
     }
 
     protected function setUpBroadSiteStructure(): void

--- a/packages/framework/tests/Feature/SitemapFeatureTest.php
+++ b/packages/framework/tests/Feature/SitemapFeatureTest.php
@@ -30,14 +30,87 @@ class SitemapFeatureTest extends TestCase
             ->assertExitCode(0);
 
         $this->assertFileExists('_site/sitemap.xml');
-        $this->assertFileEqualsString($this->expected(), '_site/sitemap.xml');
+        $this->assertFileEqualsString(
+            '<?xml version="1.0" encoding="UTF-8"?>'."\n".$this->stripFormatting($this->expected()), '_site/sitemap.xml');
     }
 
     protected function expected(): string
     {
         return <<<XML
-        <?xml version="1.0" encoding="UTF-8"?>
-        TODO
+        <urlset xmlns="https://www.sitemaps.org/schemas/sitemap/0.9" generator="HydePHP 1.6.0" processing_time_ms="31.628131866455">
+            <url>
+                <loc>https://example.com/contact.html</loc>
+                <lastmod>2024-06-28T09:48:58+00:00</lastmod>
+                <changefreq>daily</changefreq>
+                <priority>0.5</priority>
+            </url>
+            <url>
+                <loc>https://example.com/404.html</loc>
+                <lastmod>2024-06-28T08:12:42+00:00</lastmod>
+                <changefreq>daily</changefreq>
+                <priority>0.5</priority>
+            </url>
+            <url>
+                <loc>https://example.com/index.html</loc>
+                <lastmod>2024-06-28T08:12:42+00:00</lastmod>
+                <changefreq>daily</changefreq>
+                <priority>1</priority>
+            </url>
+            <url>
+                <loc>https://example.com/about.html</loc>
+                <lastmod>2024-06-28T09:48:58+00:00</lastmod>
+                <changefreq>daily</changefreq>
+                <priority>0.9</priority>
+            </url>
+            <url>
+                <loc>https://example.com/posts/hello-world.html</loc>
+                <lastmod>2024-06-28T09:48:58+00:00</lastmod>
+                <changefreq>daily</changefreq>
+                <priority>0.75</priority>
+            </url>
+            <url>
+                <loc>https://example.com/posts/second-post.html</loc>
+                <lastmod>2024-06-28T09:48:58+00:00</lastmod>
+                <changefreq>daily</changefreq>
+                <priority>0.75</priority>
+            </url>
+            <url>
+                <loc>https://example.com/docs/404.html</loc>
+                <lastmod>2024-06-28T09:48:58+00:00</lastmod>
+                <changefreq>daily</changefreq>
+                <priority>0.9</priority>
+            </url>
+            <url>
+                <loc>https://example.com/docs/index.html</loc>
+                <lastmod>2024-06-28T09:48:58+00:00</lastmod>
+                <changefreq>daily</changefreq>
+                <priority>0.9</priority>
+            </url>
+            <url>
+                <loc>https://example.com/docs/installation.html</loc>
+                <lastmod>2024-06-28T09:48:58+00:00</lastmod>
+                <changefreq>daily</changefreq>
+                <priority>0.9</priority>
+            </url>
+            <url>
+                <loc>https://example.com/docs/usage.html</loc>
+                <lastmod>2024-06-28T09:48:58+00:00</lastmod>
+                <changefreq>daily</changefreq>
+                <priority>0.9</priority>
+            </url>
+            <url>
+                <loc>https://example.com/docs/search.json</loc>
+                <lastmod>2024-06-28T09:48:58+00:00</lastmod>
+                <changefreq>daily</changefreq>
+                <priority>0.5</priority>
+            </url>
+            <url>
+                <loc>https://example.com/docs/search.html</loc>
+                <lastmod>2024-06-28T09:48:58+00:00</lastmod>
+                <changefreq>daily</changefreq>
+                <priority>0.5</priority>
+            </url>
+        </urlset>
         XML;
     }
 
@@ -51,5 +124,10 @@ class SitemapFeatureTest extends TestCase
         $this->file('_docs/installation.md', "# Installation\n\nThis is the installation guide.");
         $this->file('_docs/usage.md', "# Usage\n\nThis is the usage guide.");
         $this->file('_docs/404.md', "# 404\n\nThis is the 404 page.");
+    }
+
+    protected function stripFormatting(string $xml): string
+    {
+        return str_replace("\n", '', $xml);
     }
 }

--- a/packages/framework/tests/Feature/SitemapFeatureTest.php
+++ b/packages/framework/tests/Feature/SitemapFeatureTest.php
@@ -104,7 +104,7 @@ class SitemapFeatureTest extends TestCase
                 <loc>https://example.com/docs/404.html</loc>
                 <lastmod>2024-01-01T12:00:00+00:00</lastmod>
                 <changefreq>daily</changefreq>
-                <priority>0.9</priority>
+                <priority>0.5</priority>
             </url>
             <url>
                 <loc>https://example.com/docs/index.html</loc>

--- a/packages/framework/tests/Feature/SitemapFeatureTest.php
+++ b/packages/framework/tests/Feature/SitemapFeatureTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Hyde\Framework\Testing\Feature;
 
 use Hyde\Testing\TestCase;
+use Illuminate\Support\Carbon;
 
 /**
  * High level test of the sitemap generation feature.
@@ -22,6 +23,8 @@ class SitemapFeatureTest extends TestCase
 {
     public function testTheSitemapFeature()
     {
+        Carbon::setTestNow('2024-01-01 12:00:00');
+
         $this->cleanUpWhenDone('_site/sitemap.xml');
         $this->setUpBroadSiteStructure();
         $this->withSiteUrl();

--- a/packages/framework/tests/Feature/SitemapFeatureTest.php
+++ b/packages/framework/tests/Feature/SitemapFeatureTest.php
@@ -28,7 +28,6 @@ class SitemapFeatureTest extends TestCase
     public function testTheSitemapFeature()
     {
         Carbon::setTestNow('2024-01-01 12:00:00');
-
         $filesystem = Mockery::mock(Filesystem::class)->makePartial();
         $filesystem->shouldReceive('lastModified')->andReturn(Carbon::now()->timestamp);
         File::swap($filesystem);
@@ -43,8 +42,10 @@ class SitemapFeatureTest extends TestCase
 
         $this->assertFileExists('_site/sitemap.xml');
 
-        $expected =  '<?xml version="1.0" encoding="UTF-8"?>'."\n{$this->stripFormatting($this->expected(Hyde::version()))}\n";
-        $this->assertSame($expected, file_get_contents('_site/sitemap.xml'));
+        $this->assertSame(
+            '<?xml version="1.0" encoding="UTF-8"?>'."\n{$this->stripFormatting($this->expected(Hyde::version()))}\n",
+            file_get_contents('_site/sitemap.xml')
+        );
     }
 
     protected function expected(string $version): string

--- a/packages/framework/tests/Feature/SitemapFeatureTest.php
+++ b/packages/framework/tests/Feature/SitemapFeatureTest.php
@@ -74,7 +74,7 @@ class SitemapFeatureTest extends TestCase
                 <loc>https://example.com/404.html</loc>
                 <lastmod>2024-01-01T12:00:00+00:00</lastmod>
                 <changefreq>daily</changefreq>
-                <priority>0.5</priority>
+                <priority>0.25</priority>
             </url>
             <url>
                 <loc>https://example.com/index.html</loc>
@@ -104,7 +104,7 @@ class SitemapFeatureTest extends TestCase
                 <loc>https://example.com/docs/404.html</loc>
                 <lastmod>2024-01-01T12:00:00+00:00</lastmod>
                 <changefreq>daily</changefreq>
-                <priority>0.5</priority>
+                <priority>0.25</priority>
             </url>
             <url>
                 <loc>https://example.com/docs/index.html</loc>

--- a/packages/framework/tests/Feature/SitemapFeatureTest.php
+++ b/packages/framework/tests/Feature/SitemapFeatureTest.php
@@ -68,7 +68,7 @@ class SitemapFeatureTest extends TestCase
                 <loc>https://example.com/contact.html</loc>
                 <lastmod>2024-01-01T12:00:00+00:00</lastmod>
                 <changefreq>daily</changefreq>
-                <priority>0.5</priority>
+                <priority>0.75</priority>
             </url>
             <url>
                 <loc>https://example.com/404.html</loc>

--- a/packages/framework/tests/Feature/SitemapFeatureTest.php
+++ b/packages/framework/tests/Feature/SitemapFeatureTest.php
@@ -23,8 +23,6 @@ class SitemapFeatureTest extends TestCase
 {
     public function testTheSitemapFeature()
     {
-        $this->markTestSkipped('This test is not yet complete.');
-
         Carbon::setTestNow('2024-01-01 12:00:00');
 
         $this->cleanUpWhenDone('_site/sitemap.xml');

--- a/packages/framework/tests/Feature/SitemapFeatureTest.php
+++ b/packages/framework/tests/Feature/SitemapFeatureTest.php
@@ -44,7 +44,7 @@ class SitemapFeatureTest extends TestCase
 
     protected function expected(): string
     {
-        return <<<XML
+        return <<<'XML'
         <urlset xmlns="https://www.sitemaps.org/schemas/sitemap/0.9" generator="HydePHP {{ dynamic }}" processing_time_ms="{{ dynamic }}">
             <url>
                 <loc>https://example.com/contact.html</loc>

--- a/packages/framework/tests/Feature/SitemapFeatureTest.php
+++ b/packages/framework/tests/Feature/SitemapFeatureTest.php
@@ -31,7 +31,7 @@ class SitemapFeatureTest extends TestCase
             ->assertExitCode(0);
 
         $this->assertFileExists('_site/sitemap.xml');
-        // TODO: Fix dynamic data in comparison
+
         $expected = '<?xml version="1.0" encoding="UTF-8"?>'."\n".$this->stripFormatting($this->expected());
         $actual = file_get_contents('_site/sitemap.xml');
         $this->assertSame($this->stripDynamicData($expected), $this->stripDynamicData($actual));
@@ -40,10 +40,10 @@ class SitemapFeatureTest extends TestCase
     protected function expected(): string
     {
         return <<<XML
-        <urlset xmlns="https://www.sitemaps.org/schemas/sitemap/0.9" generator="HydePHP 1.6.0" processing_time_ms="31.628131866455">
+        <urlset xmlns="https://www.sitemaps.org/schemas/sitemap/0.9" generator="HydePHP {{ dynamic }}" processing_time_ms="{{ dynamic }}">
             <url>
                 <loc>https://example.com/contact.html</loc>
-                <lastmod>2024-06-28T09:48:58+00:00</lastmod>
+                <lastmod>{{ dynamic }}</lastmod>
                 <changefreq>daily</changefreq>
                 <priority>0.5</priority>
             </url>
@@ -61,55 +61,55 @@ class SitemapFeatureTest extends TestCase
             </url>
             <url>
                 <loc>https://example.com/about.html</loc>
-                <lastmod>2024-06-28T09:48:58+00:00</lastmod>
+                <lastmod>{{ dynamic }}</lastmod>
                 <changefreq>daily</changefreq>
                 <priority>0.9</priority>
             </url>
             <url>
                 <loc>https://example.com/posts/hello-world.html</loc>
-                <lastmod>2024-06-28T09:48:58+00:00</lastmod>
+                <lastmod>{{ dynamic }}</lastmod>
                 <changefreq>daily</changefreq>
                 <priority>0.75</priority>
             </url>
             <url>
                 <loc>https://example.com/posts/second-post.html</loc>
-                <lastmod>2024-06-28T09:48:58+00:00</lastmod>
+                <lastmod>{{ dynamic }}</lastmod>
                 <changefreq>daily</changefreq>
                 <priority>0.75</priority>
             </url>
             <url>
                 <loc>https://example.com/docs/404.html</loc>
-                <lastmod>2024-06-28T09:48:58+00:00</lastmod>
+                <lastmod>{{ dynamic }}</lastmod>
                 <changefreq>daily</changefreq>
                 <priority>0.9</priority>
             </url>
             <url>
                 <loc>https://example.com/docs/index.html</loc>
-                <lastmod>2024-06-28T09:48:58+00:00</lastmod>
+                <lastmod>{{ dynamic }}</lastmod>
                 <changefreq>daily</changefreq>
                 <priority>0.9</priority>
             </url>
             <url>
                 <loc>https://example.com/docs/installation.html</loc>
-                <lastmod>2024-06-28T09:48:58+00:00</lastmod>
+                <lastmod>{{ dynamic }}</lastmod>
                 <changefreq>daily</changefreq>
                 <priority>0.9</priority>
             </url>
             <url>
                 <loc>https://example.com/docs/usage.html</loc>
-                <lastmod>2024-06-28T09:48:58+00:00</lastmod>
+                <lastmod>{{ dynamic }}</lastmod>
                 <changefreq>daily</changefreq>
                 <priority>0.9</priority>
             </url>
             <url>
                 <loc>https://example.com/docs/search.json</loc>
-                <lastmod>2024-06-28T09:48:58+00:00</lastmod>
+                <lastmod>{{ dynamic }}</lastmod>
                 <changefreq>daily</changefreq>
                 <priority>0.5</priority>
             </url>
             <url>
                 <loc>https://example.com/docs/search.html</loc>
-                <lastmod>2024-06-28T09:48:58+00:00</lastmod>
+                <lastmod>{{ dynamic }}</lastmod>
                 <changefreq>daily</changefreq>
                 <priority>0.5</priority>
             </url>
@@ -136,6 +136,10 @@ class SitemapFeatureTest extends TestCase
 
     protected function stripDynamicData(string $string): string
     {
+        $string = preg_replace('/HydePHP \d+\.\d+\.\d+/', 'HydePHP {{ dynamic }}', $string);
+        $string = preg_replace('/processing_time_ms="\d+"/', 'processing_time_ms="{{ dynamic }}"', $string);
+        $string = preg_replace('/<lastmod>\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\+\d{2}:\d{2}<\/lastmod>/', '<lastmod>{{ dynamic }}</lastmod>', $string);
+
         return $string;
     }
 }

--- a/packages/framework/tests/Feature/SitemapFeatureTest.php
+++ b/packages/framework/tests/Feature/SitemapFeatureTest.php
@@ -30,8 +30,7 @@ class SitemapFeatureTest extends TestCase
             ->assertExitCode(0);
 
         $this->assertFileExists('_site/sitemap.xml');
-        $this->assertFileEqualsString(
-            '<?xml version="1.0" encoding="UTF-8"?>'."\n".$this->stripFormatting($this->expected()), '_site/sitemap.xml');
+        $this->assertFileEqualsString('<?xml version="1.0" encoding="UTF-8"?>'."\n".$this->stripFormatting($this->expected()), '_site/sitemap.xml');
     }
 
     protected function expected(): string

--- a/packages/framework/tests/Feature/SitemapFeatureTest.php
+++ b/packages/framework/tests/Feature/SitemapFeatureTest.php
@@ -45,7 +45,7 @@ class SitemapFeatureTest extends TestCase
     protected function expected(): string
     {
         return <<<'XML'
-        <urlset xmlns="https://www.sitemaps.org/schemas/sitemap/0.9" generator="HydePHP {{ dynamic }}" processing_time_ms="{{ dynamic }}">
+        <urlset xmlns="https://www.sitemaps.org/schemas/sitemap/0.9" generator="HydePHP {{ dynamic }}">
             <url>
                 <loc>https://example.com/contact.html</loc>
                 <lastmod>{{ dynamic }}</lastmod>

--- a/packages/framework/tests/Feature/SitemapFeatureTest.php
+++ b/packages/framework/tests/Feature/SitemapFeatureTest.php
@@ -145,8 +145,14 @@ class SitemapFeatureTest extends TestCase
         return implode('', array_map('trim', explode("\n", $xml)));
     }
 
+    protected function expandLines(string $xml): string
+    {
+        // Expand the XML to make it easier to read in the test output.
+        return str_replace('><', ">\n<", $xml);
+    }
+
     protected function assertSameXml(string $expected, string $actual): void
     {
-        $this->assertSame($expected, $actual);
+        $this->assertSame($this->expandLines($expected), $this->expandLines($actual));
     }
 }

--- a/packages/framework/tests/Feature/SitemapFeatureTest.php
+++ b/packages/framework/tests/Feature/SitemapFeatureTest.php
@@ -43,7 +43,7 @@ class SitemapFeatureTest extends TestCase
 
         $this->assertFileExists('_site/sitemap.xml');
 
-        $expected = '<?xml version="1.0" encoding="UTF-8"?>'."\n".$this->stripFormatting($this->expected(Hyde::version()))."\n";
+        $expected =  '<?xml version="1.0" encoding="UTF-8"?>'."\n{$this->stripFormatting($this->expected(Hyde::version()))}\n";
         $actual = file_get_contents('_site/sitemap.xml');
         $this->assertSame($expected, $actual);
     }


### PR DESCRIPTION
Main changes:

- [x] 404 pages now have a sitemap lower priority 
- [x] Sitemap change frequencies are now dynamic in 48cef462816c97aa41a1e89b48efa3cd1f8230a3
- [x] Removed the `processing_time_ms` attribute in the `sitemap.xml` file as it adds no value in f2ee36f250265b5c32149bde01a672e24074fb3e
- [x] Removed unreachable legacy relative sitemap link resolving in 31ffc5eadc239999d361e30ca2b4733143562845
- [x] Removed undocumented `sitemap.dynamic_priority` config option in 6c619285c53a0fdf9b7488ae8d87b5931cac7186
- [x] Add improved broad level feature testing
