### PR TITLE
Shorten the realtime compiler server start message to better fit within 80 column terminals

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -27,6 +27,7 @@ This serves two purposes:
 - Updated to HydeFront v3.4 in https://github.com/hydephp/develop/pull/1803
 - Realtime Compiler: Virtual routes are now managed through the service container in https://github.com/hydephp/develop/pull/1858
 - Realtime Compiler: Improved the dashboard layout in https://github.com/hydephp/develop/pull/1866
+- Realtime Compiler: Shorten the realtime compiler server start message from "Press Ctrl+C to stop" to "Use Ctrl+C to stop" to better fit 80 column terminals in https://github.com/hydephp/develop/pull/2017
 
 ### Deprecated
 - The `PostAuthor::getName()` method is now deprecated and will be removed in v2. (use `$author->name` instead) in https://github.com/hydephp/develop/pull/1794

--- a/packages/framework/src/Console/Commands/ServeCommand.php
+++ b/packages/framework/src/Console/Commands/ServeCommand.php
@@ -101,7 +101,7 @@ class ServeCommand extends Command
     protected function printStartMessage(): void
     {
         $this->useBasicOutput()
-            ? $this->output->writeln('<info>Starting the HydeRC server...</info> Press Ctrl+C to stop')
+            ? $this->output->writeln('<info>Starting the HydeRC server...</info> Use Ctrl+C to stop')
             : $this->console->printStartMessage($this->getHostSelection(), $this->getPortSelection(), $this->getEnvironmentVariables());
     }
 

