### PR TITLE
[2.x] Fix realtime compiler search index serving 

### DIFF
--- a/packages/realtime-compiler/src/Routing/Router.php
+++ b/packages/realtime-compiler/src/Routing/Router.php
@@ -63,6 +63,11 @@ class Router
             return false;
         }
 
+        // Don't proxy the search.json file, as it's generated on the fly.
+        if (str_ends_with($request->path, 'search.json')) {
+            return false;
+        }
+
         // The page is not a web page, so we assume it should be proxied.
         return true;
     }


### PR DESCRIPTION
Fixes https://github.com/hydephp/develop/issues/1802. We could add some code to save to disk if preview saving is enabled, something for later. I considered having this read from the file if it exists, but think that is not intuitive as it then won't change with content changes.