### PR TITLE
No longer copy files to site output from the asset bundler command

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -90,6 +90,7 @@ This serves two purposes:
     - We now use the much faster `CRC32` hashing algorithm instead of `MD5` for cache busting keys in https://github.com/hydephp/develop/pull/1918
 - **Replaced Laravel Mix with Vite for frontend asset compilation** in https://github.com/hydephp/develop/pull/2010
     - **Breaking:** You must now use `npm run build` to compile your assets, instead of `npm run prod`
+    - Bundled assets are now compiled directly into the `_media` folder, and will not be copied to the `_site/media` folder by the NPM command in https://github.com/hydephp/develop/pull/2011
 
 
 ### Deprecated

--- a/docs/creating-content/managing-assets.md
+++ b/docs/creating-content/managing-assets.md
@@ -62,10 +62,9 @@ Then run `npm run dev` to compile the assets in development mode. For production
 
 Hyde uses [Vite](https://vite.dev/) to compile assets.
 
-When running the `npm run dev/prod` command, the following happens:
+When running the `npm run dev/prod` command, Vite will compile the `resources/assets/app.css` file into `_media/app.css` using PostCSS with TailwindCSS and AutoPrefixer.
 
-1. Vite will compile the `resources/assets/app.css` file into `_media/app.css` using PostCSS with TailwindCSS and AutoPrefixer.
-2. Vite then copies the `_media` folder into `_site/media`, this is so that they are automatically accessible to your site without having to rerun `php hyde build`.
+The compiled assets will then be automatically copied to `_site/media` when you run `php hyde build`.
 
 ## Telling Hyde where to find assets
 

--- a/monorepo/scripts/tests/project-styles.php
+++ b/monorepo/scripts/tests/project-styles.php
@@ -20,8 +20,5 @@ test('can build assets using vite', function () {
     $output = shell_exec('cd '.BASE_PATH.' && npm run build');
 
     $this->assert(file_exists(BASE_PATH.'/_media/app.css'), 'CSS file does not exist');
-    $this->assert(file_exists(BASE_PATH.'/_site/media/app.css'), 'CSS file does not exist');
-
     $this->assert(file_exists(BASE_PATH.'/_media/app.js'), 'JS file does not exist');
-    $this->assert(file_exists(BASE_PATH.'/_site/media/app.js'), 'JS file does not exist');
 });

--- a/vite.config.js
+++ b/vite.config.js
@@ -17,7 +17,7 @@ export default defineConfig({
         }
     },
     build: {
-        outDir: '_site/media',
+        outDir: '_media',
         emptyOutDir: true,
         rollupOptions: {
             input: [
@@ -30,43 +30,5 @@ export default defineConfig({
                 assetFileNames: '[name].[ext]'
             }
         }
-    },
-    plugins: [
-        {
-            name: 'copy-media',
-            writeBundle() {
-                // Copy files from _site/media to _media
-                const fs = require('fs');
-                const path = require('path');
-
-                const sourceDir = '_site/media';
-                const targetDir = '_media';
-
-                if (!fs.existsSync(targetDir)) {
-                    fs.mkdirSync(targetDir, { recursive: true });
-                }
-
-                // Copy all files recursively
-                function copyRecursively(source, target) {
-                    const files = fs.readdirSync(source);
-
-                    files.forEach(file => {
-                        const sourcePath = path.join(source, file);
-                        const targetPath = path.join(target, file);
-
-                        if (fs.lstatSync(sourcePath).isDirectory()) {
-                            if (!fs.existsSync(targetPath)) {
-                                fs.mkdirSync(targetPath, { recursive: true });
-                            }
-                            copyRecursively(sourcePath, targetPath);
-                        } else {
-                            fs.copyFileSync(sourcePath, targetPath);
-                        }
-                    });
-                }
-
-                copyRecursively(sourceDir, targetDir);
-            }
-        }
-    ]
+    }
 });


### PR DESCRIPTION
## Abstract

This pull request changes where compiled assets are saved during build. Currently, they go to `_site/media`. This request moves them to `_media` to better match project structure and simplify the build process.

- Targets https://github.com/hydephp/develop/pull/1565 via https://github.com/hydephp/develop/pull/2006


### Motivation

Based on the documentation and project structure, I believe `npm run build` should save assets to `_media` directory. Here's my reasoning:

Our documented conventions establish that:
- `resources/assets` contains source files that need compilation
- `_media` contains compiled/minified files
- `_site/media` is the final output directory for serving to users

This pattern makes sense because:

- It separates source, compiled, and output files clearly
- `_media` acts as a version-controlled cache of compiled assets
- When running `php hyde build`, it can simply copy from `_media` to `_site/media`
- Other developers can use the pre-compiled assets in `_media` without needing to run npm/node
- The `_site` directory is typically gitignored and meant for final output only

So while the current Vite config outputs to `_site/media` and then copies back to `_media`, I believe the more logical flow would be:

1. Vite builds assets from `resources/assets` into `_media`
2. `php hyde build` copies from `_media` to `_site/media`

This maintains a cleaner separation of concerns and better matches the documented purpose of each directory.