--- a/packages/framework/tests/Feature/Commands/ServeCommandTest.php
+++ b/packages/framework/tests/Feature/Commands/ServeCommandTest.php
@@ -27,7 +27,7 @@ class ServeCommandTest extends TestCase
     public function testHydeServeCommand()
     {
         $this->artisan('serve --no-ansi')
-            ->expectsOutput('Starting the HydeRC server... Press Ctrl+C to stop')
+            ->expectsOutput('Starting the HydeRC server... Use Ctrl+C to stop')
             ->assertExitCode(0);
 
         Process::assertRan("php -S localhost:8080 {$this->binaryPath()}");
@@ -36,7 +36,7 @@ class ServeCommandTest extends TestCase
     public function testHydeServeCommandWithPortOption()
     {
         $this->artisan('serve --no-ansi --port=8081')
-            ->expectsOutput('Starting the HydeRC server... Press Ctrl+C to stop')
+            ->expectsOutput('Starting the HydeRC server... Use Ctrl+C to stop')
             ->assertExitCode(0);
 
         Process::assertRan("php -S localhost:8081 {$this->binaryPath()}");
@@ -45,7 +45,7 @@ class ServeCommandTest extends TestCase
     public function testHydeServeCommandWithHostOption()
     {
         $this->artisan('serve --no-ansi --host=foo')
-            ->expectsOutput('Starting the HydeRC server... Press Ctrl+C to stop')
+            ->expectsOutput('Starting the HydeRC server... Use Ctrl+C to stop')
             ->assertExitCode(0);
 
         Process::assertRan("php -S foo:8080 {$this->binaryPath()}");
@@ -54,7 +54,7 @@ class ServeCommandTest extends TestCase
     public function testHydeServeCommandWithPortAndHostOption()
     {
         $this->artisan('serve --no-ansi --port=8081 --host=foo')
-            ->expectsOutput('Starting the HydeRC server... Press Ctrl+C to stop')
+            ->expectsOutput('Starting the HydeRC server... Use Ctrl+C to stop')
             ->assertExitCode(0);
 
         Process::assertRan("php -S foo:8081 {$this->binaryPath()}");
@@ -65,7 +65,7 @@ class ServeCommandTest extends TestCase
         config(['hyde.server.port' => 8081]);
 
         $this->artisan('serve --no-ansi')
-            ->expectsOutput('Starting the HydeRC server... Press Ctrl+C to stop')
+            ->expectsOutput('Starting the HydeRC server... Use Ctrl+C to stop')
             ->assertExitCode(0);
 
         Process::assertRan("php -S localhost:8081 {$this->binaryPath()}");
@@ -76,7 +76,7 @@ class ServeCommandTest extends TestCase
         config(['hyde.server.port' => 8081]);
 
         $this->artisan('serve --no-ansi --port=8082')
-            ->expectsOutput('Starting the HydeRC server... Press Ctrl+C to stop')
+            ->expectsOutput('Starting the HydeRC server... Use Ctrl+C to stop')
             ->assertExitCode(0);
 
         Process::assertRan("php -S localhost:8082 {$this->binaryPath()}");
@@ -87,7 +87,7 @@ class ServeCommandTest extends TestCase
         config(['hyde.server.port' => null]);
 
         $this->artisan('serve --no-ansi --port=8081')
-            ->expectsOutput('Starting the HydeRC server... Press Ctrl+C to stop')
+            ->expectsOutput('Starting the HydeRC server... Use Ctrl+C to stop')
             ->assertExitCode(0);
 
         Process::assertRan("php -S localhost:8081 {$this->binaryPath()}");
@@ -98,7 +98,7 @@ class ServeCommandTest extends TestCase
         config(['hyde.server.host' => 'foo']);
 
         $this->artisan('serve --no-ansi')
-            ->expectsOutput('Starting the HydeRC server... Press Ctrl+C to stop')
+            ->expectsOutput('Starting the HydeRC server... Use Ctrl+C to stop')
             ->assertExitCode(0);
 
         Process::assertRan("php -S foo:8080 {$this->binaryPath()}");
@@ -109,7 +109,7 @@ class ServeCommandTest extends TestCase
         config(['hyde.server.host' => 'foo']);
 
         $this->artisan('serve --no-ansi --host=bar')
-            ->expectsOutput('Starting the HydeRC server... Press Ctrl+C to stop')
+            ->expectsOutput('Starting the HydeRC server... Use Ctrl+C to stop')
             ->assertExitCode(0);
 
         Process::assertRan("php -S bar:8080 {$this->binaryPath()}");
@@ -120,7 +120,7 @@ class ServeCommandTest extends TestCase
         config(['hyde.server.host' => null]);
 
         $this->artisan('serve --no-ansi --host=foo')
-            ->expectsOutput('Starting the HydeRC server... Press Ctrl+C to stop')
+            ->expectsOutput('Starting the HydeRC server... Use Ctrl+C to stop')
             ->assertExitCode(0);
 
         Process::assertRan("php -S foo:8080 {$this->binaryPath()}");
@@ -132,7 +132,7 @@ class ServeCommandTest extends TestCase
         config(['hyde.server.port' => 'foo']);
 
         $this->artisan('serve --no-ansi')
-            ->expectsOutput('Starting the HydeRC server... Press Ctrl+C to stop')
+            ->expectsOutput('Starting the HydeRC server... Use Ctrl+C to stop')
             ->assertExitCode(0);
     }
 
@@ -158,7 +158,7 @@ class ServeCommandTest extends TestCase
             ->andReturnSelf();
 
         $this->artisan('serve --no-ansi')
-            ->expectsOutput('Starting the HydeRC server... Press Ctrl+C to stop')
+            ->expectsOutput('Starting the HydeRC server... Use Ctrl+C to stop')
             ->expectsOutput('foo')
             ->assertExitCode(0);
     }

--- a/packages/realtime-compiler/src/ConsoleOutput.php
+++ b/packages/realtime-compiler/src/ConsoleOutput.php
@@ -101,7 +101,7 @@ class ConsoleOutput
 
     protected function formatServerStartedLine(string $line): string
     {
-        return $this->formatLine(sprintf('PHP %s Development Server started. <span class="text-yellow-500">Press Ctrl+C to stop.</span>', PHP_VERSION), $this->parseDate($line), 'green-500');
+        return $this->formatLine(sprintf('PHP %s Development Server started. <span class="text-yellow-500">Use Ctrl+C to stop.</span>', PHP_VERSION), $this->parseDate($line), 'green-500');
     }
 
     protected function formatRequestLine(string $line): string


### PR DESCRIPTION
```bash
i PHP 8.3.7 Development Server started. Press Ctrl+C to stop.2024-11-12 11:25:28 # Before
i PHP 8.3.7 Development Server started. Use Ctrl+C to stop.  2024-11-12 11:26:26 # After
```