### PR TITLE
[2.x] Remove deprecated method `FeaturedImage::isRemote()`

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -62,6 +62,7 @@ This serves two purposes:
 - Removed the deprecated `BaseUrlNotSetException` class, with the `Hyde::url()` helper now returning `null` if no base URL is set in https://github.com/hydephp/develop/pull/1760
 - Removed: The deprecated `PostAuthor::getName()` method is now removed (use `$author->name`) in https://github.com/hydephp/develop/pull/1782
 - Internal: Removed the internal `DocumentationSearchPage::generate()` method as it was unused in https://github.com/hydephp/develop/pull/1569
+- Removed the deprecated `FeaturedImage::isRemote()` method in https://github.com/hydephp/develop/pull/1883. Use `Hyperlinks::isRemote()` instead.
 
 ### Fixed
 - Added missing collection key types in Hyde facade method annotations in https://github.com/hydephp/develop/pull/1784

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -343,6 +343,26 @@ For example, an empty or malformed JSON file will now throw an exception like th
 In order to normalize the thrown exceptions, we now rethrow the `ParseException` from `Symfony/Yaml` as our custom `ParseException` to match the JSON and Markdown validation.
 Additionally, an exception will be thrown if a data file is empty, as this is unlikely to be intentional. Markdown files can have an empty body if front matter is present.
 
+### Removal of `FeaturedImage::isRemote()` method
+
+The `FeaturedImage::isRemote()` method has been removed in v2.0. This method was deprecated in v1.8.0 and has now been completely removed.
+
+#### Upgrade guide
+
+If you were using `FeaturedImage::isRemote()` in your code, you should replace it with `Hyperlinks::isRemote()`. Here's how to update your code:
+
+```php
+// Old code
+FeaturedImage::isRemote($source);
+
+// New code
+use Hyde\Foundation\Kernel\Hyperlinks;
+
+Hyperlinks::isRemote($source);
+```
+
+This change was implemented in https://github.com/hydephp/develop/pull/1883. Make sure to update any instances of `FeaturedImage::isRemote()` in your codebase to ensure compatibility with HydePHP v2.0.
+
 ## New features
 
 <!-- Editors note: Todo: Maybe move to the relevant docs... -->

--- a/packages/framework/src/Framework/Features/Blogging/Models/FeaturedImage.php
+++ b/packages/framework/src/Framework/Features/Blogging/Models/FeaturedImage.php
@@ -9,7 +9,6 @@ use Stringable;
 use Hyde\Facades\Config;
 use Illuminate\Support\Str;
 use Hyde\Support\BuildWarnings;
-use JetBrains\PhpStorm\Deprecated;
 use Illuminate\Support\Facades\Http;
 use Hyde\Foundation\Kernel\Hyperlinks;
 use Hyde\Framework\Exceptions\FileNotFoundException;
@@ -240,16 +239,5 @@ class FeaturedImage implements Stringable, FeaturedImageSchema
         }
 
         return 0;
-    }
-
-    /**
-     * @codeCoverageIgnore Deprecated method.
-     *
-     * @deprecated This method will be removed in v2.0. Please use `Hyperlinks::isRemote` instead.
-     */
-    #[Deprecated(reason: 'Replaced by the \Hyde\Foundation\Kernel\Hyperlinks::isRemote method', replacement: '\Hyde\Foundation\Kernel\Hyperlinks::isRemote(%parametersList%)', since: '1.8.0')]
-    public static function isRemote(string $source): bool
-    {
-        return Hyperlinks::isRemote($source);
     }
 }


### PR DESCRIPTION
Tie in with https://github.com/hydephp/develop/pull/1882