### PR TITLE
[2.x] Lazy loaded MediaFile metadata properties

### DIFF
--- a/packages/framework/src/Support/Filesystem/MediaFile.php
+++ b/packages/framework/src/Support/Filesystem/MediaFile.php
@@ -32,8 +32,6 @@ class MediaFile extends ProjectFile
     public function __construct(string $path)
     {
         parent::__construct($this->getNormalizedPath($path));
-
-        $this->boot();
     }
 
     /**
@@ -99,16 +97,28 @@ class MediaFile extends ProjectFile
 
     public function getContentLength(): int
     {
+        if (! isset($this->length)) {
+            $this->boot();
+        }
+
         return $this->length;
     }
 
     public function getMimeType(): string
     {
+        if (! isset($this->mimeType)) {
+            $this->boot();
+        }
+
         return $this->mimeType;
     }
 
     public function getHash(): string
     {
+        if (! isset($this->hash)) {
+            $this->boot();
+        }
+
         return $this->hash;
     }
 

--- a/packages/framework/src/Support/Filesystem/MediaFile.php
+++ b/packages/framework/src/Support/Filesystem/MediaFile.php
@@ -25,9 +25,9 @@ class MediaFile extends ProjectFile
     /** @var array<string> The default extensions for media types */
     final public const EXTENSIONS = ['png', 'svg', 'jpg', 'jpeg', 'gif', 'ico', 'css', 'js'];
 
