### PR TITLE
[2.x] Clean up the navigation documentation

### DIFF
--- a/docs/digging-deeper/navigation.md
+++ b/docs/digging-deeper/navigation.md
@@ -333,8 +333,7 @@ _docs/
 If you're not interested in using numerical prefix ordering, you can disable it in the Hyde config file. Hyde will then no longer extract the priority and will no longer strip the prefix from the route key.
 
 ```php
-// filepath config/hyde.php
-
+// filepath: config/hyde.php
 'numerical_page_ordering' => false,
 ```
 

--- a/docs/digging-deeper/navigation.md
+++ b/docs/digging-deeper/navigation.md
@@ -286,7 +286,7 @@ For example: `_docs/getting-started/installation.md` will be placed in a group c
 
 HydePHP v2 introduces navigation item ordering based on numerical prefixes in filenames. This feature works for both the primary navigation menu and the documentation sidebar.
 
-For example, the following will have the same order in the navigation menu as in a file explorer:
+This has the great benefit of matching the navigation menu layout with the file structure view, and works especially great with subdirectory-based navigation grouping.
 
 ```shell
 _pages/

--- a/docs/digging-deeper/navigation.md
+++ b/docs/digging-deeper/navigation.md
@@ -65,7 +65,7 @@ You only need to specify the keys you want to customize.
 
 ### `label`
 
-Customizes the text appearing in the navigation menu link for the page.
+Customizes the text appearing in the navigation menu link for the page. If not set anywhere else, Hyde will search for a title in the page content or generate one from the filename.
 
 ```yaml
 navigation:

--- a/docs/digging-deeper/navigation.md
+++ b/docs/digging-deeper/navigation.md
@@ -307,7 +307,7 @@ As you can seem Hyde parses the number from the filename and uses it as the prio
 
 ### Using Numerical Prefix Ordering in Subdirectories
 
-The numerical prefix ordering feature works great when using the automatic subdirectory-based grouping for navigation menu dropdowns and documentation sidebar categories.
+This feature integrates well with automatic subdirectory-based grouping for navigation menu dropdowns and documentation sidebar categories:
 
 This integration has two main features to consider:
 1. You can use numerical prefixes in subdirectories to control the order of dropdowns.

--- a/docs/digging-deeper/navigation.md
+++ b/docs/digging-deeper/navigation.md
@@ -19,7 +19,7 @@ There are two types of navigation menus in Hyde:
 This documentation will guide you through the customization process. To learn even more about sidebars, visit the [Documentation Pages](documentation-pages) documentation.
 
 
-### Quick primer on the internals
+### Internal Structure Overview
 
 It may be beneficial to understand the internal workings of the navigation menus to take full advantage of the options.
 
