### PR TITLE
Internal: Adding an experimental config converter command to the monorepo

### DIFF
--- a/monorepo/DevTools/src/MonorepoDevToolsServiceProvider.php
+++ b/monorepo/DevTools/src/MonorepoDevToolsServiceProvider.php
@@ -17,6 +17,7 @@ class MonorepoDevToolsServiceProvider extends ServiceProvider
     {
         $this->commands([
             MonorepoReleaseCommand::class,
+            RefactorConfigCommand::class,
         ]);
     }
 }

--- a/monorepo/DevTools/src/RefactorConfigCommand.php
+++ b/monorepo/DevTools/src/RefactorConfigCommand.php
@@ -5,9 +5,23 @@ declare(strict_types=1);
 namespace Hyde\MonorepoDevTools;
 
 use Hyde\Hyde;
+use Hyde\Enums\Feature;
+use Illuminate\Support\Str;
 use Symfony\Component\Yaml\Yaml;
 use Hyde\Console\Concerns\Command;
+use Hyde\Framework\Features\Blogging\Models\PostAuthor;
+use Hyde\Framework\Features\Metadata\MetadataElementContract;
 
+use function copy;
+use function config;
+use function substr;
+use function collect;
+use function implode;
+use function in_array;
+use function is_array;
+use function is_string;
+use function file_exists;
+use function str_starts_with;
 use function file_put_contents;
 
 /**
@@ -45,14 +59,55 @@ class RefactorConfigCommand extends Command
 
     protected function migrateToYaml(): void
     {
-        // todo if file exists, add backup
+        if (file_exists(Hyde::path('hyde.yml')) && ! file_exists(Hyde::path('hyde.yml.bak'))) {
+            copy(Hyde::path('hyde.yml'), Hyde::path('hyde.yml.bak'));
+        }
 
         $config = config('hyde');
+        $config = $this->serializePhpData($config);
 
-        $yaml = Yaml::dump($config);
+        $yaml = Yaml::dump($config, 16, 4, Yaml::DUMP_MULTI_LINE_LITERAL_BLOCK | Yaml::DUMP_EMPTY_ARRAY_AS_SEQUENCE);
 
-        // todo diff out defaults?
+        // Todo: Diff out defaults? (unless with argument)
 
         file_put_contents(Hyde::path('hyde.yml'), $yaml);
+    }
+
+    protected function serializePhpData(array $config): array
+    {
+        return collect($config)->mapWithKeys(function ($value, $key) {
+            if (is_array($value)) {
+                return [$key => $this->serializePhpData($value)];
+            }
+
+            return $this->serializePhpValue($value, $key);
+        })->toArray();
+    }
+
+    protected function serializePhpValue(mixed $value, string|int $key): array
+    {
+        if ($value instanceof Feature) {
+            return [$key => Str::kebab($value->name)];
+        }
+
+        if (is_string($key) && str_starts_with($key, 'Hyde\Pages\\')) {
+            return [Str::kebab(substr($key, 11)) => $value];
+        }
+
+        if ($value instanceof MetadataElementContract) {
+            // We don't have deserialization logic for this (yet?)
+            return [$key => $value->__toString()];
+        }
+
+        if ($value instanceof PostAuthor) {
+            // Not fully supported in v1
+            return [$key => [
+                'username' => $value->username,
+                'name' => $value->name,
+                'website' => $value->website,
+            ]];
+        }
+
+        return [$key => $value];
     }
 }

--- a/monorepo/DevTools/src/RefactorConfigCommand.php
+++ b/monorepo/DevTools/src/RefactorConfigCommand.php
@@ -75,6 +75,11 @@ class RefactorConfigCommand extends Command
 
         $yaml = Yaml::dump($config, 16, 4, Yaml::DUMP_MULTI_LINE_LITERAL_BLOCK | Yaml::DUMP_EMPTY_ARRAY_AS_SEQUENCE);
 
+        if ($yaml === '[]') {
+            $this->warn("You don't seem to have any configuration to migrate.");
+            return;
+        }
+
         file_put_contents(Hyde::path('hyde.yml'), $yaml);
     }
 

--- a/monorepo/DevTools/src/RefactorConfigCommand.php
+++ b/monorepo/DevTools/src/RefactorConfigCommand.php
@@ -1,0 +1,58 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Hyde\MonorepoDevTools;
+
+use Hyde\Hyde;
+use Symfony\Component\Yaml\Yaml;
+use Hyde\Console\Concerns\Command;
+
+use function file_put_contents;
+
+/**
+ * @internal This class is internal to the hydephp/develop monorepo.
+ */
+class RefactorConfigCommand extends Command
+{
+    /** @var string */
+    protected $signature = 'refactor:config {format : The new configuration format}';
+
+    /** @var string */
+    protected $description = 'Migrate the configuration to a different format.';
+
+    protected const FORMATS = ['yaml'];
+
+    public function handle(): int
+    {
+        $format = $this->argument('format');
+        if (! in_array($format, self::FORMATS)) {
+            $this->error('Invalid format. Supported formats: '.implode(', ', self::FORMATS));
+
+            return 1;
+        }
+
+        $this->gray(' > Migrating configuration to '.$format);
+
+        match ($format) {
+            'yaml' => $this->migrateToYaml(),
+        };
+
+        $this->info('All done!');
+
+        return 0;
+    }
+
+    protected function migrateToYaml(): void
+    {
+        // todo if file exists, add backup
+
+        $config = config('hyde');
+
+        $yaml = Yaml::dump($config);
+
+        // todo diff out defaults?
+
+        file_put_contents(Hyde::path('hyde.yml'), $yaml);
+    }
+}

