### PR TITLE
Update the `HydeKernel` array representation to include the Hyde version

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -10,7 +10,7 @@ This serves two purposes:
 2. At release time, you can move the Unreleased section changes into a new release version section.
 
 ### Added
-- for new features.
+- Updated the `HydeKernel` array representation to include the Hyde version in https://github.com/hydephp/develop/pull/1786
 
 ### Changed
 - for changes in existing functionality.

--- a/packages/framework/src/Foundation/HydeKernel.php
+++ b/packages/framework/src/Foundation/HydeKernel.php
@@ -136,6 +136,7 @@ class HydeKernel implements SerializableContract
     public function toArray(): array
     {
         return [
+            'version' => self::VERSION,
             'basePath' => $this->basePath,
             'sourceRoot' => $this->sourceRoot,
             'outputDirectory' => $this->outputDirectory,

--- a/packages/framework/tests/Feature/HydeKernelTest.php
+++ b/packages/framework/tests/Feature/HydeKernelTest.php
@@ -273,6 +273,7 @@ class HydeKernelTest extends TestCase
     {
         // AssertSame cannot be used as features is reinstantiated on each call
         $this->assertEquals([
+            'version' => Hyde::version(),
             'basePath' => Hyde::getBasePath(),
             'sourceRoot' => Hyde::getSourceRoot(),
             'outputDirectory' => Hyde::getOutputDirectory(),


### PR DESCRIPTION
In case an external service uses the Kernel's array representation, for example through Json, this can help that system know the schema for that version, as it can parse the SemVer tag added.