### PR TITLE
HydePHP v1.7.0 - 2024-07-05

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,51 @@ HydePHP consists of two primary components, Hyde/Hyde and Hyde/Framework. Develo
 
 <!-- CHANGELOG_START -->
 
+## [1.7.0](https://github.com/hydephp/develop/releases/tag/1.7.0) - 2024-07-05
+### Added
+- Added support for using HTML comments to create Markdown code block filepath labels in https://github.com/hydephp/develop/pull/1693
+- Added a config option to disable the theme toggle buttons to automatically use browser settings in https://github.com/hydephp/develop/pull/1697
+- You can now specify which path to open when using the `--open` option in the serve command in https://github.com/hydephp/develop/pull/1694
+- Added a `--format=json` option to the `route:list` command in https://github.com/hydephp/develop/pull/1724
+
+### Changed
+- When a navigation group is set in front matter, it will now be used regardless of the subdirectory configuration in https://github.com/hydephp/develop/pull/1703 (fixes https://github.com/hydephp/develop/issues/1515)
+- Use late static bindings to support overriding data collections file finding in https://github.com/hydephp/develop/pull/1717 (fixes https://github.com/hydephp/develop/issues/1716)
+- Method `Hyde::hasSiteUrl()` now returns false if the site URL is for localhost in https://github.com/hydephp/develop/pull/1726
+- Method `Hyde::url()` will now return a relative URL instead of throwing an exception when supplied a path even if the site URL is not set in https://github.com/hydephp/develop/pull/1726
+- Updated the `.env.example` file to contain more details on the site URL setting's usages in https://github.com/hydephp/develop/pull/1746
+- Added a version prefix to the sitemap's generator attribute in https://github.com/hydephp/develop/pull/1767
+- Setting a site name in the Yaml config file will now influence all configuration values where this is used, unless already set, in https://github.com/hydephp/develop/pull/1770 and https://github.com/hydephp/develop/pull/1773
+
+### Deprecated
+- Deprecated the global `unslash()` function, replaced with the existing namespaced `\Hyde\unslash()` function in https://github.com/hydephp/develop/pull/1753
+- Deprecated the `BaseUrlNotSetException` class in https://github.com/hydephp/develop/pull/1759
+
+### Removed
+- The Git version is no longer displayed in the debug screen and dashboard in https://github.com/hydephp/develop/pull/1756
+
+### Fixed
+- Fixed explicitly set front matter navigation group behavior being dependent on subdirectory configuration, fixing https://github.com/hydephp/develop/issues/1515 in https://github.com/hydephp/develop/pull/1703
+- Fixed DataCollections file finding method not being able to be overridden https://github.com/hydephp/develop/issues/1716 in https://github.com/hydephp/develop/pull/1717
+- Fixed PHP warning when trying to parse a Markdown file with just front matter without body https://github.com/hydephp/develop/issues/1705 in https://github.com/hydephp/develop/pull/1728
+- Fixed https://github.com/hydephp/develop/issues/1748 by normalizing generator version prefixes in https://github.com/hydephp/develop/pull/1767
+- Yaml data files no longer need to start with triple dashes to be parsed by DataCollections in https://github.com/hydephp/develop/pull/1733
+- Updated the Hyde URL helper to not modify already qualified URLs in https://github.com/hydephp/develop/pull/1757
+### Extra information
+
+This release contains changes to how HydePHP behaves when a site URL is not set by the user.
+
+These changes are made to reduce the chance of the default `localhost` value showing up in production environments.
+
+Most notably, HydePHP now considers that default site URL `localhost` to mean that a site URL is not set, as the user has not set it.
+This means that things like automatic canonical URLs will not be added, as Hyde won't know how to make them without a site URL.
+The previous behaviour was that Hyde used `localhost` in canonical URLs, which is never useful in production environments.
+
+For this reason, we felt it worth it to make this change in a minor release, as it has a such large benefit for sites.
+
+You can read more about the details and design decisions of this change in the following pull request https://github.com/hydephp/develop/pull/1726.
+
+
 ## [1.6.0](https://github.com/hydephp/develop/releases/tag/1.6.0) - 2024-04-17
 ### Added
 - Added a `@head` stack to the `head.blade.php` component in https://github.com/hydephp/develop/pull/1567

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -10,48 +10,19 @@ This serves two purposes:
 2. At release time, you can move the Unreleased section changes into a new release version section.
 
 ### Added
