### PR TITLE
[2.x] Revert to throwing an exception when trying to get non-configured base URL

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -38,7 +38,7 @@ This serves two purposes:
 - Minor: Methods in the `Includes` facade now return `HtmlString` objects instead of `string` in https://github.com/hydephp/develop/pull/1738. For more information, see below.
 - Minor: `Includes::path()` and  `Includes::get()` methods now normalizes paths to be basenames to match the behaviour of the other include methods in https://github.com/hydephp/develop/pull/1738. This means that nested directories are no longer supported, as you should use a data collection for that.
 - Minor: The `processing_time_ms` attribute in the `sitemap.xml` file has now been removed in https://github.com/hydephp/develop/pull/1744
-- Minor: Updated the `Hyde::url()` helper to return `null` instead of throwing a `BaseUrlNotSetException` when no site URL is set and no path was provided to the method in https://github.com/hydephp/develop/pull/1760
+- Minor: Updated the `Hyde::url()` helper throw a `BadMethodCallException` instead `BaseUrlNotSetException` when no site URL is set and no path was provided to the method in https://github.com/hydephp/develop/pull/1760 and https://github.com/hydephp/develop/pull/1890
 - Minor: Updated the blog post layout and post feed component to use the `BlogPosting` Schema.org type instead of `Article` in https://github.com/hydephp/develop/pull/1887
 - Added more rich markup data to blog post components in https://github.com/hydephp/develop/pull/1888 (Note that this inevitably changes the HTML output of the blog post components, and that any customized templates will need to be republished to reflect these changes)
 - Overhauled the blog post author feature in https://github.com/hydephp/develop/pull/1782
@@ -61,7 +61,7 @@ This serves two purposes:
 - Breaking: Removed the build task `\Hyde\Framework\Actions\PostBuildTasks\GenerateSearch` (see upgrade guide below)
 - Breaking: Removed the deprecated `\Hyde\Framework\Services\BuildService::transferMediaAssets()` method (see upgrade guide below)
 - Removed the deprecated global`unslash()` function, replaced with the namespaced `\Hyde\unslash()` function in https://github.com/hydephp/develop/pull/1754
-- Removed the deprecated `BaseUrlNotSetException` class, with the `Hyde::url()` helper now returning `null` if no base URL is set in https://github.com/hydephp/develop/pull/1760
+- Removed the deprecated `BaseUrlNotSetException` class, with the `Hyde::url()` helper now throwing `BadMethodCallException` if no base URL is set in https://github.com/hydephp/develop/pull/1760
 - Removed: The deprecated `PostAuthor::getName()` method is now removed (use `$author->name`) in https://github.com/hydephp/develop/pull/1782
 - Internal: Removed the internal `DocumentationSearchPage::generate()` method as it was unused in https://github.com/hydephp/develop/pull/1569
 - Removed the deprecated `FeaturedImage::isRemote()` method in https://github.com/hydephp/develop/pull/1883. Use `Hyperlinks::isRemote()` instead.

--- a/packages/framework/src/Foundation/Concerns/ForwardsHyperlinks.php
+++ b/packages/framework/src/Foundation/Concerns/ForwardsHyperlinks.php
@@ -33,7 +33,7 @@ trait ForwardsHyperlinks
         return $this->hyperlinks->asset($name, $preferQualifiedUrl);
     }
 
-    public function url(string $path = ''): ?string
+    public function url(string $path = ''): string
     {
         return $this->hyperlinks->url($path);
     }

--- a/packages/framework/src/Foundation/Kernel/Hyperlinks.php
+++ b/packages/framework/src/Foundation/Kernel/Hyperlinks.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Hyde\Foundation\Kernel;
 
 use Hyde\Facades\Config;
+use BadMethodCallException;
 use Hyde\Support\Models\Route;
 use Hyde\Foundation\HydeKernel;
 use Hyde\Framework\Exceptions\FileNotFoundException;
@@ -139,9 +140,11 @@ class Hyperlinks
      * Return a qualified URL to the supplied path if a base URL is set.
      *
      * @param  string  $path  An optional relative path suffix. Omit to return the base URL.
-     * @return string|null The qualified URL, or null if the base URL is not set and no path is provided.
+     * @return string The qualified URL, or the base URL if no path is supplied.
+     *
+     * @throws BadMethodCallException If the site URL is not set in the configuration and no path is supplied.
      */