--- a/monorepo/DevTools/src/RefactorConfigCommand.php
+++ b/monorepo/DevTools/src/RefactorConfigCommand.php
@@ -26,6 +26,7 @@ use function file_put_contents;
 
 /**
  * @internal This class is internal to the hydephp/develop monorepo.
+ * @experimental https://github.com/hydephp/develop/pull/1833
  */
 class RefactorConfigCommand extends Command
 {

--- a/monorepo/DevTools/src/RefactorConfigCommand.php
+++ b/monorepo/DevTools/src/RefactorConfigCommand.php
@@ -61,8 +61,13 @@ class RefactorConfigCommand extends Command
 
     protected function migrateToYaml(): void
     {
+        $usesGit = file_exists(Hyde::path('.git'));
+
         if (file_exists(Hyde::path('hyde.yml')) && ! file_exists(Hyde::path('hyde.yml.bak'))) {
             copy(Hyde::path('hyde.yml'), Hyde::path('hyde.yml.bak'));
+            if (! $usesGit) {
+                $this->warn("You're not using Git for version control, so a backup of your configuration has been created at hyde.yml.bak.");
+            }
         }
 
         try {
@@ -81,6 +86,10 @@ class RefactorConfigCommand extends Command
             unlink(Hyde::path('hyde.yml.bak'));
 
             return;
+        } finally {
+            if ($usesGit && file_exists(Hyde::path('hyde.yml.bak'))) {
+                unlink(Hyde::path('hyde.yml.bak'));
+            }
         }
     }
 

--- a/monorepo/DevTools/src/RefactorConfigCommand.php
+++ b/monorepo/DevTools/src/RefactorConfigCommand.php
@@ -128,7 +128,8 @@ class RefactorConfigCommand extends Command
                 }
             }
 
-            if (isset($default[$key]) && $value === $default[$key]) {
+            // Loose comparison
+            if (isset($default[$key]) && $value == $default[$key]) {
                 continue;
             }
 

--- a/monorepo/DevTools/src/RefactorConfigCommand.php
+++ b/monorepo/DevTools/src/RefactorConfigCommand.php
@@ -85,7 +85,7 @@ class RefactorConfigCommand extends Command
             copy(Hyde::path('hyde.yml.bak'), Hyde::path('hyde.yml'));
             unlink(Hyde::path('hyde.yml.bak'));
 
-            return;
+            throw $exception;
         } finally {
             if ($usesGit && file_exists(Hyde::path('hyde.yml.bak'))) {
                 unlink(Hyde::path('hyde.yml.bak'));

--- a/monorepo/DevTools/src/RefactorConfigCommand.php
+++ b/monorepo/DevTools/src/RefactorConfigCommand.php
@@ -23,6 +23,7 @@ use function in_array;
 use function is_array;
 use function is_string;
 use function file_exists;
+use function array_udiff;
 use function str_starts_with;
 use function file_put_contents;
 
@@ -72,11 +73,15 @@ class RefactorConfigCommand extends Command
 
         try {
             $config = config('hyde');
+
+            $default = require Hyde::vendorPath('config/hyde.php');
+
+            // Todo: Add argument to not diff out defaults
+            $config = array_udiff($config, $default, fn ($a, $b) => $a === $b ? 0 : 1);
+
             $config = $this->serializePhpData($config);
 
             $yaml = Yaml::dump($config, 16, 4, Yaml::DUMP_MULTI_LINE_LITERAL_BLOCK | Yaml::DUMP_EMPTY_ARRAY_AS_SEQUENCE);
-
-            // Todo: Diff out defaults? (unless with argument)
 
             file_put_contents(Hyde::path('hyde.yml'), $yaml);
         } catch (Throwable $exception) {


### PR DESCRIPTION
Adds a command we can use to convert configuration, initially intended to quickly document alternate config syntaxes, but we could bundle it in the framework later on if we wanted. We may also then want to normalize the command namespace with the ChangeSourceDirectoryCommand