@@ -28,13 +28,13 @@ they are configured is very similar, making the documentation here applicable to
 
 See the [Digging Deeper](#digging-deeper-into-the-internals) section of this page if you want the full scoop on the internals!
 
-### Primer on priorities
+### Understanding Priorities
 
 All navigation menu items have an internal priority value that determines their order in the navigation.
 Lower values mean that the item will be higher up in the menu. The default for pages is `999` which puts them last.
 However, some pages are autoconfigured to have a lower priority, for example, the `index` page defaults to a priority of `0`.
 
-### What to customize?
+### Customization Options
 
 Here is a quick overview of what you might want to customize in your navigation menus:
 
@@ -43,7 +43,7 @@ Here is a quick overview of what you might want to customize in your navigation 
 - Navigation menu item visibility - control if pages may show up in the menus
 - Navigation menu item grouping - group pages together in dropdowns
 
-### How and where to customize?
+### Customization Methods
 
 Hyde provides a few different ways to customize the navigation menus, depending on what you prefer.
 

--- a/docs/digging-deeper/navigation.md
+++ b/docs/digging-deeper/navigation.md
@@ -189,7 +189,7 @@ From the Hyde config you can override the label of navigation links using the by
 This is not yet supported for the sidebar, but will be in the future.
 
 ```php
-// filepath config/hyde.php
+// filepath: config/hyde.php
 'navigation' => [
     'labels' => [
         'index' => 'Start',
@@ -204,7 +204,7 @@ Sometimes, especially if you have a lot of pages, you may want to prevent links 
 To remove items from being automatically added, simply add the page's route key to the blacklist.
 
 ```php
-// filepath config/hyde.php
+// filepath: config/hyde.php
 'navigation' => [
     'exclude' => [
         '404'
@@ -220,7 +220,7 @@ When linking to an external site, you should use the `NavigationItem::create()` 
 destination and label, both required. The third argument is the priority, which is optional, and defaults to `500`.
 
 ```php
-// filepath config/hyde.php
+// filepath: config/hyde.php
 use Hyde\Framework\Features\Navigation\NavigationItem;
 
 'navigation' => [
@@ -241,7 +241,7 @@ Simplified, this will then be rendered as follows:
 Within the Hyde config you can configure how subdirectories should be displayed in the menu.
 
 ```php
-// filepath config/hyde.php
+// filepath: config/hyde.php
 'navigation' => [
     'subdirectory_display' => 'dropdown'
 ]

--- a/docs/digging-deeper/navigation.md
+++ b/docs/digging-deeper/navigation.md
@@ -14,8 +14,8 @@ This documentation will guide you through the customization process.
 
 There are two types of navigation menus in Hyde:
 
-- **Primary Navigation Menu**: This is the main navigation menu that appears on most pages of your site.
-- **Documentation Sidebar**: This is a sidebar that appears on documentation pages and contains links to other documentation pages.
+1. **Primary Navigation Menu**: The main navigation menu appearing on most pages of your site. Unique features include dropdowns for subdirectories, depending on configuration.
+2. **Documentation Sidebar**: The sidebar on documentation pages with links to other documentation pages. Unique features include automatic grouping based on subdirectories.
 
 
 Keep on reading to learn how! To learn even more about the sidebars, visit the [Documentation Pages](documentation-pages) documentation.

--- a/docs/digging-deeper/navigation.md
+++ b/docs/digging-deeper/navigation.md
@@ -32,7 +32,7 @@ All navigation menu items have an internal priority value determining their orde
 
 ### Customization Options
 
-Here is a quick overview of what you might want to customize in your navigation menus:
+Here's an overview of what you can customize in your navigation menus:
 
 - Navigation menu item labels - the text that appears in the menu links
 - Navigation menu item priority - control the order in which the links appear

--- a/docs/digging-deeper/navigation.md
+++ b/docs/digging-deeper/navigation.md
@@ -235,11 +235,6 @@ use Hyde\Facades\Navigation;
 
 **Tip:** While named arguments are used in the example for clarity, they are not required.
 
-Simplified, this will then be rendered as follows:
-
-```html
-<a href="https://github.com/hydephp/hyde">GitHub</a>
-```
 
 ### Configure subdirectory handling
 

--- a/docs/digging-deeper/navigation.md
+++ b/docs/digging-deeper/navigation.md
@@ -216,10 +216,7 @@ To exclude items from being added, simply add the page's route key to the naviga
 
 ### Adding Custom Navigation Menu Links
 
-You can easily add custom navigation menu links similar to how we add Authors. Simply add a `NavigationItem` model to the `navigation.custom` array.
-
-When linking to an external site, you should use the `NavigationItem::create()` method facade. The first two arguments are the
-destination and label, both required. The third argument is the priority, which is optional, and defaults to `500`.
+You can easily add custom navigation menu links in the Hyde config:
 
 ```php
 // filepath: config/hyde.php

--- a/docs/digging-deeper/navigation.md
+++ b/docs/digging-deeper/navigation.md
@@ -55,10 +55,10 @@ Front matter options allow per-page customization of navigation menus. Here's a 
 
 ```yaml
 navigation:
-    label: string  # The text to display
-    priority: int  # The priority of the page used for determining the order, lower means higher up/first
+    label: string  # The displayed text in the navigation item link
+    priority: int  # The page's priority for ordering (lower means higher up/first)
     hidden: bool   # Whether the page should be hidden from the navigation menu
-    group: string  # For sidebars, this is the sidebar group, for the main menu, this is the dropdown group
+    group: string  # Set main menu dropdown or sidebar group key
 ```
 
 You only need to specify the keys you want to customize.

--- a/docs/digging-deeper/navigation.md
+++ b/docs/digging-deeper/navigation.md
@@ -185,8 +185,7 @@ You could also combine these methods if desired:
 
 Hyde makes a few attempts to find a suitable label for the navigation menu items to automatically create helpful titles.
 
-From the Hyde config you can override the label of navigation links using the by mapping the route key to the desired title.
-This is not yet supported for the sidebar, but will be in the future.
+If you're not happy with these, it's easy to override navigation link labels by mapping the route key to the desired title in the Hyde config:
 
 ```php
 // filepath: config/hyde.php
@@ -197,6 +196,8 @@ This is not yet supported for the sidebar, but will be in the future.
     ]
 ]
 ```
+
+**Note:** This feature is not yet supported for the sidebar.
 
 ### Excluding Items (Blacklist)
 

--- a/docs/digging-deeper/navigation.md
+++ b/docs/digging-deeper/navigation.md
@@ -305,7 +305,7 @@ As you can seem Hyde parses the number from the filename and uses it as the prio
    For example: Both `_pages/01-home.md` and `_pages/01_home.md` are valid.
 3. Leading zeros are optional. `_pages/1-home.md` is equally valid.
 
-### Using numerical prefix ordering in subdirectories
+### Using Numerical Prefix Ordering in Subdirectories
 
 The numerical prefix ordering feature works great when using the automatic subdirectory-based grouping for navigation menu dropdowns and documentation sidebar categories.
 

--- a/docs/digging-deeper/navigation.md
+++ b/docs/digging-deeper/navigation.md
@@ -330,7 +330,7 @@ _docs/
 
 ### Customization
 
-You can disable this feature by setting the `numerical_page_ordering` setting to `false` in the `hyde.php` config file. Hyde will then no longer extract the priority and will no longer strip the prefix from the route key.
+If you're not interested in using numerical prefix ordering, you can disable it in the Hyde config file. Hyde will then no longer extract the priority and will no longer strip the prefix from the route key.
 
 ```php
 // filepath config/hyde.php

--- a/docs/digging-deeper/navigation.md
+++ b/docs/digging-deeper/navigation.md
@@ -170,14 +170,14 @@ You can also specify explicit priorities by adding a value to the array keys. We
 ]
 ```
 
-**You can of course also combine these methods if you want:**
+You could also combine these methods if desired:
 
 ```php
 // filepath: Applicable to both
 [
-    'readme' => 10, // Gets priority 10
-    'installation', // Gets priority 500
-    'getting-started', // Gets priority 501
+    'readme' => 10, // Priority: 10
+    'installation', // Priority: 500
+    'getting-started', // Priority: 501
 ]
 ```
 

--- a/docs/digging-deeper/navigation.md
+++ b/docs/digging-deeper/navigation.md
@@ -112,7 +112,7 @@ Let's explore how to customize navigation menus using configuration files:
 
 When customizing the main navigation menu, use the [route key](core-concepts#route-keys) of the page. For the sidebar, you can use either the route key or the [page identifier](core-concepts#page-identifiers).
 
-### Changing the priorities
+### Changing Priorities
 
 The `navigation.order` and `sidebar.order` settings allow you to customize the order of the pages in the navigation menus.
 
@@ -145,7 +145,7 @@ The offset is added to make it easier to place pages earlier in the list using f
 ]
 ```
 
-#### Explicit syntax for changing the priorities
+#### Explicit Priority Syntax
 
 You can also specify explicit priorities by adding a value to the array key:
 

--- a/docs/digging-deeper/navigation.md
+++ b/docs/digging-deeper/navigation.md
@@ -200,8 +200,9 @@ This is not yet supported for the sidebar, but will be in the future.
 
 ### Excluding Items (Blacklist)
 
