### PR TITLE
Refactor console kernel bootstrapper loading 

### DIFF
--- a/packages/framework/src/Foundation/ConsoleKernel.php
+++ b/packages/framework/src/Foundation/ConsoleKernel.php
@@ -5,12 +5,6 @@ declare(strict_types=1);
 namespace Hyde\Foundation;
 
 use LaravelZero\Framework\Kernel;
-use Hyde\Foundation\Internal\LoadYamlConfiguration;
-
-use function array_combine;
-use function array_splice;
-use function array_values;
-use function tap;
 
 class ConsoleKernel extends Kernel
 {
@@ -24,19 +18,15 @@ class ConsoleKernel extends Kernel
         // We do this by swapping out the LoadConfiguration class with our own.
         // We also inject our Yaml configuration loading bootstrapper.
 
-        /** @var array<class-string> $bootstrappers */
-        $bootstrappers = $this->bootstrappers;
-
-        // First we key the array by the class name so we can easily manipulate it.
-        $bootstrappers = array_combine($bootstrappers, $bootstrappers);
-
-        // Remove the Laravel Zero LoadConfiguration bootstrapper
-        unset($bootstrappers[\LaravelZero\Framework\Bootstrap\LoadConfiguration::class]);
-
-        // Inject our custom LoadConfiguration bootstrapper
-        $bootstrappers[\Hyde\Foundation\Internal\LoadConfiguration::class] = \Hyde\Foundation\Internal\LoadConfiguration::class;
-
-        // Now we return the bootstrappers as a numerically indexed array, like it was before.
-        return array_values($bootstrappers);
+        return [
+            \LaravelZero\Framework\Bootstrap\CoreBindings::class,
+            \LaravelZero\Framework\Bootstrap\LoadEnvironmentVariables::class,
+            \Hyde\Foundation\Internal\LoadConfiguration::class,
+            \Illuminate\Foundation\Bootstrap\HandleExceptions::class,
+            \LaravelZero\Framework\Bootstrap\RegisterFacades::class,
+            \Hyde\Foundation\Internal\LoadYamlConfiguration::class,
+            \LaravelZero\Framework\Bootstrap\RegisterProviders::class,
+            \Illuminate\Foundation\Bootstrap\BootProviders::class,
+        ];
     }
 }

--- a/packages/framework/src/Foundation/ConsoleKernel.php
+++ b/packages/framework/src/Foundation/ConsoleKernel.php
@@ -27,11 +27,16 @@ class ConsoleKernel extends Kernel
         /** @var array<class-string> $bootstrappers */
         $bootstrappers = $this->bootstrappers;
 
-        // Insert our bootstrapper between load configuration and register provider bootstrappers.
-        array_splice($bootstrappers, 5, 0, LoadYamlConfiguration::class);
+        // First we key the array by the class name so we can easily manipulate it.
+        $bootstrappers = array_combine($bootstrappers, $bootstrappers);
 
-        return array_values((array) tap(array_combine($bootstrappers, $bootstrappers), function (array &$array): void {
-            $array[\LaravelZero\Framework\Bootstrap\LoadConfiguration::class] = \Hyde\Foundation\Internal\LoadConfiguration::class;
-        }));
+        // Remove the Laravel Zero LoadConfiguration bootstrapper
+        unset($bootstrappers[\LaravelZero\Framework\Bootstrap\LoadConfiguration::class]);
+
+        // Inject our custom LoadConfiguration bootstrapper
+        $bootstrappers[\Hyde\Foundation\Internal\LoadConfiguration::class] = \Hyde\Foundation\Internal\LoadConfiguration::class;
+
+        // Now we return the bootstrappers as a numerically indexed array, like it was before.
+        return array_values($bootstrappers);
     }
 }

