### PR TITLE
[2x] Use a non-zero exit code 3 when skipping build tasks

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -29,6 +29,7 @@ This serves two purposes:
 - Minor: `Includes::path()` and  `Includes::get()` methods now normalizes paths to be basenames to match the behaviour of the other include methods in https://github.com/hydephp/develop/pull/1738. This means that nested directories are no longer supported, as you should use a data collection for that.
 - Minor: The `processing_time_ms` attribute in the `sitemap.xml` file has now been removed in https://github.com/hydephp/develop/pull/1744
 - Improved the sitemap data generation to be smarter and more dynamic in https://github.com/hydephp/develop/pull/1744
+- Skipped build tasks will now exit with an exit code of 3 instead of 0 in https://github.com/hydephp/develop/pull/1749
 - The `hasFeature` method on the Hyde facade and HydeKernel now only accepts a Feature enum value instead of a string for its parameter.
 - Changed how the documentation search is generated, to be an `InMemoryPage` instead of a post-build task.
 - Media asset files are now copied using the new build task instead of the deprecated `BuildService::transferMediaAssets()` method.

--- a/packages/framework/src/Framework/Features/BuildTasks/BuildTaskSkippedException.php
+++ b/packages/framework/src/Framework/Features/BuildTasks/BuildTaskSkippedException.php
@@ -8,7 +8,7 @@ use RuntimeException;
 
 class BuildTaskSkippedException extends RuntimeException
 {
-    public function __construct(string $message = 'Task was skipped', int $code = 0)
+    public function __construct(string $message = 'Task was skipped', int $code = 2)
     {
         parent::__construct($message, $code);
     }

--- a/packages/framework/src/Framework/Features/BuildTasks/BuildTaskSkippedException.php
+++ b/packages/framework/src/Framework/Features/BuildTasks/BuildTaskSkippedException.php
@@ -8,7 +8,7 @@ use RuntimeException;
 
 class BuildTaskSkippedException extends RuntimeException
 {
-    public function __construct(string $message = 'Task was skipped', int $code = 2)
+    public function __construct(string $message = 'Task was skipped', int $code = 3)
     {
         parent::__construct($message, $code);
     }

--- a/packages/framework/tests/Feature/Commands/BuildSitemapCommandTest.php
+++ b/packages/framework/tests/Feature/Commands/BuildSitemapCommandTest.php
@@ -40,7 +40,7 @@ class BuildSitemapCommandTest extends TestCase
             ->expectsOutputToContain('Generating sitemap...')
             ->expectsOutputToContain('Skipped')
             ->expectsOutput(' > Cannot generate sitemap without a valid base URL')
-            ->assertExitCode(0);
+            ->assertExitCode(3);
 
         $this->assertFileDoesNotExist(Hyde::path('_site/sitemap.xml'));
     }

--- a/packages/framework/tests/Unit/BuildTaskSkippedExceptionTest.php
+++ b/packages/framework/tests/Unit/BuildTaskSkippedExceptionTest.php
@@ -39,7 +39,7 @@ class BuildTaskSkippedExceptionTest extends UnitTestCase
     {
         $exception = new BuildTaskSkippedException();
 
-        $this->assertSame(0, $exception->getCode());
+        $this->assertSame(3, $exception->getCode());
     }
 
     public function testCustomExceptionCode()

--- a/packages/framework/tests/Unit/BuildTaskUnitTest.php
+++ b/packages/framework/tests/Unit/BuildTaskUnitTest.php
@@ -192,7 +192,7 @@ class BuildTaskUnitTest extends UnitTestCase
             })->run();
         });
 
-        $this->assertSame(0, $task->property('exitCode'));
+        $this->assertSame(3, $task->property('exitCode'));
         $this->assertSame('<bg=yellow>Skipped</>', trim($task->buffer[1]));
         $this->assertSame('<fg=gray> > Task was skipped</>', $task->buffer[2]);
     }
@@ -205,7 +205,7 @@ class BuildTaskUnitTest extends UnitTestCase
             })->run();
         });
 
-        $this->assertSame(0, $task->property('exitCode'));
+        $this->assertSame(3, $task->property('exitCode'));
         $this->assertSame('<bg=yellow>Skipped</>', trim($task->buffer[1]));
         $this->assertSame('<fg=gray> > Custom reason</>', $task->buffer[2]);
     }


### PR DESCRIPTION
When calling a build task directly, for example with a wrapper like `php hyde sitemap:build`, the command will now exit with status code `3` instead of `0`, in order to signal that something went wrong. If a task is skipped during the main `php hyde build` command, nothing will change.

The reason behind this is that if you call a specific command like the sitemap build command directly, and it is skipped, then something other than what the user expected happened, so the exit code should reflect that. In comparison: A skipped build task as part of the main site build is not as critical, because in those cases the build task is auxiliary to the expected outcome.

This fixes https://github.com/hydephp/develop/issues/1745, please see that issue on how we landed on using exit code `3` when deciding on which non-zero exit code to use.