### PR TITLE
[2.x] Add a navigation config builder class

### DIFF
--- a/config/hyde.php
+++ b/config/hyde.php
@@ -334,25 +334,20 @@ return [
 
     'navigation' => Navigation::configure()
         ->setPagePriorities([
-            // Override page priority order
             'index' => 0,
             'posts' => 10,
             'docs/index' => 100,
         ])
         ->setPageLabels([
-            // Override page labels
             'index' => 'Home',
             'docs/index' => 'Docs',
         ])
         ->excludePages([
-            // Exclude pages from the navigation
             '404',
         ])
         ->addCustomNavigationItems([
-            // Add custom items to the navigation menu
             // Navigation::item('https://github.com/hydephp/hyde', 'GitHub', 200),
         ])
-        // Configure how subdirectories are displayed in the navigation
         ->setSubdirectoryDisplayMode('hidden'),
 
     /*

--- a/config/hyde.php
+++ b/config/hyde.php
@@ -345,7 +345,7 @@ return [
         ->excludePages([
             '404',
         ])
-        ->addCustomNavigationItems([
+        ->addNavigationItems([
             // Navigation::item('https://github.com/hydephp/hyde', 'GitHub', 200),
         ])
         ->setSubdirectoryDisplayMode('hidden'),

--- a/config/hyde.php
+++ b/config/hyde.php
@@ -332,40 +332,28 @@ return [
     |
     */
 
-    'navigation' => [
-        // This configuration sets the priorities used to determine the order of the menu.
-        // The default values have been added below for reference and easy editing.
-        // The array key is the page's route key, the value is the priority.
-        // Lower values show up first in the menu. The default is 999.
-        'order' => [
+    'navigation' => Navigation::configure()
+        ->order([
+            // Override page priority order
             'index' => 0,
             'posts' => 10,
             'docs/index' => 100,
-        ],
-
-        // In case you want to customize the labels for the menu items, you can do so here.
-        // Simply add the route key as the array key, and the label as the value.
-        'labels' => [
+        ])
+        ->labels([
+            // Override page labels
             'index' => 'Home',
             'docs/index' => 'Docs',
-        ],
-
-        // These are the route keys of pages that should not show up in the navigation menu.
-        'exclude' => [
+        ])
+        ->exclude([
+            // Exclude pages from the navigation
             '404',
-        ],
-
-        // Any extra links you want to add to the navigation menu can be added here.
-        // To get started quickly, you can uncomment the defaults here.
-        // See the documentation link above for more information.
-        'custom' => [
+        ])
+        ->custom([
+            // Add custom items to the navigation menu
             // Navigation::item('https://github.com/hydephp/hyde', 'GitHub', 200),
-        ],
-
-        // How should pages in subdirectories be displayed in the menu?
-        // You can choose between 'dropdown', 'flat', and 'hidden'.
-        'subdirectory_display' => 'hidden',
-    ],
+        ])
+        // Configure how subdirectories are displayed in the navigation
+        ->subdirectoryDisplay('hidden'),
 
     /*
     |--------------------------------------------------------------------------

--- a/config/hyde.php
+++ b/config/hyde.php
@@ -333,27 +333,27 @@ return [
     */
 
     'navigation' => Navigation::configure()
-        ->order([
+        ->setPagePriorities([
             // Override page priority order
             'index' => 0,
             'posts' => 10,
             'docs/index' => 100,
         ])
-        ->labels([
+        ->setPageLabels([
             // Override page labels
             'index' => 'Home',
             'docs/index' => 'Docs',
         ])
-        ->exclude([
+        ->excludePages([
             // Exclude pages from the navigation
             '404',
         ])
-        ->custom([
+        ->addCustomNavigationItems([
             // Add custom items to the navigation menu
             // Navigation::item('https://github.com/hydephp/hyde', 'GitHub', 200),
         ])
         // Configure how subdirectories are displayed in the navigation
-        ->subdirectoryDisplay('hidden'),
+        ->setSubdirectoryDisplayMode('hidden'),
 
     /*
     |--------------------------------------------------------------------------

--- a/packages/framework/config/hyde.php
+++ b/packages/framework/config/hyde.php
@@ -334,25 +334,20 @@ return [
 
     'navigation' => Navigation::configure()
         ->setPagePriorities([
-            // Override page priority order
             'index' => 0,
             'posts' => 10,
             'docs/index' => 100,
         ])
         ->setPageLabels([
-            // Override page labels
             'index' => 'Home',
             'docs/index' => 'Docs',
         ])
         ->excludePages([
-            // Exclude pages from the navigation
             '404',
         ])
         ->addCustomNavigationItems([
-            // Add custom items to the navigation menu
             // Navigation::item('https://github.com/hydephp/hyde', 'GitHub', 200),
         ])
-        // Configure how subdirectories are displayed in the navigation
         ->setSubdirectoryDisplayMode('hidden'),
 
     /*

--- a/packages/framework/config/hyde.php
+++ b/packages/framework/config/hyde.php
@@ -345,7 +345,7 @@ return [
         ->excludePages([
             '404',
         ])
-        ->addCustomNavigationItems([
+        ->addNavigationItems([
             // Navigation::item('https://github.com/hydephp/hyde', 'GitHub', 200),
         ])
         ->setSubdirectoryDisplayMode('hidden'),

--- a/packages/framework/config/hyde.php
+++ b/packages/framework/config/hyde.php
@@ -332,40 +332,28 @@ return [
     |
     */
 
-    'navigation' => [
-        // This configuration sets the priorities used to determine the order of the menu.
-        // The default values have been added below for reference and easy editing.
-        // The array key is the page's route key, the value is the priority.
-        // Lower values show up first in the menu. The default is 999.
-        'order' => [
+    'navigation' => Navigation::configure()
+        ->order([
+            // Override page priority order
             'index' => 0,
             'posts' => 10,
             'docs/index' => 100,
-        ],
-
-        // In case you want to customize the labels for the menu items, you can do so here.
-        // Simply add the route key as the array key, and the label as the value.
-        'labels' => [
+        ])
+        ->labels([
+            // Override page labels
             'index' => 'Home',
             'docs/index' => 'Docs',
-        ],
-
-        // These are the route keys of pages that should not show up in the navigation menu.
-        'exclude' => [
+        ])
+        ->exclude([
+            // Exclude pages from the navigation
             '404',
-        ],
-
-        // Any extra links you want to add to the navigation menu can be added here.
-        // To get started quickly, you can uncomment the defaults here.
-        // See the documentation link above for more information.
-        'custom' => [
+        ])
+        ->custom([
+            // Add custom items to the navigation menu
             // Navigation::item('https://github.com/hydephp/hyde', 'GitHub', 200),
-        ],
-
-        // How should pages in subdirectories be displayed in the menu?
-        // You can choose between 'dropdown', 'flat', and 'hidden'.
-        'subdirectory_display' => 'hidden',
-    ],
+        ])
+        // Configure how subdirectories are displayed in the navigation
+        ->subdirectoryDisplay('hidden'),
 
     /*
     |--------------------------------------------------------------------------

--- a/packages/framework/config/hyde.php
+++ b/packages/framework/config/hyde.php
@@ -333,27 +333,27 @@ return [
     */
 
     'navigation' => Navigation::configure()
-        ->order([
+        ->setPagePriorities([
             // Override page priority order
             'index' => 0,
             'posts' => 10,
             'docs/index' => 100,
         ])
-        ->labels([
+        ->setPageLabels([
             // Override page labels
             'index' => 'Home',
             'docs/index' => 'Docs',
         ])
-        ->exclude([
+        ->excludePages([
             // Exclude pages from the navigation
             '404',
         ])
-        ->custom([
+        ->addCustomNavigationItems([
             // Add custom items to the navigation menu
             // Navigation::item('https://github.com/hydephp/hyde', 'GitHub', 200),
         ])
         // Configure how subdirectories are displayed in the navigation
-        ->subdirectoryDisplay('hidden'),
+        ->setSubdirectoryDisplayMode('hidden'),
 
     /*
     |--------------------------------------------------------------------------

--- a/packages/framework/src/Facades/Navigation.php
+++ b/packages/framework/src/Facades/Navigation.php
@@ -36,7 +36,7 @@ class Navigation
      *
      * @experimental This method is experimental and may change in the future.
      */
-    public static function builder()
+    public static function define()
     {
         //
     }

--- a/packages/framework/src/Facades/Navigation.php
+++ b/packages/framework/src/Facades/Navigation.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Hyde\Facades;
 
+use Hyde\Framework\Features\Navigation\NavigationMenuConfigurationBuilder;
 use function compact;
 
 /**
@@ -36,8 +37,8 @@ class Navigation
      *
      * @experimental This method is experimental and may change in the future.
      */
-    public static function configure()
+    public static function configure(): NavigationMenuConfigurationBuilder
     {
-        //
+        return new NavigationMenuConfigurationBuilder();
     }
 }

--- a/packages/framework/src/Facades/Navigation.php
+++ b/packages/framework/src/Facades/Navigation.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Hyde\Facades;
 
 use Hyde\Framework\Features\Navigation\NavigationMenuConfigurationBuilder;
+
 use function compact;
 
 /**

--- a/packages/framework/src/Facades/Navigation.php
+++ b/packages/framework/src/Facades/Navigation.php
@@ -34,9 +34,9 @@ class Navigation
     /**
      * Configuration helper method to define the navigation menu configuration with better IDE support.
      *
-     * The returned object will then be cast to an array that will be used by the framework to set the config data.
+     * The builder is an array object that will be used by the framework to set the navigation menu configuration.
      *
-     * @experimental This method is experimental and may change in the future.
+     * @experimental This method is experimental and may change or be removed before the final release.
      */
     public static function configure(): NavigationMenuConfigurationBuilder
     {

--- a/packages/framework/src/Facades/Navigation.php
+++ b/packages/framework/src/Facades/Navigation.php
@@ -28,4 +28,9 @@ class Navigation
     {
         return compact('destination', 'label', 'priority', 'attributes');
     }
+
+    public static function builder()
+    {
+        //
+    }
 }

--- a/packages/framework/src/Facades/Navigation.php
+++ b/packages/framework/src/Facades/Navigation.php
@@ -29,6 +29,13 @@ class Navigation
         return compact('destination', 'label', 'priority', 'attributes');
     }
 
+    /**
+     * Configuration helper method to define the navigation menu configuration with better IDE support.
+     *
+     * The returned object will then be cast to an array that will be used by the framework to set the config data.
+     *
+     * @experimental This method is experimental and may change in the future.
+     */
     public static function builder()
     {
         //

--- a/packages/framework/src/Facades/Navigation.php
+++ b/packages/framework/src/Facades/Navigation.php
@@ -36,7 +36,7 @@ class Navigation
      *
      * @experimental This method is experimental and may change in the future.
      */
-    public static function define()
+    public static function configure()
     {
         //
     }

--- a/packages/framework/src/Framework/Features/Navigation/NavigationMenuConfigurationBuilder.php
+++ b/packages/framework/src/Framework/Features/Navigation/NavigationMenuConfigurationBuilder.php
@@ -78,7 +78,7 @@ class NavigationMenuConfigurationBuilder extends ArrayObject implements Arrayabl
     }
 
     /**
-     * Set the display mode for subdirectories.
+     * Set the display mode for pages in subdirectories.
      *
      * You can choose between 'dropdown', 'flat', and 'hidden'.
      *

--- a/packages/framework/src/Framework/Features/Navigation/NavigationMenuConfigurationBuilder.php
+++ b/packages/framework/src/Framework/Features/Navigation/NavigationMenuConfigurationBuilder.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Hyde\Framework\Features\Navigation;
 
+use ArrayObject;
+
 /**
  * Configuration helper method to define the navigation menu configuration with better IDE support.
  *
@@ -11,7 +13,7 @@ namespace Hyde\Framework\Features\Navigation;
  *
  * @experimental This method is experimental and may change in the future.
  */
-class NavigationMenuConfigurationBuilder
+class NavigationMenuConfigurationBuilder extends ArrayObject
 {
     protected array $config = [];
 }

--- a/packages/framework/src/Framework/Features/Navigation/NavigationMenuConfigurationBuilder.php
+++ b/packages/framework/src/Framework/Features/Navigation/NavigationMenuConfigurationBuilder.php
@@ -26,6 +26,7 @@ class NavigationMenuConfigurationBuilder extends ArrayObject implements Arrayabl
     /**
      * Set the order of the navigation items.
      *
+     * @param array $order
      * @return $this
      */
     public function order(array $order): static
@@ -36,6 +37,7 @@ class NavigationMenuConfigurationBuilder extends ArrayObject implements Arrayabl
     /**
      * Set the labels for the navigation items.
      *
+     * @param array $labels
      * @return $this
      */
     public function labels(array $labels): static
@@ -46,6 +48,7 @@ class NavigationMenuConfigurationBuilder extends ArrayObject implements Arrayabl
     /**
      * Exclude certain items from the navigation.
      *
+     * @param array $exclude
      * @return $this
      */
     public function exclude(array $exclude): static
@@ -56,6 +59,7 @@ class NavigationMenuConfigurationBuilder extends ArrayObject implements Arrayabl
     /**
      * Add custom items to the navigation.
      *
+     * @param array $custom
      * @return $this
      */
     public function custom(array $custom): static
@@ -66,6 +70,7 @@ class NavigationMenuConfigurationBuilder extends ArrayObject implements Arrayabl
     /**
      * Set the display mode for subdirectories.
      *
+     * @param string $displayMode
      * @return $this
      */
     public function subdirectoryDisplay(string $displayMode): static

--- a/packages/framework/src/Framework/Features/Navigation/NavigationMenuConfigurationBuilder.php
+++ b/packages/framework/src/Framework/Features/Navigation/NavigationMenuConfigurationBuilder.php
@@ -94,7 +94,7 @@ class NavigationMenuConfigurationBuilder extends ArrayObject implements Arrayabl
         return $this->getArrayCopy();
     }
 
-    /** @internal */
+    /** @experimental May be moved to a separate helper class in the future. */
     protected static function assertType(array $types, string $value): void
     {
         if (! in_array($value, $types)) {

--- a/packages/framework/src/Framework/Features/Navigation/NavigationMenuConfigurationBuilder.php
+++ b/packages/framework/src/Framework/Features/Navigation/NavigationMenuConfigurationBuilder.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Hyde\Framework\Features\Navigation;
 
 use ArrayObject;
+use Illuminate\Contracts\Support\Arrayable;
 
 /**
  * Configuration helper method to define the navigation menu configuration with better IDE support.
@@ -13,7 +14,7 @@ use ArrayObject;
  *
  * @experimental This method is experimental and may change in the future.
  */
-class NavigationMenuConfigurationBuilder extends ArrayObject
+class NavigationMenuConfigurationBuilder extends ArrayObject implements Arrayable
 {
     protected array $config = [];
 }

--- a/packages/framework/src/Framework/Features/Navigation/NavigationMenuConfigurationBuilder.php
+++ b/packages/framework/src/Framework/Features/Navigation/NavigationMenuConfigurationBuilder.php
@@ -70,7 +70,7 @@ class NavigationMenuConfigurationBuilder extends ArrayObject implements Arrayabl
      * @param  array<array{destination: string, label: ?string, priority: ?int, attributes: array<string, scalar>}>  $custom
      * @return $this
      */
-    public function addCustomNavigationItems(array $custom): static
+    public function addNavigationItems(array $custom): static
     {
         $this['custom'] = $custom;
 

--- a/packages/framework/src/Framework/Features/Navigation/NavigationMenuConfigurationBuilder.php
+++ b/packages/framework/src/Framework/Features/Navigation/NavigationMenuConfigurationBuilder.php
@@ -16,8 +16,6 @@ use Illuminate\Contracts\Support\Arrayable;
  */
 class NavigationMenuConfigurationBuilder extends ArrayObject implements Arrayable
 {
-    protected array $config = [];
-
     /**
      * Set the order of the navigation items.
      *
@@ -26,7 +24,7 @@ class NavigationMenuConfigurationBuilder extends ArrayObject implements Arrayabl
      */
     public function order(array $order): static
     {
-        $this->config['order'] = $order;
+        $this['order'] = $order;
 
         return $this;
     }
@@ -39,7 +37,7 @@ class NavigationMenuConfigurationBuilder extends ArrayObject implements Arrayabl
      */
     public function labels(array $labels): static
     {
-        $this->config['labels'] = $labels;
+        $this['labels'] = $labels;
 
         return $this;
     }
@@ -52,7 +50,7 @@ class NavigationMenuConfigurationBuilder extends ArrayObject implements Arrayabl
      */
     public function exclude(array $exclude): static
     {
-        $this->config['exclude'] = $exclude;
+        $this['exclude'] = $exclude;
 
         return $this;
     }
@@ -65,7 +63,7 @@ class NavigationMenuConfigurationBuilder extends ArrayObject implements Arrayabl
      */
     public function custom(array $custom): static
     {
-        $this->config['custom'] = $custom;
+        $this['custom'] = $custom;
 
         return $this;
     }
@@ -78,13 +76,13 @@ class NavigationMenuConfigurationBuilder extends ArrayObject implements Arrayabl
      */
     public function subdirectoryDisplay(string $displayMode): static
     {
-        $this->config['subdirectory_display'] = $displayMode;
+        $this['subdirectory_display'] = $displayMode;
 
         return $this;
     }
 
     public function toArray(): array
     {
-        return $this->config;
+        return $this->getArrayCopy();
     }
 }

--- a/packages/framework/src/Framework/Features/Navigation/NavigationMenuConfigurationBuilder.php
+++ b/packages/framework/src/Framework/Features/Navigation/NavigationMenuConfigurationBuilder.php
@@ -19,7 +19,7 @@ class NavigationMenuConfigurationBuilder extends ArrayObject implements Arrayabl
     /**
      * Set the order of the navigation items.
      *
-     * @param array<string, int>|array<string> $order
+     * @param  array<string, int>|array<string>  $order
      * @return $this
      */
     public function order(array $order): static
@@ -32,7 +32,7 @@ class NavigationMenuConfigurationBuilder extends ArrayObject implements Arrayabl
     /**
      * Set the labels for the navigation items.
      *
-     * @param array<string, string> $labels
+     * @param  array<string, string>  $labels
      * @return $this
      */
     public function labels(array $labels): static
@@ -45,7 +45,7 @@ class NavigationMenuConfigurationBuilder extends ArrayObject implements Arrayabl
     /**
      * Exclude certain items from the navigation.
      *
-     * @param array<string> $exclude
+     * @param  array<string>  $exclude
      * @return $this
      */
     public function exclude(array $exclude): static
@@ -58,7 +58,7 @@ class NavigationMenuConfigurationBuilder extends ArrayObject implements Arrayabl
     /**
      * Add custom items to the navigation.
      *
-     * @param array<array{destination: string, label: ?string, priority: ?int, attributes: array<string, scalar>}> $custom
+     * @param  array<array{destination: string, label: ?string, priority: ?int, attributes: array<string, scalar>}>  $custom
      * @return $this
      */
     public function custom(array $custom): static
@@ -71,7 +71,7 @@ class NavigationMenuConfigurationBuilder extends ArrayObject implements Arrayabl
     /**
      * Set the display mode for subdirectories.
      *
-     * @param 'dropdown'|'flat'|'hidden' $displayMode
+     * @param  'dropdown'|'flat'|'hidden'  $displayMode
      * @return $this
      */
     public function subdirectoryDisplay(string $displayMode): static

--- a/packages/framework/src/Framework/Features/Navigation/NavigationMenuConfigurationBuilder.php
+++ b/packages/framework/src/Framework/Features/Navigation/NavigationMenuConfigurationBuilder.php
@@ -81,6 +81,11 @@ class NavigationMenuConfigurationBuilder extends ArrayObject implements Arrayabl
         return $this;
     }
 
+    /**
+     * Get the instance as an array.
+     *
+     * @return array{order: array<string, int>, labels: array<string, string>, exclude: array<string>, custom: array<array{destination: string, label: ?string, priority: ?int, attributes: array<string, scalar>}>, subdirectory_display: string}
+     */
     public function toArray(): array
     {
         return $this->getArrayCopy();

--- a/packages/framework/src/Framework/Features/Navigation/NavigationMenuConfigurationBuilder.php
+++ b/packages/framework/src/Framework/Features/Navigation/NavigationMenuConfigurationBuilder.php
@@ -13,5 +13,5 @@ namespace Hyde\Framework\Features\Navigation;
  */
 class NavigationMenuConfigurationBuilder
 {
-    //
+    protected array $config = [];
 }

--- a/packages/framework/src/Framework/Features/Navigation/NavigationMenuConfigurationBuilder.php
+++ b/packages/framework/src/Framework/Features/Navigation/NavigationMenuConfigurationBuilder.php
@@ -20,6 +20,8 @@ class NavigationMenuConfigurationBuilder extends ArrayObject implements Arrayabl
     /**
      * Set the order of the navigation items.
      *
+     * Either define a map of route keys to priorities, or just a list of route keys and we'll try to match that order.
+     *
      * @param  array<string, int>|array<string>  $order
      * @return $this
      */
@@ -32,6 +34,8 @@ class NavigationMenuConfigurationBuilder extends ArrayObject implements Arrayabl
 
     /**
      * Set the labels for the navigation items.
+     *
+     * Each key should be a route key, and the value should be the label to display.
      *
      * @param  array<string, string>  $labels
      * @return $this
@@ -46,6 +50,8 @@ class NavigationMenuConfigurationBuilder extends ArrayObject implements Arrayabl
     /**
      * Exclude certain items from the navigation.
      *
+     * Each item should be a route key for the page to exclude.
+     *
      * @param  array<string>  $exclude
      * @return $this
      */
@@ -59,6 +65,8 @@ class NavigationMenuConfigurationBuilder extends ArrayObject implements Arrayabl
     /**
      * Add custom items to the navigation.
      *
+     * @example `[Navigation::item('https://github.com/hydephp/hyde', 'GitHub', 200, ['target' => '_blank'])]`
+     *
      * @param  array<array{destination: string, label: ?string, priority: ?int, attributes: array<string, scalar>}>  $custom
      * @return $this
      */
@@ -71,6 +79,8 @@ class NavigationMenuConfigurationBuilder extends ArrayObject implements Arrayabl
 
     /**
      * Set the display mode for subdirectories.
+     *
+     * You can choose between 'dropdown', 'flat', and 'hidden'.
      *
      * @param  'dropdown'|'flat'|'hidden'  $displayMode
      * @return $this

--- a/packages/framework/src/Framework/Features/Navigation/NavigationMenuConfigurationBuilder.php
+++ b/packages/framework/src/Framework/Features/Navigation/NavigationMenuConfigurationBuilder.php
@@ -26,7 +26,7 @@ class NavigationMenuConfigurationBuilder extends ArrayObject implements Arrayabl
     /**
      * Set the order of the navigation items.
      *
-     * @param array $order
+     * @param array<string, int>|array<string> $order
      * @return $this
      */
     public function order(array $order): static
@@ -37,7 +37,7 @@ class NavigationMenuConfigurationBuilder extends ArrayObject implements Arrayabl
     /**
      * Set the labels for the navigation items.
      *
-     * @param array $labels
+     * @param array<string, string> $labels
      * @return $this
      */
     public function labels(array $labels): static
@@ -48,7 +48,7 @@ class NavigationMenuConfigurationBuilder extends ArrayObject implements Arrayabl
     /**
      * Exclude certain items from the navigation.
      *
-     * @param array $exclude
+     * @param array<string> $exclude
      * @return $this
      */
     public function exclude(array $exclude): static
@@ -59,7 +59,7 @@ class NavigationMenuConfigurationBuilder extends ArrayObject implements Arrayabl
     /**
      * Add custom items to the navigation.
      *
-     * @param array $custom
+     * @param array<array{destination: string, label: ?string, priority: ?int, attributes: array<string, scalar>}> $custom
      * @return $this
      */
     public function custom(array $custom): static
@@ -70,7 +70,7 @@ class NavigationMenuConfigurationBuilder extends ArrayObject implements Arrayabl
     /**
      * Set the display mode for subdirectories.
      *
-     * @param string $displayMode
+     * @param 'dropdown'|'flat'|'hidden' $displayMode
      * @return $this
      */
     public function subdirectoryDisplay(string $displayMode): static

--- a/packages/framework/src/Framework/Features/Navigation/NavigationMenuConfigurationBuilder.php
+++ b/packages/framework/src/Framework/Features/Navigation/NavigationMenuConfigurationBuilder.php
@@ -17,4 +17,9 @@ use Illuminate\Contracts\Support\Arrayable;
 class NavigationMenuConfigurationBuilder extends ArrayObject implements Arrayable
 {
     protected array $config = [];
+
+    public function toArray(): array
+    {
+        return $this->config;
+    }
 }

--- a/packages/framework/src/Framework/Features/Navigation/NavigationMenuConfigurationBuilder.php
+++ b/packages/framework/src/Framework/Features/Navigation/NavigationMenuConfigurationBuilder.php
@@ -25,7 +25,7 @@ class NavigationMenuConfigurationBuilder extends ArrayObject implements Arrayabl
      * @param  array<string, int>|array<string>  $order
      * @return $this
      */
-    public function order(array $order): static
+    public function setPagePriorities(array $order): static
     {
         $this['order'] = $order;
 
@@ -40,7 +40,7 @@ class NavigationMenuConfigurationBuilder extends ArrayObject implements Arrayabl
      * @param  array<string, string>  $labels
      * @return $this
      */
-    public function labels(array $labels): static
+    public function setPageLabels(array $labels): static
     {
         $this['labels'] = $labels;
 
@@ -55,7 +55,7 @@ class NavigationMenuConfigurationBuilder extends ArrayObject implements Arrayabl
      * @param  array<string>  $exclude
      * @return $this
      */
-    public function exclude(array $exclude): static
+    public function excludePages(array $exclude): static
     {
         $this['exclude'] = $exclude;
 
@@ -70,7 +70,7 @@ class NavigationMenuConfigurationBuilder extends ArrayObject implements Arrayabl
      * @param  array<array{destination: string, label: ?string, priority: ?int, attributes: array<string, scalar>}>  $custom
      * @return $this
      */
-    public function custom(array $custom): static
+    public function addCustomNavigationItems(array $custom): static
     {
         $this['custom'] = $custom;
 
@@ -85,7 +85,7 @@ class NavigationMenuConfigurationBuilder extends ArrayObject implements Arrayabl
      * @param  'dropdown'|'flat'|'hidden'  $displayMode
      * @return $this
      */
-    public function subdirectoryDisplay(string $displayMode): static
+    public function setSubdirectoryDisplayMode(string $displayMode): static
     {
         self::assertType(['dropdown', 'flat', 'hidden'], $displayMode);
 

--- a/packages/framework/src/Framework/Features/Navigation/NavigationMenuConfigurationBuilder.php
+++ b/packages/framework/src/Framework/Features/Navigation/NavigationMenuConfigurationBuilder.php
@@ -23,26 +23,41 @@ class NavigationMenuConfigurationBuilder extends ArrayObject implements Arrayabl
         return $this->config;
     }
 
+    /**
+     * Set the order of the navigation items.
+     */
     public function order(array $order): static
     {
         // TODO: Implement order() method.
     }
 
+    /**
+     * Set the labels for the navigation items.
+     */
     public function labels(array $labels): static
     {
         // TODO: Implement labels() method.
     }
 
+    /**
+     * Exclude certain items from the navigation.
+     */
     public function exclude(array $exclude): static
     {
         // TODO: Implement exclude() method.
     }
 
+    /**
+     * Add custom items to the navigation.
+     */
     public function custom(array $custom): static
     {
         // TODO: Implement custom() method.
     }
 
+    /**
+     * Set the display mode for subdirectories.
+     */
     public function subdirectoryDisplay(string $displayMode): static
     {
         // TODO: Implement subdirectoryDisplay() method.

--- a/packages/framework/src/Framework/Features/Navigation/NavigationMenuConfigurationBuilder.php
+++ b/packages/framework/src/Framework/Features/Navigation/NavigationMenuConfigurationBuilder.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Hyde\Framework\Features\Navigation;
 
+use TypeError;
 use ArrayObject;
 use Illuminate\Contracts\Support\Arrayable;
 
@@ -76,6 +77,8 @@ class NavigationMenuConfigurationBuilder extends ArrayObject implements Arrayabl
      */
     public function subdirectoryDisplay(string $displayMode): static
     {
+        self::assertType(['dropdown', 'flat', 'hidden'], $displayMode);
+
         $this['subdirectory_display'] = $displayMode;
 
         return $this;
@@ -89,5 +92,13 @@ class NavigationMenuConfigurationBuilder extends ArrayObject implements Arrayabl
     public function toArray(): array
     {
         return $this->getArrayCopy();
+    }
+
+    /** @internal */
+    protected static function assertType(array $types, string $value): void
+    {
+        if (! in_array($value, $types)) {
+            throw new TypeError('Value must be one of: '.implode(', ', $types));
+        }
     }
 }

--- a/packages/framework/src/Framework/Features/Navigation/NavigationMenuConfigurationBuilder.php
+++ b/packages/framework/src/Framework/Features/Navigation/NavigationMenuConfigurationBuilder.php
@@ -22,4 +22,29 @@ class NavigationMenuConfigurationBuilder extends ArrayObject implements Arrayabl
     {
         return $this->config;
     }
+
+    public function order(array $order): static
+    {
+        // TODO: Implement order() method.
+    }
+
+    public function labels(array $labels): static
+    {
+        // TODO: Implement labels() method.
+    }
+
+    public function exclude(array $exclude): static
+    {
+        // TODO: Implement exclude() method.
+    }
+
+    public function custom(array $custom): static
+    {
+        // TODO: Implement custom() method.
+    }
+
+    public function subdirectoryDisplay(string $displayMode): static
+    {
+        // TODO: Implement subdirectoryDisplay() method.
+    }
 }

--- a/packages/framework/src/Framework/Features/Navigation/NavigationMenuConfigurationBuilder.php
+++ b/packages/framework/src/Framework/Features/Navigation/NavigationMenuConfigurationBuilder.php
@@ -18,11 +18,6 @@ class NavigationMenuConfigurationBuilder extends ArrayObject implements Arrayabl
 {
     protected array $config = [];
 
-    public function __construct()
-    {
-        parent::__construct($this->config);
-    }
-
     /**
      * Set the order of the navigation items.
      *

--- a/packages/framework/src/Framework/Features/Navigation/NavigationMenuConfigurationBuilder.php
+++ b/packages/framework/src/Framework/Features/Navigation/NavigationMenuConfigurationBuilder.php
@@ -26,7 +26,9 @@ class NavigationMenuConfigurationBuilder extends ArrayObject implements Arrayabl
      */
     public function order(array $order): static
     {
-        // TODO: Implement order() method.
+        $this->config['order'] = $order;
+
+        return $this;
     }
 
     /**
@@ -37,7 +39,9 @@ class NavigationMenuConfigurationBuilder extends ArrayObject implements Arrayabl
      */
     public function labels(array $labels): static
     {
-        // TODO: Implement labels() method.
+        $this->config['labels'] = $labels;
+
+        return $this;
     }
 
     /**
@@ -48,7 +52,9 @@ class NavigationMenuConfigurationBuilder extends ArrayObject implements Arrayabl
      */
     public function exclude(array $exclude): static
     {
-        // TODO: Implement exclude() method.
+        $this->config['exclude'] = $exclude;
+
+        return $this;
     }
 
     /**
@@ -59,7 +65,9 @@ class NavigationMenuConfigurationBuilder extends ArrayObject implements Arrayabl
      */
     public function custom(array $custom): static
     {
-        // TODO: Implement custom() method.
+        $this->config['custom'] = $custom;
+
+        return $this;
     }
 
     /**
@@ -70,7 +78,9 @@ class NavigationMenuConfigurationBuilder extends ArrayObject implements Arrayabl
      */
     public function subdirectoryDisplay(string $displayMode): static
     {
-        // TODO: Implement subdirectoryDisplay() method.
+        $this->config['subdirectory_display'] = $displayMode;
+
+        return $this;
     }
 
     public function toArray(): array

--- a/packages/framework/src/Framework/Features/Navigation/NavigationMenuConfigurationBuilder.php
+++ b/packages/framework/src/Framework/Features/Navigation/NavigationMenuConfigurationBuilder.php
@@ -20,7 +20,7 @@ class NavigationMenuConfigurationBuilder extends ArrayObject implements Arrayabl
 
     public function __construct()
     {
-        parent::__construct($this->config);
+        parent::__construct($this->config, ArrayObject::ARRAY_AS_PROPS | ArrayObject::STD_PROP_LIST);
     }
 
     /**

--- a/packages/framework/src/Framework/Features/Navigation/NavigationMenuConfigurationBuilder.php
+++ b/packages/framework/src/Framework/Features/Navigation/NavigationMenuConfigurationBuilder.php
@@ -18,11 +18,6 @@ class NavigationMenuConfigurationBuilder extends ArrayObject implements Arrayabl
 {
     protected array $config = [];
 
-    public function toArray(): array
-    {
-        return $this->config;
-    }
-
     /**
      * Set the order of the navigation items.
      *
@@ -76,5 +71,10 @@ class NavigationMenuConfigurationBuilder extends ArrayObject implements Arrayabl
     public function subdirectoryDisplay(string $displayMode): static
     {
         // TODO: Implement subdirectoryDisplay() method.
+    }
+
+    public function toArray(): array
+    {
+        return $this->config;
     }
 }

--- a/packages/framework/src/Framework/Features/Navigation/NavigationMenuConfigurationBuilder.php
+++ b/packages/framework/src/Framework/Features/Navigation/NavigationMenuConfigurationBuilder.php
@@ -80,7 +80,7 @@ class NavigationMenuConfigurationBuilder extends ArrayObject implements Arrayabl
     /**
      * Set the display mode for pages in subdirectories.
      *
-     * You can choose between 'dropdown', 'flat', and 'hidden'.
+     * You can choose between 'dropdown', 'flat', and 'hidden'. The default is 'hidden'.
      *
      * @param  'dropdown'|'flat'|'hidden'  $displayMode
      * @return $this

--- a/packages/framework/src/Framework/Features/Navigation/NavigationMenuConfigurationBuilder.php
+++ b/packages/framework/src/Framework/Features/Navigation/NavigationMenuConfigurationBuilder.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Hyde\Framework\Features\Navigation;
+
+class NavigationMenuConfigurationBuilder
+{
+    //
+}

--- a/packages/framework/src/Framework/Features/Navigation/NavigationMenuConfigurationBuilder.php
+++ b/packages/framework/src/Framework/Features/Navigation/NavigationMenuConfigurationBuilder.php
@@ -4,6 +4,13 @@ declare(strict_types=1);
 
 namespace Hyde\Framework\Features\Navigation;
 
+/**
+ * Configuration helper method to define the navigation menu configuration with better IDE support.
+ *
+ * The configured object will be cast to an array that will be used by the framework to set the config data.
+ *
+ * @experimental This method is experimental and may change in the future.
+ */
 class NavigationMenuConfigurationBuilder
 {
     //

--- a/packages/framework/src/Framework/Features/Navigation/NavigationMenuConfigurationBuilder.php
+++ b/packages/framework/src/Framework/Features/Navigation/NavigationMenuConfigurationBuilder.php
@@ -11,7 +11,9 @@ use Illuminate\Contracts\Support\Arrayable;
 /**
  * Configuration helper class to define the navigation menu configuration with better IDE support.
  *
- * The configured object will be cast to an array that will be used by the framework to set the config data.
+ * The configured data will then be used by the framework to set the navigation menu configuration.
+ *
+ * @see \Hyde\Facades\Navigation::configure()
  *
  * @experimental This class is experimental and may change or be removed before the final release.
  */

--- a/packages/framework/src/Framework/Features/Navigation/NavigationMenuConfigurationBuilder.php
+++ b/packages/framework/src/Framework/Features/Navigation/NavigationMenuConfigurationBuilder.php
@@ -12,7 +12,7 @@ use Illuminate\Contracts\Support\Arrayable;
  *
  * The configured object will be cast to an array that will be used by the framework to set the config data.
  *
- * @experimental This method is experimental and may change in the future.
+ * @experimental This class is experimental and may change in the future.
  */
 class NavigationMenuConfigurationBuilder extends ArrayObject implements Arrayable
 {

--- a/packages/framework/src/Framework/Features/Navigation/NavigationMenuConfigurationBuilder.php
+++ b/packages/framework/src/Framework/Features/Navigation/NavigationMenuConfigurationBuilder.php
@@ -25,6 +25,8 @@ class NavigationMenuConfigurationBuilder extends ArrayObject implements Arrayabl
 
     /**
      * Set the order of the navigation items.
+     *
+     * @return $this
      */
     public function order(array $order): static
     {
@@ -33,6 +35,8 @@ class NavigationMenuConfigurationBuilder extends ArrayObject implements Arrayabl
 
     /**
      * Set the labels for the navigation items.
+     *
+     * @return $this
      */
     public function labels(array $labels): static
     {
@@ -41,6 +45,8 @@ class NavigationMenuConfigurationBuilder extends ArrayObject implements Arrayabl
 
     /**
      * Exclude certain items from the navigation.
+     *
+     * @return $this
      */
     public function exclude(array $exclude): static
     {
@@ -49,6 +55,8 @@ class NavigationMenuConfigurationBuilder extends ArrayObject implements Arrayabl
 
     /**
      * Add custom items to the navigation.
+     *
+     * @return $this
      */
     public function custom(array $custom): static
     {
@@ -57,6 +65,8 @@ class NavigationMenuConfigurationBuilder extends ArrayObject implements Arrayabl
 
     /**
      * Set the display mode for subdirectories.
+     *
+     * @return $this
      */
     public function subdirectoryDisplay(string $displayMode): static
     {

--- a/packages/framework/src/Framework/Features/Navigation/NavigationMenuConfigurationBuilder.php
+++ b/packages/framework/src/Framework/Features/Navigation/NavigationMenuConfigurationBuilder.php
@@ -95,6 +95,18 @@ class NavigationMenuConfigurationBuilder extends ArrayObject implements Arrayabl
     }
 
     /**
+     * Hide pages in subdirectories from the navigation.
+     *
+     * @experimental This method is experimental and may change or be removed before the final release.
+     *
+     * @return $this
+     */
+    public function hideSubdirectoriesFromNavigation(): static
+    {
+        return $this->setSubdirectoryDisplayMode('hidden');
+    }
+
+    /**
      * Get the instance as an array.
      *
      * @return array{order: array<string, int>, labels: array<string, string>, exclude: array<string>, custom: array<array{destination: string, label: ?string, priority: ?int, attributes: array<string, scalar>}>, subdirectory_display: string}

--- a/packages/framework/src/Framework/Features/Navigation/NavigationMenuConfigurationBuilder.php
+++ b/packages/framework/src/Framework/Features/Navigation/NavigationMenuConfigurationBuilder.php
@@ -20,7 +20,7 @@ class NavigationMenuConfigurationBuilder extends ArrayObject implements Arrayabl
 
     public function __construct()
     {
-        parent::__construct($this->config, ArrayObject::ARRAY_AS_PROPS | ArrayObject::STD_PROP_LIST);
+        parent::__construct($this->config);
     }
 
     /**

--- a/packages/framework/src/Framework/Features/Navigation/NavigationMenuConfigurationBuilder.php
+++ b/packages/framework/src/Framework/Features/Navigation/NavigationMenuConfigurationBuilder.php
@@ -13,7 +13,7 @@ use Illuminate\Contracts\Support\Arrayable;
  *
  * The configured object will be cast to an array that will be used by the framework to set the config data.
  *
- * @experimental This class is experimental and may change in the future.
+ * @experimental This class is experimental and may change or be removed before the final release.
  */
 class NavigationMenuConfigurationBuilder extends ArrayObject implements Arrayable
 {

--- a/packages/framework/src/Framework/Features/Navigation/NavigationMenuConfigurationBuilder.php
+++ b/packages/framework/src/Framework/Features/Navigation/NavigationMenuConfigurationBuilder.php
@@ -8,7 +8,7 @@ use ArrayObject;
 use Illuminate\Contracts\Support\Arrayable;
 
 /**
- * Configuration helper method to define the navigation menu configuration with better IDE support.
+ * Configuration helper class to define the navigation menu configuration with better IDE support.
  *
  * The configured object will be cast to an array that will be used by the framework to set the config data.
  *

--- a/packages/framework/src/Framework/Features/Navigation/NavigationMenuConfigurationBuilder.php
+++ b/packages/framework/src/Framework/Features/Navigation/NavigationMenuConfigurationBuilder.php
@@ -18,6 +18,11 @@ class NavigationMenuConfigurationBuilder extends ArrayObject implements Arrayabl
 {
     protected array $config = [];
 
+    public function __construct()
+    {
+        parent::__construct($this->config);
+    }
+
     /**
      * Set the order of the navigation items.
      *

--- a/packages/framework/tests/Feature/AutomaticNavigationConfigurationsTest.php
+++ b/packages/framework/tests/Feature/AutomaticNavigationConfigurationsTest.php
@@ -1234,6 +1234,61 @@ class AutomaticNavigationConfigurationsTest extends TestCase
         $this->assertSidebarEquals(['Hello World'], [new DocumentationPage('foo', ['navigation.group' => 'hello world'])]);
     }
 
+    // Configuration tests
+
+    public function testCanConfigureMainMenuUsingArraySettings()
+    {
+        $config = [
+            'navigation' => [
+                'order' => [
+                    'foo' => 3,
+                    'bar' => 2,
+                    'baz' => 1,
+                ],
+
+                'labels' => [
+                    'foo' => 'Foo Page',
+                    'bar' => 'Bar Page',
+                    'baz' => 'Baz Page',
+                    'dropdown/item' => 'Dropdown Item Page',
+                ],
+
+                'exclude' => [
+                    'qux',
+                ],
+
+                'custom' => [
+                    [
+                        'label' => 'Custom',
+                        'destination' => 'https://example.com',
+                        'priority' => 120,
+                        'attributes' => [
+                            'target' => '_blank',
+                        ],
+                    ],
+                ],
+
+                'subdirectory_display' => 'flat',
+            ],
+        ];
+
+        config(['hyde' => $config]);
+
+        $this->assertMenuEquals([
+            ['label' => 'Baz Page', 'priority' => 1],
+            ['label' => 'Bar Page', 'priority' => 2],
+            ['label' => 'Foo Page', 'priority' => 3],
+            ['label' => 'Custom', 'priority' => 120, 'attributes' => ['target' => '_blank']],
+            ['label' => 'Dropdown Item Page', 'priority' => 999],
+        ], [
+            new MarkdownPage('foo'),
+            new MarkdownPage('bar'),
+            new MarkdownPage('baz'),
+            new MarkdownPage('qux'),
+            new MarkdownPage('dropdown/item'),
+        ]);
+    }
+
     // Testing helpers
 
     protected function assertSidebarEquals(array $expected, array $menuPages): AssertableNavigationMenu

--- a/packages/framework/tests/Feature/AutomaticNavigationConfigurationsTest.php
+++ b/packages/framework/tests/Feature/AutomaticNavigationConfigurationsTest.php
@@ -1308,7 +1308,7 @@ class AutomaticNavigationConfigurationsTest extends TestCase
                 ->excludePages([
                     'qux',
                 ])
-                ->addCustomNavigationItems([
+                ->addNavigationItems([
                     [
                         'label' => 'Custom',
                         'destination' => 'https://example.com',

--- a/packages/framework/tests/Feature/AutomaticNavigationConfigurationsTest.php
+++ b/packages/framework/tests/Feature/AutomaticNavigationConfigurationsTest.php
@@ -1292,35 +1292,33 @@ class AutomaticNavigationConfigurationsTest extends TestCase
 
     public function testCanConfigureMainMenuUsingBuilderSettings()
     {
-        $builder = Navigation::configure()
-            ->order([
-                'foo' => 3,
-                'bar' => 2,
-                'baz' => 1,
-            ])
-            ->labels([
-                'foo' => 'Foo Page',
-                'bar' => 'Bar Page',
-                'baz' => 'Baz Page',
-                'dropdown/item' => 'Dropdown Item Page',
-            ])
-            ->exclude([
-                'qux',
-            ])
-            ->custom([
-                [
-                    'label' => 'Custom',
-                    'destination' => 'https://example.com',
-                    'priority' => 120,
-                    'attributes' => [
-                        'target' => '_blank',
-                    ],
-                ],
-            ])
-            ->subdirectoryDisplay('flat');
-
         $config = [
-            'navigation' => $builder,
+            'navigation' => Navigation::configure()
+                ->order([
+                    'foo' => 3,
+                    'bar' => 2,
+                    'baz' => 1,
+                ])
+                ->labels([
+                    'foo' => 'Foo Page',
+                    'bar' => 'Bar Page',
+                    'baz' => 'Baz Page',
+                    'dropdown/item' => 'Dropdown Item Page',
+                ])
+                ->exclude([
+                    'qux',
+                ])
+                ->custom([
+                    [
+                        'label' => 'Custom',
+                        'destination' => 'https://example.com',
+                        'priority' => 120,
+                        'attributes' => [
+                            'target' => '_blank',
+                        ],
+                    ],
+                ])
+                ->subdirectoryDisplay('flat'),
         ];
 
         config(['hyde' => $config]);

--- a/packages/framework/tests/Feature/AutomaticNavigationConfigurationsTest.php
+++ b/packages/framework/tests/Feature/AutomaticNavigationConfigurationsTest.php
@@ -10,6 +10,7 @@ use Hyde\Testing\TestCase;
 use Hyde\Pages\MarkdownPage;
 use Hyde\Pages\MarkdownPost;
 use Hyde\Pages\InMemoryPage;
+use Hyde\Facades\Navigation;
 use Hyde\Foundation\HydeKernel;
 use JetBrains\PhpStorm\NoReturn;
 use Hyde\Pages\Concerns\HydePage;
@@ -1270,6 +1271,56 @@ class AutomaticNavigationConfigurationsTest extends TestCase
 
                 'subdirectory_display' => 'flat',
             ],
+        ];
+
+        config(['hyde' => $config]);
+
+        $this->assertMenuEquals([
+            ['label' => 'Baz Page', 'priority' => 1],
+            ['label' => 'Bar Page', 'priority' => 2],
+            ['label' => 'Foo Page', 'priority' => 3],
+            ['label' => 'Custom', 'priority' => 120, 'attributes' => ['target' => '_blank']],
+            ['label' => 'Dropdown Item Page', 'priority' => 999],
+        ], [
+            new MarkdownPage('foo'),
+            new MarkdownPage('bar'),
+            new MarkdownPage('baz'),
+            new MarkdownPage('qux'),
+            new MarkdownPage('dropdown/item'),
+        ]);
+    }
+
+    public function testCanConfigureMainMenuUsingBuilderSettings()
+    {
+        $builder = Navigation::configure()
+            ->order([
+                'foo' => 3,
+                'bar' => 2,
+                'baz' => 1,
+            ])
+            ->labels([
+                'foo' => 'Foo Page',
+                'bar' => 'Bar Page',
+                'baz' => 'Baz Page',
+                'dropdown/item' => 'Dropdown Item Page',
+            ])
+            ->exclude([
+                'qux',
+            ])
+            ->custom([
+                [
+                    'label' => 'Custom',
+                    'destination' => 'https://example.com',
+                    'priority' => 120,
+                    'attributes' => [
+                        'target' => '_blank',
+                    ],
+                ],
+            ])
+            ->subdirectoryDisplay('flat');
+
+        $config = [
+            'navigation' => $builder,
         ];
 
         config(['hyde' => $config]);

--- a/packages/framework/tests/Feature/AutomaticNavigationConfigurationsTest.php
+++ b/packages/framework/tests/Feature/AutomaticNavigationConfigurationsTest.php
@@ -1294,21 +1294,21 @@ class AutomaticNavigationConfigurationsTest extends TestCase
     {
         $config = [
             'navigation' => Navigation::configure()
-                ->order([
+                ->setPagePriorities([
                     'foo' => 3,
                     'bar' => 2,
                     'baz' => 1,
                 ])
-                ->labels([
+                ->setPageLabels([
                     'foo' => 'Foo Page',
                     'bar' => 'Bar Page',
                     'baz' => 'Baz Page',
                     'dropdown/item' => 'Dropdown Item Page',
                 ])
-                ->exclude([
+                ->excludePages([
                     'qux',
                 ])
-                ->custom([
+                ->addCustomNavigationItems([
                     [
                         'label' => 'Custom',
                         'destination' => 'https://example.com',
@@ -1318,7 +1318,7 @@ class AutomaticNavigationConfigurationsTest extends TestCase
                         ],
                     ],
                 ])
-                ->subdirectoryDisplay('flat'),
+                ->setSubdirectoryDisplayMode('flat'),
         ];
 
         config(['hyde' => $config]);

--- a/packages/framework/tests/Unit/Facades/NavigationFacadeTest.php
+++ b/packages/framework/tests/Unit/Facades/NavigationFacadeTest.php
@@ -62,7 +62,7 @@ class NavigationFacadeTest extends UnitTestCase
             ->setPagePriorities(['index' => 0, 'posts' => 10])
             ->setPageLabels(['index' => 'Home'])
             ->excludePages(['404'])
-            ->addCustomNavigationItems([Navigation::item('https://github.com', 'GitHub', 200)])
+            ->addNavigationItems([Navigation::item('https://github.com', 'GitHub', 200)])
             ->setSubdirectoryDisplayMode('dropdown')
             ->toArray();
 

--- a/packages/framework/tests/Unit/Facades/NavigationFacadeTest.php
+++ b/packages/framework/tests/Unit/Facades/NavigationFacadeTest.php
@@ -59,11 +59,11 @@ class NavigationFacadeTest extends UnitTestCase
     public function testConfigureWithChainedMethods()
     {
         $config = Navigation::configure()
-            ->order(['index' => 0, 'posts' => 10])
-            ->labels(['index' => 'Home'])
-            ->exclude(['404'])
-            ->custom([Navigation::item('https://github.com', 'GitHub', 200)])
-            ->subdirectoryDisplay('dropdown')
+            ->setPagePriorities(['index' => 0, 'posts' => 10])
+            ->setPageLabels(['index' => 'Home'])
+            ->excludePages(['404'])
+            ->addCustomNavigationItems([Navigation::item('https://github.com', 'GitHub', 200)])
+            ->setSubdirectoryDisplayMode('dropdown')
             ->toArray();
 
         $this->assertIsArray($config);
@@ -83,9 +83,9 @@ class NavigationFacadeTest extends UnitTestCase
     public function testConfigureWithSomeChainedMethods()
     {
         $config = Navigation::configure()
-            ->order(['about' => 1, 'contact' => 2])
-            ->labels(['about' => 'About Us'])
-            ->subdirectoryDisplay('flat')
+            ->setPagePriorities(['about' => 1, 'contact' => 2])
+            ->setPageLabels(['about' => 'About Us'])
+            ->setSubdirectoryDisplayMode('flat')
             ->toArray();
 
         $this->assertSame(['about' => 1, 'contact' => 2], $config['order']);

--- a/packages/framework/tests/Unit/Facades/NavigationFacadeTest.php
+++ b/packages/framework/tests/Unit/Facades/NavigationFacadeTest.php
@@ -73,11 +73,11 @@ class NavigationFacadeTest extends UnitTestCase
         $this->assertArrayHasKey('custom', $config);
         $this->assertArrayHasKey('subdirectory_display', $config);
 
-        $this->assertEquals(['index' => 0, 'posts' => 10], $config['order']);
-        $this->assertEquals(['index' => 'Home'], $config['labels']);
-        $this->assertEquals(['404'], $config['exclude']);
-        $this->assertEquals([Navigation::item('https://github.com', 'GitHub', 200)], $config['custom']);
-        $this->assertEquals('dropdown', $config['subdirectory_display']);
+        $this->assertSame(['index' => 0, 'posts' => 10], $config['order']);
+        $this->assertSame(['index' => 'Home'], $config['labels']);
+        $this->assertSame(['404'], $config['exclude']);
+        $this->assertSame([Navigation::item('https://github.com', 'GitHub', 200)], $config['custom']);
+        $this->assertSame('dropdown', $config['subdirectory_display']);
     }
 
     public function testConfigureWithSomeChainedMethods()
@@ -88,9 +88,9 @@ class NavigationFacadeTest extends UnitTestCase
             ->subdirectoryDisplay('flat')
             ->toArray();
 
-        $this->assertEquals(['about' => 1, 'contact' => 2], $config['order']);
-        $this->assertEquals(['about' => 'About Us'], $config['labels']);
-        $this->assertEquals('flat', $config['subdirectory_display']);
+        $this->assertSame(['about' => 1, 'contact' => 2], $config['order']);
+        $this->assertSame(['about' => 'About Us'], $config['labels']);
+        $this->assertSame('flat', $config['subdirectory_display']);
         $this->assertArrayNotHasKey('exclude', $config);
         $this->assertArrayNotHasKey('custom', $config);
     }

--- a/packages/framework/tests/Unit/Facades/NavigationFacadeTest.php
+++ b/packages/framework/tests/Unit/Facades/NavigationFacadeTest.php
@@ -6,6 +6,7 @@ namespace Hyde\Framework\Testing\Unit\Facades;
 
 use Hyde\Facades\Navigation;
 use Hyde\Testing\UnitTestCase;
+use Hyde\Framework\Features\Navigation\NavigationMenuConfigurationBuilder;
 
 /**
  * @covers \Hyde\Facades\Navigation
@@ -46,5 +47,51 @@ class NavigationFacadeTest extends UnitTestCase
             'priority' => 200,
             'attributes' => [],
         ], $item);
+    }
+
+    public function testConfigure()
+    {
+        $builder = Navigation::configure();
+
+        $this->assertInstanceOf(NavigationMenuConfigurationBuilder::class, $builder);
+    }
+
+    public function testConfigureWithChainedMethods()
+    {
+        $config = Navigation::configure()
+            ->order(['index' => 0, 'posts' => 10])
+            ->labels(['index' => 'Home'])
+            ->exclude(['404'])
+            ->custom([Navigation::item('https://github.com', 'GitHub', 200)])
+            ->subdirectoryDisplay('dropdown')
+            ->toArray();
+
+        $this->assertIsArray($config);
+        $this->assertArrayHasKey('order', $config);
+        $this->assertArrayHasKey('labels', $config);
+        $this->assertArrayHasKey('exclude', $config);
+        $this->assertArrayHasKey('custom', $config);
+        $this->assertArrayHasKey('subdirectory_display', $config);
+
+        $this->assertEquals(['index' => 0, 'posts' => 10], $config['order']);
+        $this->assertEquals(['index' => 'Home'], $config['labels']);
+        $this->assertEquals(['404'], $config['exclude']);
+        $this->assertEquals([Navigation::item('https://github.com', 'GitHub', 200)], $config['custom']);
+        $this->assertEquals('dropdown', $config['subdirectory_display']);
+    }
+
+    public function testConfigureWithSomeChainedMethods()
+    {
+        $config = Navigation::configure()
+            ->order(['about' => 1, 'contact' => 2])
+            ->labels(['about' => 'About Us'])
+            ->subdirectoryDisplay('flat')
+            ->toArray();
+
+        $this->assertEquals(['about' => 1, 'contact' => 2], $config['order']);
+        $this->assertEquals(['about' => 'About Us'], $config['labels']);
+        $this->assertEquals('flat', $config['subdirectory_display']);
+        $this->assertArrayNotHasKey('exclude', $config);
+        $this->assertArrayNotHasKey('custom', $config);
     }
 }

--- a/packages/framework/tests/Unit/NavigationMenuConfigurationBuilderTest.php
+++ b/packages/framework/tests/Unit/NavigationMenuConfigurationBuilderTest.php
@@ -26,7 +26,7 @@ class NavigationMenuConfigurationBuilderTest extends UnitTestCase
         $result = $this->builder->order($order)->toArray();
 
         $this->assertArrayHasKey('order', $result);
-        $this->assertEquals($order, $result['order']);
+        $this->assertSame($order, $result['order']);
     }
 
     public function testLabels()
@@ -35,7 +35,7 @@ class NavigationMenuConfigurationBuilderTest extends UnitTestCase
         $result = $this->builder->labels($labels)->toArray();
 
         $this->assertArrayHasKey('labels', $result);
-        $this->assertEquals($labels, $result['labels']);
+        $this->assertSame($labels, $result['labels']);
     }
 
     public function testExclude()
@@ -44,7 +44,7 @@ class NavigationMenuConfigurationBuilderTest extends UnitTestCase
         $result = $this->builder->exclude($exclude)->toArray();
 
         $this->assertArrayHasKey('exclude', $result);
-        $this->assertEquals($exclude, $result['exclude']);
+        $this->assertSame($exclude, $result['exclude']);
     }
 
     public function testCustom()
@@ -56,7 +56,7 @@ class NavigationMenuConfigurationBuilderTest extends UnitTestCase
         $result = $this->builder->custom($custom)->toArray();
 
         $this->assertArrayHasKey('custom', $result);
-        $this->assertEquals($custom, $result['custom']);
+        $this->assertSame($custom, $result['custom']);
     }
 
     public function testSubdirectoryDisplay()
@@ -67,7 +67,7 @@ class NavigationMenuConfigurationBuilderTest extends UnitTestCase
             $result = $this->builder->subdirectoryDisplay($mode)->toArray();
 
             $this->assertArrayHasKey('subdirectory_display', $result);
-            $this->assertEquals($mode, $result['subdirectory_display']);
+            $this->assertSame($mode, $result['subdirectory_display']);
         }
     }
 
@@ -124,7 +124,7 @@ class NavigationMenuConfigurationBuilderTest extends UnitTestCase
             ->subdirectoryDisplay('dropdown')
             ->toArray();
 
-        $this->assertEquals([
+        $this->assertSame([
             'order' => ['index' => 0, 'posts' => 10, 'docs/index' => 100],
             'labels' => ['index' => 'Home', 'docs/index' => 'Docs'],
             'exclude' => ['404'],
@@ -146,9 +146,9 @@ class NavigationMenuConfigurationBuilderTest extends UnitTestCase
 
         // ArrayObject methods now operate on the configuration data
         $this->assertCount(1, $this->builder);
-        $this->assertEquals(['order' => ['index' => 0]], $this->builder->getArrayCopy());
+        $this->assertSame(['order' => ['index' => 0]], $this->builder->getArrayCopy());
 
         // toArray() method should return the same result
-        $this->assertEquals(['order' => ['index' => 0]], $this->builder->toArray());
+        $this->assertSame(['order' => ['index' => 0]], $this->builder->toArray());
     }
 }

--- a/packages/framework/tests/Unit/NavigationMenuConfigurationBuilderTest.php
+++ b/packages/framework/tests/Unit/NavigationMenuConfigurationBuilderTest.php
@@ -139,10 +139,15 @@ class NavigationMenuConfigurationBuilderTest extends UnitTestCase
         $this->assertInstanceOf(\Illuminate\Contracts\Support\Arrayable::class, $this->builder);
     }
 
-    public function testArrayObjectMethods()
+    public function testArrayObjectBehavior()
     {
         $this->builder->order(['index' => 0]);
+
+        // ArrayObject methods now operate on the configuration data
         $this->assertCount(1, $this->builder);
         $this->assertEquals(['order' => ['index' => 0]], $this->builder->getArrayCopy());
+
+        // toArray() method should return the same result
+        $this->assertEquals(['order' => ['index' => 0]], $this->builder->toArray());
     }
 }

--- a/packages/framework/tests/Unit/NavigationMenuConfigurationBuilderTest.php
+++ b/packages/framework/tests/Unit/NavigationMenuConfigurationBuilderTest.php
@@ -146,8 +146,12 @@ class NavigationMenuConfigurationBuilderTest extends UnitTestCase
 
         $this->assertCount(1, $this->builder);
         $this->assertSame(['order' => ['index' => 0]], $this->builder->getArrayCopy());
+    }
 
-        // toArray() method should return the same result
+    public function testToArrayMethodReturnsSameResultAsArrayObject()
+    {
+        $this->builder->order(['index' => 0]);
+
         $this->assertSame(['order' => ['index' => 0]], $this->builder->toArray());
     }
 }

--- a/packages/framework/tests/Unit/NavigationMenuConfigurationBuilderTest.php
+++ b/packages/framework/tests/Unit/NavigationMenuConfigurationBuilderTest.php
@@ -3,6 +3,7 @@
 declare(strict_types=1);
 
 use Hyde\Testing\UnitTestCase;
+use Illuminate\Contracts\Support\Arrayable;
 use Hyde\Framework\Features\Navigation\NavigationMenuConfigurationBuilder;
 use Hyde\Facades\Navigation;
 
@@ -136,7 +137,7 @@ class NavigationMenuConfigurationBuilderTest extends UnitTestCase
 
     public function testArrayableInterface()
     {
-        $this->assertInstanceOf(\Illuminate\Contracts\Support\Arrayable::class, $this->builder);
+        $this->assertInstanceOf(Arrayable::class, $this->builder);
     }
 
     public function testArrayObjectBehavior()

--- a/packages/framework/tests/Unit/NavigationMenuConfigurationBuilderTest.php
+++ b/packages/framework/tests/Unit/NavigationMenuConfigurationBuilderTest.php
@@ -17,6 +17,7 @@ class NavigationMenuConfigurationBuilderTest extends UnitTestCase
     protected function setUp(): void
     {
         parent::setUp();
+
         $this->builder = new NavigationMenuConfigurationBuilder();
     }
 
@@ -53,6 +54,7 @@ class NavigationMenuConfigurationBuilderTest extends UnitTestCase
             Navigation::item('https://example.com', 'Example', 200),
             Navigation::item('https://github.com', 'GitHub', 300),
         ];
+
         $result = $this->builder->addNavigationItems($custom)->toArray();
 
         $this->assertArrayHasKey('custom', $result);

--- a/packages/framework/tests/Unit/NavigationMenuConfigurationBuilderTest.php
+++ b/packages/framework/tests/Unit/NavigationMenuConfigurationBuilderTest.php
@@ -97,8 +97,6 @@ class NavigationMenuConfigurationBuilderTest extends UnitTestCase
 
     public function testInvalidSubdirectoryDisplay()
     {
-        $this->markTestSkipped('Not yet implemented');
-
         $this->expectException(\TypeError::class);
         $this->builder->subdirectoryDisplay('invalid');
     }

--- a/packages/framework/tests/Unit/NavigationMenuConfigurationBuilderTest.php
+++ b/packages/framework/tests/Unit/NavigationMenuConfigurationBuilderTest.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+use Hyde\Testing\UnitTestCase;
+
+/**
+ * @covers \Hyde\Framework\Features\Navigation\NavigationMenuConfigurationBuilder
+ */
+class NavigationMenuConfigurationBuilderTest extends UnitTestCase
+{
+    public function testExample()
+    {
+        $this->assertTrue(true);
+    }
+}

--- a/packages/framework/tests/Unit/NavigationMenuConfigurationBuilderTest.php
+++ b/packages/framework/tests/Unit/NavigationMenuConfigurationBuilderTest.php
@@ -96,6 +96,8 @@ class NavigationMenuConfigurationBuilderTest extends UnitTestCase
 
     public function testInvalidSubdirectoryDisplay()
     {
+        $this->markTestSkipped('Not yet implemented');
+
         $this->expectException(\TypeError::class);
         $this->builder->subdirectoryDisplay('invalid');
     }

--- a/packages/framework/tests/Unit/NavigationMenuConfigurationBuilderTest.php
+++ b/packages/framework/tests/Unit/NavigationMenuConfigurationBuilderTest.php
@@ -47,13 +47,13 @@ class NavigationMenuConfigurationBuilderTest extends UnitTestCase
         $this->assertSame($exclude, $result['exclude']);
     }
 
-    public function testAddCustomNavigationItems()
+    public function testAddNavigationItems()
     {
         $custom = [
             Navigation::item('https://example.com', 'Example', 200),
             Navigation::item('https://github.com', 'GitHub', 300),
         ];
-        $result = $this->builder->addCustomNavigationItems($custom)->toArray();
+        $result = $this->builder->addNavigationItems($custom)->toArray();
 
         $this->assertArrayHasKey('custom', $result);
         $this->assertSame($custom, $result['custom']);
@@ -77,7 +77,7 @@ class NavigationMenuConfigurationBuilderTest extends UnitTestCase
             ->setPagePriorities(['index' => 0, 'posts' => 10])
             ->setPageLabels(['index' => 'Home'])
             ->excludePages(['404'])
-            ->addCustomNavigationItems([Navigation::item('https://github.com', 'GitHub', 200)])
+            ->addNavigationItems([Navigation::item('https://github.com', 'GitHub', 200)])
             ->setSubdirectoryDisplayMode('dropdown')
             ->toArray();
 
@@ -116,7 +116,7 @@ class NavigationMenuConfigurationBuilderTest extends UnitTestCase
             ->excludePages([
                 '404',
             ])
-            ->addCustomNavigationItems([
+            ->addNavigationItems([
                 Navigation::item('https://github.com/hydephp/hyde', 'GitHub', 200),
             ])
             ->setSubdirectoryDisplayMode('dropdown')

--- a/packages/framework/tests/Unit/NavigationMenuConfigurationBuilderTest.php
+++ b/packages/framework/tests/Unit/NavigationMenuConfigurationBuilderTest.php
@@ -135,6 +135,13 @@ class NavigationMenuConfigurationBuilderTest extends UnitTestCase
         ], $result);
     }
 
+    public function testHideSubdirectoriesFromNavigationShorthand()
+    {
+        $result = $this->builder->hideSubdirectoriesFromNavigation()->toArray();
+
+        $this->assertSame('hidden', $result['subdirectory_display']);
+    }
+
     public function testArrayableInterface()
     {
         $this->assertInstanceOf(Arrayable::class, $this->builder);

--- a/packages/framework/tests/Unit/NavigationMenuConfigurationBuilderTest.php
+++ b/packages/framework/tests/Unit/NavigationMenuConfigurationBuilderTest.php
@@ -20,51 +20,51 @@ class NavigationMenuConfigurationBuilderTest extends UnitTestCase
         $this->builder = new NavigationMenuConfigurationBuilder();
     }
 
-    public function testOrder()
+    public function testSetPagePriorities()
     {
         $order = ['index' => 0, 'posts' => 10, 'docs/index' => 100];
-        $result = $this->builder->order($order)->toArray();
+        $result = $this->builder->setPagePriorities($order)->toArray();
 
         $this->assertArrayHasKey('order', $result);
         $this->assertSame($order, $result['order']);
     }
 
-    public function testLabels()
+    public function testSetPageLabels()
     {
         $labels = ['index' => 'Home', 'docs/index' => 'Docs'];
-        $result = $this->builder->labels($labels)->toArray();
+        $result = $this->builder->setPageLabels($labels)->toArray();
 
         $this->assertArrayHasKey('labels', $result);
         $this->assertSame($labels, $result['labels']);
     }
 
-    public function testExclude()
+    public function testExcludePages()
     {
         $exclude = ['404', 'admin'];
-        $result = $this->builder->exclude($exclude)->toArray();
+        $result = $this->builder->excludePages($exclude)->toArray();
 
         $this->assertArrayHasKey('exclude', $result);
         $this->assertSame($exclude, $result['exclude']);
     }
 
-    public function testCustom()
+    public function testAddCustomNavigationItems()
     {
         $custom = [
             Navigation::item('https://example.com', 'Example', 200),
             Navigation::item('https://github.com', 'GitHub', 300),
         ];
-        $result = $this->builder->custom($custom)->toArray();
+        $result = $this->builder->addCustomNavigationItems($custom)->toArray();
 
         $this->assertArrayHasKey('custom', $result);
         $this->assertSame($custom, $result['custom']);
     }
 
-    public function testSubdirectoryDisplay()
+    public function testSetSubdirectoryDisplayMode()
     {
         $displayModes = ['dropdown', 'flat', 'hidden'];
 
         foreach ($displayModes as $mode) {
-            $result = $this->builder->subdirectoryDisplay($mode)->toArray();
+            $result = $this->builder->setSubdirectoryDisplayMode($mode)->toArray();
 
             $this->assertArrayHasKey('subdirectory_display', $result);
             $this->assertSame($mode, $result['subdirectory_display']);
@@ -74,11 +74,11 @@ class NavigationMenuConfigurationBuilderTest extends UnitTestCase
     public function testChainedMethods()
     {
         $result = $this->builder
-            ->order(['index' => 0, 'posts' => 10])
-            ->labels(['index' => 'Home'])
-            ->exclude(['404'])
-            ->custom([Navigation::item('https://github.com', 'GitHub', 200)])
-            ->subdirectoryDisplay('dropdown')
+            ->setPagePriorities(['index' => 0, 'posts' => 10])
+            ->setPageLabels(['index' => 'Home'])
+            ->excludePages(['404'])
+            ->addCustomNavigationItems([Navigation::item('https://github.com', 'GitHub', 200)])
+            ->setSubdirectoryDisplayMode('dropdown')
             ->toArray();
 
         $this->assertArrayHasKey('order', $result);
@@ -98,28 +98,28 @@ class NavigationMenuConfigurationBuilderTest extends UnitTestCase
     public function testInvalidSubdirectoryDisplay()
     {
         $this->expectException(\TypeError::class);
-        $this->builder->subdirectoryDisplay('invalid');
+        $this->builder->setSubdirectoryDisplayMode('invalid');
     }
 
     public function testRealLifeUsageScenario()
     {
         $result = $this->builder
-            ->order([
+            ->setPagePriorities([
                 'index' => 0,
                 'posts' => 10,
                 'docs/index' => 100,
             ])
-            ->labels([
+            ->setPageLabels([
                 'index' => 'Home',
                 'docs/index' => 'Docs',
             ])
-            ->exclude([
+            ->excludePages([
                 '404',
             ])
-            ->custom([
+            ->addCustomNavigationItems([
                 Navigation::item('https://github.com/hydephp/hyde', 'GitHub', 200),
             ])
-            ->subdirectoryDisplay('dropdown')
+            ->setSubdirectoryDisplayMode('dropdown')
             ->toArray();
 
         $this->assertSame([
@@ -140,7 +140,7 @@ class NavigationMenuConfigurationBuilderTest extends UnitTestCase
 
     public function testArrayObjectBehavior()
     {
-        $this->builder->order(['index' => 0]);
+        $this->builder->setPagePriorities(['index' => 0]);
 
         $this->assertCount(1, $this->builder);
         $this->assertSame(['order' => ['index' => 0]], $this->builder->getArrayCopy());
@@ -148,7 +148,7 @@ class NavigationMenuConfigurationBuilderTest extends UnitTestCase
 
     public function testToArrayMethodReturnsSameResultAsArrayObject()
     {
-        $this->builder->order(['index' => 0]);
+        $this->builder->setPagePriorities(['index' => 0]);
 
         $this->assertSame(['order' => ['index' => 0]], $this->builder->toArray());
     }

--- a/packages/framework/tests/Unit/NavigationMenuConfigurationBuilderTest.php
+++ b/packages/framework/tests/Unit/NavigationMenuConfigurationBuilderTest.php
@@ -3,14 +3,144 @@
 declare(strict_types=1);
 
 use Hyde\Testing\UnitTestCase;
+use Hyde\Framework\Features\Navigation\NavigationMenuConfigurationBuilder;
+use Hyde\Facades\Navigation;
 
 /**
  * @covers \Hyde\Framework\Features\Navigation\NavigationMenuConfigurationBuilder
  */
 class NavigationMenuConfigurationBuilderTest extends UnitTestCase
 {
-    public function testExample()
+    private NavigationMenuConfigurationBuilder $builder;
+
+    protected function setUp(): void
     {
-        $this->assertTrue(true);
+        parent::setUp();
+        $this->builder = new NavigationMenuConfigurationBuilder();
+    }
+
+    public function testOrder()
+    {
+        $order = ['index' => 0, 'posts' => 10, 'docs/index' => 100];
+        $result = $this->builder->order($order)->toArray();
+
+        $this->assertArrayHasKey('order', $result);
+        $this->assertEquals($order, $result['order']);
+    }
+
+    public function testLabels()
+    {
+        $labels = ['index' => 'Home', 'docs/index' => 'Docs'];
+        $result = $this->builder->labels($labels)->toArray();
+
+        $this->assertArrayHasKey('labels', $result);
+        $this->assertEquals($labels, $result['labels']);
+    }
+
+    public function testExclude()
+    {
+        $exclude = ['404', 'admin'];
+        $result = $this->builder->exclude($exclude)->toArray();
+
+        $this->assertArrayHasKey('exclude', $result);
+        $this->assertEquals($exclude, $result['exclude']);
+    }
+
+    public function testCustom()
+    {
+        $custom = [
+            Navigation::item('https://example.com', 'Example', 200),
+            Navigation::item('https://github.com', 'GitHub', 300),
+        ];
+        $result = $this->builder->custom($custom)->toArray();
+
+        $this->assertArrayHasKey('custom', $result);
+        $this->assertEquals($custom, $result['custom']);
+    }
+
+    public function testSubdirectoryDisplay()
+    {
+        $displayModes = ['dropdown', 'flat', 'hidden'];
+
+        foreach ($displayModes as $mode) {
+            $result = $this->builder->subdirectoryDisplay($mode)->toArray();
+
+            $this->assertArrayHasKey('subdirectory_display', $result);
+            $this->assertEquals($mode, $result['subdirectory_display']);
+        }
+    }
+
+    public function testChainedMethods()
+    {
+        $result = $this->builder
+            ->order(['index' => 0, 'posts' => 10])
+            ->labels(['index' => 'Home'])
+            ->exclude(['404'])
+            ->custom([Navigation::item('https://github.com', 'GitHub', 200)])
+            ->subdirectoryDisplay('dropdown')
+            ->toArray();
+
+        $this->assertArrayHasKey('order', $result);
+        $this->assertArrayHasKey('labels', $result);
+        $this->assertArrayHasKey('exclude', $result);
+        $this->assertArrayHasKey('custom', $result);
+        $this->assertArrayHasKey('subdirectory_display', $result);
+    }
+
+    public function testEmptyConfiguration()
+    {
+        $result = $this->builder->toArray();
+
+        $this->assertEmpty($result);
+    }
+
+    public function testInvalidSubdirectoryDisplay()
+    {
+        $this->expectException(\TypeError::class);
+        $this->builder->subdirectoryDisplay('invalid');
+    }
+
+    public function testRealLifeUsageScenario()
+    {
+        $result = $this->builder
+            ->order([
+                'index' => 0,
+                'posts' => 10,
+                'docs/index' => 100,
+            ])
+            ->labels([
+                'index' => 'Home',
+                'docs/index' => 'Docs',
+            ])
+            ->exclude([
+                '404',
+            ])
+            ->custom([
+                Navigation::item('https://github.com/hydephp/hyde', 'GitHub', 200),
+            ])
+            ->subdirectoryDisplay('dropdown')
+            ->toArray();
+
+        $this->assertEquals([
+            'order' => ['index' => 0, 'posts' => 10, 'docs/index' => 100],
+            'labels' => ['index' => 'Home', 'docs/index' => 'Docs'],
+            'exclude' => ['404'],
+            'custom' => [
+                ['destination' => 'https://github.com/hydephp/hyde', 'label' => 'GitHub', 'priority' => 200, 'attributes' => []],
+            ],
+            'subdirectory_display' => 'dropdown',
+        ], $result);
+    }
+
+    public function testArrayableInterface()
+    {
+        $this->assertInstanceOf(\Illuminate\Contracts\Support\Arrayable::class, $this->builder);
+    }
+
+    public function testArrayObjectMethods()
+    {
+        $this->builder->order(['index' => 0]);
+        $this->assertCount(1, $this->builder);
+        $this->assertEquals(['order' => ['index' => 0]], $this->builder->getArrayCopy());
     }
 }

--- a/packages/framework/tests/Unit/NavigationMenuConfigurationBuilderTest.php
+++ b/packages/framework/tests/Unit/NavigationMenuConfigurationBuilderTest.php
@@ -144,7 +144,6 @@ class NavigationMenuConfigurationBuilderTest extends UnitTestCase
     {
         $this->builder->order(['index' => 0]);
 
-        // ArrayObject methods now operate on the configuration data
         $this->assertCount(1, $this->builder);
         $this->assertSame(['order' => ['index' => 0]], $this->builder->getArrayCopy());
 


### PR DESCRIPTION
Part of https://github.com/hydephp/develop/pull/1818, please see the changelog there.

Inspired by https://github.com/hydephp/develop/issues/1508#issuecomment-1941638495 which could be adapted into this: (to normalize sidebar/mainmenu configuration)

```php
 'menus' => [
     NavigationMenu::configure('main')
         ->doStuff()
     
     NavigationMenu::configure('docs')
         ->doStuff()
 ],
```

--- 

This syntax is optional, but can still be used as the default. It's fully compatible with array syntaxes as the builder instance can be used as an array as it's an `ArrayObject`

- Main benefit: Get IDE support and method autocomplete when defining the config
- Main drawback: Laravel Idea can't autocomplete `config()` values

---

![Navigation Builder](https://github.com/hydephp/develop/assets/95144705/71272b27-22c2-4994-b3fe-4e66b5d45526)

