### PR TITLE
Remove the Git version displays

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -26,7 +26,7 @@ This serves two purposes:
 - Deprecated the global `unslash()` function, replaced with the existing namespaced `\Hyde\unslash()` function in https://github.com/hydephp/develop/pull/1753
 
 ### Removed
-- for now removed features.
+- The Git version is no longer displayed in the debug screen and dashboard in https://github.com/hydephp/develop/pull/1756
 
 ### Fixed
 - Fixed explicitly set front matter navigation group behavior being dependent on subdirectory configuration, fixing https://github.com/hydephp/develop/issues/1515 in https://github.com/hydephp/develop/pull/1703

--- a/packages/framework/src/Console/Commands/DebugCommand.php
+++ b/packages/framework/src/Console/Commands/DebugCommand.php
@@ -40,7 +40,6 @@ class DebugCommand extends Command
         $this->info('HydePHP Debug Screen');
         $this->newLine();
 
-        $this->comment('Git Version: '.(string) app('git.version'));
         $this->comment('Hyde Version: '.((InstalledVersions::isInstalled('hyde/hyde') ? InstalledVersions::getPrettyVersion('hyde/hyde') : null) ?: 'unreleased'));
         $this->comment('Framework Version: '.(InstalledVersions::getPrettyVersion('hyde/framework') ?: 'unreleased'));
         $this->newLine();

--- a/packages/framework/tests/Feature/Commands/DebugCommandTest.php
+++ b/packages/framework/tests/Feature/Commands/DebugCommandTest.php
@@ -15,13 +15,6 @@ use Hyde\Console\Commands\DebugCommand;
  */
 class DebugCommandTest extends TestCase
 {
-    protected function setUp(): void
-    {
-        parent::setUp();
-
-        $this->app->bind('git.version', fn () => 'foo');
-    }
-
     public function testDebugCommandCanRun()
     {
         $this->artisan('debug')->assertExitCode(0);
@@ -31,7 +24,6 @@ class DebugCommandTest extends TestCase
     {
         $this->artisan('debug')
             ->expectsOutput('HydePHP Debug Screen')
-            ->expectsOutputToContain('Git Version:')
             ->expectsOutputToContain('Hyde Version:')
             ->expectsOutputToContain('Framework Version:')
             ->expectsOutputToContain('App Env:')

--- a/packages/realtime-compiler/src/Http/DashboardController.php
+++ b/packages/realtime-compiler/src/Http/DashboardController.php
@@ -122,7 +122,6 @@ class DashboardController extends BaseController
     public function getProjectInformation(): array
     {
         return [
-            'Git Version' => app('git.version'),
             'Hyde Version' => self::getPackageVersion('hyde/hyde'),
             'Framework Version' => self::getPackageVersion('hyde/framework'),
             'Project Path' => Hyde::path(),


### PR DESCRIPTION
This feature works great in the monorepo, but in other places it's just confusing, as it shows the project version, and it's also quite uncommon to version sites using tags. The original container binding is from Laravel Zero, presumably for finding the version in the compiled standalone, something we are not using due to our version constant.

This PR targets v1 as it is not breaking, we just remove displays of this from the dashboard and debug screen.