-Sometimes, especially if you have a lot of pages, you may want to prevent links from showing up in the main navigation menu.
-To remove items from being automatically added, simply add the page's route key to the blacklist.
+When you have a lot of pages, it may be useful to prevent links from being added to the main navigation menu.
+
+To exclude items from being added, simply add the page's route key to the navigation blacklist in the Hyde config:
 
 ```php
 // filepath: config/hyde.php

--- a/docs/digging-deeper/navigation.md
+++ b/docs/digging-deeper/navigation.md
@@ -8,18 +8,16 @@ navigation:
 
 ## Introduction
 
-A great time-saving feature of HydePHP is the automatic navigation menu and documentation sidebar generation.
-Hyde is designed to automatically configure these menus for you based on the content you have in your project.
+HydePHP offers an automatic navigation menu and documentation sidebar generation feature, designed to take the pain out of creating navigation menus.
+While Hyde does its best to configure these menus automatically based on understanding your project files, you may want to customize them further.
+This documentation will guide you through the customization process.
 
 There are two types of navigation menus in Hyde:
 
 - **Primary Navigation Menu**: This is the main navigation menu that appears on most pages of your site.
 - **Documentation Sidebar**: This is a sidebar that appears on documentation pages and contains links to other documentation pages.
 
-HydePHP automatically generates all of these menus for you based on the content of your project,
-and does its best to automatically configure them in the way that you most likely want them to be.
 
-Of course, this won't always be perfect, so thankfully Hyde makes it a breeze to customize these menus to your liking.
 Keep on reading to learn how! To learn even more about the sidebars, visit the [Documentation Pages](documentation-pages) documentation.
 
 ### Quick primer on the internals

--- a/docs/digging-deeper/navigation.md
+++ b/docs/digging-deeper/navigation.md
@@ -105,7 +105,7 @@ navigation:
 
 ## Config File Configuration
 
-Next up, let's look at how to customize the navigation menus using the config files.
+Let's explore how to customize navigation menus using config files:
 
 - To customize the navigation menu, use the setting `navigation.order` in the `hyde.php` config.
 - When customizing the navigation menu, you should use the [route key](core-concepts#route-keys) of the page.

--- a/docs/digging-deeper/navigation.md
+++ b/docs/digging-deeper/navigation.md
@@ -341,6 +341,8 @@ If you're not interested in using numerical prefix ordering, you can disable it 
 
 While not essential, understanding the internal workings of the navigation system can be as beneficial as it's interesting. Here's a quick high-level overview of the [Navigation API](navigation-api).
 
+### Navigation Menu Classes
+
 The main navigation menu is the `MainNavigationMenu` class, and the documentation sidebar is the `DocumentationSidebar` class. Both extend the same base `NavigationMenu` class.
 
 ```php

--- a/docs/digging-deeper/navigation.md
+++ b/docs/digging-deeper/navigation.md
@@ -65,7 +65,7 @@ You only need to specify the keys you want to customize.
 
 ### `label`
 
-The `label` option allows you to customize the text that appears in the navigation menu for the page.
+Customizes the text appearing in the navigation menu link for the page.
 
 ```yaml
 navigation:
@@ -74,7 +74,7 @@ navigation:
 
 ### `priority`
 
-The `priority` option allows you to control the order in which the page appears in the navigation menu. 
+Controls the order in which the page appears in the navigation menu.
 
 ```yaml
 navigation:
@@ -83,7 +83,7 @@ navigation:
 
 ### `hidden`
 
-The `hidden` option allows you to control if the page appears in the navigation menu. 
+Determines if the page appears in the navigation menu.
 
 ```yaml
 navigation:

--- a/docs/digging-deeper/navigation.md
+++ b/docs/digging-deeper/navigation.md
@@ -116,7 +116,7 @@ When customizing the main navigation menu, use the [route key](core-concepts#rou
 
 The `navigation.order` and `sidebar.order` settings allow you to customize the order of the pages in the navigation menus.
 
-#### Basic syntax for changing the priorities
+#### Basic Priority Syntax
 
 The cleanest way is to use the list-style syntax where each item will get the priority calculated according to its position in the list, plus an offset of `500`.
 The offset is added to make it easier to place pages earlier in the list using front matter or with explicit priority settings.

--- a/docs/digging-deeper/navigation.md
+++ b/docs/digging-deeper/navigation.md
@@ -236,7 +236,7 @@ use Hyde\Facades\Navigation;
 **Tip:** While named arguments are used in the example for clarity, they are not required.
 
 
-### Configure subdirectory handling
+### Configure Subdirectory Display
 
 Within the Hyde config you can configure how subdirectories should be displayed in the menu.
 

--- a/docs/digging-deeper/navigation.md
+++ b/docs/digging-deeper/navigation.md
@@ -200,8 +200,7 @@ This is not yet supported for the sidebar, but will be in the future.
 
 ### Excluding Items (Blacklist)
 
-Sometimes, especially if you have a lot of pages, you may want to prevent links from showing up in the main navigation menu.
-To remove items from being automatically added, simply add the page's route key to the blacklist.
+To prevent specific pages from showing up in the main navigation menu, simply add their route keys to the blacklist:
 
 ```php
 // filepath: config/hyde.php

--- a/docs/digging-deeper/navigation.md
+++ b/docs/digging-deeper/navigation.md
@@ -339,8 +339,7 @@ If you're not interested in using numerical prefix ordering, you can disable it 
 
 ## Digging Deeper into the Internals
 
-While not required to know, you may find it interesting to learn more about how the navigation is handled internally. Here is a high level overview,
-but you can find more detailed information in the [Navigation API](navigation-api) documentation.
+While not essential, understanding the internal workings of the navigation system can be as beneficial as it's interesting. Here's a quick high-level overview of the [Navigation API](navigation-api).
 
 The main navigation menu is the `MainNavigationMenu` class, and the documentation sidebar is the `DocumentationSidebar` class. Both extend the same base `NavigationMenu` class.
 

--- a/docs/digging-deeper/navigation.md
+++ b/docs/digging-deeper/navigation.md
@@ -252,7 +252,7 @@ You can configure how subdirectories should be displayed in the menu:
 - `hidden`: Pages in subdirectories are not displayed at all the menus
 - `flat`: Pages in subdirectories are displayed as individual items
 
