### PR TITLE
[1.x] Deprecate the `BaseUrlNotSetException` class

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -24,6 +24,7 @@ This serves two purposes:
 
 ### Deprecated
 - Deprecated the global `unslash()` function, replaced with the existing namespaced `\Hyde\unslash()` function in https://github.com/hydephp/develop/pull/1753
+- Deprecated the `BaseUrlNotSetException` class in https://github.com/hydephp/develop/pull/1759
 
 ### Removed
 - The Git version is no longer displayed in the debug screen and dashboard in https://github.com/hydephp/develop/pull/1756

--- a/packages/framework/src/Foundation/Kernel/Hyperlinks.php
+++ b/packages/framework/src/Foundation/Kernel/Hyperlinks.php
@@ -162,6 +162,7 @@ class Hyperlinks
         }
 
         // User is trying to get the base URL, but it's not set
+        // This exception is deprecated and will be removed in v2.0.0, and we will return null instead.
         throw new BaseUrlNotSetException();
     }
 

--- a/packages/framework/src/Framework/Exceptions/BaseUrlNotSetException.php
+++ b/packages/framework/src/Framework/Exceptions/BaseUrlNotSetException.php
@@ -6,6 +6,9 @@ namespace Hyde\Framework\Exceptions;
 
 use Exception;
 
+/**
+ * @deprecated This exception will be removed in v2.0.0.
+ */
 class BaseUrlNotSetException extends Exception
 {
     /** @var string */


### PR DESCRIPTION
This fixes part one of https://github.com/hydephp/develop/issues/1758. See https://github.com/hydephp/develop/pulls/1760 for part two.