### PR TITLE
[2.x] Add an invalid configuration exception class

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -13,6 +13,7 @@ This serves two purposes:
 - You can now specify navigation priorities by adding a numeric prefix to the source file names in https://github.com/hydephp/develop/pull/1709
 - Added a new `\Hyde\Framework\Actions\PreBuildTasks\TransferMediaAssets` build task handle media assets transfers for site builds.
 - Added a new `\Hyde\Framework\Exceptions\ParseException` exception class to handle parsing exceptions in data collection files in https://github.com/hydephp/develop/pull/1732
+- Added a new `\Hyde\Framework\Exceptions\InvalidConfigurationException` exception class to handle invalid configuration exceptions in https://github.com/hydephp/develop/pull/1799
 - The `\Hyde\Facades\Features` class is no longer marked as internal, and is now thus part of the public API.
 
 ### Changed

--- a/packages/framework/src/Framework/Exceptions/InvalidConfigurationException.php
+++ b/packages/framework/src/Framework/Exceptions/InvalidConfigurationException.php
@@ -16,10 +16,7 @@ class InvalidConfigurationException extends InvalidArgumentException
     public function __construct(string $message = 'Invalid configuration detected.', ?string $namespace = null, ?string $key = null)
     {
         if ($namespace && $key) {
-            [$file, $line] = $this->findConfigLine($namespace, $key);
-
-            $this->file = $file;
-            $this->line = $line;
+            [$this->file, $this->line] = $this->findConfigLine($namespace, $key);
         }
 
         parent::__construct($message);

--- a/packages/framework/src/Framework/Exceptions/InvalidConfigurationException.php
+++ b/packages/framework/src/Framework/Exceptions/InvalidConfigurationException.php
@@ -8,5 +8,8 @@ use InvalidArgumentException;
 
 class InvalidConfigurationException extends InvalidArgumentException
 {
-    //
+    public function __construct(string $message = 'Invalid configuration detected.')
+    {
+        parent::__construct($message);
+    }
 }

--- a/packages/framework/src/Framework/Exceptions/InvalidConfigurationException.php
+++ b/packages/framework/src/Framework/Exceptions/InvalidConfigurationException.php
@@ -30,10 +30,10 @@ class InvalidConfigurationException extends InvalidArgumentException
 
         foreach ($lines as $line => $content) {
             if (str_contains($content, "'$key' =>")) {
-                break;
+                return [$file, $line + 1];
             }
         }
 
-        return [$file, $line + 1];
+        return [null, null];
     }
 }

--- a/packages/framework/src/Framework/Exceptions/InvalidConfigurationException.php
+++ b/packages/framework/src/Framework/Exceptions/InvalidConfigurationException.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Hyde\Framework\Exceptions;
+
+class InvalidConfigurationException
+{
+    //
+}

--- a/packages/framework/src/Framework/Exceptions/InvalidConfigurationException.php
+++ b/packages/framework/src/Framework/Exceptions/InvalidConfigurationException.php
@@ -22,6 +22,7 @@ class InvalidConfigurationException extends InvalidArgumentException
         parent::__construct($message);
     }
 
+    /** @return array{string|null, int|null} */
     protected function findConfigLine(string $namespace, string $key): array
     {
         $file = "config/$namespace.php";

--- a/packages/framework/src/Framework/Exceptions/InvalidConfigurationException.php
+++ b/packages/framework/src/Framework/Exceptions/InvalidConfigurationException.php
@@ -13,10 +13,8 @@ class InvalidConfigurationException extends InvalidArgumentException
         if ($namespace && $key) {
             [$file, $line] = $this->findConfigLine($namespace, $key);
 
-            if ($file && $line) {
-                $this->file = $file;
-                $this->line = $line;
-            }
+            $this->file = $file;
+            $this->line = $line;
         }
 
         parent::__construct($message);
@@ -27,15 +25,14 @@ class InvalidConfigurationException extends InvalidArgumentException
     {
         $file = "config/$namespace.php";
         $contents = file_get_contents(base_path($file));
-
         $lines = explode("\n", $contents);
 
         foreach ($lines as $line => $content) {
             if (str_contains($content, "'$key' =>")) {
-                return [$file, $line + 1];
+                break;
             }
         }
 
-        return [null, null];
+        return [$file, $line + 1];
     }
 }

