### PR TITLE
Move the sidebar documentation to the documentation pages page

### DIFF
--- a/docs/creating-content/documentation-pages.md
+++ b/docs/creating-content/documentation-pages.md
@@ -272,6 +272,61 @@ Please note that this option is not added to the config file by default, as it's
 ],
 ```
 
+### Numerical Prefix Sidebar Ordering
+
+HydePHP v2 introduces sidebar item ordering based on numerical prefixes in filenames. This feature works for the documentation sidebar.
+
+This has the great benefit of matching the sidebar layout with the file structure view. It also works especially well with subdirectory-based sidebar grouping.
+
+```shell
+_docs/
+  01-installation.md     # Priority: 1
+  02-configuration.md    # Priority: 2
+  03-usage.md            # Priority: 3
+```
+
+As you can see, Hyde parses the number from the filename and uses it as the priority for the page in the sidebar, while stripping the prefix from the route key.
+
+#### Important Notes
+
+1. The numerical prefix remains part of the page identifier but is stripped from the route key.
+   For example: `_docs/01-installation.md` has route key `installation` and page identifier `01-installation`.
+2. You can delimit the numerical prefix with either a dash or an underscore.
+   For example: Both `_docs/01-installation.md` and `_docs/01_installation.md` are valid.
+3. Leading zeros are optional. `_docs/1-installation.md` is equally valid.
+
+#### Using Numerical Prefix Ordering in Subdirectories
+
+This feature integrates well with automatic subdirectory-based sidebar grouping. Here's an example of how you could organize a documentation site:
+
+```shell
+_docs/
+  01-getting-started/
+    01-installation.md
+    02-requirements.md
+    03-configuration.md
+  02-usage/
+    01-quick-start.md
+    02-advanced-usage.md
+  03-features/
+    01-feature-1.md
+    02-feature-2.md
+```
+
+Here are two useful tips:
+
+1. You can use numerical prefixes in subdirectories to control the sidebar group order.
+2. The numbering within a subdirectory works independently of its siblings, so you can start from one in each subdirectory.
+
+#### Customization
+
+If you're not interested in using numerical prefix ordering, you can disable it in the Hyde config file. Hyde will then no longer extract the priority and will no longer strip the prefix from the route key.
+
+```php
+// filepath: config/hyde.php
+'numerical_page_ordering' => false,
+```
+
 ### Table of Contents Settings
 
 Hyde automatically generates a table of contents for the page and adds it to the sidebar.

--- a/docs/creating-content/documentation-pages.md
+++ b/docs/creating-content/documentation-pages.md
@@ -162,7 +162,7 @@ navigation:
 
 #### Automatic Subdirectory-Based Grouping
 
-You can also automatically group your documentation pages by placing source files in sub-directories.
+You can also automatically group your documentation pages by placing source files in subdirectories.
 
 For example, putting a Markdown file in `_docs/getting-started/` is equivalent to adding the same front matter seen above.
 

--- a/docs/creating-content/documentation-pages.md
+++ b/docs/creating-content/documentation-pages.md
@@ -100,7 +100,52 @@ navigation:
     priority: 5
 ```
 
