### PR TITLE
Internal: More reliable internal testing helper implementation

### DIFF
--- a/packages/testing/src/Support/HtmlTesting/TestableHtmlDocument.php
+++ b/packages/testing/src/Support/HtmlTesting/TestableHtmlDocument.php
@@ -80,21 +80,18 @@ class TestableHtmlDocument
      */
     public function getElementsByClass(string $class): Collection
     {
-        $matchingNodes = collect();
+        $xpath = new \DOMXPath($this->document); // Use the existing DOMDocument
+        $nodeList = $xpath->query("//*[contains(concat(' ', normalize-space(@class), ' '), ' $class ')]");
 
-        $traverse = function (TestableHtmlElement $node) use (&$traverse, $class, &$matchingNodes): void {
-            if (in_array($class, $node->classes, true)) {
-                $matchingNodes->push($node);
+        $collection = collect();
+        foreach ($nodeList as $node) {
+            // Ensure we are only adding DOMElement objects to the collection.
+            if ($node instanceof DOMElement) {
+                $collection->push($this->parseNodeRecursive($node));
             }
+        }
 
-            foreach ($node->nodes as $childNode) {
-                $traverse($childNode);
-            }
-        };
-
-        $traverse($this->getRootElement());
-
-        return $matchingNodes;
+        return $collection;
     }
 
     /**

--- a/packages/testing/src/Support/HtmlTesting/TestableHtmlDocument.php
+++ b/packages/testing/src/Support/HtmlTesting/TestableHtmlDocument.php
@@ -6,6 +6,7 @@ namespace Hyde\Testing\Support\HtmlTesting;
 
 use DOMElement;
 use DOMDocument;
+use DOMXPath;
 use InvalidArgumentException;
 use Illuminate\Support\Collection;
 use Illuminate\Testing\Assert as PHPUnit;
@@ -80,12 +81,11 @@ class TestableHtmlDocument
      */
     public function getElementsByClass(string $class): Collection
     {
-        $xpath = new \DOMXPath($this->document); // Use the existing DOMDocument
+        $xpath = new DOMXPath($this->document);
         $nodeList = $xpath->query("//*[contains(concat(' ', normalize-space(@class), ' '), ' $class ')]");
 
         $collection = collect();
         foreach ($nodeList as $node) {
-            // Ensure we are only adding DOMElement objects to the collection.
             if ($node instanceof DOMElement) {
                 $collection->push($this->parseNodeRecursive($node));
             }


### PR DESCRIPTION
Fixes an issue where the old implementation does not work reliably on macOS when running the full suite.


---

**Explanation of Changes:**

1. **Using XPath:**  XPath is a powerful language for querying XML documents (and HTML, which is XML-like). It's much more efficient and reliable for complex queries than manual traversal.

2. **`DOMXPath` Object:** We create a `DOMXPath` object using the existing `$this->document` object, which is already a parsed DOM. This avoids re-parsing the HTML.

3. **Robust Class Matching:** The XPath expression `//*[contains(concat(' ', normalize-space(@class), ' '), ' $class ')]` is a standard and robust way to find elements with a specific class, even if they have multiple classes.  It handles leading/trailing spaces correctly.

4. **Iterating `DOMNodeList`:**  The `query()` method returns a `DOMNodeList`.  We iterate over this list and add the matching elements to our collection.

5. **Type Safety:** The added `if ($node instanceof DOMElement)` check ensures type safety and prevents unexpected behavior if non-element nodes are encountered in the `DOMNodeList`.

6. **`parseNodeRecursive`:** We reuse your existing `parseNodeRecursive` method to convert the `DOMElement` objects into `TestableHtmlElement` objects for consistency.


**Why this is better:**

* **Reliability:** XPath is standardized and less prone to platform-specific quirks.
* **Efficiency:** XPath is generally faster than manual DOM traversal.
* **Maintainability:**  The code is simpler and easier to understand.
* **Robustness:**  The class matching logic is more robust.

