### PR TITLE
Refactor the serve command and add more unit tests for it

### DIFF
--- a/packages/framework/src/Console/Commands/ServeCommand.php
+++ b/packages/framework/src/Console/Commands/ServeCommand.php
@@ -146,12 +146,7 @@ class ServeCommand extends Command
 
     protected function openInBrowser(string $path = '/'): void
     {
-        $binary = match (PHP_OS_FAMILY) {
-            'Windows' => 'start',
-            'Darwin' => 'open',
-            'Linux' => 'xdg-open',
-            default => null
-        };
+        $binary = $this->getOpenCommand();
 
         $command = sprintf('%s http://%s:%d', $binary, $this->getHostSelection(), $this->getPortSelection());
         $command = rtrim("$command/$path", '/');
@@ -163,5 +158,15 @@ class ServeCommand extends Command
             $this->line(sprintf('  %s', str_replace("\n", "\n  ", $process ? $process->errorOutput() : "Missing suitable 'open' binary.")));
             $this->newLine();
         }
+    }
+
+    protected function getOpenCommand(): ?string
+    {
+        return match (PHP_OS_FAMILY) {
+            'Windows' => 'start',
+            'Darwin' => 'open',
+            'Linux' => 'xdg-open',
+            default => null
+        };
     }
 }

--- a/packages/framework/src/Console/Commands/ServeCommand.php
+++ b/packages/framework/src/Console/Commands/ServeCommand.php
@@ -146,7 +146,7 @@ class ServeCommand extends Command
 
     protected function openInBrowser(string $path = '/'): void
     {
-        $binary = $this->getOpenCommand();
+        $binary = $this->getOpenCommand(PHP_OS_FAMILY);
 
         $command = sprintf('%s http://%s:%d', $binary, $this->getHostSelection(), $this->getPortSelection());
         $command = rtrim("$command/$path", '/');
@@ -160,9 +160,9 @@ class ServeCommand extends Command
         }
     }
 
-    protected function getOpenCommand(): ?string
+    protected function getOpenCommand(string $osFamily): ?string
     {
-        return match (PHP_OS_FAMILY) {
+        return match ($osFamily) {
             'Windows' => 'start',
             'Darwin' => 'open',
             'Linux' => 'xdg-open',

--- a/packages/framework/tests/Unit/ServeCommandOptionsUnitTest.php
+++ b/packages/framework/tests/Unit/ServeCommandOptionsUnitTest.php
@@ -321,26 +321,22 @@ class ServeCommandOptionsUnitTest extends UnitTestCase
 
     public function testGetOpenCommandForWindows()
     {
-        $command = $this->getMockWithCustomOS('Windows');
-        $this->assertSame('start', $command->getOpenCommand());
+        $this->assertSame('start', $this->getMock()->getOpenCommand('Windows'));
     }
 
     public function testGetOpenCommandForDarwin()
     {
-        $command = $this->getMockWithCustomOS('Darwin');
-        $this->assertSame('open', $command->getOpenCommand());
+        $this->assertSame('open', $this->getMock()->getOpenCommand('Darwin'));
     }
 
     public function testGetOpenCommandForLinux()
     {
-        $command = $this->getMockWithCustomOS('Linux');
-        $this->assertSame('xdg-open', $command->getOpenCommand());
+        $this->assertSame('xdg-open', $this->getMock()->getOpenCommand('Linux'));
     }
 
     public function testGetOpenCommandForUnknownOS()
     {
-        $command = $this->getMockWithCustomOS('UnknownOS');
-        $this->assertNull($command->getOpenCommand());
+        $this->assertNull($this->getMock()->getOpenCommand('UnknownOS'));
     }
 
     protected function getTestRunnerBinary(): string
@@ -411,6 +407,11 @@ class ServeCommandMock extends ServeCommand
     public function option($key = null)
     {
         return $this->input->getOption($key);
+    }
+
+    public function getOpenCommand(string $osFamily): ?string
+    {
+        return parent::getOpenCommand($osFamily);
     }
 }
 

--- a/packages/framework/tests/Unit/ServeCommandOptionsUnitTest.php
+++ b/packages/framework/tests/Unit/ServeCommandOptionsUnitTest.php
@@ -360,6 +360,29 @@ class ServeCommandOptionsUnitTest extends UnitTestCase
             }
         };
     }
+
+    protected function getMockWithCustomOS(string $osFamily): ServeCommandMock
+    {
+        return new class($osFamily) extends ServeCommandMock {
+            private string $osFamily;
+
+            public function __construct(string $osFamily)
+            {
+                parent::__construct();
+                $this->osFamily = $osFamily;
+            }
+
+            protected function getOpenCommand(): ?string
+            {
+                return match ($this->osFamily) {
+                    'Windows' => 'start',
+                    'Darwin' => 'open',
+                    'Linux' => 'xdg-open',
+                    default => null
+                };
+            }
+        };
+    }
 }
 
 /**

--- a/packages/framework/tests/Unit/ServeCommandOptionsUnitTest.php
+++ b/packages/framework/tests/Unit/ServeCommandOptionsUnitTest.php
@@ -384,29 +384,6 @@ class ServeCommandOptionsUnitTest extends UnitTestCase
             }
         };
     }
-
-    protected function getMockWithCustomOS(string $osFamily): ServeCommandMock
-    {
-        return new class($osFamily) extends ServeCommandMock {
-            private string $osFamily;
-
-            public function __construct(string $osFamily)
-            {
-                parent::__construct();
-                $this->osFamily = $osFamily;
-            }
-
-            protected function getOpenCommand(): ?string
-            {
-                return match ($this->osFamily) {
-                    'Windows' => 'start',
-                    'Darwin' => 'open',
-                    'Linux' => 'xdg-open',
-                    default => null
-                };
-            }
-        };
-    }
 }
 
 /**

--- a/packages/framework/tests/Unit/ServeCommandOptionsUnitTest.php
+++ b/packages/framework/tests/Unit/ServeCommandOptionsUnitTest.php
@@ -319,6 +319,30 @@ class ServeCommandOptionsUnitTest extends UnitTestCase
         $command->openInBrowser();
     }
 
+    public function testGetOpenCommandForWindows()
+    {
+        $command = $this->getMockWithCustomOS('Windows');
+        $this->assertSame('start', $command->getOpenCommand());
+    }
+
+    public function testGetOpenCommandForDarwin()
+    {
+        $command = $this->getMockWithCustomOS('Darwin');
+        $this->assertSame('open', $command->getOpenCommand());
+    }
+
+    public function testGetOpenCommandForLinux()
+    {
+        $command = $this->getMockWithCustomOS('Linux');
+        $this->assertSame('xdg-open', $command->getOpenCommand());
+    }
+
+    public function testGetOpenCommandForUnknownOS()
+    {
+        $command = $this->getMockWithCustomOS('UnknownOS');
+        $this->assertNull($command->getOpenCommand());
+    }
+
     protected function getTestRunnerBinary(): string
     {
         return match (PHP_OS_FAMILY) {


### PR DESCRIPTION
Improves how we get the "open" command by extracting a helper method that can be unit tested without the OS constant 