### PR TITLE
[1.x] Update the post author class to prepare for the v2 overhaul

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -14,9 +14,11 @@ This serves two purposes:
 
 ### Changed
 - Updated the `Serializable` trait to provide a default automatic `toArray` method in https://github.com/hydephp/develop/pull/1791
+- Updated the `PostAuthor` class's `name` property to fall back to the `username` property if the `name` property is not set in https://github.com/hydephp/develop/pull/1794
+- Removed the nullable type hint from the `PostAuthor` class's `name` property as it is now always set in https://github.com/hydephp/develop/pull/1794
 
 ### Deprecated
-- for soon-to-be removed features.
+- The `PostAuthor::getName()` method is now deprecated and will be removed in v2. (use `$author->name` instead) in https://github.com/hydephp/develop/pull/1794
 
 ### Removed
 - for now removed features.

--- a/packages/framework/src/Framework/Features/Blogging/Models/PostAuthor.php
+++ b/packages/framework/src/Framework/Features/Blogging/Models/PostAuthor.php
@@ -8,6 +8,7 @@ use Stringable;
 use Hyde\Facades\Author;
 use Hyde\Facades\Config;
 use Illuminate\Support\Collection;
+use JetBrains\PhpStorm\Deprecated;
 
 use function strtolower;
 use function is_string;
@@ -85,6 +86,10 @@ class PostAuthor implements Stringable
         return $this->getName();
     }
 
+    /**
+     * @deprecated This is not needed as the name property can be accessed directly.
+     */
+    #[Deprecated(reason: 'Use the name property instead.', replacement: '%class%->name')]
     public function getName(): string
     {
         return $this->name;

--- a/packages/framework/src/Framework/Features/Blogging/Models/PostAuthor.php
+++ b/packages/framework/src/Framework/Features/Blogging/Models/PostAuthor.php
@@ -48,7 +48,7 @@ class PostAuthor implements Stringable
     public function __construct(string $username, ?string $name = null, ?string $website = null)
     {
         $this->username = $username;
-        $this->name = $name;
+        $this->name = $name ?? $this->username;
         $this->website = $website;
     }
 
@@ -87,7 +87,7 @@ class PostAuthor implements Stringable
 
     public function getName(): string
     {
-        return $this->name ?? $this->username;
+        return $this->name;
     }
 
     /** @param array{username?: string, name?: string, website?: string} $data */

--- a/packages/framework/src/Framework/Features/Blogging/Models/PostAuthor.php
+++ b/packages/framework/src/Framework/Features/Blogging/Models/PostAuthor.php
@@ -83,7 +83,7 @@ class PostAuthor implements Stringable
 
     public function __toString(): string
     {
-        return $this->getName();
+        return $this->name;
     }
 
     /**

--- a/packages/framework/src/Framework/Features/Blogging/Models/PostAuthor.php
+++ b/packages/framework/src/Framework/Features/Blogging/Models/PostAuthor.php
@@ -26,7 +26,7 @@ class PostAuthor implements Stringable
     /**
      * The display name of the author.
      */
-    public readonly ?string $name;
+    public readonly string $name;
 
     /**
      * The author's website URL.

--- a/packages/framework/tests/Feature/MarkdownPostTest.php
+++ b/packages/framework/tests/Feature/MarkdownPostTest.php
@@ -25,7 +25,7 @@ class MarkdownPostTest extends TestCase
 
         $this->assertInstanceOf(PostAuthor::class, $post->author);
         $this->assertSame('John Doe', $post->author->username);
-        $this->assertNull($post->author->name);
+        $this->assertSame('John Doe', $post->author->name);
         $this->assertNull($post->author->website);
     }
 

--- a/packages/framework/tests/Unit/PostAuthorTest.php
+++ b/packages/framework/tests/Unit/PostAuthorTest.php
@@ -134,6 +134,13 @@ class PostAuthorTest extends UnitTestCase
         $this->assertEquals('username', $author->getName());
     }
 
+    public function testNameIsSetToUsernameIfNameIsNotSet()
+    {
+        $author = new PostAuthor('username');
+
+        $this->assertEquals('username', $author->name);
+    }
+
     public function testToStringHelperReturnsTheName()
     {
         $author = new PostAuthor('username', 'John Doe');


### PR DESCRIPTION
## Abstract

Tie in with https://github.com/hydephp/develop/pull/1782 to smooth over the upgrade to v2

## Changes

### Update post author name to fall back to username at construct time

Cherry picks commit https://github.com/hydephp/develop/pull/1782/commits/0dfb841b809d41149ba870b69d09baacf072e18d from https://github.com/hydephp/develop/pull/1782

### Deprecate the `PostAuthor::getName()` method

Cherry picks commit https://github.com/hydephp/develop/pull/1782/commits/2f54b9f9aad5a9065ae51ec9df5dc9ee0d023795 from https://github.com/hydephp/develop/pull/1782


### Remove nullable modifier from author name as it is now never null

Since the author name is now always set at construct time, we can remove the nullable modifier from the property.
