### PR TITLE
[2.x] Update the `Markdown::render` method to always use the smart Markdown service

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -57,6 +57,7 @@ This serves two purposes:
 - Reorganized and cleaned up the navigation and sidebar documentation for improved clarity.
 - Moved the sidebar documentation to the documentation pages section for better organization.
 - The build command now groups together all `InMemoryPage` instances under one progress bar group in https://github.com/hydephp/develop/pull/1897
+- The `Markdown::render()` method will now always render Markdown using the custom HydePHP Markdown service (thus getting smart features like our Markdown processors) in https://github.com/hydephp/develop/pull/1900
 
 ### Deprecated
 - for soon-to-be removed features.

--- a/packages/framework/src/Markdown/Models/Markdown.php
+++ b/packages/framework/src/Markdown/Models/Markdown.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Hyde\Markdown\Models;
 
 use Hyde\Framework\Services\MarkdownService;
-use Hyde\Markdown\MarkdownConverter;
 use Illuminate\Contracts\Support\Arrayable;
 use Illuminate\Contracts\Support\Htmlable;
 use Illuminate\Support\HtmlString;
@@ -84,20 +83,13 @@ class Markdown implements Arrayable, Stringable, Htmlable
     /**
      * Render a Markdown string into HTML.
      *
-     * If a source model is provided, the Markdown will be converted using the dynamic MarkdownService,
-     * otherwise, the pre-configured singleton from the service container will be used instead.
+     * If a source page class is provided, that class will be used to configure
+     * the Hyde Markdown converter to enable features specific to that page.
      *
      * @return string $html
      */
     public static function render(string $markdown, ?string $pageClass = null): string
     {
-        if ($pageClass !== null) {
-            return (new MarkdownService($markdown, $pageClass))->parse();
-        } else {
-            /** @var MarkdownConverter $converter */
-            $converter = app(MarkdownConverter::class);
-
-            return (string) $converter->convert($markdown);
-        }
+        return (new MarkdownService($markdown, $pageClass))->parse();
     }
 }

--- a/packages/framework/tests/Feature/ColoredBlockquoteShortcodesTest.php
+++ b/packages/framework/tests/Feature/ColoredBlockquoteShortcodesTest.php
@@ -12,6 +12,9 @@ use Hyde\Testing\UnitTestCase;
  */
 class ColoredBlockquoteShortcodesTest extends UnitTestCase
 {
+    protected static bool $needsKernel = true;
+    protected static bool $needsConfig = true;
+
     public function testSignature()
     {
         $this->assertSame('>', ColoredBlockquotes::signature());

--- a/packages/framework/tests/Unit/MarkdownFacadeTest.php
+++ b/packages/framework/tests/Unit/MarkdownFacadeTest.php
@@ -12,6 +12,9 @@ use Hyde\Markdown\Models\Markdown;
  */
 class MarkdownFacadeTest extends UnitTestCase
 {
+    protected static bool $needsKernel = true;
+    protected static bool $needsConfig = true;
+
     public function testRender(): void
     {
         $html = Markdown::render('# Hello World!');


### PR DESCRIPTION
This simplification means that the method is more predictable, and better follows the principle of least astonishment. I've been so confused so many times about this that using our Markdown helper does not always mean that we get our Markdown features. This change means that any time you call this method, custom Markdown features like our shortcodes and processors will be applied.

A side effect of this is in unit tests, as the method now requires the kernel and config to be set up.