-    public function url(string $path = ''): ?string
+    public function url(string $path = ''): string
     {
         $path = $this->formatLink(trim($path, '/'));
 
@@ -159,8 +162,8 @@ class Hyperlinks
             return $path;
         }
 
-        // User is trying to get the base URL, but it's not set
-        return null;
+        // User is trying to get the base URL, but it's not set, so we throw an exception.
+        throw new BadMethodCallException('The site URL is not set in the configuration.');
     }
 
     /**

--- a/packages/framework/src/Hyde.php
+++ b/packages/framework/src/Hyde.php
@@ -39,7 +39,7 @@ use JetBrains\PhpStorm\Pure;
  * @method static string relativeLink(string $destination)
  * @method static string mediaLink(string $destination, bool $validate = false)
  * @method static string asset(string $name, bool $preferQualifiedUrl = false)
- * @method static string|null url(string $path = '')
+ * @method static string url(string $path = '')
  * @method static Route|null route(string $key)
  * @method static string makeTitle(string $value)
  * @method static string normalizeNewlines(string $string)

--- a/packages/framework/src/helpers.php
+++ b/packages/framework/src/helpers.php
@@ -42,7 +42,7 @@ namespace {
             /**
              * Get a qualified URL to the supplied path if a base URL is set.
              */
-            function url(string $path = ''): ?string
+            function url(string $path = ''): string
             {
                 return hyde()->url($path);
             }

--- a/packages/framework/tests/Feature/HelpersTest.php
+++ b/packages/framework/tests/Feature/HelpersTest.php
@@ -6,6 +6,7 @@ declare(strict_types=1);
 
 namespace Hyde\Framework\Testing\Feature;
 
+use BadMethodCallException;
 use Hyde\Foundation\HydeKernel;
 use Hyde\Hyde;
 use Hyde\Testing\TestCase;
@@ -178,6 +179,7 @@ class HelpersTest extends TestCase
     public function testUrlFunctionWithoutBaseUrlOrPath()
     {
         $this->app['config']->set(['hyde.url' => null]);
+        $this->expectException(BadMethodCallException::class);
         $this->assertNull(url());
     }
 
@@ -185,6 +187,7 @@ class HelpersTest extends TestCase
     public function testUrlFunctionWithLocalhostBaseUrlButNoPath()
     {
         $this->app['config']->set(['hyde.url' => 'http://localhost']);
+        $this->expectException(BadMethodCallException::class);
         $this->assertNull(url());
     }
 

--- a/packages/framework/tests/Unit/Foundation/HyperlinksUrlPathHelpersTest.php
+++ b/packages/framework/tests/Unit/Foundation/HyperlinksUrlPathHelpersTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Hyde\Framework\Testing\Unit\Foundation;
 
+use BadMethodCallException;
 use Hyde\Foundation\HydeKernel;
 use Hyde\Foundation\Kernel\Hyperlinks;
 use Hyde\Testing\TestCase;
@@ -153,11 +154,14 @@ class HyperlinksUrlPathHelpersTest extends TestCase
         $this->assertSame('http://localhost/foo/bar', $this->class->url('http://localhost/foo/bar/'));
     }
 
-    public function testQualifiedUrlReturnsNullWhenNoSiteUrlIsSet()
+    public function testQualifiedUrlThrowsExceptionWhenNoSiteUrlIsSet()
     {
         $this->withSiteUrl(null);
 
-        $this->assertNull($this->class->url());
+        $this->expectException(BadMethodCallException::class);
+        $this->expectExceptionMessage('The site URL is not set in the configuration.');
+
+        $this->class->url();
     }
 
     public function testHelperFallsBackToRelativeLinksWhenNoSiteUrlIsSet()


### PR DESCRIPTION
Reverts the unreleased behaviour where this returns null. Returning null for a fault path means the developer needs to check for null types, but that solves the problem. If the developer cares about site URLs they need to set the site URL, and having a null that can silently be ignored is unintuitive. If the user tries to get a base URL and one is not set, that's a bug, and throwing an exception alerts them of it. It is not justified to have the custom exception for this, so that is still removed, and we now throw a BadMethodCallException instead. This essentially reverts most of https://github.com/hydephp/develop/pull/1760. See tie in with https://github.com/hydephp/develop/commit/e9778a968ef746ecf6f8a58b40e7e431f590e3a5