### PR TITLE
[2.x] Remove HydeFront version and CDN URL configuration options

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -59,6 +59,7 @@ This serves two purposes:
 - Moved the sidebar documentation to the documentation pages section for better organization.
 - The build command now groups together all `InMemoryPage` instances under one progress bar group in https://github.com/hydephp/develop/pull/1897
 - The `Markdown::render()` method will now always render Markdown using the custom HydePHP Markdown service (thus getting smart features like our Markdown processors) in https://github.com/hydephp/develop/pull/1900
+- The HydeFront asset version and CDN URL are now hardcoded in the `AssetService` class instead of being configurable in https://github.com/hydephp/develop/pull/1909
 
 ### Deprecated
 - for soon-to-be removed features.
@@ -66,6 +67,7 @@ This serves two purposes:
 ### Removed
 - Breaking: Removed the build task `\Hyde\Framework\Actions\PostBuildTasks\GenerateSearch` (see upgrade guide below)
 - Breaking: Removed the deprecated `\Hyde\Framework\Services\BuildService::transferMediaAssets()` method (see upgrade guide below)
+- Breaking: Removed the `hydefront_version` and `hydefront_cdn_url` configuration options from the `hyde.php` config file in https://github.com/hydephp/develop/pull/1909
 - Removed the deprecated global`unslash()` function, replaced with the namespaced `\Hyde\unslash()` function in https://github.com/hydephp/develop/pull/1754
 - Removed the deprecated `BaseUrlNotSetException` class, with the `Hyde::url()` helper now throwing `BadMethodCallException` if no base URL is set in https://github.com/hydephp/develop/pull/1760
 - Removed: The deprecated `PostAuthor::getName()` method is now removed (use `$author->name`) in https://github.com/hydephp/develop/pull/1782
@@ -238,6 +240,31 @@ The following methods in the `Features` class have been renamed to follow a more
 - `Features::rss()` has been renamed to `Features::hasRss()`
 
 Note that this class was previously marked as internal in v1, but the change is logged here in case it was used in configuration files or custom code.
+
+### Asset API Changes
+
+The overall asset API has been improved and cleaned up. Unfortunately, this means that there are some breaking changes to the API.
+
+#### Removal of HydeFront version and CDN URL configuration options
+
+The `hydefront_version` and `hydefront_cdn_url` configuration options have been removed from the `config/hyde.php` file. These options were previously used to specify the HydeFront version and CDN URL for loading assets.
+
+**Impact:** Low. This change will only affect users who have customized these options.
+
+**Upgrade steps:**
+
+<!-- TODO: Deprecate the constants in v1 -->
+
+1. Remove the following lines from your `config/hyde.php` file if they exist:
+   ```php
+   'hydefront_version' => \Hyde\Framework\Services\AssetService::HYDEFRONT_VERSION,
+   'hydefront_cdn_url' => \Hyde\Framework\Services\AssetService::HYDEFRONT_CDN_URL,
+   ```
+2. If you were using a custom CDN URL, you will need to implement your own solution for serving HydeFront assets from a different CDN. Consider copying the assets to your preferred CDN and updating your templates accordingly.
+
+**Rationale:** The ability to change the HydeFront version was removed because using a different version than the one bundled with your Hyde project could lead to compatibility issues. The CDN URL configuration was removed to simplify the asset loading process.
+
+If you need to use a different CDN for serving HydeFront assets, you should implement a custom solution tailored to your specific needs. You may also open a feature request if you believe this functionality should be added back in a future release.
 
 ## Low impact
 

--- a/config/hyde.php
+++ b/config/hyde.php
@@ -470,11 +470,6 @@ return [
     // Where should the build manifest be saved? (Relative to project root, for example _site/build-manifest.json)
     'build_manifest_path' => 'app/storage/framework/cache/build-manifest.json',
 
-    // Here you can specify HydeFront version and URL for when loading app.css from the CDN.
-    // Only change these if you know what you're doing as some versions may be incompatible with your Hyde version.
-    'hydefront_version' => \Hyde\Framework\Services\AssetService::HYDEFRONT_VERSION,
-    'hydefront_cdn_url' => \Hyde\Framework\Services\AssetService::HYDEFRONT_CDN_URL,
-
     // Should the theme toggle buttons be displayed in the layouts?
     'theme_toggle_buttons' => true,
 

--- a/docs/digging-deeper/customization.md
+++ b/docs/digging-deeper/customization.md
@@ -342,20 +342,6 @@ Specifies the path where the build manifest should be saved, relative to the pro
 'build_manifest_path' => 'app/storage/framework/cache/build-manifest.json',
 ```
 
-### `hydefront_version` and `hydefront_cdn_url`
-
-These options allow you to specify the HydeFront version and CDN URL when loading `app.css` from the CDN.
-
-Only change these if you know what you're doing as some versions may be incompatible with your Hyde version.
-
-```php
-// filepath config/hyde.php
-use \Hyde\Framework\Services\AssetService;
-
-'hydefront_version' => AssetService::HYDEFRONT_VERSION,
-'hydefront_cdn_url' => AssetService::HYDEFRONT_CDN_URL,
-```
-
 ### `theme_toggle_buttons`
 
 >info This feature was added in HydePHP v1.7.0

--- a/packages/framework/config/hyde.php
+++ b/packages/framework/config/hyde.php
@@ -470,11 +470,6 @@ return [
     // Where should the build manifest be saved? (Relative to project root, for example _site/build-manifest.json)
     'build_manifest_path' => 'app/storage/framework/cache/build-manifest.json',
 
-    // Here you can specify HydeFront version and URL for when loading app.css from the CDN.
-    // Only change these if you know what you're doing as some versions may be incompatible with your Hyde version.
-    'hydefront_version' => \Hyde\Framework\Services\AssetService::HYDEFRONT_VERSION,
-    'hydefront_cdn_url' => \Hyde\Framework\Services\AssetService::HYDEFRONT_CDN_URL,
-
     // Should the theme toggle buttons be displayed in the layouts?
     'theme_toggle_buttons' => true,
 

--- a/packages/framework/src/Framework/Services/AssetService.php
+++ b/packages/framework/src/Framework/Services/AssetService.php
@@ -41,8 +41,8 @@ class AssetService
 
     public function __construct()
     {
-        $this->version = Config::getString('hyde.hydefront_version', self::HYDEFRONT_VERSION);
-        $this->cdnUrl = Config::getString('hyde.hydefront_url', self::HYDEFRONT_CDN_URL);
+        $this->version = self::HYDEFRONT_VERSION;
+        $this->cdnUrl = self::HYDEFRONT_CDN_URL;
     }
 
     public function version(): string

--- a/packages/framework/tests/Unit/AssetServiceUnitTest.php
+++ b/packages/framework/tests/Unit/AssetServiceUnitTest.php
@@ -36,48 +36,9 @@ class AssetServiceUnitTest extends UnitTestCase
         $this->assertSame(AssetService::HYDEFRONT_VERSION, (new AssetService())->version());
     }
 
-    public function testVersionCanBeSetInConfig()
-    {
-        self::mockConfig(['hyde.hydefront_version' => '1.0.0']);
-        $this->assertSame('1.0.0', (new AssetService())->version());
-    }
-
     public function testCdnPatternConstant()
     {
         $this->assertSame('https://cdn.jsdelivr.net/npm/hydefront@{{ $version }}/dist/{{ $file }}', AssetService::HYDEFRONT_CDN_URL);
-    }
-
-    public function testCanSetCustomCdnUrlInConfig()
-    {
-        self::mockConfig(['hyde.hydefront_url' => 'https://example.com']);
-        $this->assertSame('https://example.com', (new AssetService())->cdnLink(''));
-    }
-
-    public function testCanUseCustomCdnUrlWithVersion()
-    {
-        self::mockConfig(['hyde.hydefront_url' => '{{ $version }}']);
-        $this->assertSame('v3.4', (new AssetService())->cdnLink(''));
-    }
-
-    public function testCanUseCustomCdnUrlWithFile()
-    {
-        self::mockConfig(['hyde.hydefront_url' => '{{ $file }}']);
-        $this->assertSame('styles.css', (new AssetService())->cdnLink('styles.css'));
-    }
-
-    public function testCanUseCustomCdnUrlWithVersionAndFile()
-    {
-        self::mockConfig(['hyde.hydefront_url' => '{{ $version }}/{{ $file }}']);
-        $this->assertSame('v3.4/styles.css', (new AssetService())->cdnLink('styles.css'));
-    }
-
-    public function testCanUseCustomCdnUrlWithCustomVersion()
-    {
-        self::mockConfig([
-            'hyde.hydefront_url' => '{{ $version }}',
-            'hyde.hydefront_version' => '1.0.0',
-        ]);
-        $this->assertSame('1.0.0', (new AssetService())->cdnLink(''));
     }
 
     public function testCdnLinkHelper()


### PR DESCRIPTION
I can't see a good reason to want to change the version to load assets that are unlikely to work with the versions in the views in the project Hyde version. Changing the CDN URL could be useful if you want to change the host to another CDN provider, but this current system is way too convoluted for that.

This is a part of https://github.com/hydephp/develop/pull/1904