### PR TITLE
Internal: Migrate PHPUnit configuration

### DIFF
--- a/packages/hyde/phpunit.xml.dist
+++ b/packages/hyde/phpunit.xml.dist
@@ -1,18 +1,18 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:noNamespaceSchemaLocation="./vendor/phpunit/phpunit/phpunit.xsd"
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.5/phpunit.xsd"
          bootstrap="vendor/autoload.php"
-         colors="true"
->
+         cacheDirectory=".phpunit.cache"
+         colors="true">
     <testsuites>
         <testsuite name="Test Suite">
             <directory suffix="Test.php">./tests</directory>
         </testsuite>
     </testsuites>
-    <coverage processUncoveredFiles="true">
+    <source>
         <include>
             <directory suffix=".php">./app</directory>
             <directory suffix=".php">./src</directory>
         </include>
-    </coverage>
+    </source>
 </phpunit>


### PR DESCRIPTION
This fixes the "Your XML configuration validates against a deprecated schema" warning in the subtree splits.