### PR TITLE
Extract helper method for automatic serialization

### DIFF
--- a/packages/framework/src/Support/Concerns/Serializable.php
+++ b/packages/framework/src/Support/Concerns/Serializable.php
@@ -17,9 +17,7 @@ trait Serializable
     /** Default implementation to dynamically serialize all public properties. Can be overridden for increased control. */
     public function toArray(): array
     {
-        // Calling the function from a different scope means we only get the public properties.
-
-        return get_object_vars(...)->__invoke($this);
+        return $this->automaticallySerialize();
     }
 
     /** Recursively serialize Arrayables */
@@ -38,5 +36,13 @@ trait Serializable
     public function toJson($options = 0): string
     {
         return json_encode($this->jsonSerialize(), $options);
+    }
+
+    /** Automatically serialize all public properties. */
+    protected function automaticallySerialize(): array
+    {
+        // Calling the function from a different scope means we only get the public properties.
+
+        return get_object_vars(...)->__invoke($this);
     }
 }


### PR DESCRIPTION
Since we can't do things like `parent::toArray` to utilize the trait logic, and we can't do `$this->toArray` from an overridden method, this allows classes using this to work on the original logic like this:

```php
use Serializable;

public function toArray(): array
{
    return array_filter($this->automaticallySerialize());
}
```
