### PR TITLE
[2.x] Normalize asset cache busting

### DIFF
--- a/config/hyde.php
+++ b/config/hyde.php
@@ -355,14 +355,12 @@ return [
     | Cache Busting
     |--------------------------------------------------------------------------
     |
-    | Any assets loaded using the Asset::mediaLink() helper will automatically
-    | have a cache busting query string appended to the URL. This is useful
+    | Any assets loaded using the Hyde Asset helpers will automatically have
+    | a "cache busting" query string appended to the URL. This is useful
     | when you want to force browsers to load a new version of an asset.
+    | All included Blade templates use this feature to load assets.
     |
-    | The mediaLink helper is used in the built-in views to load the
-    | default stylesheets and scripts, and thus use this feature.
-    |
-    | To disable cache busting, set this setting to false.
+    | To disable the cache busting, set this setting to false.
     |
     */
 

--- a/packages/framework/config/hyde.php
+++ b/packages/framework/config/hyde.php
@@ -355,14 +355,12 @@ return [
     | Cache Busting
     |--------------------------------------------------------------------------
     |
-    | Any assets loaded using the Asset::mediaLink() helper will automatically
-    | have a cache busting query string appended to the URL. This is useful
+    | Any assets loaded using the Hyde Asset helpers will automatically have
+    | a "cache busting" query string appended to the URL. This is useful
     | when you want to force browsers to load a new version of an asset.
+    | All included Blade templates use this feature to load assets.
     |
-    | The mediaLink helper is used in the built-in views to load the
-    | default stylesheets and scripts, and thus use this feature.
-    |
-    | To disable cache busting, set this setting to false.
+    | To disable the cache busting, set this setting to false.
     |
     */
 

--- a/packages/framework/src/Facades/Asset.php
+++ b/packages/framework/src/Facades/Asset.php
@@ -24,16 +24,11 @@ class Asset
 
     public static function mediaLink(string $file): string
     {
-        return Hyde::mediaLink($file).static::getCacheBustKey($file);
+        return Hyde::mediaLink($file).MediaFile::getCacheBustKey($file);
     }
 
     public static function hasMediaFile(string $file): bool
     {
         return file_exists(MediaFile::sourcePath($file));
-    }
-
-    protected static function getCacheBustKey(string $file): string
-    {
-        return MediaFile::getCacheBustKey($file);
     }
 }

--- a/packages/framework/src/Facades/Asset.php
+++ b/packages/framework/src/Facades/Asset.php
@@ -24,7 +24,7 @@ class Asset
 
     public static function mediaLink(string $file): string
     {
-        return hyde()->mediaLink($file).MediaFile::getCacheBustKey($file);
+        return hyde()->mediaLink($file);
     }
 
     public static function hasMediaFile(string $file): bool

--- a/packages/framework/src/Facades/Asset.php
+++ b/packages/framework/src/Facades/Asset.php
@@ -4,9 +4,9 @@ declare(strict_types=1);
 
 namespace Hyde\Facades;
 
-use Hyde\Hyde;
 use Hyde\Support\Filesystem\MediaFile;
 
+use function hyde;
 use function file_exists;
 
 /**
@@ -19,12 +19,12 @@ class Asset
 {
     public static function get(string $file): string
     {
-        return Hyde::asset($file);
+        return hyde()->asset($file);
     }
 
     public static function mediaLink(string $file): string
     {
-        return Hyde::mediaLink($file).MediaFile::getCacheBustKey($file);
+        return hyde()->mediaLink($file).MediaFile::getCacheBustKey($file);
     }
 
     public static function hasMediaFile(string $file): bool

--- a/packages/framework/src/Facades/Asset.php
+++ b/packages/framework/src/Facades/Asset.php
@@ -7,7 +7,6 @@ namespace Hyde\Facades;
 use Hyde\Hyde;
 use Hyde\Support\Filesystem\MediaFile;
 
-use function md5_file;
 use function file_exists;
 
 /**
@@ -35,8 +34,6 @@ class Asset
 
     protected static function getCacheBustKey(string $file): string
     {
-        return Config::getBool('hyde.enable_cache_busting', true)
-            ? '?v='.md5_file(MediaFile::sourcePath("$file"))
-            : '';
+        return MediaFile::getCacheBustKey($file);
     }
 }

--- a/packages/framework/src/Foundation/Kernel/Hyperlinks.php
+++ b/packages/framework/src/Foundation/Kernel/Hyperlinks.php
@@ -8,6 +8,7 @@ use Hyde\Facades\Config;
 use BadMethodCallException;
 use Hyde\Support\Models\Route;
 use Hyde\Foundation\HydeKernel;
+use Hyde\Support\Filesystem\MediaFile;
 use Hyde\Framework\Exceptions\FileNotFoundException;
 use Illuminate\Support\Str;
 
@@ -99,7 +100,7 @@ class Hyperlinks
             throw new FileNotFoundException($sourcePath);
         }
 
-        return $this->relativeLink("{$this->kernel->getMediaOutputDirectory()}/$destination");
+        return $this->relativeLink("{$this->kernel->getMediaOutputDirectory()}/$destination").MediaFile::getCacheBustKey($destination);
     }
 
     /**

--- a/packages/framework/src/Foundation/Kernel/Hyperlinks.php
+++ b/packages/framework/src/Foundation/Kernel/Hyperlinks.php
@@ -118,10 +118,10 @@ class Hyperlinks
         $name = Str::start($name, "{$this->kernel->getMediaOutputDirectory()}/");
 
         if ($this->hasSiteUrl()) {
-            return $this->url($name);
+            return $this->url($name).MediaFile::getCacheBustKey($name);
         }
 
-        return $this->relativeLink($name);
+        return $this->relativeLink($name).MediaFile::getCacheBustKey($name);
     }
 
     /**

--- a/packages/framework/src/Foundation/Kernel/Hyperlinks.php
+++ b/packages/framework/src/Foundation/Kernel/Hyperlinks.php
@@ -100,7 +100,7 @@ class Hyperlinks
             throw new FileNotFoundException($sourcePath);
         }
 
-        return $this->relativeLink("{$this->kernel->getMediaOutputDirectory()}/$destination").MediaFile::getCacheBustKey($destination);
+        return $this->withCacheBusting($this->relativeLink("{$this->kernel->getMediaOutputDirectory()}/$destination"), $destination);
     }
 
     /**
@@ -118,10 +118,10 @@ class Hyperlinks
         $name = Str::start($name, "{$this->kernel->getMediaOutputDirectory()}/");
 
         if ($this->hasSiteUrl()) {
-            return $this->url($name).MediaFile::getCacheBustKey($name);
+            return $this->withCacheBusting($this->url($name), $name);
         }
 
-        return $this->relativeLink($name).MediaFile::getCacheBustKey($name);
+        return $this->withCacheBusting($this->relativeLink($name), $name);
     }
 
     /**
@@ -180,5 +180,13 @@ class Hyperlinks
     public static function isRemote(string $url): bool
     {
         return str_starts_with($url, 'http') || str_starts_with($url, '//');
+    }
+
+    /**
+     * Apply cache to the URL if enabled in the configuration.
+     */
+    protected function withCacheBusting(string $url, string $file): string
+    {
+        return $url.MediaFile::getCacheBustKey($file);
     }
 }

--- a/packages/framework/src/Support/Filesystem/MediaFile.php
+++ b/packages/framework/src/Support/Filesystem/MediaFile.php
@@ -143,4 +143,11 @@ class MediaFile extends ProjectFile
             Config::getArray('hyde.media_extensions', self::EXTENSIONS)
         ));
     }
+
+    protected static function getCacheBustKey(string $file): string
+    {
+        return Config::getBool('hyde.enable_cache_busting', true)
+            ? '?v='.md5_file(MediaFile::sourcePath("$file"))
+            : '';
+    }
 }

--- a/packages/framework/src/Support/Filesystem/MediaFile.php
+++ b/packages/framework/src/Support/Filesystem/MediaFile.php
@@ -147,7 +147,7 @@ class MediaFile extends ProjectFile
     /** @internal */
     public static function getCacheBustKey(string $file): string
     {
-        return Config::getBool('hyde.enable_cache_busting', true)
+        return Config::getBool('hyde.enable_cache_busting', true) && file_exists(MediaFile::sourcePath("$file"))
             ? '?v='.md5_file(MediaFile::sourcePath("$file"))
             : '';
     }

--- a/packages/framework/src/Support/Filesystem/MediaFile.php
+++ b/packages/framework/src/Support/Filesystem/MediaFile.php
@@ -144,7 +144,8 @@ class MediaFile extends ProjectFile
         ));
     }
 
-    protected static function getCacheBustKey(string $file): string
+    /** @internal */
+    public static function getCacheBustKey(string $file): string
     {
         return Config::getBool('hyde.enable_cache_busting', true)
             ? '?v='.md5_file(MediaFile::sourcePath("$file"))

--- a/packages/framework/tests/Feature/Foundation/HyperlinksTest.php
+++ b/packages/framework/tests/Feature/Foundation/HyperlinksTest.php
@@ -108,7 +108,7 @@ class HyperlinksTest extends TestCase
     public function testMediaLinkHelperWithValidationAndExistingFile()
     {
         $this->file('_media/foo');
-        $this->assertSame('media/foo', $this->class->mediaLink('foo', true));
+        $this->assertSame('media/foo?v=d41d8cd98f00b204e9800998ecf8427e', $this->class->mediaLink('foo', true));
     }
 
     public function testMediaLinkHelperWithValidationAndNonExistingFile()

--- a/packages/framework/tests/Feature/Services/RssFeedServiceTest.php
+++ b/packages/framework/tests/Feature/Services/RssFeedServiceTest.php
@@ -86,6 +86,8 @@ class RssFeedServiceTest extends TestCase
 
     public function testMarkdownBlogPostsAreAddedToRssFeedThroughAutodiscovery()
     {
+        config(['hyde.enable_cache_busting' => false]);
+
         file_put_contents(Hyde::path('_posts/rss.md'), <<<'MD'
             ---
             title: RSS


### PR DESCRIPTION
This PR is part of https://github.com/hydephp/develop/pull/1904 and fixes a major discrepancy where `Asset::mediaLink()` adds a cache busting key but `Hyde::mediaLink()` does not. Now, all asset helpers will use cache busting when enabled.