### PR TITLE
 Update the Hyde URL helper to not modify already qualified URLs

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -33,6 +33,7 @@ This serves two purposes:
 - Fixed DataCollections file finding method not being able to be overridden https://github.com/hydephp/develop/issues/1716 in https://github.com/hydephp/develop/pull/1717
 - Fixed PHP warning when trying to parse a Markdown file with just front matter without body https://github.com/hydephp/develop/issues/1705 in https://github.com/hydephp/develop/pull/1728
 - Yaml data files no longer need to start with triple dashes to be parsed by DataCollections in https://github.com/hydephp/develop/pull/1733
+- Updated the Hyde URL helper to not modify already qualified URLs in https://github.com/hydephp/develop/pull/1757
 
 ### Security
 - in case of vulnerabilities.

--- a/packages/framework/src/Foundation/Kernel/Hyperlinks.php
+++ b/packages/framework/src/Foundation/Kernel/Hyperlinks.php
@@ -142,6 +142,8 @@ class Hyperlinks
      * @param  string  $path  An optional relative path suffix. Omit to return the base URL.
      *
      * @throws BaseUrlNotSetException If no site URL is set and no path is provided.
+     *
+     * TODO: Check if the URL is already qualified and return it as is.
      */
     public function url(string $path = ''): string
     {

--- a/packages/framework/src/Foundation/Kernel/Hyperlinks.php
+++ b/packages/framework/src/Foundation/Kernel/Hyperlinks.php
@@ -142,12 +142,14 @@ class Hyperlinks
      * @param  string  $path  An optional relative path suffix. Omit to return the base URL.
      *
      * @throws BaseUrlNotSetException If no site URL is set and no path is provided.
-     *
-     * TODO: Check if the URL is already qualified and return it as is.
      */
     public function url(string $path = ''): string
     {
         $path = $this->formatLink(trim($path, '/'));
+
+        if (str_starts_with($path, 'http')) {
+            return $path;
+        }
 
         if ($this->hasSiteUrl()) {
             return rtrim(rtrim(Config::getString('hyde.url'), '/')."/$path", '/');

--- a/packages/framework/tests/Feature/HelpersTest.php
+++ b/packages/framework/tests/Feature/HelpersTest.php
@@ -201,6 +201,24 @@ class HelpersTest extends TestCase
         $this->assertSame('http://localhost/foo', url('http://localhost/foo'));
     }
 
+    /** @covers ::url */
+    public function testUrlFunctionWithAlreadyQualifiedUrlWhenSiteUrlIsSet()
+    {
+        $this->app['config']->set(['hyde.url' => 'https://example.com']);
+
+        $this->assertSame('https://example.com/foo', url('https://example.com/foo'));
+        $this->assertSame('http://localhost/foo', url('http://localhost/foo'));
+    }
+
+    /** @covers ::url */
+    public function testUrlFunctionWithAlreadyQualifiedUrlWhenSiteUrlIsSetToSomethingElse()
+    {
+        $this->app['config']->set(['hyde.url' => 'my-site.com']);
+
+        $this->assertSame('https://example.com/foo', url('https://example.com/foo'));
+        $this->assertSame('http://localhost/foo', url('http://localhost/foo'));
+    }
+
     /** @covers ::\Hyde\hyde */
     public function testHydeFunctionExistsInHydeNamespace()
     {

--- a/packages/framework/tests/Feature/HelpersTest.php
+++ b/packages/framework/tests/Feature/HelpersTest.php
@@ -197,8 +197,6 @@ class HelpersTest extends TestCase
     /** @covers ::url */
     public function testUrlFunctionWithAlreadyQualifiedUrl()
     {
-        $this->markTestSkipped('The url function does not check if the URL is already qualified.');
-
         $this->assertSame('https://example.com/foo', url('https://example.com/foo'));
         $this->assertSame('http://localhost/foo', url('http://localhost/foo'));
     }

--- a/packages/framework/tests/Unit/Foundation/HyperlinksUrlPathHelpersTest.php
+++ b/packages/framework/tests/Unit/Foundation/HyperlinksUrlPathHelpersTest.php
@@ -110,6 +110,51 @@ class HyperlinksUrlPathHelpersTest extends TestCase
         $this->assertSame('http://example.com', $this->class->url());
     }
 
+    public function testQualifiedUrlHelperWithAlreadyQualifiedUrl()
+    {
+        $this->assertSame('https://example.com/foo', $this->class->url('https://example.com/foo'));
+        $this->assertSame('http://localhost/foo', $this->class->url('http://localhost/foo'));
+    }
+
+    public function testQualifiedUrlHelperWithAlreadyQualifiedUrlWhenSiteUrlIsSet()
+    {
+        $this->app['config']->set(['hyde.url' => 'https://example.com']);
+
+        $this->assertSame('https://example.com/foo', $this->class->url('https://example.com/foo'));
+        $this->assertSame('http://localhost/foo', $this->class->url('http://localhost/foo'));
+    }
+
+    public function testQualifiedUrlHelperWithAlreadyQualifiedUrlWhenSiteUrlIsSetToSomethingElse()
+    {
+        $this->app['config']->set(['hyde.url' => 'my-site.com']);
+
+        $this->assertSame('https://example.com/foo', $this->class->url('https://example.com/foo'));
+        $this->assertSame('http://localhost/foo', $this->class->url('http://localhost/foo'));
+    }
+
+    public function testQualifiedUrlHelperWithAlreadyQualifiedUrlStillFormatsPath()
+    {
+        $this->assertSame('https://example.com/foo/bar.html', $this->class->url('https://example.com/foo/bar.html'));
+        $this->assertSame('http://localhost/foo/bar.html', $this->class->url('http://localhost/foo/bar.html'));
+        $this->assertSame('http://localhost/foo/bar', $this->class->url('http://localhost/foo/bar/'));
+    }
+
+    public function testQualifiedUrlHelperWithAlreadyQualifiedUrlStillFormatsPathWhenSiteUrlIsSet()
+    {
+        $this->app['config']->set(['hyde.url' => 'https://example.com']);
+        $this->assertSame('https://example.com/foo/bar.html', $this->class->url('https://example.com/foo/bar.html'));
+        $this->assertSame('http://localhost/foo/bar.html', $this->class->url('http://localhost/foo/bar.html'));
+        $this->assertSame('http://localhost/foo/bar', $this->class->url('http://localhost/foo/bar/'));
+    }
+
+    public function testQualifiedUrlHelperWithAlreadyQualifiedUrlStillFormatsPathWithPrettyUrls()
+    {
+        $this->app['config']->set(['hyde.url' => 'https://example.com', 'hyde.pretty_urls' => true]);
+        $this->assertSame('https://example.com/foo/bar', $this->class->url('https://example.com/foo/bar.html'));
+        $this->assertSame('http://localhost/foo/bar', $this->class->url('http://localhost/foo/bar.html'));
+        $this->assertSame('http://localhost/foo/bar', $this->class->url('http://localhost/foo/bar/'));
+    }
+
     public function testQualifiedUrlThrowsExceptionWhenNoSiteUrlIsSet()
     {
         $this->withSiteUrl(null);


### PR DESCRIPTION
This is implemented in the `Hyperlinks` class meaning it effects both the `Hyde::url()` helper and the global `url()` function.

```php
Hyde::url('https://example.com/foo');

// Before https://example.com/https://example.com/foo
// After https://example.com/foo
```