--- a/packages/framework/src/Framework/Exceptions/InvalidConfigurationException.php
+++ b/packages/framework/src/Framework/Exceptions/InvalidConfigurationException.php
@@ -26,6 +26,7 @@ class InvalidConfigurationException extends InvalidArgumentException
     {
         $file = "config/$namespace.php";
         $contents = file_get_contents(base_path($file));
+
         $lines = explode("\n", $contents);
 
         foreach ($lines as $line => $content) {

--- a/packages/framework/src/Framework/Exceptions/InvalidConfigurationException.php
+++ b/packages/framework/src/Framework/Exceptions/InvalidConfigurationException.php
@@ -22,7 +22,11 @@ class InvalidConfigurationException extends InvalidArgumentException
         parent::__construct($message);
     }
 
-    /** @return array{string, int} */
+    /**
+     * @experimental Please report any issues with this method to the authors at https://github.com/hydephp/develop/issues
+     *
+     * @return array{string, int}
+     */
     protected function findConfigLine(string $namespace, string $key): array
     {
         $file = realpath("config/$namespace.php");

--- a/packages/framework/src/Framework/Exceptions/InvalidConfigurationException.php
+++ b/packages/framework/src/Framework/Exceptions/InvalidConfigurationException.php
@@ -8,8 +8,32 @@ use InvalidArgumentException;
 
 class InvalidConfigurationException extends InvalidArgumentException
 {
-    public function __construct(string $message = 'Invalid configuration detected.')
+    public function __construct(string $message = 'Invalid configuration detected.', ?string $namespace = null, ?string $key = null)
     {
+        if ($namespace && $key) {
+            [$file, $line] = $this->findConfigLine($namespace, $key);
+
+            if ($file && $line) {
+                $this->file = $file;
+                $this->line = $line;
+            }
+        }
+
         parent::__construct($message);
+    }
+
+    protected function findConfigLine(string $namespace, string $key): array
+    {
+        $file = "config/$namespace.php";
+        $contents = file_get_contents(base_path($file));
+        $lines = explode("\n", $contents);
+
+        foreach ($lines as $line => $content) {
+            if (str_contains($content, "'$key' =>")) {
+                break;
+            }
+        }
+
+        return [$file, $line + 1];
     }
 }

--- a/packages/framework/src/Framework/Exceptions/InvalidConfigurationException.php
+++ b/packages/framework/src/Framework/Exceptions/InvalidConfigurationException.php
@@ -4,7 +4,12 @@ declare(strict_types=1);
 
 namespace Hyde\Framework\Exceptions;
 
+use Hyde\Facades\Filesystem;
 use InvalidArgumentException;
+
+use function assert;
+use function explode;
+use function realpath;
 
 class InvalidConfigurationException extends InvalidArgumentException
 {
@@ -20,11 +25,11 @@ class InvalidConfigurationException extends InvalidArgumentException
         parent::__construct($message);
     }
 
-    /** @return array{string|null, int|null} */
+    /** @return array{string, int} */
     protected function findConfigLine(string $namespace, string $key): array
     {
-        $file = "config/$namespace.php";
-        $contents = file_get_contents(base_path($file));
+        $file = realpath("config/$namespace.php");
+        $contents = Filesystem::getContents($file);
         $lines = explode("\n", $contents);
 
         foreach ($lines as $line => $content) {
@@ -32,6 +37,9 @@ class InvalidConfigurationException extends InvalidArgumentException
                 break;
             }
         }
+
+        assert($file !== false);
+        assert(isset($line));
 
         return [$file, $line + 1];
     }

--- a/packages/framework/src/Framework/Exceptions/InvalidConfigurationException.php
+++ b/packages/framework/src/Framework/Exceptions/InvalidConfigurationException.php
@@ -4,7 +4,9 @@ declare(strict_types=1);
 
 namespace Hyde\Framework\Exceptions;
 
-class InvalidConfigurationException
+use InvalidArgumentException;
+
+class InvalidConfigurationException extends InvalidArgumentException
 {
     //
 }

--- a/packages/framework/tests/Unit/CustomExceptionsTest.php
+++ b/packages/framework/tests/Unit/CustomExceptionsTest.php
@@ -201,32 +201,4 @@ class CustomExceptionsTest extends UnitTestCase
         $this->assertStringContainsString('config'.DIRECTORY_SEPARATOR.'hyde.php', $exception->getFile());
         $this->assertGreaterThan(0, $exception->getLine());
     }
