### PR TITLE
[2.x] Simplify numerical page ordering

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -11,7 +11,7 @@ This serves two purposes:
 
 ### Added
 
-- You can now specify navigation priorities by adding a numeric prefix to the source file names in https://github.com/hydephp/develop/pull/1709
+- You can now specify sidebar item priorities by adding a numeric prefix to doc umentation page source file names in https://github.com/hydephp/develop/pull/1709
 - Added support for resolving dynamic links to source files in Markdown documents in https://github.com/hydephp/develop/pull/1590
 - Added a new `\Hyde\Framework\Actions\PreBuildTasks\TransferMediaAssets` build task handle media assets transfers for site builds.
 - Added a new `\Hyde\Framework\Exceptions\ParseException` exception class to handle parsing exceptions in data collection files in https://github.com/hydephp/develop/pull/1732

--- a/docs/creating-content/documentation-pages.md
+++ b/docs/creating-content/documentation-pages.md
@@ -320,15 +320,6 @@ Here are two useful tips:
 1. You can use numerical prefixes in subdirectories to control the sidebar group order.
 2. The numbering within a subdirectory works independently of its siblings, so you can start from one in each subdirectory.
 
-#### Customization
-
-If you're not interested in using numerical prefix ordering, you can disable it in the Hyde config file. Hyde will then no longer extract the priority and will no longer strip the prefix from the route key.
-
-```php
-// filepath: config/hyde.php
-'numerical_page_ordering' => false,
-```
-
 ### Table of Contents Settings
 
 Hyde automatically generates a table of contents for the page and adds it to the sidebar.

--- a/docs/digging-deeper/navigation.md
+++ b/docs/digging-deeper/navigation.md
@@ -236,45 +236,6 @@ Now if you create a page called `_pages/about/contact.md`, it will automatically
 - Dropdowns take priority over standard items. If you have a dropdown with the key `about` and a page with the key `about`, the dropdown will be created, and the page won't be in the menu.
 - Example: With this file structure: `_pages/foo.md`, `_pages/foo/bar.md`, `_pages/foo/baz.md`, the link to `foo` will be lost, so please keep this in mind when using this feature.
 
-## Numerical Prefix Navigation Ordering
-
-HydePHP v2 introduces navigation item ordering based on numerical prefixes in filenames. This feature works for the primary navigation menu.
-
-This has the great benefit of matching the navigation menu layout with the file structure view. It also works especially well with subdirectory-based navigation grouping.
-
-```shell
-_pages/
-  01-home.md     # Priority: 1 (saved to _site/index.html)
-  02-about.md    # Priority: 2 (saved to _site/about.html)
-  03-contact.md  # Priority: 3 (saved to _site/contact.html)
-```
-
-As you can see, Hyde parses the number from the filename and uses it as the priority for the page in navigation menus, while stripping the prefix from the route key.
-
-### Important Notes
-
-1. The numerical prefix remains part of the page identifier but is stripped from the route key.
-   For example: `_pages/01-home.md` has route key `home` and page identifier `01-home`.
-2. You can delimit the numerical prefix with either a dash or an underscore.
-   For example: Both `_pages/01-home.md` and `_pages/01_home.md` are valid.
-3. Leading zeros are optional. `_pages/1-home.md` is equally valid.
-
-### Using Numerical Prefix Ordering in Subdirectories
-
-This feature integrates well with automatic subdirectory-based navigation grouping. Here are two useful tips:
-
-1. You can use numerical prefixes in subdirectories to control the dropdown order.
-2. The numbering within a subdirectory works independently of its siblings, so you can start from one in each subdirectory.
-
-### Customization
-
-If you're not interested in using numerical prefix ordering, you can disable it in the Hyde config file. Hyde will then no longer extract the priority and will no longer strip the prefix from the route key.
-
-```php
-// filepath: config/hyde.php
-'numerical_page_ordering' => false,
-```
-
 ## Digging Deeper Into the Internals
 
 While not essential, understanding the internal workings of the navigation system can be as beneficial as it's interesting. Here's a quick high-level overview of the [Navigation API](navigation-api).