-### Automatic menu groups
+### Automatic Menu Groups
 
 HydePHP has a neat feature to automatically place pages in dropdowns based on subdirectories.
 

--- a/docs/digging-deeper/navigation.md
+++ b/docs/digging-deeper/navigation.md
@@ -94,9 +94,7 @@ navigation:
 
 ### `group`
 
-The `group` option has a slightly different meaning depending on the type of navigation menu.
-For the primary navigation menu, it allows you to group pages together in dropdowns.
-For the sidebar, it allows you to group pages together in the sidebar under a common heading.
+For the primary navigation menu, this groups pages together in dropdowns. For the sidebar, it groups pages under a common heading.
 
 ```yaml
 navigation:

--- a/docs/digging-deeper/navigation.md
+++ b/docs/digging-deeper/navigation.md
@@ -101,6 +101,7 @@ navigation:
     group: "My Group"
 ```
 
+**Note:** Sidebar group keys are normalized, so `My Group` and `my-group` are equivalent.
 
 ## Config File Configuration
 

--- a/docs/digging-deeper/navigation.md
+++ b/docs/digging-deeper/navigation.md
@@ -28,9 +28,7 @@ For a deeper understanding of the internal workings, refer to the [Digging Deepe
 
 ### Understanding Priorities
 
-All navigation menu items have an internal priority value that determines their order in the navigation.
-Lower values mean that the item will be higher up in the menu. The default for pages is `999` which puts them last.
-However, some pages are autoconfigured to have a lower priority, for example, the `index` page defaults to a priority of `0`.
+All navigation menu items have an internal priority value determining their order. Lower values place items higher in the menu. The default priority for pages is `999`, placing them last unless you specify a value. Some pages, like the `index` page, are by default configured with the lowest priority of `0`.
 
 ### Customization Options
 

--- a/docs/digging-deeper/navigation.md
+++ b/docs/digging-deeper/navigation.md
@@ -21,12 +21,10 @@ This documentation will guide you through the customization process. To learn ev
 
 ### Internal Structure Overview
 
-It may be beneficial to understand the internal workings of the navigation menus to take full advantage of the options.
+Internally, both navigation menu types extend the same base class, and thus share core functionality. This means the configuration process is similar for both types, making the documentation applicable to both.
 
-In short, both navigation menu types extend the same class (meaning they share the same base code), this means that the way
-they are configured is very similar, making the documentation here applicable to both types of menus.
+For a deeper understanding of the internal workings, refer to the [Digging Deeper](#digging-deeper-into-the-internals) section.
 
-See the [Digging Deeper](#digging-deeper-into-the-internals) section of this page if you want the full scoop on the internals!
 
 ### Understanding Priorities
 

--- a/docs/digging-deeper/navigation.md
+++ b/docs/digging-deeper/navigation.md
@@ -118,8 +118,9 @@ The `navigation.order` and `sidebar.order` settings allow you to customize the o
 
 #### Basic Priority Syntax
 
-The cleanest way is to use the list-style syntax where each item will get the priority calculated according to its position in the list, plus an offset of `500`.
-The offset is added to make it easier to place pages earlier in the list using front matter or with explicit priority settings.
+A nice and simple way to define the order of pages, is to add their route keys as a simple list array. We'll then match that array order.
+
+It may be useful to know that we internally will assign a priority calculated according to its position in the list, plus an offset of `500`. The offset is added to make it easier to place pages earlier in the list using front matter or with explicit priority settings.
 
 ```php
 // filepath: config/hyde.php

--- a/docs/digging-deeper/navigation.md
+++ b/docs/digging-deeper/navigation.md
@@ -338,7 +338,7 @@ If you're not interested in using numerical prefix ordering, you can disable it 
 ```
 
 
-## Digging Deeper into the internals
+## Digging Deeper into the Internals
 
 While not required to know, you may find it interesting to learn more about how the navigation is handled internally. Here is a high level overview,
 but you can find more detailed information in the [Navigation API](navigation-api) documentation.

--- a/docs/digging-deeper/navigation.md
+++ b/docs/digging-deeper/navigation.md
@@ -373,7 +373,6 @@ use Hyde\Framework\Features\Navigation\NavigationGroup;
 
 ## The Navigation API
 
-If you want to interact with the site navigation programmatically, or if you want to create complex custom menus, you can do so through the new Navigation API.
-For most cases you don't need this, as Hyde creates the navigation for you. But it can be useful for advanced users and package developers.
+For advanced users and package developers, Hyde offers a Navigation API for programmatic interaction with site navigation. This API consists of a set of PHP classes allowing fluent interaction with navigation menus.
 
-The Navigation API consists of a set of PHP classes, allowing you to fluently interact with the navigation menus. You can learn more about the API in the [Navigation API](navigation-api) documentation.
+For more detailed information about the API, refer to the [Navigation API](navigation-api) documentation.

--- a/docs/digging-deeper/navigation.md
+++ b/docs/digging-deeper/navigation.md
@@ -181,7 +181,7 @@ You could also combine these methods if desired:
 ]
 ```
 
-### Changing the menu item labels
+### Changing Menu Item Labels
 
 Hyde makes a few attempts to find a suitable label for the navigation menu items to automatically create helpful titles.
 

--- a/docs/digging-deeper/navigation.md
+++ b/docs/digging-deeper/navigation.md
@@ -105,7 +105,7 @@ navigation:
 
 ## Config File Configuration
 
-Let's explore how to customize navigation menus using config files:
+Let's explore how to customize navigation menus using configuration files:
 
 - To customize the navigation menu, use the setting `navigation.order` in the `hyde.php` config.
 - When customizing the navigation menu, you should use the [route key](core-concepts#route-keys) of the page.

--- a/docs/digging-deeper/navigation.md
+++ b/docs/digging-deeper/navigation.md
@@ -124,7 +124,6 @@ It may be useful to know that we internally will assign a priority calculated ac
 
 ```php
 // filepath: config/hyde.php
-
 'navigation' => [
     'order' => [
         'home', // Priority: 500
@@ -136,7 +135,6 @@ It may be useful to know that we internally will assign a priority calculated ac
 
 ```php
 // filepath: config/docs.php
-
 'sidebar' => [
     'order' => [
         'readme', // Priority: 500
@@ -152,7 +150,6 @@ You can also specify explicit priorities by adding a value to the array keys. We
 
 ```php
 // filepath: config/hyde.php
-
 'navigation' => [
     'order' => [
         'home' => 10,
@@ -164,7 +161,6 @@ You can also specify explicit priorities by adding a value to the array keys. We
 
 ```php
 // filepath: config/docs.php
-
 'sidebar' => [
     'order' => [
         'readme' => 10,

--- a/docs/digging-deeper/navigation.md
+++ b/docs/digging-deeper/navigation.md
@@ -290,9 +290,9 @@ This has the great benefit of matching the navigation menu layout with the file 
 
 ```shell
 _pages/
-  01-home.md # Gets priority 1, putting it first (will be saved to _site/index.html)
-  02-about.md # Gets priority 2, putting it second (will be saved to _site/about.html)
-  03-contact.md # Gets priority 3, putting it third (will be saved to _site/contact.html)
+  01-home.md     # Priority: 1 (saved to _site/index.html)
+  02-about.md    # Priority: 2 (saved to _site/about.html)
+  03-contact.md  # Priority: 3 (saved to _site/contact.html)
 ```
 
 Hyde will then parse the number from the filename and use it as the priority for the page in the navigation menus.

--- a/docs/digging-deeper/navigation.md
+++ b/docs/digging-deeper/navigation.md
@@ -107,11 +107,10 @@ navigation:
 
 Let's explore how to customize navigation menus using configuration files:
 
-- To customize the navigation menu, use the setting `navigation.order` in the `hyde.php` config.
-- When customizing the navigation menu, you should use the [route key](core-concepts#route-keys) of the page.
+- For the main navigation menu, use `navigation` setting in the `hyde.php` config file.
+- For the sidebar, use `sidebar` setting in the `docs.php` config file.
 
-- To customize the sidebar, use the setting `sidebar.order` in the `docs.php` config.
-- When customizing the sidebar, can use the route key, or just the [page identifier](core-concepts#page-identifiers) of the page.
+When customizing the main navigation menu, use the [route key](core-concepts#route-keys) of the page. For the sidebar, you can use either the route key or the [page identifier](core-concepts#page-identifiers).
 
 ### Changing the priorities
 

--- a/docs/digging-deeper/navigation.md
+++ b/docs/digging-deeper/navigation.md
@@ -10,15 +10,14 @@ navigation:
 
 HydePHP offers an automatic navigation menu and documentation sidebar generation feature, designed to take the pain out of creating navigation menus.
 While Hyde does its best to configure these menus automatically based on understanding your project files, you may want to customize them further.
-This documentation will guide you through the customization process.
 
 There are two types of navigation menus in Hyde:
 
 1. **Primary Navigation Menu**: The main navigation menu appearing on most pages of your site. Unique features include dropdowns for subdirectories, depending on configuration.
 2. **Documentation Sidebar**: The sidebar on documentation pages with links to other documentation pages. Unique features include automatic grouping based on subdirectories.
 
+This documentation will guide you through the customization process. To learn even more about sidebars, visit the [Documentation Pages](documentation-pages) documentation.
 
-Keep on reading to learn how! To learn even more about the sidebars, visit the [Documentation Pages](documentation-pages) documentation.
 
 ### Quick primer on the internals
 

--- a/docs/digging-deeper/navigation.md
+++ b/docs/digging-deeper/navigation.md
@@ -343,7 +343,7 @@ While not essential, understanding the internal workings of the navigation syste
 
 ### Navigation Menu Classes
 
-The main navigation menu is the `MainNavigationMenu` class, and the documentation sidebar is the `DocumentationSidebar` class. Both extend the same base `NavigationMenu` class.
+The main navigation menu uses the `MainNavigationMenu` class, while the documentation sidebar uses the `DocumentationSidebar` class. Both extend the base `NavigationMenu` class:
 
 ```php
 use Hyde\Framework\Features\Navigation\MainNavigationMenu;
@@ -351,13 +351,9 @@ use Hyde\Framework\Features\Navigation\DocumentationSidebar;
 use Hyde\Framework\Features\Navigation\NavigationMenu;
 ```
 
-Within the base `NavigationMenu` class, you will find the main logic for how the menus are generated,
-while the child implementations contain the extra logic tailored for their specific use cases.
+The base `NavigationMenu` class contains the main logic for menu generation, while child implementations contain extra logic for specific use cases.
 
-All the navigation menus store the menu items in their `$items` collection containing instances of the `NavigationItem` class.
-
-The `NavigationItem` class is a simple class that contains the label and URL of the menu item and is used to represent each item in the menu.
-Dropdowns are represented by `NavigationGroup` instances, which extend the `NavigationMenu` class and contain a collection of additional `NavigationItem` instances.
+All navigation menus store items in their `$items` collection, containing instances of the `NavigationItem` class. Dropdowns are represented by `NavigationGroup` instances, which extend the `NavigationMenu` class and contain additional `NavigationItem` instances:
 
 ```php
 use Hyde\Framework\Features\Navigation\NavigationItem;

--- a/docs/digging-deeper/navigation.md
+++ b/docs/digging-deeper/navigation.md
@@ -127,9 +127,9 @@ It may be useful to know that we internally will assign a priority calculated ac
 
 'navigation' => [
     'order' => [
-        'home', // Gets priority 500
-        'about', // Gets priority 501
-        'contact', // Gets priority 502
+        'home', // Priority: 500
+        'about', // Priority: 501
+        'contact', // Priority: 502
     ]
 ]
 ```
@@ -139,9 +139,9 @@ It may be useful to know that we internally will assign a priority calculated ac
 
 'sidebar' => [
     'order' => [
-        'readme', // Gets priority 500
-        'installation', // Gets priority 501
-        'getting-started', // Gets priority 502
+        'readme', // Priority: 500
+        'installation', // Priority: 501
+        'getting-started', // Priority: 502
     ]
 ]
 ```

--- a/docs/digging-deeper/navigation.md
+++ b/docs/digging-deeper/navigation.md
@@ -148,16 +148,16 @@ It may be useful to know that we internally will assign a priority calculated ac
 
 #### Explicit Priority Syntax
 
-You can also specify explicit priorities by adding a value to the array key:
+You can also specify explicit priorities by adding a value to the array keys. We'll then use these exact values as the priorities.
 
 ```php
 // filepath: config/hyde.php
 
 'navigation' => [
     'order' => [
-        'home' => 10, // Gets priority 10
-        'about' => 15, // Gets priority 15
-        'contact' => 20, // Gets priority 20
+        'home' => 10,
+        'about' => 15,
+        'contact' => 20,
     ]
 ]
 ```
@@ -167,9 +167,9 @@ You can also specify explicit priorities by adding a value to the array key:
 
 'sidebar' => [
     'order' => [
-        'readme' => 10, // Gets priority 10
-        'installation' => 15, // Gets priority 15
-        'getting-started' => 20, // Gets priority 20
+        'readme' => 10,
+        'installation' => 15,
+        'getting-started' => 20,
     ]
 ]
 ```

--- a/docs/digging-deeper/navigation.md
+++ b/docs/digging-deeper/navigation.md
@@ -299,11 +299,11 @@ As you can seem Hyde parses the number from the filename and uses it as the prio
 
 ### Important Notes
 
-1. The numerical prefix will still be part of the page identifier, but it will be stripped from the route key.
-    - For example: `_pages/01-home.md` will have the route key `home` and the page identifier `01-home`.
+1. The numerical prefix remains part of the page identifier but is stripped from the route key.
+   For example: `_pages/01-home.md` has route key `home` and page identifier `01-home`.
 2. You can delimit the numerical prefix with either a dash or an underscore.
-    - For example: `_pages/01-home.md` and `_pages/01_home.md` are both valid.
-3. The leading zeroes are optional, so `_pages/1-home.md` is also valid.
+   For example: Both `_pages/01-home.md` and `_pages/01_home.md` are valid.
+3. Leading zeros are optional. `_pages/1-home.md` is equally valid.
 
 ### Using numerical prefix ordering in subdirectories
 

--- a/docs/digging-deeper/navigation.md
+++ b/docs/digging-deeper/navigation.md
@@ -299,7 +299,6 @@ As you can seem Hyde parses the number from the filename and uses it as the prio
 
 ### Important Notes
 
-
 1. The numerical prefix will still be part of the page identifier, but it will be stripped from the route key.
     - For example: `_pages/01-home.md` will have the route key `home` and the page identifier `01-home`.
 2. You can delimit the numerical prefix with either a dash or an underscore.

--- a/docs/digging-deeper/navigation.md
+++ b/docs/digging-deeper/navigation.md
@@ -233,6 +233,8 @@ use Hyde\Facades\Navigation;
 ]
 ```
 
+**Tip:** While named arguments are used in the example for clarity, they are not required.
+
 Simplified, this will then be rendered as follows:
 
 ```html

--- a/docs/digging-deeper/navigation.md
+++ b/docs/digging-deeper/navigation.md
@@ -254,15 +254,14 @@ You can configure how subdirectories should be displayed in the menu:
 
 ### Automatic Menu Groups
 
-HydePHP has a neat feature to automatically place pages in dropdowns based on subdirectories.
+A handy feature HydePHP has is that it can automatically place pages in dropdowns based on subdirectory structures.
 
-#### Automatic navigation menu dropdowns
+#### Automatic Navigation Menu Dropdowns
 
-For pages that can be in the main site menu, this feature needs to be enabled in the `hyde.php` config file.
+Enable this feature in the `hyde.php` config file by setting the `subdirectory_display` key to `dropdown`.
 
 ```php
-// filepath config/hyde.php
-
+// filepath: config/hyde.php
 'navigation' => [
     'subdirectory_display' => 'dropdown',
 ],
@@ -270,20 +269,18 @@ For pages that can be in the main site menu, this feature needs to be enabled in
 
 Now if you create a page called `_pages/about/contact.md` it will automatically be placed in a dropdown called "About".
 
-#### Automatic documentation sidebar grouping
+#### Automatic Documentation Sidebar Grouping
 
-This feature works similarly to the automatic navigation menu dropdowns, but instead places the sidebar items in named groups.
-This feature is enabled by default, so you only need to place your pages in subdirectories to have them grouped.
+This feature is always enabled for documentation pages. Simply place your pages in subdirectories to have them grouped in the sidebar.
 
 For example: `_docs/getting-started/installation.md` will be placed in a group called "Getting Started".
 
 >info Tip: When using subdirectory-based dropdowns, you can set their priority using the directory name as the array key.
 
-#### Dropdown menu notes
+#### Dropdown Menu Notes
 
-Here are some things to keep in mind when using dropdown menus, regardless of the configuration:
-- Dropdowns take priority over standard items. So if you have a dropdown with the key `about` and a page with the key `about`, the dropdown will be created, and the page won't be in the menu.
-    - For example: With this file structure: `_pages/foo.md`, `_pages/foo/bar.md`, `_pages/foo/baz.md`, the link to `foo` will be lost.
+- Dropdowns take priority over standard items. If you have a dropdown with the key `about` and a page with the key `about`, the dropdown will be created, and the page won't be in the menu.
+- Example: With this file structure: `_pages/foo.md`, `_pages/foo/bar.md`, `_pages/foo/baz.md`, the link to `foo` will be lost, so please keep this in mind when using this feature.
 
 ## Numerical Prefix Navigation Ordering
 

--- a/docs/digging-deeper/navigation.md
+++ b/docs/digging-deeper/navigation.md
@@ -90,6 +90,8 @@ navigation:
     hidden: true
 ```
 
+**Tip:** You can also use `visible: false` to achieve the same effect.
+
 ### `group`
 
 The `group` option has a slightly different meaning depending on the type of navigation menu.

--- a/docs/digging-deeper/navigation.md
+++ b/docs/digging-deeper/navigation.md
@@ -51,9 +51,7 @@ Additionally, general options for the entire navigation menus are also available
 
 ## Front Matter Configuration
 
-The front matter options allow you to customize the navigation menus on a per-page basis.
-Here is a quick reference of the available options. The full documentation of each option is below.
-You don't need to specify all the keys, only the ones you want to customize.
+Front matter options allow per-page customization of navigation menus. Here's a quick reference of available options:
 
 ```yaml
 navigation:
@@ -62,6 +60,8 @@ navigation:
     hidden: bool   # Whether the page should be hidden from the navigation menu
     group: string  # For sidebars, this is the sidebar group, for the main menu, this is the dropdown group
 ```
+
+You only need to specify the keys you want to customize.
 
 ### `label`
 

--- a/docs/digging-deeper/navigation.md
+++ b/docs/digging-deeper/navigation.md
@@ -41,7 +41,7 @@ Here's an overview of what you can customize in your navigation menus:
 
 ### Customization Methods
 
-Hyde provides a few different ways to customize the navigation menus, depending on what you prefer.
+Hyde provides multiple ways to customize navigation menus to suit your needs:
 
 Specifying the data in the front matter will override any dynamically inferred or config-defined priority.
 While this is useful for one-offs, it can make it harder to reorder items later on as you can't see the whole picture at once.

--- a/docs/digging-deeper/navigation.md
+++ b/docs/digging-deeper/navigation.md
@@ -284,9 +284,7 @@ For example: `_docs/getting-started/installation.md` will be placed in a group c
 
 ## Numerical Prefix Navigation Ordering
 
-HydePHP v2 introduces a new feature that allows navigation items to be ordered based on a numerical prefix in the filename.
-This is a great way to control the ordering of pages in both the primary navigation menu and the documentation sidebar,
-as your file structure will match the order of the pages in the navigation menus.
+HydePHP v2 introduces navigation item ordering based on numerical prefixes in filenames. This feature works for both the primary navigation menu and the documentation sidebar.
 
 For example, the following will have the same order in the navigation menu as in a file explorer:
 

--- a/docs/digging-deeper/navigation.md
+++ b/docs/digging-deeper/navigation.md
@@ -295,7 +295,7 @@ _pages/
   03-contact.md  # Priority: 3 (saved to _site/contact.html)
 ```
 
-Hyde will then parse the number from the filename and use it as the priority for the page in the navigation menus.
+As you can seem Hyde parses the number from the filename and uses it as the priority for the page in navigation menus, while stripping the prefix from the route key.
 
 ### Keep in mind
 

--- a/docs/digging-deeper/navigation.md
+++ b/docs/digging-deeper/navigation.md
@@ -337,7 +337,6 @@ If you're not interested in using numerical prefix ordering, you can disable it 
 'numerical_page_ordering' => false,
 ```
 
-
 ## Digging Deeper into the Internals
 
 While not required to know, you may find it interesting to learn more about how the navigation is handled internally. Here is a high level overview,

--- a/docs/digging-deeper/navigation.md
+++ b/docs/digging-deeper/navigation.md
@@ -114,7 +114,7 @@ When customizing the main navigation menu, use the [route key](core-concepts#rou
 
 ### Changing Priorities
 
-The `navigation.order` and `sidebar.order` settings allow you to customize the order of the pages in the navigation menus.
+The `navigation.order` and `sidebar.order` settings allow you to customize the order of pages in the navigation menus.
 
 #### Basic Priority Syntax
 

--- a/docs/digging-deeper/navigation.md
+++ b/docs/digging-deeper/navigation.md
@@ -200,7 +200,8 @@ This is not yet supported for the sidebar, but will be in the future.
 
 ### Excluding Items (Blacklist)
 
-To prevent specific pages from showing up in the main navigation menu, simply add their route keys to the blacklist:
+Sometimes, especially if you have a lot of pages, you may want to prevent links from showing up in the main navigation menu.
+To remove items from being automatically added, simply add the page's route key to the blacklist.
 
 ```php
 // filepath: config/hyde.php

--- a/docs/digging-deeper/navigation.md
+++ b/docs/digging-deeper/navigation.md
@@ -18,13 +18,11 @@ There are two types of navigation menus in Hyde:
 
 This documentation will guide you through the customization process. To learn even more about sidebars, visit the [Documentation Pages](documentation-pages) documentation.
 
-
 ### Internal Structure Overview
 
 Internally, both navigation menu types extend the same base class, and thus share core functionality. This means the configuration process is similar for both types, making the documentation applicable to both.
 
 For a deeper understanding of the internal workings, refer to the [Digging Deeper](#digging-deeper-into-the-internals) section.
-
 
 ### Understanding Priorities
 

--- a/docs/digging-deeper/navigation.md
+++ b/docs/digging-deeper/navigation.md
@@ -299,7 +299,6 @@ As you can seem Hyde parses the number from the filename and uses it as the prio
 
 ### Important Notes
 
-Here are some things to keep in mind, especially if you mix numerical prefix ordering with other ordering methods:
 
 1. The numerical prefix will still be part of the page identifier, but it will be stripped from the route key.
     - For example: `_pages/01-home.md` will have the route key `home` and the page identifier `01-home`.

--- a/docs/digging-deeper/navigation.md
+++ b/docs/digging-deeper/navigation.md
@@ -313,7 +313,7 @@ This integration has two main features to consider:
 1. You can use numerical prefixes in subdirectories to control the order of dropdowns.
 2. The ordering within a subdirectory works independently of its siblings, so you can start from one in each subdirectory.
 
-Here is an example structure of how you may want to organize a documentation site:
+Here is an example structure of how could organize a documentation site:
 
 ```shell
 _docs/

--- a/docs/digging-deeper/navigation.md
+++ b/docs/digging-deeper/navigation.md
@@ -307,11 +307,10 @@ As you can seem Hyde parses the number from the filename and uses it as the prio
 
 ### Using Numerical Prefix Ordering in Subdirectories
 
-This feature integrates well with automatic subdirectory-based grouping for navigation menu dropdowns and documentation sidebar categories:
+This feature integrates well with automatic subdirectory-based navigation grouping. Here are two useful tips:
 
-This integration has two main features to consider:
-1. You can use numerical prefixes in subdirectories to control the order of dropdowns.
-2. The ordering within a subdirectory works independently of its siblings, so you can start from one in each subdirectory.
+1. You can use numerical prefixes in subdirectories to control the dropdown/sidebar order.
+2. The numbering within a subdirectory works independently of its siblings, so you can start from one in each subdirectory.
 
 Here is an example structure of how could organize a documentation site:
 

--- a/docs/digging-deeper/navigation.md
+++ b/docs/digging-deeper/navigation.md
@@ -238,7 +238,7 @@ use Hyde\Facades\Navigation;
 
 ### Configure Subdirectory Display
 
-Within the Hyde config you can configure how subdirectories should be displayed in the menu.
+You can configure how subdirectories should be displayed in the menu:
 
 ```php
 // filepath: config/hyde.php
@@ -247,9 +247,10 @@ Within the Hyde config you can configure how subdirectories should be displayed 
 ]
 ```
 
-Dropdown means that pages in subdirectories will be displayed in a dropdown menu,
-while `flat` means that pages in subdirectories will be displayed as individual items in the menu.
-Hidden means that pages in subdirectories will not be displayed in the menu at all.
+**Supported Options:**
+- `dropdown`: Pages in subdirectories are displayed in a dropdown menu
+- `hidden`: Pages in subdirectories are not displayed at all the menus
+- `flat`: Pages in subdirectories are displayed as individual items
 
 ### Automatic menu groups
 

--- a/docs/digging-deeper/navigation.md
+++ b/docs/digging-deeper/navigation.md
@@ -43,16 +43,13 @@ Here's an overview of what you can customize in your navigation menus:
 
 Hyde provides multiple ways to customize navigation menus to suit your needs:
 
-Specifying the data in the front matter will override any dynamically inferred or config-defined priority.
-While this is useful for one-offs, it can make it harder to reorder items later on as you can't see the whole picture at once.
-It's up to you which method you prefer to use.
+1. Front matter data in Markdown and Blade page files, applicable to all menu types
+2. Configuration in the `hyde` config file for main navigation items
+3. Configuration in the `docs` config file for documentation sidebar items
 
-To customize how a page is represented in navigation, you can either set the `navigation` front matter data in the page's markdown file,
-or configure it in the config file. Main navigation items are in the `hyde` config file, while documentation sidebar items are in the `docs` config file.
-General options for the entire navigation menus are also available in the `hyde` and `docs` config files.
+Keep in mind that front matter data overrides dynamically inferred or config-defined priorities. While useful for quick one-off changes on small sites, it can make reordering items later on more challenging as you can't see the entire structure at once.
 
-Now that you know the basics, let's dive into the details of how to customize the navigation menus!
-
+Additionally, general options for the entire navigation menus are also available in the `hyde` and `docs` config files.
 
 ## Front Matter Configuration
 

--- a/docs/digging-deeper/navigation.md
+++ b/docs/digging-deeper/navigation.md
@@ -34,10 +34,10 @@ All navigation menu items have an internal priority value determining their orde
 
 Here's an overview of what you can customize in your navigation menus:
 
-- Navigation menu item labels - the text that appears in the menu links
-- Navigation menu item priority - control the order in which the links appear
-- Navigation menu item visibility - control if pages may show up in the menus
-- Navigation menu item grouping - group pages together in dropdowns
+- Item labels: The text displayed in menu links
+- Item priorities: Control the order of link appearance
+- Item visibility: Choose to hide or show pages in the menu
+- Item grouping: Group pages together in dropdowns or sidebar categories
 
 ### Customization Methods
 

--- a/docs/digging-deeper/navigation.md
+++ b/docs/digging-deeper/navigation.md
@@ -297,7 +297,7 @@ _pages/
 
 As you can seem Hyde parses the number from the filename and uses it as the priority for the page in navigation menus, while stripping the prefix from the route key.
 
-### Keep in mind
+### Important Notes
 
 Here are some things to keep in mind, especially if you mix numerical prefix ordering with other ordering methods:
 

--- a/docs/digging-deeper/navigation.md
+++ b/docs/digging-deeper/navigation.md
@@ -220,11 +220,15 @@ You can easily add custom navigation menu links in the Hyde config:
 
 ```php
 // filepath: config/hyde.php
-use Hyde\Framework\Features\Navigation\NavigationItem;
+use Hyde\Facades\Navigation;
 
 'navigation' => [
     'custom' => [
-        NavigationItem::create('https://github.com/hydephp/hyde', 'GitHub', 200),
+        Navigation::item(
+            destination: 'https://github.com/hydephp/hyde', // Required
+            label: 'GitHub', // Optional, defaults to the destination value
+            priority: 200 // Optional, defaults to 500
+        ),
     ]
 ]
 ```

--- a/docs/digging-deeper/navigation.md
+++ b/docs/digging-deeper/navigation.md
@@ -338,7 +338,6 @@ You can disable this feature by setting the `numerical_page_ordering` setting to
 'numerical_page_ordering' => false,
 ```
 
-While it's not recommended, as you lose out on the convenience of the automatic ordering, any front matter priority settings will override the numerical prefix ordering if you for some reason need to.
 
 ## Digging Deeper into the internals
 

--- a/packages/framework/src/Facades/Navigation.php
+++ b/packages/framework/src/Facades/Navigation.php
@@ -16,7 +16,7 @@ class Navigation
     /**
      * Configuration helper method to define a new navigation item, with better IDE support.
      *
-     * The returned array will then be used by the framework to create a new NavigationItem instance.
+     * The returned array will then be used by the framework to create a new NavigationItem instance. {@see \Hyde\Framework\Features\Navigation\NavigationItem}
      *
      * @see https://hydephp.com/docs/2.x/navigation-api
      *


### PR DESCRIPTION
Part of https://github.com/hydephp/develop/pull/1818 and goes over the entire navigation documentation to ensure it's consistent and concise, without losing information.

Additionally, it rethinks the document outline to account for many people not reading the document top to bottom, and instead only read sections at a time. As such, words that tie together sections have been removed, in order to make each section usable on its own.

It also updates headings to be more concise, instead of fluent English, to make the sections more skimmable.