### PR TITLE
Normalize documented link in code documentation

### DIFF
--- a/packages/framework/src/Facades/Author.php
+++ b/packages/framework/src/Facades/Author.php
@@ -18,7 +18,7 @@ class Author
      * Construct a new Post Author. For Hyde to discover this author,
      * you must call this method from your hyde.php config file.
      *
-     * @see https://hydephp.com/docs/1.x/customization.html#authors
+     * @see https://hydephp.com/docs/1.x/customization#authors
      *
      * @param  string  $username  The username of the author. This is the key used to find authors in the config.
      * @param  string|null  $name  The optional display name of the author, leave blank to use the username.


### PR DESCRIPTION
May want something in HydeStan for this to detect if line uses link to our site but with the HTML extension.