### PR TITLE
[2.x] Rename method `Asset::hasMediaFile` to `Asset::exists`

### DIFF
--- a/ide.json
+++ b/ide.json
@@ -22,7 +22,7 @@
             },
             "condition": [
                 {
-                    "methodNames": ["get", "hasMediaFile"],
+                    "methodNames": ["get", "exists"],
                     "place": "parameter",
                     "classFqn": ["\\Hyde\\Facades\\Asset"],
                     "parameters": [1]

--- a/packages/framework/resources/views/layouts/scripts.blade.php
+++ b/packages/framework/resources/views/layouts/scripts.blade.php
@@ -1,5 +1,5 @@
 {{-- The compiled Laravel Mix scripts --}}
-@if(Asset::hasMediaFile('app.js'))
+@if(Asset::exists('app.js'))
     <script defer src="{{ Asset::get('app.js') }}"></script>
 @endif
 

--- a/packages/framework/resources/views/layouts/styles.blade.php
+++ b/packages/framework/resources/views/layouts/styles.blade.php
@@ -4,7 +4,7 @@
 {{-- The compiled Tailwind/App styles --}}
 @if(config('hyde.load_app_styles_from_cdn', false))
     <link rel="stylesheet" href="{{ HydeFront::cdnLink('app.css') }}">
-@elseif(Asset::hasMediaFile('app.css'))
+@elseif(Asset::exists('app.css'))
     <link rel="stylesheet" href="{{ Asset::get('app.css') }}">
 @endif
 

--- a/packages/framework/src/Facades/Asset.php
+++ b/packages/framework/src/Facades/Asset.php
@@ -22,7 +22,7 @@ class Asset
         return hyde()->asset($file);
     }
 
-    public static function hasMediaFile(string $file): bool
+    public static function exists(string $file): bool
     {
         return file_exists(MediaFile::sourcePath($file));
     }

--- a/packages/framework/tests/Feature/AssetAPIFeatureTest.php
+++ b/packages/framework/tests/Feature/AssetAPIFeatureTest.php
@@ -22,8 +22,8 @@ class AssetAPIFeatureTest extends TestCase
         // Tests for the Asset API, can be used to try out the PhpStorm autocompletion
 
         $conditions = [
-            'hasMediaFileTrue' => \Hyde\Facades\Asset::hasMediaFile('app.css'),
-            'hasMediaFileFalse' => \Hyde\Facades\Asset::hasMediaFile('missing.png'),
+            'existsTrue' => \Hyde\Facades\Asset::exists('app.css'),
+            'existsFalse' => \Hyde\Facades\Asset::exists('missing.png'),
             'getters' => [
                 (string) \Hyde\Facades\Asset::get('app.css'),
                 \Hyde\Facades\Asset::get('app.css'),
@@ -44,8 +44,8 @@ class AssetAPIFeatureTest extends TestCase
         ];
 
         $this->assertEquals([
-            'hasMediaFileTrue' => true,
-            'hasMediaFileFalse' => false,
+            'existsTrue' => true,
+            'existsFalse' => false,
             'getters' => [
                 "media/app.css?v={$this->getAppStylesVersion()}",
                 MediaFile::get('app.css'),
@@ -69,13 +69,13 @@ class AssetAPIFeatureTest extends TestCase
     public function testAssetAPIUsagesInBladeViews()
     {
         $view = /** @lang Blade */ <<<'Blade'
-        @if(Asset::hasMediaFile('app.css'))
+        @if(Asset::exists('app.css'))
             <link rel="stylesheet" href="{{ Asset::get('app.css') }}">
             <link rel="stylesheet" href="{{ Hyde::asset('app.css') }}">
             <link rel="stylesheet" href="{{ asset('app.css') }}">
         @endif
         
-        @if(Asset::hasMediaFile('missing.png'))
+        @if(Asset::exists('missing.png'))
             Found missing.png
         @else
             Missing missing.png

--- a/packages/framework/tests/Unit/Facades/AssetFacadeUnitTest.php
+++ b/packages/framework/tests/Unit/Facades/AssetFacadeUnitTest.php
@@ -45,12 +45,12 @@ class AssetFacadeUnitTest extends UnitTestCase
 
     public function testHasMediaFileHelper()
     {
-        $this->assertFalse(Asset::hasMediaFile('styles.css'));
+        $this->assertFalse(Asset::exists('styles.css'));
     }
 
     public function testHasMediaFileHelperReturnsTrueForExistingFile()
     {
-        $this->assertTrue(Asset::hasMediaFile('app.css'));
+        $this->assertTrue(Asset::exists('app.css'));
     }
 
     public function testAssetReturnsMediaPathWithCacheKey()


### PR DESCRIPTION
Also considered `has`, but exists is generally better for clarity, as it directly indicates that you're checking for the presence of a file. has can be more ambiguous, as it might imply ownership or possession rather than existence. Therefore, exists is often preferred for methods that check for the presence of an item. It's also what the Laravel Filesystem facade uses.

Part of https://github.com/hydephp/develop/pull/1904