-- Added support for using HTML comments to create Markdown code block filepath labels in https://github.com/hydephp/develop/pull/1693
-- Added a config option to disable the theme toggle buttons to automatically use browser settings in https://github.com/hydephp/develop/pull/1697
-- You can now specify which path to open when using the `--open` option in the serve command in https://github.com/hydephp/develop/pull/1694
-- Added a `--format=json` option to the `route:list` command in https://github.com/hydephp/develop/pull/1724
+- for new features.
 
 ### Changed
-- When a navigation group is set in front matter, it will now be used regardless of the subdirectory configuration in https://github.com/hydephp/develop/pull/1703 (fixes https://github.com/hydephp/develop/issues/1515)
-- Use late static bindings to support overriding data collections file finding in https://github.com/hydephp/develop/pull/1717 (fixes https://github.com/hydephp/develop/issues/1716)
-- Method `Hyde::hasSiteUrl()` now returns false if the site URL is for localhost in https://github.com/hydephp/develop/pull/1726
-- Method `Hyde::url()` will now return a relative URL instead of throwing an exception when supplied a path even if the site URL is not set in https://github.com/hydephp/develop/pull/1726
-- Updated the `.env.example` file to contain more details on the site URL setting's usages in https://github.com/hydephp/develop/pull/1746
-- Added a version prefix to the sitemap's generator attribute in https://github.com/hydephp/develop/pull/1767
-- Setting a site name in the Yaml config file will now influence all configuration values where this is used, unless already set, in https://github.com/hydephp/develop/pull/1770 and https://github.com/hydephp/develop/pull/1773
+- for changes in existing functionality.
 
 ### Deprecated
-- Deprecated the global `unslash()` function, replaced with the existing namespaced `\Hyde\unslash()` function in https://github.com/hydephp/develop/pull/1753
-- Deprecated the `BaseUrlNotSetException` class in https://github.com/hydephp/develop/pull/1759
+- for soon-to-be removed features.
 
 ### Removed
-- The Git version is no longer displayed in the debug screen and dashboard in https://github.com/hydephp/develop/pull/1756
+- for now removed features.
 
 ### Fixed
-- Fixed explicitly set front matter navigation group behavior being dependent on subdirectory configuration, fixing https://github.com/hydephp/develop/issues/1515 in https://github.com/hydephp/develop/pull/1703
-- Fixed DataCollections file finding method not being able to be overridden https://github.com/hydephp/develop/issues/1716 in https://github.com/hydephp/develop/pull/1717
-- Fixed PHP warning when trying to parse a Markdown file with just front matter without body https://github.com/hydephp/develop/issues/1705 in https://github.com/hydephp/develop/pull/1728
-- Fixed https://github.com/hydephp/develop/issues/1748 by normalizing generator version prefixes in https://github.com/hydephp/develop/pull/1767
-- Yaml data files no longer need to start with triple dashes to be parsed by DataCollections in https://github.com/hydephp/develop/pull/1733
-- Updated the Hyde URL helper to not modify already qualified URLs in https://github.com/hydephp/develop/pull/1757
+- for any bug fixes.
 
 ### Security
 - in case of vulnerabilities.
-
-### Extra information
-
-This release contains changes to how HydePHP behaves when a site URL is not set by the user.
-
-These changes are made to reduce the chance of the default `localhost` value showing up in production environments.
-
-Most notably, HydePHP now considers that default site URL `localhost` to mean that a site URL is not set, as the user has not set it.
-This means that things like automatic canonical URLs will not be added, as Hyde won't know how to make them without a site URL.
-The previous behaviour was that Hyde used `localhost` in canonical URLs, which is never useful in production environments.
-
-For this reason, we felt it worth it to make this change in a minor release, as it has a such large benefit for sites.
-
-You can read more about the details and design decisions of this change in the following pull request https://github.com/hydephp/develop/pull/1726.

--- a/packages/framework/src/Foundation/HydeKernel.php
+++ b/packages/framework/src/Foundation/HydeKernel.php
@@ -58,7 +58,7 @@ class HydeKernel implements SerializableContract
     use Serializable;
     use Macroable;
 
-    final public const VERSION = '1.6.0';
+    final public const VERSION = '1.7.0';
 
     protected static self $instance;
 

--- a/packages/hyde/composer.json
+++ b/packages/hyde/composer.json
@@ -25,7 +25,7 @@
     ],
     "require": {
         "php": "^8.1",
-        "hyde/framework": "^1.6",
+        "hyde/framework": "^1.7",
         "laravel-zero/framework": "^10.0"
     },
     "require-dev": {


### PR DESCRIPTION
## Version [v1.7.0](https://github.com/hydephp/develop/releases/tag/1.7.0) - 2024-07-05
### Added
- Added support for using HTML comments to create Markdown code block filepath labels in https://github.com/hydephp/develop/pull/1693
- Added a config option to disable the theme toggle buttons to automatically use browser settings in https://github.com/hydephp/develop/pull/1697
- You can now specify which path to open when using the `--open` option in the serve command in https://github.com/hydephp/develop/pull/1694
- Added a `--format=json` option to the `route:list` command in https://github.com/hydephp/develop/pull/1724

### Changed
- When a navigation group is set in front matter, it will now be used regardless of the subdirectory configuration in https://github.com/hydephp/develop/pull/1703 (fixes https://github.com/hydephp/develop/issues/1515)
- Use late static bindings to support overriding data collections file finding in https://github.com/hydephp/develop/pull/1717 (fixes https://github.com/hydephp/develop/issues/1716)
- Method `Hyde::hasSiteUrl()` now returns false if the site URL is for localhost in https://github.com/hydephp/develop/pull/1726
- Method `Hyde::url()` will now return a relative URL instead of throwing an exception when supplied a path even if the site URL is not set in https://github.com/hydephp/develop/pull/1726
- Updated the `.env.example` file to contain more details on the site URL setting's usages in https://github.com/hydephp/develop/pull/1746
- Added a version prefix to the sitemap's generator attribute in https://github.com/hydephp/develop/pull/1767
- Setting a site name in the Yaml config file will now influence all configuration values where this is used, unless already set, in https://github.com/hydephp/develop/pull/1770 and https://github.com/hydephp/develop/pull/1773

### Deprecated
- Deprecated the global `unslash()` function, replaced with the existing namespaced `\Hyde\unslash()` function in https://github.com/hydephp/develop/pull/1753
- Deprecated the `BaseUrlNotSetException` class in https://github.com/hydephp/develop/pull/1759

### Removed
- The Git version is no longer displayed in the debug screen and dashboard in https://github.com/hydephp/develop/pull/1756

### Fixed
- Fixed explicitly set front matter navigation group behavior being dependent on subdirectory configuration, fixing https://github.com/hydephp/develop/issues/1515 in https://github.com/hydephp/develop/pull/1703
- Fixed DataCollections file finding method not being able to be overridden https://github.com/hydephp/develop/issues/1716 in https://github.com/hydephp/develop/pull/1717
- Fixed PHP warning when trying to parse a Markdown file with just front matter without body https://github.com/hydephp/develop/issues/1705 in https://github.com/hydephp/develop/pull/1728
- Fixed https://github.com/hydephp/develop/issues/1748 by normalizing generator version prefixes in https://github.com/hydephp/develop/pull/1767
- Yaml data files no longer need to start with triple dashes to be parsed by DataCollections in https://github.com/hydephp/develop/pull/1733
- Updated the Hyde URL helper to not modify already qualified URLs in https://github.com/hydephp/develop/pull/1757
### Extra information

This release contains changes to how HydePHP behaves when a site URL is not set by the user.

These changes are made to reduce the chance of the default `localhost` value showing up in production environments.

Most notably, HydePHP now considers that default site URL `localhost` to mean that a site URL is not set, as the user has not set it.
This means that things like automatic canonical URLs will not be added, as Hyde won't know how to make them without a site URL.
The previous behaviour was that Hyde used `localhost` in canonical URLs, which is never useful in production environments.

For this reason, we felt it worth it to make this change in a minor release, as it has a such large benefit for sites.

You can read more about the details and design decisions of this change in the following pull request https://github.com/hydephp/develop/pull/1726.
