### PR TITLE
[2.x] Only compile app scripts if it has contents

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -123,6 +123,7 @@ This serves two purposes:
 ### Fixed
 
 - Added missing collection key types in Hyde facade method annotations in https://github.com/hydephp/develop/pull/1784
+- The `app.js` file will now only be compiled if it has scripts in https://github.com/hydephp/develop/pull/2028
 
 ### Security
 

--- a/vite.config.js
+++ b/vite.config.js
@@ -37,6 +37,13 @@ const hydeVitePlugin = () => ({
     }
 });
 
+const hasJavaScriptContent = () => {
+    const appJsPath = resolve(__dirname, 'resources/assets/app.js');
+    if (!fs.existsSync(appJsPath)) return false;
+    const content = fs.readFileSync(appJsPath, 'utf-8');
+    return content.replace(/\/\*[\s\S]*?\*\/|\/\/.*/g, '').trim().length > 0;
+};
+
 export default defineConfig({
     server: {
         port: 5173,
@@ -60,7 +67,7 @@ export default defineConfig({
         emptyOutDir: false,
         rollupOptions: {
             input: [
-                resolve(__dirname, 'resources/assets/app.js'),
+                ...(hasJavaScriptContent() ? [resolve(__dirname, 'resources/assets/app.js')] : []),
                 resolve(__dirname, 'resources/assets/app.css')
             ],
             output: {


### PR DESCRIPTION
## Abstract

- Closes https://github.com/hydephp/develop/issues/2027
- Targets https://github.com/hydephp/develop/pull/1565 via https://github.com/hydephp/develop/pull/2006

## Comparison

### Before


PS H:\monorepo> npm run build

```bash
> build
> vite build

vite v5.4.10 building for production...
✓ 2 modules transformed.
Generated an empty chunk: "app".
_media/app.css  38.78 kB │ gzip: 7.51 kB
_media/app.js    0.00 kB │ gzip: 0.02 kB
✓ built in 1.09s
```


### After

#### Without contents

```bash
PS H:\monorepo> npm run build

> build
> vite build

vite v5.4.10 building for production...
✓ 1 modules transformed.
_media/app.css  37.77 kB │ gzip: 7.27 kB
✓ built in 1.44s
```

#### With contents

```bash
PS H:\monorepo> npm run build

> build
> vite build

vite v5.4.10 building for production...
✓ 2 modules transformed.
_media/app.css  37.77 kB │ gzip: 7.27 kB
_media/app.js    0.02 kB │ gzip: 0.04 kB
✓ built in 986ms
```