### PR TITLE
Normalize protocol relative URL handling

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -12,6 +12,7 @@ This serves two purposes:
 ### Added
 - Updated the `HydeKernel` array representation to include the Hyde version in https://github.com/hydephp/develop/pull/1786
 - Registered the `cache:clear` command to make it easier to clear the cache in https://github.com/hydephp/develop/pull/1881
+- Added a new `Hyperlinks::isRemote()` helper method to check if a URL is remote in https://github.com/hydephp/develop/pull/1882
 
 ### Changed
 - Updated the `Serializable` trait to provide a default automatic `toArray` method in https://github.com/hydephp/develop/pull/1791

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -27,6 +27,7 @@ This serves two purposes:
 
 ### Deprecated
 - The `PostAuthor::getName()` method is now deprecated and will be removed in v2. (use `$author->name` instead) in https://github.com/hydephp/develop/pull/1794
+- Deprecated the `FeaturedImage::isRemote()` method in favor of the new `Hyperlinks::isRemote()` method in https://github.com/hydephp/develop/pull/1882
 
 ### Removed
 - for now removed features.

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -21,6 +21,7 @@ This serves two purposes:
 - Improved the accessibility of the heading permalinks feature in https://github.com/hydephp/develop/pull/1803
 - The `torchlight:install` command is now hidden from the command list as it's already installed in https://github.com/hydephp/develop/pull/1879
 - Updated the home page fallback link in the 404 template to lead to the site root in https://github.com/hydephp/develop/pull/1880 (fixes https://github.com/hydephp/develop/issues/1781)
+- Normalized remote URL checks so that protocol relative URLs `//` are consistently considered to be remote in all places in https://github.com/hydephp/develop/pull/1882 (fixes https://github.com/hydephp/develop/issues/1788)
 - Updated to HydeFront v3.4 in https://github.com/hydephp/develop/pull/1803
 - Realtime Compiler: Virtual routes are now managed through the service container in https://github.com/hydephp/develop/pull/1858
 - Realtime Compiler: Improved the dashboard layout in https://github.com/hydephp/develop/pull/1866