-
-    public function testInvalidConfigurationExceptionWithNonExistentNamespace()
-    {
-        $this->expectException(\AssertionError::class);
-        new InvalidConfigurationException('Invalid configuration.', 'non_existent', 'key');
-    }
-
-    public function testInvalidConfigurationExceptionWithNonExistentKey()
-    {
-        $this->expectException(\AssertionError::class);
-        new InvalidConfigurationException('Invalid configuration.', 'app', 'non_existent_key');
-    }
-
-    public function testInvalidConfigurationExceptionFindConfigLine()
-    {
-        $exception = new class('Invalid configuration.', 'hyde', 'name') extends InvalidConfigurationException {
-            public function exposedFindConfigLine(string $namespace, string $key): array
-            {
-                return $this->findConfigLine($namespace, $key);
-            }
-        };
-
-        [$file, $line] = $exception->exposedFindConfigLine('app', 'debug');
-
-        $this->assertFileExists($file);
-        $this->assertIsInt($line);
-        $this->assertGreaterThan(0, $line);
-    }
 }

--- a/packages/framework/tests/Unit/CustomExceptionsTest.php
+++ b/packages/framework/tests/Unit/CustomExceptionsTest.php
@@ -19,6 +19,7 @@ use Exception;
  * @covers \Hyde\Framework\Exceptions\FileNotFoundException
  * @covers \Hyde\Framework\Exceptions\RouteNotFoundException
  * @covers \Hyde\Framework\Exceptions\UnsupportedPageTypeException
+ * @covers \Hyde\Framework\Exceptions\InvalidConfigurationException
  * @covers \Hyde\Framework\Exceptions\ParseException
  */
 class CustomExceptionsTest extends UnitTestCase

--- a/packages/framework/tests/Unit/CustomExceptionsTest.php
+++ b/packages/framework/tests/Unit/CustomExceptionsTest.php
@@ -192,11 +192,14 @@ class CustomExceptionsTest extends UnitTestCase
 
     public function testInvalidConfigurationExceptionWithNamespaceAndKey()
     {
-        $exception = new InvalidConfigurationException('Invalid configuration.', 'app', 'debug');
+        $exception = new InvalidConfigurationException('Invalid configuration.', 'hyde', 'name');
 
         $this->assertSame('Invalid configuration.', $exception->getMessage());
-        $this->assertFileExists($exception->file);
-        $this->assertIsInt($exception->line);
+        $this->assertFileExists($exception->getFile());
+        $this->assertIsInt($exception->getLine());
+
+        $this->assertStringContainsString('config'.DIRECTORY_SEPARATOR.'hyde.php', $exception->getFile());
+        $this->assertGreaterThan(0, $exception->getLine());
     }
 
     public function testInvalidConfigurationExceptionWithNonExistentNamespace()
@@ -213,7 +216,7 @@ class CustomExceptionsTest extends UnitTestCase
 
     public function testInvalidConfigurationExceptionFindConfigLine()
     {
-        $exception = new class('Invalid configuration.', 'app', 'debug') extends InvalidConfigurationException {
+        $exception = new class('Invalid configuration.', 'hyde', 'name') extends InvalidConfigurationException {
             public function exposedFindConfigLine(string $namespace, string $key): array
             {
                 return $this->findConfigLine($namespace, $key);


### PR DESCRIPTION
Adds a new `\Hyde\Framework\Exceptions\InvalidConfigurationException` exception class to handle invalid configuration exceptions with support for showing the errored line.

Cherry picked from https://github.com/hydephp/develop/pull/1798