--- a/packages/framework/src/Framework/Factories/NavigationDataFactory.php
+++ b/packages/framework/src/Framework/Factories/NavigationDataFactory.php
@@ -245,6 +245,10 @@ class NavigationDataFactory extends Concerns\PageDataFactory implements Navigati
 
     private function checkFilePrefixForOrder(): ?int
     {
+        if (! $this->isInstanceOf(DocumentationPage::class)) {
+            return null;
+        }
+
         if (! NumericalPageOrderingHelper::enabled()) {
             return null;
         }

--- a/packages/framework/src/Framework/Factories/NavigationDataFactory.php
+++ b/packages/framework/src/Framework/Factories/NavigationDataFactory.php
@@ -249,10 +249,6 @@ class NavigationDataFactory extends Concerns\PageDataFactory implements Navigati
             return null;
         }
 
-        if (! NumericalPageOrderingHelper::enabled()) {
-            return null;
-        }
-
         if (! NumericalPageOrderingHelper::hasNumericalPrefix($this->identifier)) {
             return null;
         }

--- a/packages/framework/src/Framework/Features/Navigation/NumericalPageOrderingHelper.php
+++ b/packages/framework/src/Framework/Features/Navigation/NumericalPageOrderingHelper.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Hyde\Framework\Features\Navigation;
 
-use Hyde\Facades\Config;
 use Illuminate\Support\Str;
 
 use function ltrim;
