### PR TITLE
Fix Tailwind content path for nested Blade pages

### DIFF
--- a/packages/hyde/tailwind.config.js
+++ b/packages/hyde/tailwind.config.js
@@ -3,7 +3,7 @@ const defaultTheme = require('tailwindcss/defaultTheme');
 module.exports = {
     darkMode: 'class',
     content: [
-        './_pages/*.blade.php',
+        './_pages/**/*.blade.php',
         './resources/views/**/*.blade.php',
         './vendor/hyde/framework/resources/views/**/*.blade.php',
     ],

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -3,7 +3,7 @@ const defaultTheme = require('tailwindcss/defaultTheme');
 module.exports = {
     darkMode: 'class',
     content: [
-        './_pages/*.blade.php',
+        './_pages/**/*.blade.php',
         './resources/views/**/*.blade.php',
         './vendor/hyde/framework/resources/views/**/*.blade.php',
     ],


### PR DESCRIPTION
This change ensures that Tailwind will scan all nested Blade pages in the `_pages` directory.

Cherry picks https://github.com/hydephp/hyde/pull/267 to the monorepo to sync up the packages.