### PR TITLE
[2.x] Remove the deprecated global `unslash` function

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -44,6 +44,7 @@ This serves two purposes:
 ### Removed
 - Breaking: Removed the build task `\Hyde\Framework\Actions\PostBuildTasks\GenerateSearch` (see upgrade guide below)
 - Breaking: Removed the deprecated `\Hyde\Framework\Services\BuildService::transferMediaAssets()` method (see upgrade guide below)
+- Internal: Removed the deprecated global`unslash()` function, replaced with the namespaced `\Hyde\unslash()` function in https://github.com/hydephp/develop/pull/1754
 - Internal: Removed the internal `DocumentationSearchPage::generate()` method as it was unused in https://github.com/hydephp/develop/pull/1569
 
 ### Fixed

--- a/packages/framework/src/helpers.php
+++ b/packages/framework/src/helpers.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace {
     use Hyde\Foundation\HydeKernel;
-    use JetBrains\PhpStorm\Deprecated;
 
     if (! function_exists('hyde')) {
         /**
@@ -13,21 +12,6 @@ namespace {
         function hyde(): HydeKernel
         {
             return HydeKernel::getInstance();
-        }
-    }
-
-    if (! function_exists('unslash')) {
-        /**
-         * Remove trailing slashes from the start and end of a string.
-         *
-         * @deprecated This function will be replaced by {@see \Hyde\unslash()} in v2.0
-         *
-         * @codeCoverageIgnore This function is deprecated and will be removed in a future release.
-         */
-        #[Deprecated(reason: 'Replaced by the \Hyde\unslash() function', replacement: '\Hyde\unslash(%parametersList%)', since: '1.7.0')]
-        function unslash(string $string): string
-        {
-            return \Hyde\unslash($string);
         }
     }
 


### PR DESCRIPTION
This fixes part two of https://github.com/hydephp/develop/issues/1751. See https://github.com/hydephp/develop/pull/1753 for part one.