--- a/packages/framework/src/Foundation/ConsoleKernel.php
+++ b/packages/framework/src/Foundation/ConsoleKernel.php
@@ -21,12 +21,13 @@ class ConsoleKernel extends Kernel
     {
         $bootstrappers = $this->bootstrappers;
 
-        // Insert our bootstrapper between load configuration and register provider bootstrappers.
-        array_splice($bootstrappers, 5, 0, LoadYamlConfiguration::class);
-
         // Since we store our application config in `app/config.php`, we need to replace
         // the default LoadConfiguration bootstrapper class with our implementation.
         // We do this by swapping out the LoadConfiguration class with our own.
+        // We also inject our Yaml configuration loading bootstrapper.
+
+        // Insert our bootstrapper between load configuration and register provider bootstrappers.
+        array_splice($bootstrappers, 5, 0, LoadYamlConfiguration::class);
 
         return array_values((array) tap(array_combine($bootstrappers, $bootstrappers), function (array &$array): void {
             $array[\LaravelZero\Framework\Bootstrap\LoadConfiguration::class] = \Hyde\Foundation\Internal\LoadConfiguration::class;

--- a/packages/framework/src/Foundation/ConsoleKernel.php
+++ b/packages/framework/src/Foundation/ConsoleKernel.php
@@ -19,13 +19,13 @@ class ConsoleKernel extends Kernel
      */
     protected function bootstrappers(): array
     {
-        /** @var array<class-string> $bootstrappers */
-        $bootstrappers = $this->bootstrappers;
-
         // Since we store our application config in `app/config.php`, we need to replace
         // the default LoadConfiguration bootstrapper class with our implementation.
         // We do this by swapping out the LoadConfiguration class with our own.
         // We also inject our Yaml configuration loading bootstrapper.
+
+        /** @var array<class-string> $bootstrappers */
+        $bootstrappers = $this->bootstrappers;
 
         // Insert our bootstrapper between load configuration and register provider bootstrappers.
         array_splice($bootstrappers, 5, 0, LoadYamlConfiguration::class);

--- a/packages/framework/src/Foundation/ConsoleKernel.php
+++ b/packages/framework/src/Foundation/ConsoleKernel.php
@@ -19,6 +19,7 @@ class ConsoleKernel extends Kernel
      */
     protected function bootstrappers(): array
     {
+        /** @var array<class-string> $bootstrappers */
         $bootstrappers = $this->bootstrappers;
 
         // Since we store our application config in `app/config.php`, we need to replace

--- a/packages/framework/tests/Feature/ConsoleKernelTest.php
+++ b/packages/framework/tests/Feature/ConsoleKernelTest.php
@@ -51,7 +51,6 @@ class ConsoleKernelTest extends TestCase
 
         $this->assertIsArray($bootstrappers);
         $this->assertContains(LoadYamlConfiguration::class, $bootstrappers);
-        $this->assertSame(range(0, count($bootstrappers) - 1), array_keys($bootstrappers));
 
         $this->assertSame([
             \LaravelZero\Framework\Bootstrap\CoreBindings::class,

--- a/packages/framework/tests/Feature/ConsoleKernelTest.php
+++ b/packages/framework/tests/Feature/ConsoleKernelTest.php
@@ -11,7 +11,13 @@ use Hyde\Testing\TestCase;
 use ReflectionMethod;
 
 /**
+ * This test covers our custom console kernel, which is responsible for registering our custom bootstrappers.
+ *
  * @covers \Hyde\Foundation\ConsoleKernel
+ *
+ * Our custom bootstrapping system depends on code from Laravel Zero which is marked as internal.
+ * Sadly, there is no way around working with this private API. Since they may change the API
+ * at any time, we have tests here to detect if their code changes, so we can catch it early.
  */
 class ConsoleKernelTest extends TestCase
 {
@@ -29,14 +35,10 @@ class ConsoleKernelTest extends TestCase
     {
         $kernel = app(ConsoleKernel::class);
 
-        // Normally, protected code does not need to be unit tested, but since this array is so vital, we want to inspect it.
         $bootstrappers = (new ReflectionMethod($kernel, 'bootstrappers'))->invoke($kernel);
 
         $this->assertIsArray($bootstrappers);
         $this->assertContains(LoadYamlConfiguration::class, $bootstrappers);
-
-        // Another assertion that is usually a no-no, testing vendor code, especially those which are marked as internal.
-        // We do this here however, so we get a heads-up if the vendor code changes as that could break our code.
 
         $this->assertSame([
             0 => 'LaravelZero\Framework\Bootstrap\CoreBindings',

--- a/packages/framework/tests/Feature/ConsoleKernelTest.php
+++ b/packages/framework/tests/Feature/ConsoleKernelTest.php
@@ -34,9 +34,6 @@ class ConsoleKernelTest extends TestCase
 
     public function testLaravelZeroBootstrappersHaveNotChanged()
     {
-        $kernel = app(LaravelZeroKernel::class);
-        $bootstrappers = $this->getBootstrappersFromKernel($kernel);
-
         $this->assertSame([
             \LaravelZero\Framework\Bootstrap\CoreBindings::class,
             \LaravelZero\Framework\Bootstrap\LoadEnvironmentVariables::class,
@@ -45,13 +42,12 @@ class ConsoleKernelTest extends TestCase
             \LaravelZero\Framework\Bootstrap\RegisterFacades::class,
             \LaravelZero\Framework\Bootstrap\RegisterProviders::class,
             \Illuminate\Foundation\Bootstrap\BootProviders::class,
-        ], $bootstrappers);
+        ], $this->getBootstrappersFromKernel(app(LaravelZeroKernel::class)));
     }
 
     public function testHydeBootstrapperInjections()
     {
-        $kernel = app(ConsoleKernel::class);
-        $bootstrappers = $this->getBootstrappersFromKernel($kernel);
+        $bootstrappers = $this->getBootstrappersFromKernel(app(ConsoleKernel::class));
 
         $this->assertIsArray($bootstrappers);
         $this->assertContains(LoadYamlConfiguration::class, $bootstrappers);

--- a/packages/framework/tests/Feature/ConsoleKernelTest.php
+++ b/packages/framework/tests/Feature/ConsoleKernelTest.php
@@ -34,7 +34,8 @@ class ConsoleKernelTest extends TestCase
 
     public function testLaravelZeroBootstrappersHaveNotChanged()
     {
-        $bootstrappers = (new ReflectionMethod(app(LaravelZeroKernel::class), 'bootstrappers'))->invoke(app(LaravelZeroKernel::class));
+        $kernel = app(LaravelZeroKernel::class);
+        $bootstrappers = $this->getBootstrappersFromKernel($kernel);
 
         $this->assertSame([
             \LaravelZero\Framework\Bootstrap\CoreBindings::class,
@@ -49,7 +50,8 @@ class ConsoleKernelTest extends TestCase
 
     public function testHydeBootstrapperInjections()
     {
-        $bootstrappers = (new ReflectionMethod(app(ConsoleKernel::class), 'bootstrappers'))->invoke(app(ConsoleKernel::class));
+        $kernel = app(ConsoleKernel::class);
+        $bootstrappers = $this->getBootstrappersFromKernel($kernel);
 
         $this->assertIsArray($bootstrappers);
         $this->assertContains(LoadYamlConfiguration::class, $bootstrappers);
@@ -65,5 +67,10 @@ class ConsoleKernelTest extends TestCase
             \LaravelZero\Framework\Bootstrap\RegisterProviders::class,
             \Illuminate\Foundation\Bootstrap\BootProviders::class,
         ], $bootstrappers);
+    }
+
+    protected function getBootstrappersFromKernel(\Illuminate\Foundation\Console\Kernel $kernel): array
+    {
+        return (new ReflectionMethod($kernel, 'bootstrappers'))->invoke($kernel);
     }
 }


### PR DESCRIPTION
Cherry picks changes from https://github.com/hydephp/develop/pull/1771 replacing our overcomplicated bootstrapper array manipulations with just returning what we expect directly from the method.