-You can also change the order in the `config/docs.php` configuration file, which may be easier to manage for larger sites. See [the chapter in the customization page](customization#navigation-menu--sidebar) for more details.
+You can also change the order in the `config/docs.php` configuration file, which may be easier to manage for larger sites.
+
+#### Basic Priority Syntax
+
+A nice and simple way to define the order of pages is to add their route keys as a simple list array. Hyde will then match that array order.
+
+It may be useful to know that Hyde internally will assign a priority calculated according to its position in the list, plus an offset of `500`. The offset is added to make it easier to place pages earlier in the list using front matter or with explicit priority settings.
+
+```php
+// filepath: config/docs.php
+'sidebar' => [
+    'order' => [
+        'readme', // Priority: 500
+        'installation', // Priority: 501
+        'getting-started', // Priority: 502
+    ]
+]
+```
+
+#### Explicit Priority Syntax
+
+You can also specify explicit priorities by adding a value to the array keys. Hyde will then use these exact values as the priorities.
+
+```php
+// filepath: config/docs.php
+'sidebar' => [
+    'order' => [
+        'readme' => 10,
+        'installation' => 15,
+        'getting-started' => 20,
+    ]
+]
+```
+
+You could also combine these methods if desired:
+
+```php
+// filepath: config/docs.php
+'sidebar' => [
+    'order' => [
+        'readme' => 10, // Priority: 10
+        'installation', // Priority: 500
+        'getting-started', // Priority: 501
+    ]
+]
+```
 
 ### Sidebar Labels
 

--- a/docs/creating-content/documentation-pages.md
+++ b/docs/creating-content/documentation-pages.md
@@ -166,9 +166,7 @@ You can also automatically group your documentation pages by placing source file
 
 For example, putting a Markdown file in `_docs/getting-started/` is equivalent to adding the same front matter seen above.
 
->info Note that when the [flattened output paths](#using-flattened-output-paths) setting is enabled (which it is by default), the file will still be compiled to the `_site/docs/` directory like it would be if you didn't use the subdirectories. Note that this means that you can't have two documentation pages with the same filename as they would overwrite each other.
-
->info Tip: When using subdirectory-based grouping, you can set the priority of the groups using the directory name as the array key in the config file.
+>warning Note that when the [flattened output paths](#using-flattened-output-paths) setting is enabled (which it is by default), the file will still be compiled to the `_site/docs/` directory like it would be if you didn't use the subdirectories. Note that this means that you can't have two documentation pages with the same filename as they would overwrite each other.
 
 ### Hiding Items
 
@@ -245,17 +243,32 @@ To quickly arrange the order of items in the sidebar, you can reorder the page i
 
 See [the chapter in the customization page](customization#navigation-menu--sidebar) for more details. <br>
 
-### Automatic Sidebar Group Labels
+### Setting Sidebar Group Labels
 
-When using the automatic sidebar grouping feature (based on subdirectories), the titles of the groups are generated from the directory names. If these are not to your liking, for example if you need to use special characters, you can override them in the Docs configuration file. The array key is the directory name, and the value is the label.
-
-Please note that this option is not added to the config file by default, as it's not a super common use case. No worries though, just add the following yourself!
+When using the automatic sidebar grouping feature the titles of the groups are generated from the subdirectory names. If these are not to your liking, for example if you need to use special characters, you can override them in the configuration file. The array key is the directory name, and the value is the label.
 
 ```php
 // Filepath: config/docs.php
 
 'sidebar_group_labels' => [
     'questions-and-answers' => 'Questions & Answers',
+],
+```
+
+Please note that this option is not added to the config file by default, as it's not a super common use case. No worries though, just add the following yourself!
+
+#### Setting Group Priorities
+
+When using subdirectory-based grouping, you can set the priority of the groups using the directory name as the array key in the config file:
+
+```php
+// Filepath: config/docs.php
+'sidebar' => [
+    'order' => [
+        'readme',
+        'installation',
+        'getting-started',
+    ],
 ],
 ```
 

--- a/docs/creating-content/documentation-pages.md
+++ b/docs/creating-content/documentation-pages.md
@@ -257,9 +257,11 @@ When using the automatic sidebar grouping feature the titles of the groups are g
 
 Please note that this option is not added to the config file by default, as it's not a super common use case. No worries though, just add the following yourself!
 
-#### Setting Group Priorities
+#### Setting Sidebar Group Priorities
 
-When using subdirectory-based grouping, you can set the priority of the groups using the directory name as the array key in the config file:
+By default, each group will be assigned the lowest priority found inside the group. However, you can specify the order and priorities for sidebar group keys the same way you can for the sidebar items.
+
+Just use the sidebar group key as instead of the page identifier/route key:
 
 ```php
 // Filepath: config/docs.php

--- a/docs/creating-content/documentation-pages.md
+++ b/docs/creating-content/documentation-pages.md
@@ -134,19 +134,6 @@ You can also specify explicit priorities by adding a value to the array keys. Hy
 ]
 ```
 
-You could also combine these methods if desired:
-
-```php
-// filepath: config/docs.php
-'sidebar' => [
-    'order' => [
-        'readme' => 10, // Priority: 10
-        'installation', // Priority: 500
-        'getting-started', // Priority: 501
-    ]
-]
-```
-
 ### Sidebar Labels
 
 The sidebar items are labelled with the `label` property. The default label is generated from the filename of the file.

--- a/docs/digging-deeper/customization.md
+++ b/docs/digging-deeper/customization.md
@@ -283,15 +283,18 @@ Still, you will likely want to customize some parts of these menus, and thankful
 
 - To customize the navigation menu, use the setting `navigation.order` in the `hyde.php` config.
 - When customizing the navigation menu, you should use the [route key](core-concepts#route-keys) of the page.
+- You can use either a basic list array or specify explicit priorities.
 
 Learn more in the [Navigation Menu](navigation) documentation.
 
 #### Customizing the documentation sidebar
 
 - To customize the sidebar, use the setting `sidebar.order` in the `docs.php` config.
-- When customizing the sidebar, can use the route key, or just the [page identifier](core-concepts#page-identifiers) of the page.
+- When customizing the sidebar, you can use the route key, or just the [page identifier](core-concepts#page-identifiers) of the page.
+- Similar to the navigation menu, you can use a basic list array or specify explicit priorities.
+- You can also use front matter in individual documentation pages to customize their appearance and behavior in the sidebar.
 
-Learn more in the [Documentation Pages](documentation-pages) documentation.
+Learn more in the [Documentation Pages](documentation-pages#sidebar) documentation.
 
 ## Additional Advanced Options
 

--- a/docs/digging-deeper/navigation.md
+++ b/docs/digging-deeper/navigation.md
@@ -146,19 +146,6 @@ You can also specify explicit priorities by adding a value to the array keys. We
 ]
 ```
 
-You could also combine these methods if desired:
-
-```php
-// filepath: config/hyde.php
-'navigation' => [
-    'order' => [
-        'home' => 10, // Priority: 10
-        'about', // Priority: 500
-        'contact', // Priority: 501
-    ]
-]
-```
-
 ### Changing Menu Item Labels
 
 Hyde makes a few attempts to find suitable labels for the navigation menu items to automatically create helpful titles.

--- a/docs/digging-deeper/navigation.md
+++ b/docs/digging-deeper/navigation.md
@@ -8,7 +8,7 @@ navigation:
 
 ## Introduction
 
-HydePHP offers automatic navigation menu and documentation sidebar generation features, designed to take the pain out of creating navigation menus.
+HydePHP offers automatic navigation menu generation features, designed to take the pain out of creating navigation menus.
 While Hyde does its best to configure these menus automatically based on understanding your project files, you may want to customize them further.
 
 There are two types of navigation menus in Hyde:
@@ -16,7 +16,7 @@ There are two types of navigation menus in Hyde:
 1. **Primary Navigation Menu**: The main navigation menu appearing on most pages of your site. Unique features include dropdowns for subdirectories, depending on configuration.
 2. **Documentation Sidebar**: The sidebar on documentation pages with links to other documentation pages. Unique features include automatic grouping based on subdirectories.
 
-This documentation will guide you through the customization process. To learn even more about sidebars, visit the [Documentation Pages](documentation-pages) documentation.
+This documentation will guide you through the customization process of the primary navigation menu. To learn about the documentation sidebar, visit the [Documentation Pages](documentation-pages) documentation.
 
 ### Internal Structure Overview
 
@@ -43,11 +43,10 @@ Hyde provides multiple ways to customize navigation menus to suit your needs:
 
 1. Front matter data in Markdown and Blade page files, applicable to all menu types
 2. Configuration in the `hyde` config file for main navigation items
-3. Configuration in the `docs` config file for documentation sidebar items
 
 Keep in mind that front matter data overrides dynamically inferred or config-defined priorities. While useful for quick one-off changes on small sites, it can make reordering items later on more challenging as you can't see the entire structure at once.
 
-Additionally, general options for the entire navigation menus are also available in the `hyde` and `docs` config files.
+Additionally, general options for the entire navigation menus are also available in the `hyde` config file.
 
 ## Front Matter Configuration
 
@@ -105,16 +104,15 @@ navigation:
 
 ## Config File Configuration
 
-Let's explore how to customize navigation menus using configuration files:
+Let's explore how to customize the main navigation menu using configuration files:
 
 - For the main navigation menu, use the `navigation` setting in the `hyde.php` config file.
-- For the sidebar, use the `sidebar` setting in the `docs.php` config file.
 
-When customizing the main navigation menu, use the [route key](core-concepts#route-keys) of the page. For the sidebar, you can use either the route key or the [page identifier](core-concepts#page-identifiers).
+When customizing the main navigation menu, use the [route key](core-concepts#route-keys) of the page.
 
 ### Changing Priorities
 
-The `navigation.order` and `sidebar.order` settings allow you to customize the order of pages in the navigation menus.
+The `navigation.order` setting allows you to customize the order of pages in the main navigation menu.
 
 #### Basic Priority Syntax
 
@@ -129,17 +127,6 @@ It may be useful to know that we internally will assign a priority calculated ac
         'home', // Priority: 500
         'about', // Priority: 501
         'contact', // Priority: 502
-    ]
-]
-```
-
-```php
-// filepath: config/docs.php
-'sidebar' => [
-    'order' => [
-        'readme', // Priority: 500
-        'installation', // Priority: 501
-        'getting-started', // Priority: 502
     ]
 ]
 ```
@@ -159,25 +146,16 @@ You can also specify explicit priorities by adding a value to the array keys. We
 ]
 ```
 
-```php
-// filepath: config/docs.php
-'sidebar' => [
-    'order' => [
-        'readme' => 10,
-        'installation' => 15,
-        'getting-started' => 20,
-    ]
-]
-```
-
 You could also combine these methods if desired:
 
 ```php
-// filepath: Applicable to both
-[
-    'readme' => 10, // Priority: 10
-    'installation', // Priority: 500
-    'getting-started', // Priority: 501
+// filepath: config/hyde.php
+'navigation' => [
+    'order' => [
+        'home' => 10, // Priority: 10
+        'about', // Priority: 500
+        'contact', // Priority: 501
+    ]
 ]
 ```
 
@@ -196,8 +174,6 @@ If you're not happy with these, it's easy to override navigation link labels by 
     ]
 ]
 ```
-
-**Note:** This feature is not yet supported for the sidebar.
 
 ### Excluding Items (Blacklist)
 
@@ -268,14 +244,6 @@ Enable this feature in the `hyde.php` config file by setting the `subdirectory_d
 
 Now if you create a page called `_pages/about/contact.md`, it will automatically be placed in a dropdown called "About".
 
-#### Automatic Documentation Sidebar Grouping
-
-This feature is always enabled for documentation pages. Simply place your pages in subdirectories to have them grouped in the sidebar.
-
-For example: `_docs/getting-started/installation.md` will be placed in a group called "Getting Started".
-
->info Tip: When using subdirectory-based dropdowns, you can set their priority using the directory name as the array key.
-
 #### Dropdown Menu Notes
 
 - Dropdowns take priority over standard items. If you have a dropdown with the key `about` and a page with the key `about`, the dropdown will be created, and the page won't be in the menu.
@@ -283,7 +251,7 @@ For example: `_docs/getting-started/installation.md` will be placed in a group c
 
 ## Numerical Prefix Navigation Ordering
 
-HydePHP v2 introduces navigation item ordering based on numerical prefixes in filenames. This feature works for both the primary navigation menu and the documentation sidebar.
+HydePHP v2 introduces navigation item ordering based on numerical prefixes in filenames. This feature works for the primary navigation menu.
 
 This has the great benefit of matching the navigation menu layout with the file structure view. It also works especially well with subdirectory-based navigation grouping.
 
@@ -308,24 +276,8 @@ As you can see, Hyde parses the number from the filename and uses it as the prio
 
 This feature integrates well with automatic subdirectory-based navigation grouping. Here are two useful tips:
 
-1. You can use numerical prefixes in subdirectories to control the dropdown/sidebar order.
+1. You can use numerical prefixes in subdirectories to control the dropdown order.
 2. The numbering within a subdirectory works independently of its siblings, so you can start from one in each subdirectory.
-
-Here is an example structure of how you could organize a documentation site:
-
-```shell
-_docs/
-  01-getting-started/
-    01-installation.md
-    02-requirements.md
-    03-configuration.md
-  02-usage/
-    01-quick-start.md
-    02-advanced-usage.md
-  03-features/
-    01-feature-1.md
-    02-feature-2.md
-```
 
 ### Customization
 

--- a/packages/framework/src/Framework/Features/Navigation/NavigationMenuGenerator.php
+++ b/packages/framework/src/Framework/Features/Navigation/NavigationMenuGenerator.php
@@ -194,6 +194,7 @@ class NavigationMenuGenerator
 
     protected function searchForGroupLabelInConfig(string $groupKey): ?string
     {
+        // TODO: Normalize this: sidebar_group_labels -> docs.sidebar.labels
         return $this->getConfigArray($this->generatesSidebar ? 'docs.sidebar_group_labels' : 'hyde.navigation.labels')[$groupKey] ?? null;
     }
 


### PR DESCRIPTION
Targets https://github.com/hydephp/develop/pull/1818

This PR reorganizes and improves the documentation for navigation menus and documentation pages in Hyde. The main changes are:

1. Move sidebar-specific content from `navigation.md` to `documentation-pages.md`
2. Update `customization.md` to reflect the new organization
3. Add missing information about numerical prefix ordering to `documentation-pages.md`

Motivation:
- Reduce duplication and potential inconsistencies in the documentation
- Improve the overall organization of the docs, making it easier for users to find relevant information
- Ensure all features, including numerical prefix ordering, are properly documented

Benefits:
- Clearer separation of concerns between main navigation and documentation sidebar
- More comprehensive and accurate documentation for Hyde users
- Easier maintenance of documentation in the future

These changes will help Hyde users better understand and utilize the navigation and documentation features, leading to improved developer experience and more efficient use of the framework. Generally readers will be looking on how to use a specific feature such as main menus or sidebars, so it's distracting to have two areas in one file.