### PR TITLE
[2.x] Replace `--run-dev` and `--run-prod` build command flags with `--run-vite` flag

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -92,6 +92,7 @@ This serves two purposes:
     - **Breaking:** You must now use `npm run build` to compile your assets, instead of `npm run prod`
     - Bundled assets are now compiled directly into the `_media` folder, and will not be copied to the `_site/media` folder by the NPM command in https://github.com/hydephp/develop/pull/2011
 - The realtime compiler now only serves assets from the media source directory (`_media`), and no longer checks the site output directory (`_site/media`) in https://github.com/hydephp/develop/pull/2012
+- **Breaking:** Replaced `--run-dev` and `--run-prod` build command flags with a single `--run-vite` flag that uses Vite to build assets in https://github.com/hydephp/develop/pull/2013
 
 ### Deprecated
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -93,6 +93,7 @@ This serves two purposes:
     - Bundled assets are now compiled directly into the `_media` folder, and will not be copied to the `_site/media` folder by the NPM command in https://github.com/hydephp/develop/pull/2011
 - The realtime compiler now only serves assets from the media source directory (`_media`), and no longer checks the site output directory (`_site/media`) in https://github.com/hydephp/develop/pull/2012
 - **Breaking:** Replaced `--run-dev` and `--run-prod` build command flags with a single `--run-vite` flag that uses Vite to build assets in https://github.com/hydephp/develop/pull/2013
+- Moved the Vite build step to run before the site build to prevent duplicate media asset transfers in https://github.com/hydephp/develop/pull/2013
 
 ### Deprecated
 

--- a/docs/getting-started/console-commands.md
+++ b/docs/getting-started/console-commands.md
@@ -66,7 +66,7 @@ Here is a quick reference of all the available commands. You can also run `php h
 <a name="build" style="display: inline-block; position: absolute; margin-top: -5rem;"></a>
 
 ```bash
