### PR TITLE
Refactor realtime compiler to handle virtual routes through the service container

### DIFF
--- a/.github/workflows/smoke-tests.yml
+++ b/.github/workflows/smoke-tests.yml
@@ -22,7 +22,7 @@ jobs:
         uses: actions/cache@v4
         with:
           path: vendor
-          key: ${{ runner.os }}-php-${{ hashFiles('**/composer.lock') }}
+          key: ${{ runner.os }}-test-${{ hashFiles('**/composer.lock') }}
           restore-keys: |
             ${{ runner.os }}-php-
 

--- a/.github/workflows/smoke-tests.yml
+++ b/.github/workflows/smoke-tests.yml
@@ -22,7 +22,7 @@ jobs:
         uses: actions/cache@v4
         with:
           path: vendor
-          key: ${{ runner.os }}-test-${{ hashFiles('**/composer.lock') }}
+          key: ${{ runner.os }}-php-${{ hashFiles('**/composer.lock') }}
           restore-keys: |
             ${{ runner.os }}-php-
 

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -78,6 +78,9 @@
       <entry_point TYPE="phpMethod" FQNAME="\Hyde\Console\Commands\PublishViewsCommand publishOption" />
       <entry_point TYPE="phpMethod" FQNAME="\Hyde\Console\Commands\BuildSiteCommand runPreBuildActions" />
       <entry_point TYPE="phpMethod" FQNAME="\Hyde\Console\Commands\MakePageCommand validateOptions" />
+      <entry_point TYPE="phpMethod" FQNAME="\Hyde\RealtimeCompiler\RealtimeCompilerServiceProvider boot" />
+      <entry_point TYPE="phpClass" FQNAME="\Hyde\RealtimeCompiler\RealtimeCompilerServiceProvider" />
+      <entry_point TYPE="phpMethod" FQNAME="\Hyde\RealtimeCompiler\RealtimeCompilerServiceProvider register" />
     </entry_point>
     <pattern value="\Hyde\Framework\Services\ValidationService" member="check_a_torchlight_api_token_is_set" />
     <pattern value="\Hyde\Framework\Services\ValidationService" />
@@ -154,5 +157,8 @@
     <pattern value="\Hyde\Console\Commands\PublishViewsCommand" member="publishOption" />
     <pattern value="\Hyde\Console\Commands\BuildSiteCommand" member="runPreBuildActions" />
     <pattern value="\Hyde\Console\Commands\MakePageCommand" member="validateOptions" />
+    <pattern value="\Hyde\RealtimeCompiler\RealtimeCompilerServiceProvider" member="boot" />
+    <pattern value="\Hyde\RealtimeCompiler\RealtimeCompilerServiceProvider" />
+    <pattern value="\Hyde\RealtimeCompiler\RealtimeCompilerServiceProvider" member="register" />
   </component>
 </project>

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -18,6 +18,7 @@ This serves two purposes:
 - Removed the nullable type hint from the `PostAuthor` class's `name` property as it is now always set in https://github.com/hydephp/develop/pull/1794
 - Improved the accessibility of the heading permalinks feature in https://github.com/hydephp/develop/pull/1803
 - Updated to HydeFront v3.4 in https://github.com/hydephp/develop/pull/1803
+- Realtime Compiler: Virtual routes are now managed through the service container in https://github.com/hydephp/develop/pull/1858
 
 ### Deprecated
 - The `PostAuthor::getName()` method is now deprecated and will be removed in v2. (use `$author->name` instead) in https://github.com/hydephp/develop/pull/1794

