### PR TITLE
[2.x] Breaking: Update in memory pages always have the same route key as their identifier

### DIFF
--- a/packages/framework/src/Pages/InMemoryPage.php
+++ b/packages/framework/src/Pages/InMemoryPage.php
@@ -6,13 +6,13 @@ namespace Hyde\Pages;
 
 use BadMethodCallException;
 use Closure;
-use Hyde\Support\Models\RouteKey;
 use Hyde\Framework\Actions\AnonymousViewCompiler;
 use Hyde\Markdown\Models\FrontMatter;
 use Hyde\Pages\Concerns\HydePage;
 use Illuminate\Support\Facades\View;
 
 use function sprintf;
+use function Hyde\unslash;
 
 /**
  * Extendable class for in-memory (or virtual) Hyde pages that are not based on any source files.
@@ -65,7 +65,7 @@ class InMemoryPage extends HydePage
      */
     public function __construct(string $identifier = '', FrontMatter|array $matter = [], string $contents = '', string $view = '')
     {
-        parent::__construct(RouteKey::fromPage(static::class, $identifier)->get(), $matter);
+        parent::__construct(unslash(static::baseRouteKey()."/$identifier"), $matter);
 
         $this->contents = $contents;
         $this->view = $view;

--- a/packages/framework/src/Pages/InMemoryPage.php
+++ b/packages/framework/src/Pages/InMemoryPage.php
@@ -65,7 +65,7 @@ class InMemoryPage extends HydePage
      */
     public function __construct(string $identifier = '', FrontMatter|array $matter = [], string $contents = '', string $view = '')
     {
-        parent::__construct(unslash(static::baseRouteKey()."/$identifier"), $matter);
+        parent::__construct($this->normalizeIdentifier($identifier), $matter);
 
         $this->contents = $contents;
         $this->view = $view;
@@ -150,5 +150,13 @@ class InMemoryPage extends HydePage
         }
 
         return $macro(...$parameters);
+    }
+
+    protected function normalizeIdentifier(string $identifier): string
+    {
+        // In order to create a unique identifier that won't conflict with other pages,
+        // we normalize the identifier to match the route key format Hyde uses.
+
+        return unslash(static::baseRouteKey()."/$identifier");
     }
 }

--- a/packages/framework/src/Pages/InMemoryPage.php
+++ b/packages/framework/src/Pages/InMemoryPage.php
@@ -6,6 +6,7 @@ namespace Hyde\Pages;
 
 use BadMethodCallException;
 use Closure;
+use Hyde\Support\Models\RouteKey;
 use Hyde\Framework\Actions\AnonymousViewCompiler;
 use Hyde\Markdown\Models\FrontMatter;
 use Hyde\Pages\Concerns\HydePage;
