### PR TITLE
Update the `Serializable` trait to provide a default automatic `toArray` method

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -13,7 +13,7 @@ This serves two purposes:
 - Updated the `HydeKernel` array representation to include the Hyde version in https://github.com/hydephp/develop/pull/1786
 
 ### Changed
-- for changes in existing functionality.
+- Updated the `Serializable` trait to provide a default automatic `toArray` method in https://github.com/hydephp/develop/pull/1791
 
 ### Deprecated
 - for soon-to-be removed features.

--- a/packages/framework/src/Support/Concerns/Serializable.php
+++ b/packages/framework/src/Support/Concerns/Serializable.php
@@ -17,6 +17,8 @@ trait Serializable
     /** @inheritDoc */
     public function toArray(): array
     {
+        // Calling the function from a different scope means we only get the public properties.
+
         return get_object_vars(...)->__invoke($this);
     }
 

--- a/packages/framework/src/Support/Concerns/Serializable.php
+++ b/packages/framework/src/Support/Concerns/Serializable.php
@@ -17,7 +17,7 @@ trait Serializable
     /** @inheritDoc */
     public function toArray(): array
     {
-        return collect($this)->toArray();
+        //
     }
 
     /** Recursively serialize Arrayables */

--- a/packages/framework/src/Support/Concerns/Serializable.php
+++ b/packages/framework/src/Support/Concerns/Serializable.php
@@ -15,7 +15,10 @@ use function collect;
 trait Serializable
 {
     /** @inheritDoc */
-    public function toArray(): array;
+    public function toArray(): array
+    {
+        //
+    }
 
     /** Recursively serialize Arrayables */
     public function arraySerialize(): array

--- a/packages/framework/src/Support/Concerns/Serializable.php
+++ b/packages/framework/src/Support/Concerns/Serializable.php
@@ -14,7 +14,7 @@ use function collect;
  */
 trait Serializable
 {
-    /** @inheritDoc */
+    /** Default implementation to dynamically serialize all public properties. Can be overridden for increased control. */
     public function toArray(): array
     {
         // Calling the function from a different scope means we only get the public properties.

--- a/packages/framework/src/Support/Concerns/Serializable.php
+++ b/packages/framework/src/Support/Concerns/Serializable.php
@@ -17,7 +17,7 @@ trait Serializable
     /** @inheritDoc */
     public function toArray(): array
     {
-        return get_object_vars($this);
+        return get_object_vars(...)->__invoke($this);
     }
 
     /** Recursively serialize Arrayables */

--- a/packages/framework/src/Support/Concerns/Serializable.php
+++ b/packages/framework/src/Support/Concerns/Serializable.php
@@ -17,7 +17,7 @@ trait Serializable
     /** @inheritDoc */
     public function toArray(): array
     {
-        //
+        return collect($this)->toArray();
     }
 
     /** Recursively serialize Arrayables */

--- a/packages/framework/src/Support/Concerns/Serializable.php
+++ b/packages/framework/src/Support/Concerns/Serializable.php
@@ -17,7 +17,7 @@ trait Serializable
     /** @inheritDoc */
     public function toArray(): array
     {
-        //
+        return get_object_vars($this);
     }
 
     /** Recursively serialize Arrayables */

--- a/packages/framework/src/Support/Concerns/Serializable.php
+++ b/packages/framework/src/Support/Concerns/Serializable.php
@@ -15,7 +15,7 @@ use function collect;
 trait Serializable
 {
     /** @inheritDoc */
-    abstract public function toArray(): array;
+    public function toArray(): array;
 
     /** Recursively serialize Arrayables */
     public function arraySerialize(): array

--- a/packages/framework/tests/Unit/SerializableTest.php
+++ b/packages/framework/tests/Unit/SerializableTest.php
@@ -53,6 +53,15 @@ class SerializableTest extends UnitTestCase
     {
         $this->assertSame('{"foo":"bar","arrayable":{"foo":"bar"}}', (new SerializableTestClassWithArrayable)->toJson());
     }
+
+    public function testAutomaticallySerialization()
+    {
+        $this->assertSame([
+            'foo' => 'foo',
+            'bar' => 'bar',
+            'baz' => ['baz' => 'baz'],
+        ], (new AutomaticallySerializableTestClass)->toArray());
+    }
 }
 
 class SerializableTestClass implements SerializableContract

--- a/packages/framework/tests/Unit/SerializableTest.php
+++ b/packages/framework/tests/Unit/SerializableTest.php
@@ -100,6 +100,8 @@ class AutomaticallySerializableTestClass implements SerializableContract
     public string $bar;
     public array $baz;
 
+    public string $uninitialized;
+
     protected string $hidden;
     private string $private;
 

--- a/packages/framework/tests/Unit/SerializableTest.php
+++ b/packages/framework/tests/Unit/SerializableTest.php
@@ -103,6 +103,8 @@ class AutomaticallySerializableTestClass implements SerializableContract
     protected string $hidden;
     private string $private;
 
+    public static string $static;
+
     public function __construct()
     {
         $this->foo = 'foo';
@@ -110,5 +112,6 @@ class AutomaticallySerializableTestClass implements SerializableContract
         $this->baz = ['baz' => 'baz'];
         $this->hidden = 'hidden';
         $this->private = 'private';
+        static::$static = 'static';
     }
 }

--- a/packages/framework/tests/Unit/SerializableTest.php
+++ b/packages/framework/tests/Unit/SerializableTest.php
@@ -82,3 +82,24 @@ class ArrayableTestClass implements Arrayable
         return ['foo' => 'bar'];
     }
 }
+
+class AutomaticallySerializableTestClass implements SerializableContract
+{
+    use Serializable;
+
+    public string $foo;
+    public string $bar;
+    public array $baz;
+
+    protected string $hidden;
+    private string $private;
+
+    public function __construct()
+    {
+        $this->foo = 'foo';
+        $this->bar = 'bar';
+        $this->baz = ['baz' => 'baz'];
+        $this->hidden = 'hidden';
+        $this->private = 'private';
+    }
+}


### PR DESCRIPTION
Updates the `Serializable` trait by providing a default `toArray` method implementation which return its public properties. Can be overridden for increased control and performance. Fixes https://github.com/hydephp/develop/issues/1783