-php hyde build [--run-dev] [--run-prod] [--run-prettier] [--pretty-urls] [--no-api]
+php hyde build [--run-vite] [--run-prettier] [--pretty-urls] [--no-api]
 ```
 
 Build the static site
@@ -75,8 +75,7 @@ Build the static site
 
 |                  |                                            |
 |------------------|--------------------------------------------|
-| `--run-dev`      | Run the NPM dev script after build         |
-| `--run-prod`     | Run the NPM prod script after build        |
+| `--run-vite`     | Build frontend assets using Vite           |
 | `--run-prettier` | Format the output using NPM Prettier       |
 | `--pretty-urls`  | Should links in output use pretty URLs?    |
 | `--no-api`       | Disable API calls, for example, Torchlight |

--- a/packages/framework/src/Console/Commands/BuildSiteCommand.php
+++ b/packages/framework/src/Console/Commands/BuildSiteCommand.php
@@ -29,7 +29,9 @@ class BuildSiteCommand extends Command
         {--run-vite : Build frontend assets using Vite}
         {--run-prettier : Format the output using NPM Prettier}
         {--pretty-urls : Should links in output use pretty URLs?}
-        {--no-api : Disable API calls, for example, Torchlight}';
+        {--no-api : Disable API calls, for example, Torchlight}
+        {--run-dev : [Removed] Use --run-vite instead}
+        {--run-prod : [Removed] Use --run-vite instead}';
 
     /** @var string */
     protected $description = 'Build the static site';
@@ -39,6 +41,12 @@ class BuildSiteCommand extends Command
 
     public function handle(): int
     {
+        // CodeCoverageIgnoreStart
+        if ($this->option('run-dev') || $this->option('run-prod')) {
+            return $this->deprecatedRunMixCommandFailure();
+        }
+        // CodeCoverageIgnoreEnd
+
         $timeStart = microtime(true);
 
         $this->title('Building your static site!');
@@ -152,5 +160,22 @@ class BuildSiteCommand extends Command
         }
 
         return Command::SUCCESS;
+    }
+
+    /**
+     * This method is called when the removed --run-dev or --run-prod options are used.
+     *
+     * @deprecated Use --run-vite instead
+     * @since v2.0 - This will be removed after 2-3 minor releases depending on the timeframe between them. (~v2.3)
+     *
+     * @codeCoverageIgnore
+     */
+    protected function deprecatedRunMixCommandFailure(): int
+    {
+        $this->error('The --run-dev and --run-prod options have been removed in HydePHP v2.0.');
+        $this->info('Please use --run-vite instead to build assets for production with Vite.');
+        $this->line('See https://github.com/hydephp/develop/pull/2013 for more information.');
+
+        return Command::FAILURE;
     }
 }

--- a/packages/framework/src/Console/Commands/BuildSiteCommand.php
+++ b/packages/framework/src/Console/Commands/BuildSiteCommand.php
@@ -6,6 +6,7 @@ namespace Hyde\Console\Commands;
 
 use Hyde\Hyde;
 use Hyde\Facades\Config;
+use Illuminate\Support\Arr;
 use Hyde\Support\BuildWarnings;
 use Hyde\Console\Concerns\Command;
 use Hyde\Framework\Services\BuildService;
@@ -101,6 +102,13 @@ class BuildSiteCommand extends Command
 
         if ($this->option('run-vite')) {
             $this->runNodeCommand('npm run build', 'Building frontend assets for production!');
+
+            /** @var \Hyde\Framework\Actions\PreBuildTasks\TransferMediaAssets $task */
+            $task = Arr::first($this->taskService->getRegisteredTasks(), function (string $task): bool {
+                return class_basename($task) === 'TransferMediaAssets';
+            });
+
+            (new $task)->run($this->output); // Transfer media assets to the public directory
         }
     }
 

--- a/packages/framework/src/Console/Commands/BuildSiteCommand.php
+++ b/packages/framework/src/Console/Commands/BuildSiteCommand.php
@@ -26,8 +26,7 @@ class BuildSiteCommand extends Command
 {
     /** @var string */
     protected $signature = 'build
-        {--run-dev : Run the NPM dev script after build}
-        {--run-prod : Run the NPM prod script after build}
+        {--run-vite : Build frontend assets using Vite}
         {--run-prettier : Format the output using NPM Prettier}
         {--pretty-urls : Should links in output use pretty URLs?}
         {--no-api : Disable API calls, for example, Torchlight}';
@@ -100,11 +99,7 @@ class BuildSiteCommand extends Command
             );
         }
 
-        if ($this->option('run-dev')) {
-            $this->runNodeCommand('npm run dev', 'Building frontend assets for development!');
-        }
-
-        if ($this->option('run-prod')) {
+        if ($this->option('run-vite')) {
             $this->runNodeCommand('npm run build', 'Building frontend assets for production!');
         }
     }

--- a/packages/framework/src/Console/Commands/BuildSiteCommand.php
+++ b/packages/framework/src/Console/Commands/BuildSiteCommand.php
@@ -84,6 +84,10 @@ class BuildSiteCommand extends Command
             Config::set(['hyde.pretty_urls' => true]);
         }
 
+        if ($this->option('run-vite')) {
+            $this->runNodeCommand('npm run build', 'Building frontend assets for production!');
+        }
+
         $this->taskService->runPreBuildTasks();
     }
 
@@ -97,10 +101,6 @@ class BuildSiteCommand extends Command
                 'Prettifying code!',
                 'prettify code'
             );
-        }
-
-        if ($this->option('run-vite')) {
-            $this->runNodeCommand('npm run build', 'Building frontend assets for production!');
         }
     }
 

--- a/packages/framework/src/Console/Commands/BuildSiteCommand.php
+++ b/packages/framework/src/Console/Commands/BuildSiteCommand.php
@@ -6,7 +6,6 @@ namespace Hyde\Console\Commands;
 
 use Hyde\Hyde;
 use Hyde\Facades\Config;
-use Illuminate\Support\Arr;
 use Hyde\Support\BuildWarnings;
 use Hyde\Console\Concerns\Command;
 use Hyde\Framework\Services\BuildService;
@@ -102,13 +101,6 @@ class BuildSiteCommand extends Command
 
         if ($this->option('run-vite')) {
             $this->runNodeCommand('npm run build', 'Building frontend assets for production!');
-
-            /** @var \Hyde\Framework\Actions\PreBuildTasks\TransferMediaAssets $task */
-            $task = Arr::first($this->taskService->getRegisteredTasks(), function (string $task): bool {
-                return class_basename($task) === 'TransferMediaAssets';
-            });
-
-            (new $task)->run($this->output); // Transfer media assets to the public directory
         }
     }
 

--- a/packages/framework/tests/Feature/StaticSiteServiceTest.php
+++ b/packages/framework/tests/Feature/StaticSiteServiceTest.php
@@ -161,12 +161,12 @@ class StaticSiteServiceTest extends TestCase
         Process::fake();
 
         $this->artisan('build --run-prettier --run-vite')
-            ->expectsOutput('Prettifying code! This may take a second.')
             ->expectsOutput('Building frontend assets for production! This may take a second.')
+            ->expectsOutput('Prettifying code! This may take a second.')
             ->assertExitCode(0);
 
-        Process::assertRan(fn ($process) => $process->command === 'npx prettier '.Hyde::pathToRelative(Hyde::sitePath()).'/**/*.html --write --bracket-same-line');
         Process::assertRan(fn ($process) => $process->command === 'npm run build');
+        Process::assertRan(fn ($process) => $process->command === 'npx prettier '.Hyde::pathToRelative(Hyde::sitePath()).'/**/*.html --write --bracket-same-line');
     }
 
     public function testPrettyUrlsOptionOutput()

--- a/packages/framework/tests/Feature/StaticSiteServiceTest.php
+++ b/packages/framework/tests/Feature/StaticSiteServiceTest.php
@@ -160,14 +160,12 @@ class StaticSiteServiceTest extends TestCase
     {
         Process::fake();
 
-        $this->artisan('build --run-prettier --run-dev --run-prod')
+        $this->artisan('build --run-prettier --run-vite')
             ->expectsOutput('Prettifying code! This may take a second.')
-            ->expectsOutput('Building frontend assets for development! This may take a second.')
             ->expectsOutput('Building frontend assets for production! This may take a second.')
             ->assertExitCode(0);
 
         Process::assertRan(fn ($process) => $process->command === 'npx prettier '.Hyde::pathToRelative(Hyde::sitePath()).'/**/*.html --write --bracket-same-line');
-        Process::assertRan(fn ($process) => $process->command === 'npm run dev');
         Process::assertRan(fn ($process) => $process->command === 'npm run build');
     }
 


### PR DESCRIPTION
## Replace Mix build flags with Vite flag

- Targets https://github.com/hydephp/develop/pull/1565 via https://github.com/hydephp/develop/pull/2006


### Description
This PR replaces the `--run-dev` and `--run-prod` build command flags with a single `--run-vite` flag. This change is needed because we switched from Laravel Mix to Vite in #2010, which has different commands and behaviors:

- `npm run dev` with Vite starts a development server (incompatible with our build process)
- `npm run prod` no longer exists, replaced by `npm run build`

**The new `--run-vite` flag will:**
1. Run `npm run build` to compile assets with Vite
2. Re-run the media asset transfer task since Vite outputs to `_site/media` (see #2011)

### Breaking Changes
- Removed `--run-dev` flag
- Removed `--run-prod` flag
- Added new `--run-vite` flag

### Related Issues/PRs
- Follows #2010 (Switch to Vite)
- Follows #2011 (Change asset output handling)

### Upgrade Guide
Replace any usage of `--run-dev` or `--run-prod` with `--run-vite`:

