### PR TITLE
Update the Hyde facade to use a mixin annotation instead of method annotations

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -16,6 +16,7 @@ This serves two purposes:
 - All page types now support the `description` front matter field (used in page metadata) in https://github.com/hydephp/develop/pull/1884
 
 ### Changed
+- Changed the `Hyde` facade to use a `@mixin` annotation instead of single method annotations in https://github.com/hydephp/develop/pull/1919
 - Updated the `Serializable` trait to provide a default automatic `toArray` method in https://github.com/hydephp/develop/pull/1791
 - Updated the `PostAuthor` class's `name` property to fall back to the `username` property if the `name` property is not set in https://github.com/hydephp/develop/pull/1794
 - Removed the nullable type hint from the `PostAuthor` class's `name` property as it is now always set in https://github.com/hydephp/develop/pull/1794

--- a/packages/framework/src/Hyde.php
+++ b/packages/framework/src/Hyde.php
@@ -4,17 +4,8 @@ declare(strict_types=1);
 
 namespace Hyde;
 
-use Hyde\Enums\Feature;
-use Hyde\Facades\Features;
 use Hyde\Foundation\HydeKernel;
-use Hyde\Foundation\Kernel\FileCollection;
-use Hyde\Foundation\Kernel\Filesystem;
-use Hyde\Foundation\Kernel\PageCollection;
-use Hyde\Foundation\Kernel\RouteCollection;
-use Hyde\Pages\Concerns\HydePage;
-use Hyde\Support\Models\Route;
 use Illuminate\Support\Facades\Facade;
-use Illuminate\Support\HtmlString;
 use JetBrains\PhpStorm\Pure;
 
 /**
@@ -26,50 +17,7 @@ use JetBrains\PhpStorm\Pure;
  * @copyright 2022 Caen De Silva
  * @license MIT License
  *
- * @method static string path(string $path = '')
- * @method static string vendorPath(string $path = '', string $package = 'framework')
- * @method static string pathToAbsolute(string $path)
- * @method static string pathToRelative(string $path)
- * @method static string sitePath(string $path = '')
- * @method static string mediaPath(string $path = '')
- * @method static string siteMediaPath(string $path = '')
- * @method static string formatLink(string $destination)
- * @method static string relativeLink(string $destination)
- * @method static string mediaLink(string $destination, bool $validate = false)
- * @method static string asset(string $name, bool $preferQualifiedUrl = false)
- * @method static string url(string $path = '')
- * @method static Route|null route(string $key)
- * @method static string makeTitle(string $value)
- * @method static string normalizeNewlines(string $string)
- * @method static string stripNewlines(string $string)
- * @method static string trimSlashes(string $string)
- * @method static HtmlString markdown(string $text, bool $stripIndentation = false)
- * @method static string currentPage()
- * @method static string currentRouteKey()
- * @method static string getBasePath()
- * @method static string getSourceRoot()
- * @method static string getOutputDirectory()
- * @method static string getMediaDirectory()
- * @method static string getMediaOutputDirectory()
- * @method static Features features()
- * @method static FileCollection files()
- * @method static PageCollection pages()
- * @method static RouteCollection routes()
- * @method static Route|null currentRoute()
- * @method static HydeKernel getInstance()
- * @method static Filesystem filesystem()
- * @method static array getRegisteredExtensions()
- * @method static bool hasFeature(Feature $feature)
- * @method static bool hasSiteUrl()
- * @method static void setInstance(HydeKernel $instance)
- * @method static void setBasePath(string $basePath)
- * @method static void setOutputDirectory(string $outputDirectory)
- * @method static void setMediaDirectory(string $mediaDirectory)
- * @method static void setSourceRoot(string $sourceRoot)
- * @method static void shareViewData(HydePage $page)
- * @method static array toArray()
- * @method static bool isBooted()
- * @method static void boot()
+ * @mixin \Hyde\Foundation\HydeKernel
  *
  * @see \Hyde\Foundation\Concerns\ForwardsFilesystem
  * @see \Hyde\Foundation\Concerns\ForwardsHyperlinks


### PR DESCRIPTION
Let's see if this has gotten better support since last time we tried this. If this works, it means that clicking a usage will actually lead to the implementation, and we can get better support for PHPDoc annotations like usages and deprecations.