### PR TITLE
[2.x] Update the realtime compiler to only serve source media files

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -91,7 +91,7 @@ This serves two purposes:
 - **Replaced Laravel Mix with Vite for frontend asset compilation** in https://github.com/hydephp/develop/pull/2010
     - **Breaking:** You must now use `npm run build` to compile your assets, instead of `npm run prod`
     - Bundled assets are now compiled directly into the `_media` folder, and will not be copied to the `_site/media` folder by the NPM command in https://github.com/hydephp/develop/pull/2011
-
+- The realtime compiler now only serves assets from the media source directory (`_media`), and no longer checks the site output directory (`_site/media`) in https://github.com/hydephp/develop/pull/2012
 
 ### Deprecated
 
@@ -123,6 +123,12 @@ This serves two purposes:
 ### Security
 
 - in case of vulnerabilities.
+
+### Package updates
+
+#### Realtime Compiler
+
+- Simplified the asset file locator to only serve files from the media source directory in https://github.com/hydephp/develop/pull/2012
 
 ### Upgrade Guide
 

--- a/packages/realtime-compiler/src/Actions/AssetFileLocator.php
+++ b/packages/realtime-compiler/src/Actions/AssetFileLocator.php
@@ -4,8 +4,6 @@ declare(strict_types=1);
 
 namespace Hyde\RealtimeCompiler\Actions;
 
-use Illuminate\Support\Str;
-
 /**
  * Locate a static file to proxy.
  */
@@ -15,19 +13,8 @@ class AssetFileLocator
     {
         $path = trim($path, '/');
 
-        $strategies = [
-            BASE_PATH.'/_site/'.$path,
-            BASE_PATH.'/_media/'.$path,
-            BASE_PATH.'/_site/'.Str::after($path, 'media/'),
-            BASE_PATH.'/_media/'.Str::after($path, 'media/'),
-        ];
+        $file = BASE_PATH.'/_media/'.str_replace('media/', '', $path);
 
-        foreach ($strategies as $strategy) {
-            if (file_exists($strategy)) {
-                return $strategy;
-            }
-        }
-
-        return null;
+        return file_exists($file) ? $file : null;
     }
 }

--- a/packages/realtime-compiler/tests/RealtimeCompilerTest.php
+++ b/packages/realtime-compiler/tests/RealtimeCompilerTest.php
@@ -85,7 +85,8 @@ class RealtimeCompilerTest extends UnitTestCase
 
     public function testHandlesRoutesStaticAssets()
     {
-        $this->mockRoute('media/app.css');
+        $this->mockRoute('media/test.css');
+        Filesystem::put('_media/test.css', 'test');
 
         $kernel = new HttpKernel();
         $response = $kernel->handle(new Request());
@@ -93,7 +94,25 @@ class RealtimeCompilerTest extends UnitTestCase
         $this->assertInstanceOf(Response::class, $response);
         $this->assertEquals(200, $response->statusCode);
         $this->assertEquals('OK', $response->statusMessage);
-        $this->assertEquals(file_get_contents(\Hyde\Hyde::path('_media/app.css')), $response->body);
+        $this->assertEquals('test', $response->body);
+
+        Filesystem::unlink('_media/test.css');
+    }
+
+    public function testNormalizesMediaPath()
+    {
+        $this->mockRoute('media/test.css');
+        Filesystem::put('_media/test.css', 'test');
+
+        $kernel = new HttpKernel();
+        $response = $kernel->handle(new Request());
+
+        $this->assertInstanceOf(Response::class, $response);
+        $this->assertEquals(200, $response->statusCode);
+        $this->assertEquals('OK', $response->statusMessage);
+        $this->assertEquals('test', $response->body);
+
+        Filesystem::unlink('_media/test.css');
     }
 
     public function testThrowsRouteNotFoundExceptionForMissingRoute()


### PR DESCRIPTION
## Abstract

This PR changes the realtime compiler to only serve assets from the media source directory (`_media`), rather than also checking the site output directory (`_site/media`).

- Targets https://github.com/hydephp/develop/pull/1565 via https://github.com/hydephp/develop/pull/2006

### Motivation

The realtime compiler is designed to emulate how the site will behave when served from a web server. When building the site, files from `_media` are copied to `_site/media`. Having the realtime compiler serve files from both locations could lead to inconsistencies and confusion about which version is being served.

While we could use `filemtime()` to serve the latest version, this would not accurately represent the production environment where only the files in `_site/media` would be available. Additionally, any file in `_site/media` would be overwritten by the next build anyway.

This change:
- Simplifies the asset serving logic
- Makes the behavior more predictable
- Better aligns with the documented purpose of the directories
- More accurately represents the production environment

### References

See the documentation about media directories in `managing-assets.md`:

```markdown
- The `resources/assets` folder contain **source** files, meaning files that will be compiled into something else.
Here you will find the `app.css` file that bootstraps the TailwindCSS styles. This file is also an excellent place
to add your custom styles. It is also where we import HydeFront. If you compile this file in the base install,
it will output the same file that's already included in Hyde.

- The `_media` folder contains **compiled** (and usually minified) files. When Hyde compiles your static site,
all asset files here will get copied as they are into the `_site/media` folder.

- The `_site/media` folder contains the files that are served to the user.
```
