### PR TITLE
Internal: Fix test removing gitkeep file

### DIFF
--- a/packages/publications/tests/Feature/PublicationPageCompilerTest.php
+++ b/packages/publications/tests/Feature/PublicationPageCompilerTest.php
@@ -47,7 +47,6 @@ class PublicationPageCompilerTest extends TestCase
         $schema = json_decode(file_get_contents(Hyde::path('test-publication/schema.json')));
         $schema->detailTemplate = 'foo';
         file_put_contents(Hyde::path('test-publication/schema.json'), json_encode($schema));
-        $this->directory('resources/views');
         $this->file('resources/views/foo.blade.php', 'Registered detail view');
 
         $publicationPage = new PublicationPage('my-publication', type: PublicationType::get('test-publication'));
@@ -62,7 +61,6 @@ class PublicationPageCompilerTest extends TestCase
         $schema = json_decode(file_get_contents(Hyde::path('test-publication/schema.json')));
         $schema->listTemplate = 'foo';
         file_put_contents(Hyde::path('test-publication/schema.json'), json_encode($schema));
-        $this->directory('resources/views');
         $this->file('resources/views/foo.blade.php', 'Registered list view');
 
         $publicationType = PublicationType::get('test-publication');


### PR DESCRIPTION
At long last tracks down this test that keeps removing `resources/views/.gitkeep`