--- a/packages/framework/src/Foundation/Kernel/Hyperlinks.php
+++ b/packages/framework/src/Foundation/Kernel/Hyperlinks.php
@@ -111,7 +111,7 @@ class Hyperlinks
      */
     public function asset(string $name, bool $preferQualifiedUrl = false): string
     {
-        if (str_starts_with($name, 'http')) {
+        if (static::isRemote($name)) {
             return $name;
         }
 
@@ -147,7 +147,7 @@ class Hyperlinks
     {
         $path = $this->formatLink(trim($path, '/'));
 
-        if (str_starts_with($path, 'http')) {
+        if (static::isRemote($path)) {
             return $path;
         }
 

--- a/packages/framework/src/Foundation/Kernel/Hyperlinks.php
+++ b/packages/framework/src/Foundation/Kernel/Hyperlinks.php
@@ -173,4 +173,12 @@ class Hyperlinks
     {
         return $this->kernel->routes()->get($key);
     }
+
+    /**
+     * Determine if the given URL is a remote link.
+     */
+    public static function isRemote(string $url): bool
+    {
+        return str_starts_with($url, 'http') || str_starts_with($url, '//');
+    }
 }

--- a/packages/framework/src/Framework/Factories/FeaturedImageFactory.php
+++ b/packages/framework/src/Framework/Factories/FeaturedImageFactory.php
@@ -8,6 +8,7 @@ use Hyde\Hyde;
 use RuntimeException;
 use Illuminate\Support\Str;
 use Hyde\Markdown\Models\FrontMatter;
+use Hyde\Foundation\Kernel\Hyperlinks;
 use Hyde\Framework\Features\Blogging\Models\FeaturedImage;
 use Hyde\Markdown\Contracts\FrontMatter\SubSchemas\FeaturedImageSchema;
 
@@ -72,7 +73,7 @@ class FeaturedImageFactory extends Concerns\PageDataFactory implements FeaturedI
             throw new RuntimeException(sprintf('No featured image source was found in "%s"', $this->filePath ?? 'unknown file'));
         }
 
-        if (FeaturedImage::isRemote($value)) {
+        if (Hyperlinks::isRemote($value)) {
             return $value;
         }
 

--- a/packages/framework/src/Framework/Features/Blogging/Models/FeaturedImage.php
+++ b/packages/framework/src/Framework/Features/Blogging/Models/FeaturedImage.php
@@ -63,7 +63,7 @@ class FeaturedImage implements Stringable, FeaturedImageSchema
         protected readonly ?string $licenseUrl = null,
         protected readonly ?string $copyrightText = null
     ) {
-        $this->type = self::isRemote($source) ? self::TYPE_REMOTE : self::TYPE_LOCAL;
+        $this->type = Hyperlinks::isRemote($source) ? self::TYPE_REMOTE : self::TYPE_LOCAL;
         $this->source = $this->setSource($source);
     }
 

--- a/packages/framework/src/Framework/Features/Blogging/Models/FeaturedImage.php
+++ b/packages/framework/src/Framework/Features/Blogging/Models/FeaturedImage.php
@@ -9,6 +9,7 @@ use Stringable;
 use Hyde\Facades\Config;
 use Illuminate\Support\Str;
 use Hyde\Support\BuildWarnings;
+use JetBrains\PhpStorm\Deprecated;
 use Illuminate\Support\Facades\Http;
 use Hyde\Foundation\Kernel\Hyperlinks;
 use Hyde\Framework\Exceptions\FileNotFoundException;
@@ -241,6 +242,12 @@ class FeaturedImage implements Stringable, FeaturedImageSchema
         return 0;
     }
 
+    /**
+     * @codeCoverageIgnore Deprecated method.
+     *
+     * @deprecated This method will be removed in v2.0. Please use `Hyperlinks::isRemote` instead.
+     */
+    #[Deprecated(reason: 'Replaced by the \Hyde\Foundation\Kernel\Hyperlinks::isRemote method', replacement: '\Hyde\Foundation\Kernel\Hyperlinks::isRemote(%parametersList%)', since: '1.8.0')]
     public static function isRemote(string $source): bool
     {
         return Hyperlinks::isRemote($source);

--- a/packages/framework/src/Framework/Features/Blogging/Models/FeaturedImage.php
+++ b/packages/framework/src/Framework/Features/Blogging/Models/FeaturedImage.php
@@ -10,6 +10,7 @@ use Hyde\Facades\Config;
 use Illuminate\Support\Str;
 use Hyde\Support\BuildWarnings;
 use Illuminate\Support\Facades\Http;
+use Hyde\Foundation\Kernel\Hyperlinks;
 use Hyde\Framework\Exceptions\FileNotFoundException;
 use Hyde\Markdown\Contracts\FrontMatter\SubSchemas\FeaturedImageSchema;
 
@@ -19,7 +20,6 @@ use function file_exists;
 use function filesize;
 use function sprintf;
 use function key;
-use function str_starts_with;
 
 /**
  * Object representation of a blog post's featured image.
@@ -243,6 +243,6 @@ class FeaturedImage implements Stringable, FeaturedImageSchema
 
     public static function isRemote(string $source): bool
     {
-        return str_starts_with($source, 'http') || str_starts_with($source, '//');
+        return Hyperlinks::isRemote($source);
     }
 }

--- a/packages/framework/src/Framework/Features/Metadata/PageMetadataBag.php
+++ b/packages/framework/src/Framework/Features/Metadata/PageMetadataBag.php
@@ -7,8 +7,8 @@ namespace Hyde\Framework\Features\Metadata;
 use Hyde\Facades\Meta;
 use Hyde\Pages\Concerns\HydePage;
 use Hyde\Pages\MarkdownPost;
+use Hyde\Foundation\Kernel\Hyperlinks;
 
-use function str_starts_with;
 use function substr_count;
 use function str_repeat;
 
@@ -77,7 +77,7 @@ class PageMetadataBag extends MetadataBag
     {
         // Since this is run before the page is rendered, we don't have the currentPage property.
         // So we need to run some of the same calculations here to resolve the image path link.
-        return str_starts_with($image, 'http') ? $image
+        return Hyperlinks::isRemote($image) ? $image
             : str_repeat('../', substr_count(MarkdownPost::outputDirectory().'/'.$this->page->identifier, '/')).$image;
     }
 }

--- a/packages/framework/tests/Feature/Foundation/HyperlinksTest.php
+++ b/packages/framework/tests/Feature/Foundation/HyperlinksTest.php
@@ -127,4 +127,34 @@ class HyperlinksTest extends TestCase
     {
         $this->assertNull($this->class->route('foo'));
     }
+
+    public function testIsRemoteWithHttpUrl()
+    {
+        $this->assertTrue(Hyperlinks::isRemote('http://example.com'));
+    }
+
+    public function testIsRemoteWithHttpsUrl()
+    {
+        $this->assertTrue(Hyperlinks::isRemote('https://example.com'));
+    }
+
+    public function testIsRemoteWithProtocolRelativeUrl()
+    {
+        $this->assertTrue(Hyperlinks::isRemote('//example.com'));
+    }
+
+    public function testIsRemoteWithRelativeUrl()
+    {
+        $this->assertFalse(Hyperlinks::isRemote('/path/to/resource'));
+    }
+
+    public function testIsRemoteWithAbsoluteLocalPath()
+    {
+        $this->assertFalse(Hyperlinks::isRemote('/var/www/html/index.php'));
+    }
+
+    public function testIsRemoteWithEmptyString()
+    {
+        $this->assertFalse(Hyperlinks::isRemote(''));
+    }
 }


### PR DESCRIPTION
# Pull Request: Improve URL Handling and Featured Image Logic

## Changes

1. New Helper Method
   - Added `Hyperlinks::isRemote()` to improve URL checking

2. Featured Image Updates
   - Updated featured image method to use extracted logic
   - Deprecated `FeaturedImage::isRemote()` method
     - Replaced by `Hyperlinks::isRemote()`

3. URL Handling Improvements
   - Normalized remote URL checking across the codebase
   - Updated `Hyde::asset()` method
     - Now considers protocol-relative URLs (`//`) as remote

## Notes
- These changes aim to standardize and improve URL handling throughout the project.
- The deprecation of `FeaturedImage::isRemote()` may require updates in code using this method.