@@ -23,12 +22,6 @@ class NumericalPageOrderingHelper
 {
     /** @var array<string> The delimiters that are used to separate the numerical prefix from the rest of the identifier. */
     protected const DELIMITERS = ['-', '_'];
-
-    /** Check if the feature is enabled. */
-    public static function enabled(): bool
-    {
-        return Config::getBool('hyde.numerical_page_ordering', true);
-    }
 
     /** Determines if a given identifier has a numerical prefix. */
     public static function hasNumericalPrefix(string $identifier): bool

--- a/packages/framework/src/Support/Models/RouteKey.php
+++ b/packages/framework/src/Support/Models/RouteKey.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Hyde\Support\Models;
 
 use Stringable;
+use Hyde\Pages\DocumentationPage;
 use Hyde\Framework\Features\Navigation\NumericalPageOrderingHelper;
 
 use function Hyde\unslash;
@@ -48,7 +49,9 @@ final class RouteKey implements Stringable
     /** @param class-string<\Hyde\Pages\Concerns\HydePage> $pageClass */
     public static function fromPage(string $pageClass, string $identifier): self
     {
-        $identifier = self::splitNumberedIdentifiersIfNeeded($identifier);
+        if (is_a($pageClass, DocumentationPage::class, true)) {
+            $identifier = self::splitNumberedIdentifiersIfNeeded($identifier);
+        }
 
         return new self(unslash("{$pageClass::baseRouteKey()}/$identifier"));
     }

--- a/packages/framework/src/Support/Models/RouteKey.php
+++ b/packages/framework/src/Support/Models/RouteKey.php
@@ -59,7 +59,7 @@ final class RouteKey implements Stringable
     /** @experimental */
     protected static function splitNumberedIdentifiersIfNeeded(string $identifier): string
     {
-        if (NumericalPageOrderingHelper::enabled() && NumericalPageOrderingHelper::hasNumericalPrefix($identifier)) {
+        if (NumericalPageOrderingHelper::hasNumericalPrefix($identifier)) {
             return NumericalPageOrderingHelper::splitNumericPrefix($identifier)[1];
         }
 

--- a/packages/framework/tests/Feature/NumericalPageOrderingHelperTest.php
+++ b/packages/framework/tests/Feature/NumericalPageOrderingHelperTest.php
@@ -17,8 +17,7 @@ use Hyde\Framework\Features\Navigation\NavigationMenuGenerator;
 /**
  * High level test for the feature that allows sidebar items to be sorted by filename prefix.
  *
- * The feature can be disabled in the config. It also works within sidebar groups,
- * so that multiple groups can have the same prefix independent of other groups.
+ * It also works within sidebar groups, so that multiple groups can have the same prefix independent of other groups.
  *
  * @covers \Hyde\Framework\Features\Navigation\NumericalPageOrderingHelper
  * @covers \Hyde\Framework\Features\Navigation\DocumentationSidebar
@@ -75,37 +74,6 @@ class NumericalPageOrderingHelperTest extends TestCase
 
         // Assert route key dependents are trimmed.
         $this->assertSame('docs/readme.html', $page->getOutputPath());
-    }
-
-    public function testSourceFilesDoNotHaveTheirNumericalPrefixTrimmedFromRouteKeysWhenFeatureIsDisabled()
-    {
-        Config::set('hyde.numerical_page_ordering', false);
-
-        $this->file('_docs/01-readme.md');
-
-        $identifier = '01-readme';
-
-        // Assert it is discovered.
-        $discovered = DocumentationPage::get($identifier);
-        $this->assertNotNull($discovered, 'The page was not discovered.');
-
-        // Assert it is parsable
-        $parsed = DocumentationPage::parse($identifier);
-        $this->assertNotNull($parsed, 'The page was not parsable.');
-
-        // Sanity check
-        $this->assertEquals($discovered, $parsed);
-
-        $page = $discovered;
-
-        // Assert identifier is the same.
-        $this->assertSame($identifier, $page->getIdentifier());
-
-        // Assert the route key is not trimmed.
-        $this->assertSame('docs/'.$identifier, $page->getRouteKey());
-
-        // Assert route key dependents are trimmed.
-        $this->assertSame("docs/$identifier.html", $page->getOutputPath());
     }
 
     public function testFlatSidebarNavigationOrdering()

--- a/packages/framework/tests/Feature/NumericalPageOrderingHelperTest.php
+++ b/packages/framework/tests/Feature/NumericalPageOrderingHelperTest.php
@@ -111,66 +111,6 @@ class NumericalPageOrderingHelperTest extends TestCase
         $this->assertSame("$identifier.html", $page->getOutputPath());
     }
 
-    public function testFlatMainNavigationOrdering()
-    {
-        $this->setupFixture([
-            '01-home.md',
-            '02-about.md',
-            '03-contact.md',
-        ]);
-
-        $this->assertOrder(['home', 'about', 'contact']);
-    }
-
-    public function testReverseOrderOfFlatMainNavigation()
-    {
-        // This is just a sanity check to make sure the helper is working, so we only need one of these.
-        $this->setupFixture(array_reverse([
-            '01-home.md',
-            '02-about.md',
-            '03-contact.md',
-        ]));
-
-        $this->assertOrder(['home', 'about', 'contact']);
-    }
-
-    public function testGroupedMainNavigationOrdering()
-    {
-        $this->setupFixture([
-            '01-home.md',
-            '02-about.md',
-            '03-contact.md',
-            '04-api' => [
-                '01-readme.md',
-                '02-installation.md',
-                '03-getting-started.md',
-            ],
-        ]);
-
-        $this->assertOrder(['home', 'about', 'contact', 'api' => [
-            'readme', 'installation', 'getting-started',
-        ]]);
-    }
-
-    public function testReverseOrderOfGroupedMainNavigation()
-    {
-        // Also a sanity check but for the inner group as well.
-        $this->setupFixture($this->arrayReverseRecursive([
-            '01-home.md',
-            '02-about.md',
-            '03-contact.md',
-            '04-api' => [
-                '01-readme.md',
-                '02-installation.md',
-                '03-getting-started.md',
-            ],
-        ]));
-
-        $this->assertOrder(['home', 'about', 'contact', 'api' => [
-            'readme', 'installation', 'getting-started',
-        ]]);
-    }
-
     public function testFlatSidebarNavigationOrdering()
     {
         $this->setUpSidebarFixture([

--- a/packages/framework/tests/Feature/Services/SitemapServiceTest.php
+++ b/packages/framework/tests/Feature/Services/SitemapServiceTest.php
@@ -7,7 +7,6 @@ declare(strict_types=1);
 namespace Hyde\Framework\Testing\Feature\Services;
 
 use SimpleXMLElement;
-use Hyde\Facades\Config;
 use Hyde\Facades\Filesystem;
 use Hyde\Framework\Features\XmlGenerators\SitemapGenerator;
 use Hyde\Hyde;
@@ -29,8 +28,6 @@ class SitemapServiceTest extends TestCase
 
         copy(Hyde::vendorPath('resources/views/homepages/welcome.blade.php'), Hyde::path('_pages/index.blade.php'));
         copy(Hyde::vendorPath('resources/views/pages/404.blade.php'), Hyde::path('_pages/404.blade.php'));
-
-        Config::set(['hyde.numerical_page_ordering' => false]);
     }
 
     public function testServiceInstantiatesXmlElement()

--- a/packages/framework/tests/Unit/NavigationDataFactoryUnitTest.php
+++ b/packages/framework/tests/Unit/NavigationDataFactoryUnitTest.php
@@ -269,7 +269,7 @@ class NavigationDataFactoryUnitTest extends UnitTestCase
 
     public function testItExtractsPriorityFromNumericalFilenamePrefix()
     {
-        $coreDataObject = $this->makeCoreDataObject('01-test.md');
+        $coreDataObject = $this->makeCoreDataObject('01-test.md', pageClass: DocumentationPage::class);
         $factory = new NavigationConfigTestClass($coreDataObject);
 
         $this->assertSame(1, $factory->makePriority());
@@ -277,47 +277,47 @@ class NavigationDataFactoryUnitTest extends UnitTestCase
 
     public function testItExtractsPriorityFromNumericalFilenamePrefixWithKebabCaseSyntax()
     {
-        $this->assertSame(1, (new NavigationConfigTestClass($this->makeCoreDataObject('01-foo.md')))->makePriority());
-        $this->assertSame(2, (new NavigationConfigTestClass($this->makeCoreDataObject('02-bar.md')))->makePriority());
-        $this->assertSame(3, (new NavigationConfigTestClass($this->makeCoreDataObject('03-baz.md')))->makePriority());
+        $this->assertSame(1, (new NavigationConfigTestClass($this->makeCoreDataObject('01-foo.md', pageClass: DocumentationPage::class)))->makePriority());
+        $this->assertSame(2, (new NavigationConfigTestClass($this->makeCoreDataObject('02-bar.md', pageClass: DocumentationPage::class)))->makePriority());
+        $this->assertSame(3, (new NavigationConfigTestClass($this->makeCoreDataObject('03-baz.md', pageClass: DocumentationPage::class)))->makePriority());
     }
 
     public function testItExtractsPriorityFromNumericalFilenamePrefixWithSnakeCaseSyntax()
     {
-        $this->assertSame(1, (new NavigationConfigTestClass($this->makeCoreDataObject('01_foo.md')))->makePriority());
-        $this->assertSame(2, (new NavigationConfigTestClass($this->makeCoreDataObject('02_bar.md')))->makePriority());
-        $this->assertSame(3, (new NavigationConfigTestClass($this->makeCoreDataObject('03_baz.md')))->makePriority());
+        $this->assertSame(1, (new NavigationConfigTestClass($this->makeCoreDataObject('01_foo.md', pageClass: DocumentationPage::class)))->makePriority());
+        $this->assertSame(2, (new NavigationConfigTestClass($this->makeCoreDataObject('02_bar.md', pageClass: DocumentationPage::class)))->makePriority());
+        $this->assertSame(3, (new NavigationConfigTestClass($this->makeCoreDataObject('03_baz.md', pageClass: DocumentationPage::class)))->makePriority());
     }
 
     public function testItExtractsPriorityFromNumericalFilenamePrefixRegardlessOfLeadingZeroes()
     {
-        $this->assertSame(123, (new NavigationConfigTestClass($this->makeCoreDataObject('123-foo.md')))->makePriority());
-        $this->assertSame(123, (new NavigationConfigTestClass($this->makeCoreDataObject('0123-foo.md')))->makePriority());
-        $this->assertSame(123, (new NavigationConfigTestClass($this->makeCoreDataObject('00123-foo.md')))->makePriority());
-        $this->assertSame(123, (new NavigationConfigTestClass($this->makeCoreDataObject('000123-foo.md')))->makePriority());
-        $this->assertSame(123, (new NavigationConfigTestClass($this->makeCoreDataObject('0000123-foo.md')))->makePriority());
+        $this->assertSame(123, (new NavigationConfigTestClass($this->makeCoreDataObject('123-foo.md', pageClass: DocumentationPage::class)))->makePriority());
+        $this->assertSame(123, (new NavigationConfigTestClass($this->makeCoreDataObject('0123-foo.md', pageClass: DocumentationPage::class)))->makePriority());
+        $this->assertSame(123, (new NavigationConfigTestClass($this->makeCoreDataObject('00123-foo.md', pageClass: DocumentationPage::class)))->makePriority());
+        $this->assertSame(123, (new NavigationConfigTestClass($this->makeCoreDataObject('000123-foo.md', pageClass: DocumentationPage::class)))->makePriority());
+        $this->assertSame(123, (new NavigationConfigTestClass($this->makeCoreDataObject('0000123-foo.md', pageClass: DocumentationPage::class)))->makePriority());
     }
 
     public function testItExtractsPriorityFromNumericalFilenamePrefixForNestedIdentifiers()
     {
-        $this->assertSame(1, (new NavigationConfigTestClass($this->makeCoreDataObject('foo/01-bar.md')))->makePriority());
-        $this->assertSame(2, (new NavigationConfigTestClass($this->makeCoreDataObject('foo/bar/02-baz.md')))->makePriority());
-        $this->assertSame(3, (new NavigationConfigTestClass($this->makeCoreDataObject('foo/01-bar/03-baz.md')))->makePriority());
+        $this->assertSame(1, (new NavigationConfigTestClass($this->makeCoreDataObject('foo/01-bar.md', pageClass: DocumentationPage::class)))->makePriority());
+        $this->assertSame(2, (new NavigationConfigTestClass($this->makeCoreDataObject('foo/bar/02-baz.md', pageClass: DocumentationPage::class)))->makePriority());
+        $this->assertSame(3, (new NavigationConfigTestClass($this->makeCoreDataObject('foo/01-bar/03-baz.md', pageClass: DocumentationPage::class)))->makePriority());
     }
 
     public function testItDoesNotExtractPriorityFromNumericalFilenamePrefixWhenFeatureIsDisabled()
     {
         self::mockConfig(['hyde.numerical_page_ordering' => false]);
 
-        $this->assertSame(999, (new NavigationConfigTestClass($this->makeCoreDataObject('01-test.md')))->makePriority());
-        $this->assertSame(999, (new NavigationConfigTestClass($this->makeCoreDataObject('01-home.md')))->makePriority());
-        $this->assertSame(999, (new NavigationConfigTestClass($this->makeCoreDataObject('01-404.md')))->makePriority());
+        $this->assertSame(999, (new NavigationConfigTestClass($this->makeCoreDataObject('01-test.md', pageClass: DocumentationPage::class)))->makePriority());
+        $this->assertSame(999, (new NavigationConfigTestClass($this->makeCoreDataObject('01-home.md', pageClass: DocumentationPage::class)))->makePriority());
+        $this->assertSame(999, (new NavigationConfigTestClass($this->makeCoreDataObject('01-404.md', pageClass: DocumentationPage::class)))->makePriority());
     }
 
     public function testItDoesNotExtractNonNumericalFilenamePrefixes()
     {
-        $this->assertSame(999, (new NavigationConfigTestClass($this->makeCoreDataObject('foo-bar.md')))->makePriority());
-        $this->assertSame(999, (new NavigationConfigTestClass($this->makeCoreDataObject('abc-bar.md')))->makePriority());
+        $this->assertSame(999, (new NavigationConfigTestClass($this->makeCoreDataObject('foo-bar.md', pageClass: DocumentationPage::class)))->makePriority());
+        $this->assertSame(999, (new NavigationConfigTestClass($this->makeCoreDataObject('abc-bar.md', pageClass: DocumentationPage::class)))->makePriority());
     }
 
     public function testFrontMatterValueOverridesFilenamePrefixPriority()

--- a/packages/framework/tests/Unit/NavigationDataFactoryUnitTest.php
+++ b/packages/framework/tests/Unit/NavigationDataFactoryUnitTest.php
@@ -305,15 +305,6 @@ class NavigationDataFactoryUnitTest extends UnitTestCase
         $this->assertSame(3, (new NavigationConfigTestClass($this->makeCoreDataObject('foo/01-bar/03-baz.md', pageClass: DocumentationPage::class)))->makePriority());
     }
 
-    public function testItDoesNotExtractPriorityFromNumericalFilenamePrefixWhenFeatureIsDisabled()
-    {
-        self::mockConfig(['hyde.numerical_page_ordering' => false]);
-
-        $this->assertSame(999, (new NavigationConfigTestClass($this->makeCoreDataObject('01-test.md', pageClass: DocumentationPage::class)))->makePriority());
-        $this->assertSame(999, (new NavigationConfigTestClass($this->makeCoreDataObject('01-home.md', pageClass: DocumentationPage::class)))->makePriority());
-        $this->assertSame(999, (new NavigationConfigTestClass($this->makeCoreDataObject('01-404.md', pageClass: DocumentationPage::class)))->makePriority());
-    }
-
     public function testItDoesNotExtractNonNumericalFilenamePrefixes()
     {
         $this->assertSame(999, (new NavigationConfigTestClass($this->makeCoreDataObject('foo-bar.md', pageClass: DocumentationPage::class)))->makePriority());

--- a/packages/framework/tests/Unit/NumericalPageOrderingHelperUnitTest.php
+++ b/packages/framework/tests/Unit/NumericalPageOrderingHelperUnitTest.php
@@ -17,25 +17,6 @@ class NumericalPageOrderingHelperUnitTest extends UnitTestCase
 {
     protected static bool $needsConfig = true;
 
-    public function testEnabledReturnsTrueWhenEnabled()
-    {
-        $this->assertTrue(NumericalPageOrderingHelper::enabled());
-    }
-
-    public function testFeatureIsEnabledByDefault()
-    {
-        self::mockConfig(['hyde' => []]);
-
-        $this->assertTrue(NumericalPageOrderingHelper::enabled());
-    }
-
-    public function testEnabledReturnsFalseWhenDisabled()
-    {
-        self::mockConfig(['hyde.numerical_page_ordering' => false]);
-
-        $this->assertFalse(NumericalPageOrderingHelper::enabled());
-    }
-
     public function testIdentifiersWithNumericalPrefixesAreDetected()
     {
         $this->assertTrue(NumericalPageOrderingHelper::hasNumericalPrefix('01-home.md'));

--- a/packages/framework/tests/Unit/RouteKeyTest.php
+++ b/packages/framework/tests/Unit/RouteKeyTest.php
@@ -132,15 +132,6 @@ class RouteKeyTest extends UnitTestCase
         $this->assertSame('docs/foo/bar/baz', RouteKey::fromPage(DocumentationPage::class, 'foo/01-bar/03-baz')->get());
     }
 
-    public function testItDoesNotExtractCoreIdentifierPartFromNumericalFilenamePrefixWhenFeatureIsDisabled()
-    {
-        self::mockConfig(['hyde.numerical_page_ordering' => false]);
-
-        $this->assertSame('docs/01-test', RouteKey::fromPage(DocumentationPage::class, '01-test')->get());
-        $this->assertSame('docs/01-home', RouteKey::fromPage(DocumentationPage::class, '01-home')->get());
-        $this->assertSame('docs/01-404', RouteKey::fromPage(DocumentationPage::class, '01-404')->get());
-    }
-
     public function testItDoesNotExtractNonNumericalFilenamePrefixes()
     {
         $this->assertSame('docs/foo-bar', RouteKey::fromPage(DocumentationPage::class, 'foo-bar')->get());

--- a/packages/framework/tests/Unit/RouteKeyTest.php
+++ b/packages/framework/tests/Unit/RouteKeyTest.php
@@ -99,51 +99,51 @@ class RouteKeyTest extends UnitTestCase
 
     public function testItExtractsCoreIdentifierPartFromNumericalFilenamePrefix()
     {
-        $this->assertSame('test', RouteKey::fromPage(MarkdownPage::class, '01-test')->get());
+        $this->assertSame('docs/test', RouteKey::fromPage(DocumentationPage::class, '01-test')->get());
     }
 
     public function testItExtractsCoreIdentifierPartFromNumericalFilenamePrefixWithKebabCaseSyntax()
     {
-        $this->assertSame('foo', RouteKey::fromPage(MarkdownPage::class, '01-foo')->get());
-        $this->assertSame('bar', RouteKey::fromPage(MarkdownPage::class, '02-bar')->get());
-        $this->assertSame('baz', RouteKey::fromPage(MarkdownPage::class, '03-baz')->get());
+        $this->assertSame('docs/foo', RouteKey::fromPage(DocumentationPage::class, '01-foo')->get());
+        $this->assertSame('docs/bar', RouteKey::fromPage(DocumentationPage::class, '02-bar')->get());
+        $this->assertSame('docs/baz', RouteKey::fromPage(DocumentationPage::class, '03-baz')->get());
     }
 
     public function testItExtractsCoreIdentifierPartFromNumericalFilenamePrefixWithSnakeCaseSyntax()
     {
-        $this->assertSame('foo', RouteKey::fromPage(MarkdownPage::class, '01_foo')->get());
-        $this->assertSame('bar', RouteKey::fromPage(MarkdownPage::class, '02_bar')->get());
-        $this->assertSame('baz', RouteKey::fromPage(MarkdownPage::class, '03_baz')->get());
+        $this->assertSame('docs/foo', RouteKey::fromPage(DocumentationPage::class, '01_foo')->get());
+        $this->assertSame('docs/bar', RouteKey::fromPage(DocumentationPage::class, '02_bar')->get());
+        $this->assertSame('docs/baz', RouteKey::fromPage(DocumentationPage::class, '03_baz')->get());
     }
 
     public function testItExtractsCoreIdentifierPartFromNumericalFilenamePrefixRegardlessOfLeadingZeroes()
     {
-        $this->assertSame('foo', RouteKey::fromPage(MarkdownPage::class, '123-foo')->get());
-        $this->assertSame('foo', RouteKey::fromPage(MarkdownPage::class, '0123-foo')->get());
-        $this->assertSame('foo', RouteKey::fromPage(MarkdownPage::class, '00123-foo')->get());
-        $this->assertSame('foo', RouteKey::fromPage(MarkdownPage::class, '000123-foo')->get());
-        $this->assertSame('foo', RouteKey::fromPage(MarkdownPage::class, '0000123-foo')->get());
+        $this->assertSame('docs/foo', RouteKey::fromPage(DocumentationPage::class, '123-foo')->get());
+        $this->assertSame('docs/foo', RouteKey::fromPage(DocumentationPage::class, '0123-foo')->get());
+        $this->assertSame('docs/foo', RouteKey::fromPage(DocumentationPage::class, '00123-foo')->get());
+        $this->assertSame('docs/foo', RouteKey::fromPage(DocumentationPage::class, '000123-foo')->get());
+        $this->assertSame('docs/foo', RouteKey::fromPage(DocumentationPage::class, '0000123-foo')->get());
     }
 
     public function testItExtractsCoreIdentifierPartFromNumericalFilenamePrefixForNestedIdentifiers()
     {
-        $this->assertSame('foo/bar', RouteKey::fromPage(MarkdownPage::class, 'foo/01-bar')->get());
-        $this->assertSame('foo/bar/baz', RouteKey::fromPage(MarkdownPage::class, 'foo/bar/02-baz')->get());
-        $this->assertSame('foo/bar/baz', RouteKey::fromPage(MarkdownPage::class, 'foo/01-bar/03-baz')->get());
+        $this->assertSame('docs/foo/bar', RouteKey::fromPage(DocumentationPage::class, 'foo/01-bar')->get());
+        $this->assertSame('docs/foo/bar/baz', RouteKey::fromPage(DocumentationPage::class, 'foo/bar/02-baz')->get());
+        $this->assertSame('docs/foo/bar/baz', RouteKey::fromPage(DocumentationPage::class, 'foo/01-bar/03-baz')->get());
     }
 
     public function testItDoesNotExtractCoreIdentifierPartFromNumericalFilenamePrefixWhenFeatureIsDisabled()
     {
         self::mockConfig(['hyde.numerical_page_ordering' => false]);
 
-        $this->assertSame('01-test', RouteKey::fromPage(MarkdownPage::class, '01-test')->get());
-        $this->assertSame('01-home', RouteKey::fromPage(MarkdownPage::class, '01-home')->get());
-        $this->assertSame('01-404', RouteKey::fromPage(MarkdownPage::class, '01-404')->get());
+        $this->assertSame('docs/01-test', RouteKey::fromPage(DocumentationPage::class, '01-test')->get());
+        $this->assertSame('docs/01-home', RouteKey::fromPage(DocumentationPage::class, '01-home')->get());
+        $this->assertSame('docs/01-404', RouteKey::fromPage(DocumentationPage::class, '01-404')->get());
     }
 
     public function testItDoesNotExtractNonNumericalFilenamePrefixes()
     {
-        $this->assertSame('foo-bar', RouteKey::fromPage(MarkdownPage::class, 'foo-bar')->get());
-        $this->assertSame('abc-bar', RouteKey::fromPage(MarkdownPage::class, 'abc-bar')->get());
+        $this->assertSame('docs/foo-bar', RouteKey::fromPage(DocumentationPage::class, 'foo-bar')->get());
+        $this->assertSame('docs/abc-bar', RouteKey::fromPage(DocumentationPage::class, 'abc-bar')->get());
     }
 }


### PR DESCRIPTION
Changes the numerical navigation prefix ordering to only work on documentation pages and removes the config option. Fixes https://github.com/hydephp/develop/issues/1997, which also has the motivations for this.