### PR TITLE
[1.x] Deprecate `Hyde::mediaLink` being replaced by `Hyde::asset()` in v2

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -31,6 +31,7 @@ This serves two purposes:
 ### Deprecated
 - The `PostAuthor::getName()` method is now deprecated and will be removed in v2. (use `$author->name` instead) in https://github.com/hydephp/develop/pull/1794
 - Deprecated the `FeaturedImage::isRemote()` method in favor of the new `Hyperlinks::isRemote()` method in https://github.com/hydephp/develop/pull/1882
+- Deprecated the `Hyde::mediaLink()` method in favor of the `Hyde::asset()` method in https://github.com/hydephp/develop/pull/1993
 
 ### Removed
 - for now removed features.

--- a/packages/framework/src/Foundation/Concerns/ForwardsHyperlinks.php
+++ b/packages/framework/src/Foundation/Concerns/ForwardsHyperlinks.php
@@ -23,8 +23,13 @@ trait ForwardsHyperlinks
         return $this->hyperlinks->relativeLink($destination);
     }
 
+    /**
+     * @deprecated This method will be removed in v2.0. Please use `asset()` instead.
+     */
     public function mediaLink(string $destination, bool $validate = false): string
     {
+        trigger_deprecation('hyde/framework', '1.8.0', 'The %s() method is deprecated, use %s() instead.', __METHOD__, 'asset');
+
         return $this->hyperlinks->mediaLink($destination, $validate);
     }
 

--- a/packages/framework/src/Foundation/Concerns/ForwardsHyperlinks.php
+++ b/packages/framework/src/Foundation/Concerns/ForwardsHyperlinks.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Hyde\Foundation\Concerns;
 
 use Hyde\Support\Models\Route;
+use JetBrains\PhpStorm\Deprecated;
 
 /**
  * @internal Single-use trait for the HydeKernel class.
@@ -26,6 +27,7 @@ trait ForwardsHyperlinks
     /**
      * @deprecated This method will be removed in v2.0. Please use `asset()` instead.
      */
+    #[Deprecated(reason: 'Use `asset` method instead.', replacement: '%class%::asset(%parameter0%)')]
     public function mediaLink(string $destination, bool $validate = false): string
     {
         trigger_deprecation('hyde/framework', '1.8.0', 'The %s() method is deprecated, use %s() instead.', __METHOD__, 'asset');

--- a/packages/framework/src/Foundation/Kernel/Hyperlinks.php
+++ b/packages/framework/src/Foundation/Kernel/Hyperlinks.php
@@ -7,6 +7,7 @@ namespace Hyde\Foundation\Kernel;
 use Hyde\Facades\Config;
 use Hyde\Support\Models\Route;
 use Hyde\Foundation\HydeKernel;
+use JetBrains\PhpStorm\Deprecated;
 use Hyde\Framework\Exceptions\BaseUrlNotSetException;
 use Hyde\Framework\Exceptions\FileNotFoundException;
 use Illuminate\Support\Str;
@@ -95,6 +96,7 @@ class Hyperlinks
      *
      * @deprecated This method will be removed in v2.0. Please use `asset()` instead.
      */
+    #[Deprecated(reason: 'Use `asset` method instead.', replacement: '%class%->asset(%parameter0%)')]
     public function mediaLink(string $destination, bool $validate = false): string
     {
         if ($validate && ! file_exists($sourcePath = "{$this->kernel->getMediaDirectory()}/$destination")) {

--- a/packages/framework/src/Foundation/Kernel/Hyperlinks.php
+++ b/packages/framework/src/Foundation/Kernel/Hyperlinks.php
@@ -92,6 +92,8 @@ class Hyperlinks
      *
      * An exception will be thrown if the file does not exist in the _media directory,
      * and the second argument is set to true.
+     *
+     * @deprecated This method will be removed in v2.0. Please use `asset()` instead.
      */
     public function mediaLink(string $destination, bool $validate = false): string
     {


### PR DESCRIPTION
See https://github.com/hydephp/develop/pull/1904