-    public readonly int $length;
-    public readonly string $mimeType;
-    public readonly string $hash;
+    protected readonly int $length;
+    protected readonly string $mimeType;
+    protected readonly string $hash;
 
     public function __construct(string $path)
     {

--- a/packages/framework/src/Support/Filesystem/MediaFile.php
+++ b/packages/framework/src/Support/Filesystem/MediaFile.php
@@ -132,6 +132,7 @@ class MediaFile extends ProjectFile
 
     protected function getNormalizedPath(string $path): string
     {
+        // Ensure we are working with a relative project path
         $path = Hyde::pathToRelative($path);
 
         // Normalize paths using output directory to have source directory prefix

--- a/packages/framework/src/Support/Filesystem/MediaFile.php
+++ b/packages/framework/src/Support/Filesystem/MediaFile.php
@@ -97,27 +97,21 @@ class MediaFile extends ProjectFile
 
     public function getContentLength(): int
     {
-        if (! isset($this->length)) {
-            $this->boot();
-        }
+        $this->ensureInstanceIsBooted('length');
 
         return $this->length;
     }
 
     public function getMimeType(): string
     {
-        if (! isset($this->mimeType)) {
-            $this->boot();
-        }
+        $this->ensureInstanceIsBooted('mimeType');
 
         return $this->mimeType;
     }
 
     public function getHash(): string
     {
-        if (! isset($this->hash)) {
-            $this->boot();
-        }
+        $this->ensureInstanceIsBooted('hash');
 
         return $this->hash;
     }
@@ -187,6 +181,13 @@ class MediaFile extends ProjectFile
     protected function findHash(): string
     {
         return Filesystem::hash($this->getPath(), 'crc32');
+    }
+
+    protected function ensureInstanceIsBooted(string $property): void
+    {
+        if (! isset($this->$property)) {
+            $this->boot();
+        }
     }
 
     protected function boot(): void

--- a/packages/framework/src/Support/Filesystem/MediaFile.php
+++ b/packages/framework/src/Support/Filesystem/MediaFile.php
@@ -33,9 +33,7 @@ class MediaFile extends ProjectFile
     {
         parent::__construct($this->getNormalizedPath($path));
 
-        $this->length = $this->findContentLength();
-        $this->mimeType = $this->findMimeType();
-        $this->hash = $this->findHash();
+        $this->boot();
     }
 
     /**
@@ -182,5 +180,12 @@ class MediaFile extends ProjectFile
     protected function findHash(): string
     {
         return Filesystem::hash($this->getPath(), 'crc32');
+    }
+
+    protected function boot(): void
+    {
+        $this->length = $this->findContentLength();
+        $this->mimeType = $this->findMimeType();
+        $this->hash = $this->findHash();
     }
 }

--- a/packages/framework/src/Support/Filesystem/MediaFile.php
+++ b/packages/framework/src/Support/Filesystem/MediaFile.php
@@ -142,10 +142,6 @@ class MediaFile extends ProjectFile
         // Normalize the path to include the media directory
         $path = static::sourcePath(trim_slashes(Str::after($path, Hyde::getMediaDirectory())));
 
-        if (Filesystem::missing($path)) {
-            throw new FileNotFoundException($path);
-        }
-
         return $path;
     }
 
@@ -194,6 +190,10 @@ class MediaFile extends ProjectFile
 
     protected function boot(): void
     {
+        if (Filesystem::missing($this->getPath())) {
+            throw new FileNotFoundException($this->getPath());
+        }
+
         $this->length = $this->findContentLength();
         $this->mimeType = $this->findMimeType();
         $this->hash = $this->findHash();

--- a/packages/framework/tests/Feature/Support/MediaFileTest.php
+++ b/packages/framework/tests/Feature/Support/MediaFileTest.php
@@ -81,7 +81,7 @@ class MediaFileTest extends TestCase
     public function testMediaFileExceptionHandling()
     {
         $this->expectException(FileNotFoundException::class);
-        MediaFile::make('non_existent_file.txt');
+        MediaFile::make('non_existent_file.txt')->getContentLength();
     }
 
     public function testMediaDirectoryCustomization()

--- a/packages/framework/tests/Unit/Support/MediaFileUnitTest.php
+++ b/packages/framework/tests/Unit/Support/MediaFileUnitTest.php
@@ -147,9 +147,9 @@ class MediaFileUnitTest extends UnitTestCase
     public function testConstructorSetsProperties()
     {
         $file = new MediaFile('foo.txt');
-        $this->assertNotNull($file->length);
-        $this->assertNotNull($file->mimeType);
-        $this->assertNotNull($file->hash);
+        $this->assertNotNull($file->getContentLength());
+        $this->assertNotNull($file->getMimeType());
+        $this->assertNotNull($file->getHash());
     }
 
     public function testNormalizePathWithAbsolutePath()

--- a/packages/framework/tests/Unit/Support/MediaFileUnitTest.php
+++ b/packages/framework/tests/Unit/Support/MediaFileUnitTest.php
@@ -271,7 +271,8 @@ class MediaFileUnitTest extends UnitTestCase
         $this->assertSame(hash('crc32', 'Hello World!'), MediaFile::make('foo.txt')->getHash());
     }
 
-    public function testExceptionIsThrownWhenBootingFileThatDoesNotExist()
+    /** @dataProvider bootableMethodsProvider */
+    public function testExceptionIsThrownWhenBootingFileThatDoesNotExist(string $bootableMethod)
     {
         $this->mockFilesystem->shouldReceive('missing')
             ->with(Hyde::path('_media/foo'))
@@ -280,7 +281,7 @@ class MediaFileUnitTest extends UnitTestCase
         $this->expectException(FileNotFoundException::class);
         $this->expectExceptionMessage('File [_media/foo] not found.');
 
-        MediaFile::make('foo')->getContentLength();
+        MediaFile::make('foo')->$bootableMethod();
     }
 
     public function testExceptionIsNotThrownWhenConstructingFileThatDoesExist()
@@ -388,5 +389,14 @@ class MediaFileUnitTest extends UnitTestCase
     public function testOutputPathWithLeadingSlash()
     {
         $this->assertSame(Hyde::sitePath('media/foo'), MediaFile::outputPath('/foo'));
+    }
+
+    public static function bootableMethodsProvider(): array
+    {
+        return [
+            ['getContentLength'],
+            ['getMimeType'],
+            ['getHash'],
+        ];
     }
 }

--- a/packages/framework/tests/Unit/Support/MediaFileUnitTest.php
+++ b/packages/framework/tests/Unit/Support/MediaFileUnitTest.php
@@ -271,7 +271,7 @@ class MediaFileUnitTest extends UnitTestCase
         $this->assertSame(hash('crc32', 'Hello World!'), MediaFile::make('foo.txt')->getHash());
     }
 
-    public function testExceptionIsThrownWhenConstructingFileThatDoesNotExist()
+    public function testExceptionIsThrownWhenBootingFileThatDoesNotExist()
     {
         $this->mockFilesystem->shouldReceive('missing')
             ->with(Hyde::path('_media/foo'))
@@ -280,7 +280,7 @@ class MediaFileUnitTest extends UnitTestCase
         $this->expectException(FileNotFoundException::class);
         $this->expectExceptionMessage('File [_media/foo] not found.');
 
-        MediaFile::make('foo');
+        MediaFile::make('foo')->getContentLength();
     }
 
     public function testExceptionIsNotThrownWhenConstructingFileThatDoesExist()


### PR DESCRIPTION
## Abstract

- Follow up to https://github.com/hydephp/develop/pull/1918 
- This is a part of https://github.com/hydephp/develop/pull/1904

## Changes

- Makes the public readonly metadata properties protected and only accessible via getter methods
- Lazy loads metadata properties using a boot system, which constructs all metadata properties when one is accessed (and when instance is serialized to array), and then caches them for future access
- No longer validates file existence in the constructor, but instead on boot, making it possible to create memory based file objects which opens up the API for more use cases, at the cost of inconsistent places where the file existence is checked but still having a robust system in place for when trying to get filesystem information for a non-existent file