### PR TITLE
[2.x] Update default configuration to no longer save previewed pages

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -51,6 +51,7 @@ This serves two purposes:
 - Minor: The `processing_time_ms` attribute in the `sitemap.xml` file has now been removed in https://github.com/hydephp/develop/pull/1744
 - Minor: Updated the `Hyde::url()` helper throw a `BadMethodCallException` instead `BaseUrlNotSetException` when no site URL is set and no path was provided to the method in https://github.com/hydephp/develop/pull/1760 and https://github.com/hydephp/develop/pull/1890
 - Minor: Updated the blog post layout and post feed component to use the `BlogPosting` Schema.org type instead of `Article` in https://github.com/hydephp/develop/pull/1887
+- Updated default configuration to no longer save previewed pages in https://github.com/hydephp/develop/pull/1995
 - Added more rich markup data to blog post components in https://github.com/hydephp/develop/pull/1888 (Note that this inevitably changes the HTML output of the blog post components, and that any customized templates will need to be republished to reflect these changes)
 - Overhauled the blog post author feature in https://github.com/hydephp/develop/pull/1782
 - Improved the sitemap data generation to be smarter and more dynamic in https://github.com/hydephp/develop/pull/1744

--- a/config/hyde.php
+++ b/config/hyde.php
@@ -423,7 +423,7 @@ return [
         'host' => env('SERVER_HOST', 'localhost'),
 
         // Should preview pages be saved to the output directory?
-        'save_preview' => true,
+        'save_preview' => false,
 
         // Should the live edit feature be enabled?
         'live_edit' => env('SERVER_LIVE_EDIT', true),

--- a/docs/extensions/realtime-compiler.md
+++ b/docs/extensions/realtime-compiler.md
@@ -31,7 +31,7 @@ The server can be configured in the `config/hyde.php` file to change the port, h
 'server' => [
     'port' => env('SERVER_PORT', 8080),
     'host' => env('SERVER_HOST', 'localhost'),
-    'save_preview' => true,
+    'save_preview' => false,
 ],
 ```
 

--- a/packages/framework/config/hyde.php
+++ b/packages/framework/config/hyde.php
@@ -423,7 +423,7 @@ return [
         'host' => env('SERVER_HOST', 'localhost'),
 
         // Should preview pages be saved to the output directory?
-        'save_preview' => true,
+        'save_preview' => false,
 
         // Should the live edit feature be enabled?
         'live_edit' => env('SERVER_LIVE_EDIT', true),

--- a/packages/realtime-compiler/tests/RealtimeCompilerTest.php
+++ b/packages/realtime-compiler/tests/RealtimeCompilerTest.php
@@ -49,11 +49,6 @@ class RealtimeCompilerTest extends UnitTestCase
         $this->assertEquals(200, $response->statusCode);
         $this->assertEquals('OK', $response->statusMessage);
         $this->assertStringContainsString('<title>Welcome to HydePHP!</title>', $response->body);
-
-        $this->assertFileExists(hyde()->path('_site/index.html'));
-        $this->assertEquals($response->body, Filesystem::get('_site/index.html'));
-
-        Filesystem::unlink('_site/index.html');
     }
 
     public function testHandlesRoutesCustomPages()
@@ -71,13 +66,10 @@ class RealtimeCompilerTest extends UnitTestCase
         $this->assertStringContainsString('<h1>Hello World!</h1>', $response->body);
 
         Filesystem::unlink('_pages/foo.md');
-        Filesystem::unlink('_site/foo.html');
     }
 
     public function testHandlesRoutesPagesWithHtmlExtension()
     {
-        $this->mockRoute('foo.html');
-
         Filesystem::put('_pages/foo.md', '# Hello World!');
 
         $kernel = new HttpKernel();
@@ -89,7 +81,6 @@ class RealtimeCompilerTest extends UnitTestCase
         $this->assertStringContainsString('<h1>Hello World!</h1>', $response->body);
 
         Filesystem::unlink('_pages/foo.md');
-        Filesystem::unlink('_site/foo.html');
     }
 
     public function testHandlesRoutesStaticAssets()
@@ -144,7 +135,6 @@ class RealtimeCompilerTest extends UnitTestCase
         $this->assertStringContainsString('<h1>Hello World!</h1>', $response->body);
 
         Filesystem::unlink('_pages/foo.md');
-        Filesystem::unlink('_site/foo.html');
     }
 
     public function testDocsUriPathIsReroutedToDocsIndex()
@@ -162,7 +152,6 @@ class RealtimeCompilerTest extends UnitTestCase
         $this->assertStringContainsString('HydePHP Docs', $response->body);
 
         Filesystem::unlink('_docs/index.md');
-        Filesystem::unlink('_site/docs/index.html');
     }
 
     public function testDocsSearchRendersSearchPage()
@@ -179,7 +168,6 @@ class RealtimeCompilerTest extends UnitTestCase
         $this->assertStringContainsString('Search the documentation site', $response->body);
 
         Filesystem::unlink('_docs/index.md');
-        Filesystem::unlink('_site/docs/search.html');
     }
 
     public function testPingRouteReturnsPingResponse()


### PR DESCRIPTION
### PR Description: Implement Changes to Serve Command

This pull request addresses issue [#1994](https://github.com/hydephp/develop/issues/1994) by updating the `serve` command to not save pages by default. This change aims to enhance the developer experience by making the behavior of the `serve` command less unexpected.

#### Motivation for the Change
- **Unexpected Behavior**: The current implementation of the `serve` command saves pages by default, which can be surprising for developers who do not anticipate this action.
- **Improved Development Workflow**: By not saving pages by default, the development workflow becomes more intuitive, allowing developers to preview changes without automatically persisting them.

#### Key Changes
- Update the `serve` command to disable automatic saving of pages by default.
- The option for users to enable saving if desired is still available. 

This PR fixes https://github.com/hydephp/develop/issues/1994