### PR TITLE
[2.x] Update the build service to group together dynamic pages

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -56,6 +56,7 @@ This serves two purposes:
 - Markdown returned from includes are now trimmed of trailing whitespace and newlines in https://github.com/hydephp/develop/pull/1738
 - Reorganized and cleaned up the navigation and sidebar documentation for improved clarity.
 - Moved the sidebar documentation to the documentation pages section for better organization.
+- The build command now groups together all `InMemoryPage` instances under one progress bar group in https://github.com/hydephp/develop/pull/1897
 
 ### Deprecated
 - for soon-to-be removed features.

--- a/packages/framework/src/Framework/Services/BuildService.php
+++ b/packages/framework/src/Framework/Services/BuildService.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Hyde\Framework\Services;
 
 use Hyde\Hyde;
+use Hyde\Pages\InMemoryPage;
 use Hyde\Foundation\Facades\Routes;
 use Hyde\Foundation\Kernel\RouteCollection;
 use Hyde\Framework\Actions\StaticPageBuilder;
@@ -62,6 +63,10 @@ class BuildService
 
     protected function getClassPluralName(string $pageClass): string
     {
+        if ($pageClass === InMemoryPage::class) {
+            return 'Dynamic Pages';
+        }
+
         return preg_replace('/([a-z])([A-Z])/', '$1 $2', class_basename($pageClass)).'s';
     }
 
@@ -69,6 +74,10 @@ class BuildService
     protected function getPageTypes(): array
     {
         return Hyde::pages()->map(function (HydePage $page): string {
+            if ($page instanceof InMemoryPage) {
+                return InMemoryPage::class;
+            }
+
             return $page::class;
         })->unique()->values()->toArray();
     }


### PR DESCRIPTION
This PR modifies the `BuildService` to group all dynamic pages (`InMemoryPage` instances) together under a "Dynamic Pages" category during the build process. This is because this otherwise can very quickly grow to have a bunch of single item progress bars when using a lot of extended pages of this type.