### PR TITLE
[2.x] Add booting and booted callbacks to the HydeExtension feature

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -15,6 +15,7 @@ This serves two purposes:
 - Added a new `\Hyde\Framework\Exceptions\ParseException` exception class to handle parsing exceptions in data collection files in https://github.com/hydephp/develop/pull/1732
 - Added a new `\Hyde\Framework\Exceptions\InvalidConfigurationException` exception class to handle invalid configuration exceptions in https://github.com/hydephp/develop/pull/1799
 - The `\Hyde\Facades\Features` class is no longer marked as internal, and is now thus part of the public API.
+- Added support for setting `booting()` and `booted()` callbacks in `HydeExtension` classes, allowing extension developers to hook into the kernel boot process more easily in https://github.com/hydephp/develop/pull/1847
 - Added support for setting custom navigation items in the YAML configuration in https://github.com/hydephp/develop/pull/1818
 - Added support for setting extra attributes for navigation items in https://github.com/hydephp/develop/pull/1824
 - Introduced a new navigation config builder class to simplify navigation configuration in https://github.com/hydephp/develop/pull/1827

--- a/docs/architecture-concepts/extensions-api.md
+++ b/docs/architecture-concepts/extensions-api.md
@@ -101,16 +101,18 @@ use Hyde\Foundation\HydeKernel;
 
 class JsonPageExtension extends HydeExtension {
     public function booting(HydeKernel $kernel): void {
-        // This runs before the kernel boots, meaning pages have not been discovered yet
+        // This runs before the kernel boots and before running auto-discovery
     }
 
     public function booted(HydeKernel $kernel): void {
-        // This runs after the kernel has booted, meaning pages have been discovered
+        // This runs after the kernel boots and after running auto-discovery
     }
 }
 ```
 
-These callbacks provide powerful hooks into the Hyde system, allowing your extensions to integrate deeply and modify Hyde's behavior as needed. The `booting` callback can be used to set up the system with information needed to discover pages, while the `booted` callback can can be used to perform operations requiring knowledge of discovered data, even modifying them if needed.
+The `booting` callback can be used to set up the system with information needed to discover pages, while the `booted` callback can can be used to perform operations requiring knowledge of discovered data, even modifying them if needed.
+
+These callbacks provide powerful hooks into the Hyde system, allowing your extensions to integrate deeply and modify Hyde's behavior as needed. 
 
 #### Discovery handler example
 

--- a/docs/architecture-concepts/extensions-api.md
+++ b/docs/architecture-concepts/extensions-api.md
@@ -92,6 +92,24 @@ public function discoverRoutes(RouteCollection $collection): void;
 Any of these can be implemented in your extension class, and they will be called during the discovery. As you can see,
 the instance of the discovery collection is injected into the method for you to interact with.
 
+### Booting and Booted Callbacks
+
+In addition to the discovery handlers, you can also define `booting` and `booted` callbacks in your extension class. These methods allow you to run custom logic before and after the kernel boots, respectively.
+
+```php
+class JsonPageExtension extends HydeExtension {
+    public function booting(): void {
+        // This runs before the kernel boots, meaning pages have not been discovered yet
+    }
+
+    public function booted(): void {
+        // This runs after the kernel has booted, meaning pages have been discovered
+    }
+}
+```
+
+These methods are particularly useful for setting up your extension's environment or performing post-boot operations.
+
 #### Discovery handler example
 
 Let's go crazy and implement a discovery handler to collect `JsonPage` files from an external API! We will do this

--- a/docs/architecture-concepts/extensions-api.md
+++ b/docs/architecture-concepts/extensions-api.md
@@ -102,12 +102,10 @@ use Hyde\Foundation\HydeKernel;
 class JsonPageExtension extends HydeExtension {
     public function booting(HydeKernel $kernel): void {
         // This runs before the kernel boots, meaning pages have not been discovered yet
-        // You can use $kernel to interact with the HydeKernel instance
     }
 
     public function booted(HydeKernel $kernel): void {
         // This runs after the kernel has booted, meaning pages have been discovered
-        // You can use $kernel to interact with the HydeKernel instance
     }
 }
 ```