@@ -64,7 +65,7 @@ class InMemoryPage extends HydePage
      */
     public function __construct(string $identifier = '', FrontMatter|array $matter = [], string $contents = '', string $view = '')
     {
-        parent::__construct($identifier, $matter);
+        parent::__construct(RouteKey::fromPage(static::class, $identifier)->get(), $matter);
 
         $this->contents = $contents;
         $this->view = $view;

--- a/packages/framework/src/Pages/InMemoryPage.php
+++ b/packages/framework/src/Pages/InMemoryPage.php
@@ -6,7 +6,6 @@ namespace Hyde\Pages;
 
 use BadMethodCallException;
 use Closure;
-use Hyde\Support\Models\RouteKey;
 use Hyde\Framework\Actions\AnonymousViewCompiler;
 use Hyde\Markdown\Models\FrontMatter;
 use Hyde\Pages\Concerns\HydePage;
@@ -65,7 +64,7 @@ class InMemoryPage extends HydePage
      */
     public function __construct(string $identifier = '', FrontMatter|array $matter = [], string $contents = '', string $view = '')
     {
-        parent::__construct(RouteKey::fromPage(static::class, $identifier)->get(), $matter);
+        parent::__construct($identifier, $matter);
 
         $this->contents = $contents;
         $this->view = $view;

--- a/packages/framework/src/Support/Models/RouteKey.php
+++ b/packages/framework/src/Support/Models/RouteKey.php
@@ -5,8 +5,10 @@ declare(strict_types=1);
 namespace Hyde\Support\Models;
 
 use Stringable;
+use Hyde\Pages\InMemoryPage;
 use Hyde\Framework\Features\Navigation\NumericalPageOrderingHelper;
 
+use function is_a;
 use function Hyde\unslash;
 
 /**
@@ -48,6 +50,12 @@ final class RouteKey implements Stringable
     /** @param class-string<\Hyde\Pages\Concerns\HydePage> $pageClass */
     public static function fromPage(string $pageClass, string $identifier): self
     {
+        if (is_a($pageClass, InMemoryPage::class, true)) {
+            // In memory pages always have the same route key as their identifier.
+
+            return new self($identifier);
+        }
+
         $identifier = self::splitNumberedIdentifiersIfNeeded($identifier);
 
         return new self(unslash("{$pageClass::baseRouteKey()}/$identifier"));

--- a/packages/framework/src/Support/Models/RouteKey.php
+++ b/packages/framework/src/Support/Models/RouteKey.php
@@ -5,10 +5,8 @@ declare(strict_types=1);
 namespace Hyde\Support\Models;
 
 use Stringable;
-use Hyde\Pages\InMemoryPage;
 use Hyde\Framework\Features\Navigation\NumericalPageOrderingHelper;
 
-use function is_a;
 use function Hyde\unslash;
 
 /**
@@ -50,12 +48,6 @@ final class RouteKey implements Stringable
     /** @param class-string<\Hyde\Pages\Concerns\HydePage> $pageClass */
     public static function fromPage(string $pageClass, string $identifier): self
     {
-        if (is_a($pageClass, InMemoryPage::class, true)) {
-            // In memory pages always have the same route key as their identifier.
-
-            return new self($identifier);
-        }
-
         $identifier = self::splitNumberedIdentifiersIfNeeded($identifier);
 
         return new self(unslash("{$pageClass::baseRouteKey()}/$identifier"));

--- a/packages/framework/tests/Unit/Pages/InMemoryPageUnitTest.php
+++ b/packages/framework/tests/Unit/Pages/InMemoryPageUnitTest.php
@@ -230,8 +230,8 @@ class InMemoryPageUnitTest extends BaseHydePageUnitTest
 
     public function testRouteKeyIsAlwaysTheIdentifierEvenWhenUsingCustomOutputDirectory()
     {
-        $this->assertSame('foo', (new InMemoryPageWithCustomOutputDirectory('foo'))->getRouteKey());
-        $this->assertSame('foo/bar', (new InMemoryPageWithCustomOutputDirectory('foo/bar'))->getRouteKey());
+        $this->assertSame('foo/foo', (new InMemoryPageWithCustomOutputDirectory('foo'))->getRouteKey());
+        $this->assertSame('foo/foo/bar', (new InMemoryPageWithCustomOutputDirectory('foo/bar'))->getRouteKey());
     }
 }
 

--- a/packages/framework/tests/Unit/Pages/InMemoryPageUnitTest.php
+++ b/packages/framework/tests/Unit/Pages/InMemoryPageUnitTest.php
@@ -221,4 +221,21 @@ class InMemoryPageUnitTest extends BaseHydePageUnitTest
     {
         $this->assertInstanceOf(FrontMatter::class, (new InMemoryPage('404'))->matter());
     }
+
+    public function testRouteKeyIsAlwaysTheIdentifier()
+    {
+        $this->assertSame('foo', (new InMemoryPage('foo'))->getRouteKey());
+        $this->assertSame('foo/bar', (new InMemoryPage('foo/bar'))->getRouteKey());
+    }
+
+    public function testRouteKeyIsAlwaysTheIdentifierEvenWhenUsingCustomOutputDirectory()
+    {
+        $this->assertSame('foo', (new InMemoryPageWithCustomOutputDirectory('foo'))->getRouteKey());
+        $this->assertSame('foo/bar', (new InMemoryPageWithCustomOutputDirectory('foo/bar'))->getRouteKey());
+    }
+}
+
+class InMemoryPageWithCustomOutputDirectory extends InMemoryPage
+{
+    public static string $outputDirectory = 'foo';
 }

--- a/packages/framework/tests/Unit/Pages/InMemoryPageUnitTest.php
+++ b/packages/framework/tests/Unit/Pages/InMemoryPageUnitTest.php
@@ -230,8 +230,8 @@ class InMemoryPageUnitTest extends BaseHydePageUnitTest
 
     public function testRouteKeyIsAlwaysTheIdentifierEvenWhenUsingCustomOutputDirectory()
     {
-        $this->assertSame('foo/foo', (new InMemoryPageWithCustomOutputDirectory('foo'))->getRouteKey());
-        $this->assertSame('foo/foo/bar', (new InMemoryPageWithCustomOutputDirectory('foo/bar'))->getRouteKey());
+        $this->assertSame('foo/bar', (new InMemoryPageWithCustomOutputDirectory('bar'))->getRouteKey());
+        $this->assertSame('foo/bar/baz', (new InMemoryPageWithCustomOutputDirectory('bar/baz'))->getRouteKey());
     }
 }
 


### PR DESCRIPTION
Currently a class like this:

```php
class InMemoryPageWithCustomOutputDirectory extends InMemoryPage
{
    public static string $outputDirectory = 'foo';
}
```
Will when having an identifier of "bar" have the route key "foo/bar", but the identifier "bar", which can make it conflict with other pages, even where not intended.