--- a/composer.lock
+++ b/composer.lock
@@ -1173,7 +1173,7 @@
         },
         {
             "name": "hyde/publications",
-            "version": "dev-master",
+            "version": "dev-deeper-realtime-compiler-integration",
             "dist": {
                 "type": "path",
                 "url": "./packages/publications",
@@ -1220,7 +1220,7 @@
         },
         {
             "name": "hyde/ui-kit",
-            "version": "dev-master",
+            "version": "dev-deeper-realtime-compiler-integration",
             "dist": {
                 "type": "path",
                 "url": "./packages/ui-kit",
@@ -7832,7 +7832,7 @@
         },
         {
             "name": "hyde/monorepo-dev-tools",
-            "version": "dev-master",
+            "version": "dev-deeper-realtime-compiler-integration",
             "dist": {
                 "type": "path",
                 "url": "./monorepo/DevTools",
@@ -7858,7 +7858,7 @@
         },
         {
             "name": "hyde/realtime-compiler",
-            "version": "dev-master",
+            "version": "dev-2.x-dev",
             "dist": {
                 "type": "path",
                 "url": "./packages/realtime-compiler",
@@ -7914,7 +7914,7 @@
         },
         {
             "name": "hyde/testing",
-            "version": "dev-master",
+            "version": "dev-deeper-realtime-compiler-integration",
             "dist": {
                 "type": "path",
                 "url": "./packages/testing",

--- a/composer.lock
+++ b/composer.lock
@@ -1173,7 +1173,7 @@
         },
         {
             "name": "hyde/publications",
-            "version": "dev-deeper-realtime-compiler-integration",
+            "version": "dev-master",
             "dist": {
                 "type": "path",
                 "url": "./packages/publications",
@@ -1220,7 +1220,7 @@
         },
         {
             "name": "hyde/ui-kit",
-            "version": "dev-deeper-realtime-compiler-integration",
+            "version": "dev-master",
             "dist": {
                 "type": "path",
                 "url": "./packages/ui-kit",
@@ -7832,7 +7832,7 @@
         },
         {
             "name": "hyde/monorepo-dev-tools",
-            "version": "dev-deeper-realtime-compiler-integration",
+            "version": "dev-master",
             "dist": {
                 "type": "path",
                 "url": "./monorepo/DevTools",
@@ -7858,7 +7858,7 @@
         },
         {
             "name": "hyde/realtime-compiler",
-            "version": "dev-2.x-dev",
+            "version": "dev-master",
             "dist": {
                 "type": "path",
                 "url": "./packages/realtime-compiler",
@@ -7914,7 +7914,7 @@
         },
         {
             "name": "hyde/testing",
-            "version": "dev-deeper-realtime-compiler-integration",
+            "version": "dev-master",
             "dist": {
                 "type": "path",
                 "url": "./packages/testing",

--- a/composer.lock
+++ b/composer.lock
@@ -7881,6 +7881,13 @@
                 "bin/server.php"
             ],
             "type": "library",
+            "extra": {
+                "laravel": {
+                    "providers": [
+                        "Hyde\\RealtimeCompiler\\RealtimeCompilerServiceProvider"
+                    ]
+                }
+            },
             "autoload": {
                 "psr-4": {
                     "Hyde\\RealtimeCompiler\\": "src/"

--- a/packages/realtime-compiler/composer.json
+++ b/packages/realtime-compiler/composer.json
@@ -33,6 +33,13 @@
             "pestphp/pest-plugin": false
         }
     },
+    "extra": {
+        "laravel": {
+            "providers": [
+                "Hyde\\RealtimeCompiler\\RealtimeCompilerServiceProvider"
+            ]
+        }
+    },
     "require-dev": {
         "phpunit/phpunit": "^10.0",
         "robiningelbrecht/phpunit-pretty-print": "^1.3",

--- a/packages/realtime-compiler/src/Http/DashboardController.php
+++ b/packages/realtime-compiler/src/Http/DashboardController.php
@@ -330,7 +330,7 @@ class DashboardController extends BaseController
         $content = $this->request->data['contentInput'] ?? $this->abort(400, 'Must provide content');
         $pageType = $this->request->data['pageTypeSelection'] ?? $this->abort(400, 'Must provide page type');
 
-        // Optional data
+        // Optional data // Todo: Filter empty data? Comment them?
         $postDescription = $this->request->data['postDescription'] ?? null;
         $postCategory = $this->request->data['postCategory'] ?? null;
         $postAuthor = $this->request->data['postAuthor'] ?? null;

--- a/packages/realtime-compiler/src/Http/VirtualRouteController.php
+++ b/packages/realtime-compiler/src/Http/VirtualRouteController.php
@@ -21,4 +21,9 @@ class VirtualRouteController
     {
         return (new DashboardController($request))->handle();
     }
+
+    public static function liveEdit(Request $request): Response
+    {
+        return (new LiveEditController($request))->handle();
+    }
 }

--- a/packages/realtime-compiler/src/Http/VirtualRouteController.php
+++ b/packages/realtime-compiler/src/Http/VirtualRouteController.php
@@ -4,7 +4,14 @@ declare(strict_types=1);
 
 namespace Hyde\RealtimeCompiler\Http;
 
+use Desilva\Microserve\JsonResponse;
+
 class VirtualRouteController
 {
-    //
+    public static function ping(): JsonResponse
+    {
+        return new JsonResponse(200, 'OK', [
+            'server' => 'Hyde/RealtimeCompiler',
+        ]);
+    }
 }

--- a/packages/realtime-compiler/src/Http/VirtualRouteController.php
+++ b/packages/realtime-compiler/src/Http/VirtualRouteController.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Hyde\RealtimeCompiler\Http;
+
+class VirtualRouteController
+{
+    //
+}

--- a/packages/realtime-compiler/src/Http/VirtualRouteController.php
+++ b/packages/realtime-compiler/src/Http/VirtualRouteController.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Hyde\RealtimeCompiler\Http;
 
+use Desilva\Microserve\Request;
+use Desilva\Microserve\Response;
 use Desilva\Microserve\JsonResponse;
 
 class VirtualRouteController
@@ -13,5 +15,10 @@ class VirtualRouteController
         return new JsonResponse(200, 'OK', [
             'server' => 'Hyde/RealtimeCompiler',
         ]);
+    }
+
+    public static function dashboard(Request $request): Response
+    {
+        return (new DashboardController($request))->handle();
     }
 }

--- a/packages/realtime-compiler/src/RealtimeCompiler.php
+++ b/packages/realtime-compiler/src/RealtimeCompiler.php
@@ -8,16 +8,16 @@ use Desilva\Microserve\Response;
 
 class RealtimeCompiler
 {
-    /** @var array<string, callable(): Response> */
+    /** @var array<string, callable(\Desilva\Microserve\Request): Response> */
     protected array $virtualRoutes = [];
 
-    /** @param callable(): Response $route */
+    /** @param callable(\Desilva\Microserve\Request): Response $route */
     public function registerVirtualRoute(string $uri, callable $route): void
     {
         $this->virtualRoutes[$uri] = $route;
     }
 
-    /** @return array<string, callable(): Response> */
+    /** @return array<string, callable(\Desilva\Microserve\Request): Response> */
     public function getVirtualRoutes(): array
     {
         return $this->virtualRoutes;

--- a/packages/realtime-compiler/src/RealtimeCompiler.php
+++ b/packages/realtime-compiler/src/RealtimeCompiler.php
@@ -8,9 +8,7 @@ use Hyde\Support\Models\Route;
 
 class RealtimeCompiler
 {
-    /**
-     * @var array<string, Route>
-     */
+    /** @var array<string, Route> */
     private array $virtualRoutes = [];
 
     public function registerVirtualRoute(string $uri, Route $route): void
@@ -18,9 +16,7 @@ class RealtimeCompiler
         $this->virtualRoutes[$uri] = $route;
     }
 
-    /**
-     * @return array<string, Route>
-     */
+    /** @return array<string, Route> */
     public function getVirtualRoutes(): array
     {
         return $this->virtualRoutes;

--- a/packages/realtime-compiler/src/RealtimeCompiler.php
+++ b/packages/realtime-compiler/src/RealtimeCompiler.php
@@ -4,19 +4,19 @@ declare(strict_types=1);
 
 namespace Hyde\RealtimeCompiler;
 
-use Hyde\Support\Models\Route;
+use Desilva\Microserve\Response;
 
 class RealtimeCompiler
 {
-    /** @var array<string, Route> */
+    /** @var array<string, Response> */
     private array $virtualRoutes = [];
 
-    public function registerVirtualRoute(string $uri, Route $route): void
+    public function registerVirtualRoute(string $uri, Response $route): void
     {
         $this->virtualRoutes[$uri] = $route;
     }
 
-    /** @return array<string, Route> */
+    /** @return array<string, Response> */
     public function getVirtualRoutes(): array
     {
         return $this->virtualRoutes;

--- a/packages/realtime-compiler/src/RealtimeCompiler.php
+++ b/packages/realtime-compiler/src/RealtimeCompiler.php
@@ -8,13 +8,29 @@ use Hyde\Support\Models\Route;
 
 class RealtimeCompiler
 {
+    /**
+     * @var array<string, Route>
+     */
+    private array $virtualRoutes = [];
+
+    /**
+     * Register a virtual route.
+     *
+     * @param  string  $uri  The URI of the virtual route
+     * @param  Route  $route  The Route object
+     */
     public function registerVirtualRoute(string $uri, Route $route): void
     {
-        //
+        $this->virtualRoutes[$uri] = $route;
     }
 
+    /**
+     * Get all registered virtual routes.
+     *
+     * @return array<string, Route>
+     */
     public function getVirtualRoutes(): array
     {
-        return [];
+        return $this->virtualRoutes;
     }
 }

--- a/packages/realtime-compiler/src/RealtimeCompiler.php
+++ b/packages/realtime-compiler/src/RealtimeCompiler.php
@@ -12,4 +12,9 @@ class RealtimeCompiler
     {
         //
     }
+
+    public function getVirtualRoutes(): array
+    {
+        return [];
+    }
 }

--- a/packages/realtime-compiler/src/RealtimeCompiler.php
+++ b/packages/realtime-compiler/src/RealtimeCompiler.php
@@ -9,7 +9,7 @@ use Desilva\Microserve\Response;
 class RealtimeCompiler
 {
     /** @var array<string, Response> */
-    private array $virtualRoutes = [];
+    protected array $virtualRoutes = [];
 
     public function registerVirtualRoute(string $uri, Response $route): void
     {

--- a/packages/realtime-compiler/src/RealtimeCompiler.php
+++ b/packages/realtime-compiler/src/RealtimeCompiler.php
@@ -6,6 +6,9 @@ namespace Hyde\RealtimeCompiler;
 
 use Desilva\Microserve\Response;
 
+/**
+ * @public This class is part of the public API and is covered by the backward compatibility promise.
+ */
 class RealtimeCompiler
 {
     /** @var array<string, callable(\Desilva\Microserve\Request): Response> */

--- a/packages/realtime-compiler/src/RealtimeCompiler.php
+++ b/packages/realtime-compiler/src/RealtimeCompiler.php
@@ -4,7 +4,12 @@ declare(strict_types=1);
 
 namespace Hyde\RealtimeCompiler;
 
+use Hyde\Support\Models\Route;
+
 class RealtimeCompiler
 {
-    //
+    public function registerVirtualRoute(string $uri, Route $route): void
+    {
+        //
+    }
 }

--- a/packages/realtime-compiler/src/RealtimeCompiler.php
+++ b/packages/realtime-compiler/src/RealtimeCompiler.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Hyde\RealtimeCompiler;
+
+class RealtimeCompiler
+{
+    //
+}

--- a/packages/realtime-compiler/src/RealtimeCompiler.php
+++ b/packages/realtime-compiler/src/RealtimeCompiler.php
@@ -8,15 +8,16 @@ use Desilva\Microserve\Response;
 
 class RealtimeCompiler
 {
-    /** @var array<string, Response> */
+    /** @var array<string, callable(): Response> */
     protected array $virtualRoutes = [];
 
-    public function registerVirtualRoute(string $uri, Response $route): void
+    /** @param callable(): Response $route */
+    public function registerVirtualRoute(string $uri, callable $route): void
     {
         $this->virtualRoutes[$uri] = $route;
     }
 
-    /** @return array<string, Response> */
+    /** @return array<string, callable(): Response> */
     public function getVirtualRoutes(): array
     {
         return $this->virtualRoutes;

--- a/packages/realtime-compiler/src/RealtimeCompiler.php
+++ b/packages/realtime-compiler/src/RealtimeCompiler.php
@@ -13,20 +13,12 @@ class RealtimeCompiler
      */
     private array $virtualRoutes = [];
 
-    /**
-     * Register a virtual route.
-     *
-     * @param  string  $uri  The URI of the virtual route
-     * @param  Route  $route  The Route object
-     */
     public function registerVirtualRoute(string $uri, Route $route): void
     {
         $this->virtualRoutes[$uri] = $route;
     }
 
     /**
-     * Get all registered virtual routes.
-     *
      * @return array<string, Route>
      */
     public function getVirtualRoutes(): array

--- a/packages/realtime-compiler/src/RealtimeCompilerServiceProvider.php
+++ b/packages/realtime-compiler/src/RealtimeCompilerServiceProvider.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Hyde\RealtimeCompiler;
 
 use Illuminate\Support\ServiceProvider;
+use Hyde\RealtimeCompiler\Http\LiveEditController;
 use Hyde\RealtimeCompiler\Http\DashboardController;
 use Hyde\RealtimeCompiler\Http\VirtualRouteController;
 
@@ -23,6 +24,10 @@ class RealtimeCompilerServiceProvider extends ServiceProvider
 
         if (DashboardController::enabled()) {
             $router->registerVirtualRoute('/dashboard', [VirtualRouteController::class, 'dashboard']);
+        }
+
+        if (LiveEditController::enabled()) {
+            $router->registerVirtualRoute('/_hyde/live-edit', [VirtualRouteController::class, 'liveEdit']);
         }
     }
 }

--- a/packages/realtime-compiler/src/RealtimeCompilerServiceProvider.php
+++ b/packages/realtime-compiler/src/RealtimeCompilerServiceProvider.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Hyde\RealtimeCompiler;
 
+use Desilva\Microserve\JsonResponse;
 use Illuminate\Support\ServiceProvider;
 
 class RealtimeCompilerServiceProvider extends ServiceProvider
@@ -17,6 +18,8 @@ class RealtimeCompilerServiceProvider extends ServiceProvider
 
     public function boot(): void
     {
-        //
+        $this->app->make(RealtimeCompiler::class)->registerVirtualRoute('/ping', new JsonResponse(200, 'OK', [
+            'server' => 'Hyde/RealtimeCompiler',
+        ]));
     }
 }

--- a/packages/realtime-compiler/src/RealtimeCompilerServiceProvider.php
+++ b/packages/realtime-compiler/src/RealtimeCompilerServiceProvider.php
@@ -14,4 +14,9 @@ class RealtimeCompilerServiceProvider extends ServiceProvider
             return new RealtimeCompiler();
         });
     }
+
+    public function boot(): void
+    {
+        //
+    }
 }

--- a/packages/realtime-compiler/src/RealtimeCompilerServiceProvider.php
+++ b/packages/realtime-compiler/src/RealtimeCompilerServiceProvider.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Hyde\RealtimeCompiler;
+
+use Illuminate\Support\ServiceProvider;
+
+class RealtimeCompilerServiceProvider extends ServiceProvider
+{
+    //
+}

--- a/packages/realtime-compiler/src/RealtimeCompilerServiceProvider.php
+++ b/packages/realtime-compiler/src/RealtimeCompilerServiceProvider.php
@@ -8,5 +8,10 @@ use Illuminate\Support\ServiceProvider;
 
 class RealtimeCompilerServiceProvider extends ServiceProvider
 {
-    //
+    public function register(): void
+    {
+        $this->app->singleton(RealtimeCompiler::class, function () {
+            return new RealtimeCompiler();
+        });
+    }
 }

--- a/packages/realtime-compiler/src/RealtimeCompilerServiceProvider.php
+++ b/packages/realtime-compiler/src/RealtimeCompilerServiceProvider.php
@@ -4,8 +4,8 @@ declare(strict_types=1);
 
 namespace Hyde\RealtimeCompiler;
 
-use Desilva\Microserve\JsonResponse;
 use Illuminate\Support\ServiceProvider;
+use Hyde\RealtimeCompiler\Http\VirtualRouteController;
 
 class RealtimeCompilerServiceProvider extends ServiceProvider
 {
@@ -18,10 +18,6 @@ class RealtimeCompilerServiceProvider extends ServiceProvider
 
     public function boot(): void
     {
-        $this->app->make(RealtimeCompiler::class)->registerVirtualRoute('/ping', function (): JsonResponse {
-            return new JsonResponse(200, 'OK', [
-                'server' => 'Hyde/RealtimeCompiler',
-            ]);
-        });
+        $this->app->make(RealtimeCompiler::class)->registerVirtualRoute('/ping', [VirtualRouteController::class, 'ping']);
     }
 }

--- a/packages/realtime-compiler/src/RealtimeCompilerServiceProvider.php
+++ b/packages/realtime-compiler/src/RealtimeCompilerServiceProvider.php
@@ -16,6 +16,8 @@ class RealtimeCompilerServiceProvider extends ServiceProvider
 
     public function boot(): void
     {
-        $this->app->make(RealtimeCompiler::class)->registerVirtualRoute('/ping', [VirtualRouteController::class, 'ping']);
+        $router = $this->app->make(RealtimeCompiler::class);
+
+        $router->registerVirtualRoute('/ping', [VirtualRouteController::class, 'ping']);
     }
 }

--- a/packages/realtime-compiler/src/RealtimeCompilerServiceProvider.php
+++ b/packages/realtime-compiler/src/RealtimeCompilerServiceProvider.php
@@ -18,8 +18,10 @@ class RealtimeCompilerServiceProvider extends ServiceProvider
 
     public function boot(): void
     {
-        $this->app->make(RealtimeCompiler::class)->registerVirtualRoute('/ping', new JsonResponse(200, 'OK', [
-            'server' => 'Hyde/RealtimeCompiler',
-        ]));
+        $this->app->make(RealtimeCompiler::class)->registerVirtualRoute('/ping', function (): JsonResponse {
+            return new JsonResponse(200, 'OK', [
+                'server' => 'Hyde/RealtimeCompiler',
+            ]);
+        });
     }
 }

--- a/packages/realtime-compiler/src/RealtimeCompilerServiceProvider.php
+++ b/packages/realtime-compiler/src/RealtimeCompilerServiceProvider.php
@@ -11,9 +11,7 @@ class RealtimeCompilerServiceProvider extends ServiceProvider
 {
     public function register(): void
     {
-        $this->app->singleton(RealtimeCompiler::class, function () {
-            return new RealtimeCompiler();
-        });
+        $this->app->singleton(RealtimeCompiler::class);
     }
 
     public function boot(): void

--- a/packages/realtime-compiler/src/RealtimeCompilerServiceProvider.php
+++ b/packages/realtime-compiler/src/RealtimeCompilerServiceProvider.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Hyde\RealtimeCompiler;
 
 use Illuminate\Support\ServiceProvider;
+use Hyde\RealtimeCompiler\Http\DashboardController;
 use Hyde\RealtimeCompiler\Http\VirtualRouteController;
 
 class RealtimeCompilerServiceProvider extends ServiceProvider
@@ -19,5 +20,9 @@ class RealtimeCompilerServiceProvider extends ServiceProvider
         $router = $this->app->make(RealtimeCompiler::class);
 
         $router->registerVirtualRoute('/ping', [VirtualRouteController::class, 'ping']);
+
+        if (DashboardController::enabled()) {
+            $router->registerVirtualRoute('/dashboard', [VirtualRouteController::class, 'dashboard']);
+        }
     }
 }

--- a/packages/realtime-compiler/src/RealtimeCompilerServiceProvider.php
+++ b/packages/realtime-compiler/src/RealtimeCompilerServiceProvider.php
@@ -9,9 +9,6 @@ use Hyde\RealtimeCompiler\Http\LiveEditController;
 use Hyde\RealtimeCompiler\Http\DashboardController;
 use Hyde\RealtimeCompiler\Http\VirtualRouteController;
 
-/**
- * @public This class is part of the public API and is covered by the backward compatibility promise.
- */
 class RealtimeCompilerServiceProvider extends ServiceProvider
 {
     public function register(): void

--- a/packages/realtime-compiler/src/RealtimeCompilerServiceProvider.php
+++ b/packages/realtime-compiler/src/RealtimeCompilerServiceProvider.php
@@ -9,6 +9,9 @@ use Hyde\RealtimeCompiler\Http\LiveEditController;
 use Hyde\RealtimeCompiler\Http\DashboardController;
 use Hyde\RealtimeCompiler\Http\VirtualRouteController;
 
+/**
+ * @public This class is part of the public API and is covered by the backward compatibility promise.
+ */
 class RealtimeCompilerServiceProvider extends ServiceProvider
 {
     public function register(): void

--- a/packages/realtime-compiler/src/Routing/PageRouter.php
+++ b/packages/realtime-compiler/src/Routing/PageRouter.php
@@ -34,10 +34,6 @@ class PageRouter
 
     protected function handlePageRequest(): Response
     {
-        if ($this->request->path === '/dashboard' && DashboardController::enabled()) {
-            return (new DashboardController($this->request))->handle();
-        }
-
         if ($this->request->path === '/_hyde/live-edit' && LiveEditController::enabled()) {
             return (new LiveEditController($this->request))->handle();
         }

--- a/packages/realtime-compiler/src/Routing/PageRouter.php
+++ b/packages/realtime-compiler/src/Routing/PageRouter.php
@@ -13,7 +13,6 @@ use Hyde\RealtimeCompiler\Http\LiveEditController;
 use Hyde\Framework\Exceptions\RouteNotFoundException;
 use Hyde\Framework\Features\Documentation\DocumentationSearchPage;
 use Hyde\Pages\Concerns\HydePage;
-use Hyde\RealtimeCompiler\Concerns\InteractsWithLaravel;
 use Hyde\RealtimeCompiler\Concerns\SendsErrorResponses;
 use Hyde\RealtimeCompiler\Http\DashboardController;
 use Desilva\Microserve\HtmlResponse;
@@ -25,14 +24,12 @@ use Hyde\Hyde;
 class PageRouter
 {
     use SendsErrorResponses;
-    use InteractsWithLaravel;
 
     protected Request $request;
 
     public function __construct(Request $request)
     {
         $this->request = $request;
-        $this->bootApplication();
     }
 
     protected function handlePageRequest(): Response

--- a/packages/realtime-compiler/src/Routing/PageRouter.php
+++ b/packages/realtime-compiler/src/Routing/PageRouter.php
@@ -34,10 +34,6 @@ class PageRouter
 
     protected function handlePageRequest(): Response
     {
-        if ($this->request->path === '/_hyde/live-edit' && LiveEditController::enabled()) {
-            return (new LiveEditController($this->request))->handle();
-        }
-
         return new HtmlResponse(200, 'OK', [
             'body' => $this->getHtml($this->getPageFromRoute()),
         ]);

--- a/packages/realtime-compiler/src/Routing/Router.php
+++ b/packages/realtime-compiler/src/Routing/Router.php
@@ -4,9 +4,9 @@ declare(strict_types=1);
 
 namespace Hyde\RealtimeCompiler\Routing;
 
-use Desilva\Microserve\JsonResponse;
 use Desilva\Microserve\Request;
 use Desilva\Microserve\Response;
+use Hyde\RealtimeCompiler\RealtimeCompiler;
 use Hyde\RealtimeCompiler\Actions\AssetFileLocator;
 use Hyde\RealtimeCompiler\Concerns\SendsErrorResponses;
 use Hyde\RealtimeCompiler\Models\FileObject;
@@ -19,13 +19,6 @@ class Router
     use InteractsWithLaravel;
 
     protected Request $request;
-
-    /**
-     * @deprecated This should be moved to the container.
-     */
-    protected array $virtualRoutes = [
-        '/ping',
-    ];
 
     public function __construct(Request $request)
     {
@@ -40,12 +33,10 @@ class Router
 
         $this->bootApplication();
 
-        if (in_array($this->request->path, $this->virtualRoutes)) {
-            if ($this->request->path === '/ping') {
-                return new JsonResponse(200, 'OK', [
-                    'server' => 'Hyde/RealtimeCompiler',
-                ]);
-            }
+        $virtualRoutes = app(RealtimeCompiler::class)->getVirtualRoutes();
+
+        if (isset($virtualRoutes[$this->request->path])) {
+            return $virtualRoutes[$this->request->path];
         }
 
         return PageRouter::handle($this->request);

--- a/packages/realtime-compiler/src/Routing/Router.php
+++ b/packages/realtime-compiler/src/Routing/Router.php
@@ -20,6 +20,9 @@ class Router
 
     protected Request $request;
 
+    /**
+     * @deprecated This should be moved to the container.
+     */
     protected array $virtualRoutes = [
         '/ping',
     ];

--- a/packages/realtime-compiler/src/Routing/Router.php
+++ b/packages/realtime-compiler/src/Routing/Router.php
@@ -38,7 +38,7 @@ class Router
             return $this->proxyStatic();
         }
 
-        // Todo: Boot app here so we can read virtual routes from container
+        $this->bootApplication();
 
         if (in_array($this->request->path, $this->virtualRoutes)) {
             if ($this->request->path === '/ping') {

--- a/packages/realtime-compiler/src/Routing/Router.php
+++ b/packages/realtime-compiler/src/Routing/Router.php
@@ -38,7 +38,7 @@ class Router
         if (isset($virtualRoutes[$this->request->path])) {
             // Todo: Also check that there is no file based page with the same path since that should take precedence
 
-            return $virtualRoutes[$this->request->path];
+            return $virtualRoutes[$this->request->path]();
         }
 
         return PageRouter::handle($this->request);

--- a/packages/realtime-compiler/src/Routing/Router.php
+++ b/packages/realtime-compiler/src/Routing/Router.php
@@ -36,6 +36,8 @@ class Router
         $virtualRoutes = app(RealtimeCompiler::class)->getVirtualRoutes();
 
         if (isset($virtualRoutes[$this->request->path])) {
+            // Todo: Also check that there is no file based page with the same path since that should take precedence
+
             return $virtualRoutes[$this->request->path];
         }
 

--- a/packages/realtime-compiler/src/Routing/Router.php
+++ b/packages/realtime-compiler/src/Routing/Router.php
@@ -35,6 +35,8 @@ class Router
             return $this->proxyStatic();
         }
 
+        // Todo: Boot app here so we can read virtual routes from container
+
         if (in_array($this->request->path, $this->virtualRoutes)) {
             if ($this->request->path === '/ping') {
                 return new JsonResponse(200, 'OK', [

--- a/packages/realtime-compiler/src/Routing/Router.php
+++ b/packages/realtime-compiler/src/Routing/Router.php
@@ -38,7 +38,7 @@ class Router
         if (isset($virtualRoutes[$this->request->path])) {
             // Todo: Also check that there is no file based page with the same path since that should take precedence
 
-            return $virtualRoutes[$this->request->path]();
+            return $virtualRoutes[$this->request->path]($this->request);
         }
 
         return PageRouter::handle($this->request);

--- a/packages/realtime-compiler/src/Routing/Router.php
+++ b/packages/realtime-compiler/src/Routing/Router.php
@@ -36,8 +36,6 @@ class Router
         $virtualRoutes = app(RealtimeCompiler::class)->getVirtualRoutes();
 
         if (isset($virtualRoutes[$this->request->path])) {
-            // Todo: Also check that there is no file based page with the same path since that should take precedence
-
             return $virtualRoutes[$this->request->path]($this->request);
         }
 


### PR DESCRIPTION
Creates a new system to instead of hardcoding virtual routes, we store them in the service container (which is loaded when the router boots)

This means it's also possible for package developers to add realtime compiler routes:

```php
<?php

namespace App\Providers;

use Illuminate\Support\ServiceProvider;
use Hyde\RealtimeCompiler\RealtimeCompiler;

class AppServiceProvider extends ServiceProvider
{
    /**
     * Bootstrap any application services.
     */
    public function boot(): void
    {
        $router = $this->app->make(RealtimeCompiler::class);

        $router->registerVirtualRoute('/foo', callable(\Desilva\Microserve\Request): \Desilva\Microserve\Response);
    }
}

```