--- a/docs/architecture-concepts/extensions-api.md
+++ b/docs/architecture-concepts/extensions-api.md
@@ -94,21 +94,25 @@ the instance of the discovery collection is injected into the method for you to 
 
 ### Booting and Booted Callbacks
 
-In addition to the discovery handlers, you can also define `booting` and `booted` callbacks in your extension class. These methods allow you to run custom logic before and after the kernel boots, respectively.
+In addition to the discovery handlers, you can also define `booting` and `booted` callbacks in your extension class. These methods allow you to run custom logic before and after the kernel boots, respectively. Both methods receive the `HydeKernel` instance as a parameter, allowing you to interact with the kernel directly.
 
 ```php
+use Hyde\Foundation\HydeKernel;
+
 class JsonPageExtension extends HydeExtension {
-    public function booting(): void {
+    public function booting(HydeKernel $kernel): void {
         // This runs before the kernel boots, meaning pages have not been discovered yet
+        // You can use $kernel to interact with the HydeKernel instance
     }
 
-    public function booted(): void {
+    public function booted(HydeKernel $kernel): void {
         // This runs after the kernel has booted, meaning pages have been discovered
+        // You can use $kernel to interact with the HydeKernel instance
     }
 }
 ```
 
-These methods are particularly useful for setting up your extension's environment or performing post-boot operations.
+These callbacks provide powerful hooks into the Hyde system, allowing your extensions to integrate deeply and modify Hyde's behavior as needed. The `booting` callback can be used to set up the system with information needed to discover pages, while the `booted` callback can can be used to perform operations requiring knowledge of discovered data, even modifying them if needed.
 
 #### Discovery handler example
 

--- a/packages/framework/src/Foundation/Concerns/HydeExtension.php
+++ b/packages/framework/src/Foundation/Concerns/HydeExtension.php
@@ -81,7 +81,7 @@ abstract class HydeExtension
 
     /**
      * Register a callback to be run before the kernel is booted,
-     * and before file/page/route discovery has begun.
+     * which is before any file/page/route discovery has begun.
      */
     public function booting(HydeKernel $kernel): void
     {
@@ -90,7 +90,7 @@ abstract class HydeExtension
 
     /**
      * Register a callback to be run after the kernel is booted,
-     * and after file/page/route discovery has completed.
+     * which is after file/page/route discovery has completed.
      */
     public function booted(HydeKernel $kernel): void
     {

--- a/packages/framework/src/Foundation/Concerns/HydeExtension.php
+++ b/packages/framework/src/Foundation/Concerns/HydeExtension.php
@@ -77,4 +77,22 @@ abstract class HydeExtension
     {
         //
     }
+
+    /**
+     * Register a callback to be run before the kernel is booted.
+     * Override this method to define your booting logic.
+     */
+    public function booting(): void
+    {
+        //
+    }
+
+    /**
+     * Register a callback to be run after the kernel is booted.
+     * Override this method to define your booted logic.
+     */
+    public function booted(): void
+    {
+        //
+    }
 }

--- a/packages/framework/src/Foundation/Concerns/HydeExtension.php
+++ b/packages/framework/src/Foundation/Concerns/HydeExtension.php
@@ -80,7 +80,8 @@ abstract class HydeExtension
     }
 
     /**
-     * Register a callback to be run before the kernel is booted.
+     * Register a callback to be run before the kernel is booted,
+     * and before file/page/route discovery has begun.
      */
     public function booting(HydeKernel $kernel): void
     {
@@ -88,7 +89,8 @@ abstract class HydeExtension
     }
 
     /**
-     * Register a callback to be run after the kernel is booted.
+     * Register a callback to be run after the kernel is booted,
+     * and after file/page/route discovery has completed.
      */
     public function booted(HydeKernel $kernel): void
     {

--- a/packages/framework/src/Foundation/Concerns/HydeExtension.php
+++ b/packages/framework/src/Foundation/Concerns/HydeExtension.php
@@ -81,7 +81,6 @@ abstract class HydeExtension
 
     /**
      * Register a callback to be run before the kernel is booted.
-     * Override this method to define your booting logic.
      */
     public function booting(HydeKernel $kernel): void
     {
@@ -90,7 +89,6 @@ abstract class HydeExtension
 
     /**
      * Register a callback to be run after the kernel is booted.
-     * Override this method to define your booted logic.
      */
     public function booted(HydeKernel $kernel): void
     {

--- a/packages/framework/src/Foundation/Concerns/HydeExtension.php
+++ b/packages/framework/src/Foundation/Concerns/HydeExtension.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Hyde\Foundation\Concerns;
 
+use Hyde\Foundation\HydeKernel;
 use Hyde\Foundation\Kernel\FileCollection;
 use Hyde\Foundation\Kernel\PageCollection;
 use Hyde\Foundation\Kernel\RouteCollection;
@@ -82,7 +83,7 @@ abstract class HydeExtension
      * Register a callback to be run before the kernel is booted.
      * Override this method to define your booting logic.
      */
-    public function booting(): void
+    public function booting(HydeKernel $kernel): void
     {
         //
     }
@@ -91,7 +92,7 @@ abstract class HydeExtension
      * Register a callback to be run after the kernel is booted.
      * Override this method to define your booted logic.
      */
-    public function booted(): void
+    public function booted(HydeKernel $kernel): void
     {
         //
     }

--- a/packages/framework/src/Foundation/Concerns/ManagesExtensions.php
+++ b/packages/framework/src/Foundation/Concerns/ManagesExtensions.php
@@ -56,6 +56,9 @@ trait ManagesExtensions
 
         $instance = new $extension();
         $this->extensions[$extension] = $instance;
+
+        $this->booting([$instance, 'booting']);
+        $this->booted([$instance, 'booted']);
     }
 
     /**

--- a/packages/framework/src/Foundation/Concerns/ManagesExtensions.php
+++ b/packages/framework/src/Foundation/Concerns/ManagesExtensions.php
@@ -54,7 +54,8 @@ trait ManagesExtensions
             throw new InvalidArgumentException("Extension [$extension] is already registered.");
         }
 
-        $this->extensions[$extension] = new $extension();
+        $instance = new $extension();
+        $this->extensions[$extension] = $instance;
     }
 
     /**

--- a/packages/framework/tests/Feature/HydeExtensionFeatureTest.php
+++ b/packages/framework/tests/Feature/HydeExtensionFeatureTest.php
@@ -133,7 +133,7 @@ class HydeExtensionFeatureTest extends TestCase
         $this->assertEquals(new Route(new TestPageClass('bar')), Routes::get('foo/bar'));
     }
 
-    public function testBootingAndBootedMethodsAreCalled()
+    public function testBootingAndBootedMethodsAreCalledWithKernel()
     {
         $this->kernel->registerExtension(BootableTestExtension::class);
 
@@ -141,7 +141,12 @@ class HydeExtensionFeatureTest extends TestCase
 
         $this->kernel->boot();
 
-        $this->assertSame(['booting', 'booted'], BootableTestExtension::$callCache);
+        $this->assertCount(2, BootableTestExtension::$callCache);
+
+        $this->assertInstanceOf(HydeKernel::class, BootableTestExtension::$callCache['booting']);
+        $this->assertInstanceOf(HydeKernel::class, BootableTestExtension::$callCache['booted']);
+        $this->assertSame($this->kernel, BootableTestExtension::$callCache['booting']);
+        $this->assertSame($this->kernel, BootableTestExtension::$callCache['booted']);
 
         BootableTestExtension::$callCache = [];
     }
@@ -179,12 +184,12 @@ class HydeTestExtension extends HydeExtension
         static::$callCache[] = 'routes';
     }
 
-    public function booting(): void
+    public function booting(HydeKernel $kernel): void
     {
         static::$callCache[] = 'booting';
     }
 
-    public function booted(): void
+    public function booted(HydeKernel $kernel): void
     {
         static::$callCache[] = 'booted';
     }
@@ -253,13 +258,13 @@ class BootableTestExtension extends HydeExtension
 {
     public static array $callCache = [];
 
-    public function booting(): void
+    public function booting(HydeKernel $kernel): void
     {
-        static::$callCache[] = 'booting';
+        static::$callCache['booting'] = $kernel;
     }
 
-    public function booted(): void
+    public function booted(HydeKernel $kernel): void
     {
-        static::$callCache[] = 'booted';
+        static::$callCache['booted'] = $kernel;
     }
 }

--- a/packages/framework/tests/Feature/HydeExtensionFeatureTest.php
+++ b/packages/framework/tests/Feature/HydeExtensionFeatureTest.php
@@ -51,7 +51,7 @@ class HydeExtensionFeatureTest extends TestCase
 
         $this->kernel->boot();
 
-        $this->assertSame(['files', 'pages', 'routes'], HydeTestExtension::$callCache);
+        $this->assertSame(['booting', 'files', 'pages', 'routes', 'booted'], HydeTestExtension::$callCache);
 
         HydeTestExtension::$callCache = [];
     }
@@ -133,6 +133,19 @@ class HydeExtensionFeatureTest extends TestCase
         $this->assertEquals(new Route(new TestPageClass('bar')), Routes::get('foo/bar'));
     }
 
+    public function testBootingAndBootedMethodsAreCalled()
+    {
+        $this->kernel->registerExtension(BootableTestExtension::class);
+
+        $this->assertSame([], BootableTestExtension::$callCache);
+
+        $this->kernel->boot();
+
+        $this->assertSame(['booting', 'booted'], BootableTestExtension::$callCache);
+
+        BootableTestExtension::$callCache = [];
+    }
+
     protected function markTestSuccessful(): void
     {
         $this->assertTrue(true);
@@ -164,6 +177,16 @@ class HydeTestExtension extends HydeExtension
     public function discoverRoutes(RouteCollection $collection): void
     {
         static::$callCache[] = 'routes';
+    }
+
+    public function booting(): void
+    {
+        static::$callCache[] = 'booting';
+    }
+
+    public function booted(): void
+    {
+        static::$callCache[] = 'booted';
     }
 }
 
@@ -223,5 +246,20 @@ class InspectableTestExtension extends HydeExtension
     public static function getCalled(string $method): array
     {
         return self::$callCache[$method];
+    }
+}
+
+class BootableTestExtension extends HydeExtension
+{
+    public static array $callCache = [];
+
+    public function booting(): void
+    {
+        static::$callCache[] = 'booting';
+    }
+
+    public function booted(): void
+    {
+        static::$callCache[] = 'booted';
     }
 }


### PR DESCRIPTION
## Abstract

This PR enhances the Extensions API by adding support for `booting` and `booted` callbacks directly in the `HydeExtension` class. This allows extension developers to hook into the Hyde kernel's boot process more easily and perform setup or cleanup tasks.

### Changes

- Added `booting()` and `booted()` methods to `HydeExtension` class
- Updated `ManagesExtensions` trait to register these callbacks
- Modified `BootsHydeKernel` trait to call the new callbacks
- Updated tests to cover the new functionality
- Updated documentation to reflect the new features

### Upgrade Notes

This change is backwards-compatible and requires no changes for existing extensions. However, developers can now take advantage of these new methods to perform actions during the kernel boot process.