### PR TITLE
[2.x] Normalize Markdown heading identifiers

### DIFF
--- a/packages/framework/src/Framework/Actions/GeneratesTableOfContents.php
+++ b/packages/framework/src/Framework/Actions/GeneratesTableOfContents.php
@@ -6,7 +6,7 @@ namespace Hyde\Framework\Actions;
 
 use Hyde\Facades\Config;
 use Hyde\Markdown\Models\Markdown;
-use Illuminate\Support\Str;
+use Hyde\Markdown\Processing\HeadingRenderer;
 
 /**
  * Generates a nested table of contents from Markdown headings.
@@ -117,7 +117,7 @@ class GeneratesTableOfContents
         return [
             'level' => $headingData['level'],
             'title' => $headingData['title'],
-            'slug' => Str::slug($headingData['title']),
+            'slug' => HeadingRenderer::makeIdentifier($headingData['title']),
         ];
     }
 

--- a/packages/framework/src/Markdown/Processing/HeadingRenderer.php
+++ b/packages/framework/src/Markdown/Processing/HeadingRenderer.php
@@ -96,6 +96,8 @@ class HeadingRenderer implements NodeRendererInterface
         return Str::slug(Str::transliterate($title), dictionary: [
             '@' => 'at',
             '&' => 'and',
+            '<' => '',
+            '>' => '',
         ]);
     }
 }

--- a/packages/framework/src/Markdown/Processing/HeadingRenderer.php
+++ b/packages/framework/src/Markdown/Processing/HeadingRenderer.php
@@ -93,11 +93,11 @@ class HeadingRenderer implements NodeRendererInterface
     /** @internal */
     public static function makeIdentifier(string $title): string
     {
-        return Str::slug(Str::transliterate($title), dictionary: [
+        return e(Str::slug(Str::transliterate(html_entity_decode($title)), dictionary: [
             '@' => 'at',
             '&' => 'and',
             '<' => '',
             '>' => '',
-        ]);
+        ]));
     }
 }

--- a/packages/framework/src/Markdown/Processing/HeadingRenderer.php
+++ b/packages/framework/src/Markdown/Processing/HeadingRenderer.php
@@ -93,6 +93,6 @@ class HeadingRenderer implements NodeRendererInterface
     /** @internal */
     public static function makeIdentifier(string $title): string
     {
-        return Str::slug($title);
+        return Str::slug(Str::transliterate($title));
     }
 }

--- a/packages/framework/src/Markdown/Processing/HeadingRenderer.php
+++ b/packages/framework/src/Markdown/Processing/HeadingRenderer.php
@@ -71,7 +71,7 @@ class HeadingRenderer implements NodeRendererInterface
 
     protected function makeHeadingId(string $contents): string
     {
-        $identifier = $this->ensureIdentifierIsUnique(Str::slug($contents));
+        $identifier = $this->ensureIdentifierIsUnique(static::makeIdentifier($contents));
 
         $this->headingRegistry[] = $identifier;
 
@@ -88,5 +88,10 @@ class HeadingRenderer implements NodeRendererInterface
         }
 
         return $identifier;
+    }
+
+    protected static function makeIdentifier(string $title): string
+    {
+        return Str::slug($title);
     }
 }

--- a/packages/framework/src/Markdown/Processing/HeadingRenderer.php
+++ b/packages/framework/src/Markdown/Processing/HeadingRenderer.php
@@ -93,11 +93,6 @@ class HeadingRenderer implements NodeRendererInterface
     /** @internal */
     public static function makeIdentifier(string $title): string
     {
-        return e(Str::slug(Str::transliterate(html_entity_decode($title)), dictionary: [
-            '@' => 'at',
-            '&' => 'and',
-            '<' => '',
-            '>' => '',
-        ]));
+        return e(Str::slug(Str::transliterate(html_entity_decode($title)), dictionary: ['@' => 'at', '&' => 'and', '<' => '', '>' => '']));
     }
 }

--- a/packages/framework/src/Markdown/Processing/HeadingRenderer.php
+++ b/packages/framework/src/Markdown/Processing/HeadingRenderer.php
@@ -93,6 +93,8 @@ class HeadingRenderer implements NodeRendererInterface
     /** @internal */
     public static function makeIdentifier(string $title): string
     {
-        return Str::slug(Str::transliterate($title));
+        return Str::slug(Str::transliterate($title), dictionary: [
+            '@' => 'at',
+        ]);
     }
 }

--- a/packages/framework/src/Markdown/Processing/HeadingRenderer.php
+++ b/packages/framework/src/Markdown/Processing/HeadingRenderer.php
@@ -90,7 +90,8 @@ class HeadingRenderer implements NodeRendererInterface
         return $identifier;
     }
 
-    protected static function makeIdentifier(string $title): string
+    /** @internal */
+    public static function makeIdentifier(string $title): string
     {
         return Str::slug($title);
     }

--- a/packages/framework/src/Markdown/Processing/HeadingRenderer.php
+++ b/packages/framework/src/Markdown/Processing/HeadingRenderer.php
@@ -95,6 +95,7 @@ class HeadingRenderer implements NodeRendererInterface
     {
         return Str::slug(Str::transliterate($title), dictionary: [
             '@' => 'at',
+            '&' => 'and',
         ]);
     }
 }

--- a/packages/framework/tests/Feature/MarkdownHeadingRendererTest.php
+++ b/packages/framework/tests/Feature/MarkdownHeadingRendererTest.php
@@ -183,9 +183,8 @@ class MarkdownHeadingRendererTest extends TestCase
         $this->assertStringContainsString('Heading with &amp; special &lt; &gt; &quot;characters&quot;', $html);
         $this->assertStringContainsString('Heading with émojis 🎉', $html);
 
-        // Todo: Try to normalize to heading-with-special-characters?
         $this->assertSame(<<<'HTML'
-        <h2 id="heading-with-amp-special-lt-gt-quotcharactersquot" class="group w-fit scroll-mt-2">Heading with &amp; special &lt; &gt; &quot;characters&quot;<a href="#heading-with-amp-special-lt-gt-quotcharactersquot" class="heading-permalink opacity-0 ml-1 transition-opacity duration-300 ease-linear px-1 group-hover:opacity-100 focus:opacity-100 group-hover:grayscale-0 focus:grayscale-0" title="Permalink">#</a></h2>
+        <h2 id="heading-with-and-special-characters" class="group w-fit scroll-mt-2">Heading with &amp; special &lt; &gt; &quot;characters&quot;<a href="#heading-with-and-special-characters" class="heading-permalink opacity-0 ml-1 transition-opacity duration-300 ease-linear px-1 group-hover:opacity-100 focus:opacity-100 group-hover:grayscale-0 focus:grayscale-0" title="Permalink">#</a></h2>
         <h3 id="heading-with-emojis" class="group w-fit scroll-mt-2">Heading with émojis 🎉<a href="#heading-with-emojis" class="heading-permalink opacity-0 ml-1 transition-opacity duration-300 ease-linear px-1 group-hover:opacity-100 focus:opacity-100 group-hover:grayscale-0 focus:grayscale-0" title="Permalink">#</a></h3>
 
         HTML, $html);

--- a/packages/framework/tests/Unit/HeadingRendererUnitTest.php
+++ b/packages/framework/tests/Unit/HeadingRendererUnitTest.php
@@ -234,6 +234,15 @@ class HeadingRendererUnitTest extends UnitTestCase
         $this->assertSame('<p>Paragraph</p>', (new HeadingRenderer())->postProcess($html));
     }
 
+    public function testHeadingIdentifierGeneration()
+    {
+        $this->assertSame('hello-world', HeadingRenderer::makeIdentifier('hello world'));
+        $this->assertSame('hello-world', HeadingRenderer::makeIdentifier('hello-world'));
+        $this->assertSame('hello-world', HeadingRenderer::makeIdentifier('hello_world'));
+        $this->assertSame('user-at-host', HeadingRenderer::makeIdentifier('user@host'));
+        $this->assertSame('', HeadingRenderer::makeIdentifier(''));
+    }
+
     protected function mockChildNodeRenderer(string $contents = 'Test Heading'): ChildNodeRendererInterface
     {
         $childRenderer = Mockery::mock(ChildNodeRendererInterface::class);

--- a/packages/framework/tests/Unit/HeadingRendererUnitTest.php
+++ b/packages/framework/tests/Unit/HeadingRendererUnitTest.php
@@ -275,7 +275,7 @@ class HeadingRendererUnitTest extends UnitTestCase
 
             // Special characters
             ['Heading with & symbol', 'heading-with-and-symbol'],
-            ['Heading with < > symbols', 'heading-with-lt-gt-symbols'],
+            ['Heading with < > symbols', 'heading-with-symbols'],
             ['Heading with "quotes"', 'heading-with-quot-quotes'],
             ['Heading with / and \\', 'heading-with-and'],
             ['Heading with punctuation!?!', 'heading-with-punctuation'],

--- a/packages/framework/tests/Unit/HeadingRendererUnitTest.php
+++ b/packages/framework/tests/Unit/HeadingRendererUnitTest.php
@@ -307,10 +307,10 @@ class HeadingRendererUnitTest extends UnitTestCase
             ['    Leading spaces', 'leading-spaces'],
             ['Trailing spaces    ', 'trailing-spaces'],
             ['  Surrounded by spaces  ', 'surrounded-by-spaces'],
-            ['----', ''], // All hyphens
-            ['%%%%%%%', ''], // All special characters
-            ['    ', ''], // Empty after trimming
-            ['1234567890', '1234567890'], // Numbers only
+            ['----', ''],
+            ['%%%%%%%', ''],
+            ['    ', ''],
+            ['1234567890', '1234567890'],
         ];
     }
 }

--- a/packages/framework/tests/Unit/HeadingRendererUnitTest.php
+++ b/packages/framework/tests/Unit/HeadingRendererUnitTest.php
@@ -234,13 +234,12 @@ class HeadingRendererUnitTest extends UnitTestCase
         $this->assertSame('<p>Paragraph</p>', (new HeadingRenderer())->postProcess($html));
     }
 
-    public function testHeadingIdentifierGeneration()
+    /**
+     * @dataProvider headingIdentifierProvider
+     */
+    public function testHeadingIdentifierGeneration($input, $expected)
     {
-        $this->assertSame('hello-world', HeadingRenderer::makeIdentifier('hello world'));
-        $this->assertSame('hello-world', HeadingRenderer::makeIdentifier('hello-world'));
-        $this->assertSame('hello-world', HeadingRenderer::makeIdentifier('hello_world'));
-        $this->assertSame('user-at-host', HeadingRenderer::makeIdentifier('user@host'));
-        $this->assertSame('', HeadingRenderer::makeIdentifier(''));
+        $this->assertSame($expected, HeadingRenderer::makeIdentifier($input));
     }
 
     protected function mockChildNodeRenderer(string $contents = 'Test Heading'): ChildNodeRendererInterface
@@ -264,5 +263,16 @@ class HeadingRendererUnitTest extends UnitTestCase
                 $this->assertStringNotContainsString('heading-permalink', $rendered);
             }
         }
+    }
+
+    public static function headingIdentifierProvider(): array
+    {
+        return [
+            ['hello world', 'hello-world'],
+            ['hello-world', 'hello-world'],
+            ['hello_world', 'hello-world'],
+            ['user@host', 'user-at-host'],
+            ['', ''],
+        ];
     }
 }

--- a/packages/framework/tests/Unit/HeadingRendererUnitTest.php
+++ b/packages/framework/tests/Unit/HeadingRendererUnitTest.php
@@ -292,6 +292,7 @@ class HeadingRendererUnitTest extends UnitTestCase
             ['Łódź and święto', 'lodz-and-swieto'],
             ['中文标题', 'zhong-wen-biao-ti'],
             ['日本語の見出し', 'ri-ben-yu-nojian-chu-si'],
+            ['한국어 제목', 'han-gug-eo-jemog'],
 
             // Edge cases
             ['    Leading spaces', 'leading-spaces'],

--- a/packages/framework/tests/Unit/HeadingRendererUnitTest.php
+++ b/packages/framework/tests/Unit/HeadingRendererUnitTest.php
@@ -278,6 +278,18 @@ class HeadingRendererUnitTest extends UnitTestCase
             ['Installation Guide', 'installation-guide'],
             ['API Reference', 'api-reference'],
             ['Frequently Asked Questions', 'frequently-asked-questions'],
+            ['123 heading', '123-heading'],
+            ['heading with multiple spaces', 'heading-with-multiple-spaces'],
+            ['heading_with_underscores_and-dashes', 'heading-with-underscores-and-dashes'],
+            ['heading with special characters !@#$', 'heading-with-special-characters-at'],
+            ['heading with numbers 123', 'heading-with-numbers-123'],
+            ['UPPERCASE HEADING', 'uppercase-heading'],
+            ['heading with emoji 😊', 'heading-with-emoji'],
+            ['heading with mixed CASE and 123 numbers', 'heading-with-mixed-case-and-123-numbers'],
+            ['heading with punctuation, commas, and periods.', 'heading-with-punctuation-commas-and-periods'],
+            ['heading with quotes "double" and \'single\'', 'heading-with-quotes-double-and-single'],
+            ['heading with slashes / and \\', 'heading-with-slashes-and'],
+            ['heading with parentheses (and brackets) [and braces] {and more}', 'heading-with-parentheses-and-brackets-and-braces-and-more'],
         ];
     }
 }

--- a/packages/framework/tests/Unit/HeadingRendererUnitTest.php
+++ b/packages/framework/tests/Unit/HeadingRendererUnitTest.php
@@ -274,7 +274,7 @@ class HeadingRendererUnitTest extends UnitTestCase
             ['Heading With Numbers 123', 'heading-with-numbers-123'],
 
             // Special characters
-            ['Heading with & symbol', 'heading-with-amp-symbol'],
+            ['Heading with & symbol', 'heading-with-and-symbol'],
             ['Heading with < > symbols', 'heading-with-lt-gt-symbols'],
             ['Heading with "quotes"', 'heading-with-quot-quotes'],
             ['Heading with / and \\', 'heading-with-and'],

--- a/packages/framework/tests/Unit/HeadingRendererUnitTest.php
+++ b/packages/framework/tests/Unit/HeadingRendererUnitTest.php
@@ -242,6 +242,15 @@ class HeadingRendererUnitTest extends UnitTestCase
         $this->assertSame($expected, HeadingRenderer::makeIdentifier($input));
     }
 
+    /**
+     * @dataProvider headingIdentifierProvider
+     */
+    public function testHeadingIdentifierGenerationWithEscapedInput($input, $expected)
+    {
+        $this->assertSame(HeadingRenderer::makeIdentifier($input), HeadingRenderer::makeIdentifier(e($input)));
+        $this->assertSame($expected, HeadingRenderer::makeIdentifier(e($input)));
+    }
+
     protected function mockChildNodeRenderer(string $contents = 'Test Heading'): ChildNodeRendererInterface
     {
         $childRenderer = Mockery::mock(ChildNodeRendererInterface::class);

--- a/packages/framework/tests/Unit/HeadingRendererUnitTest.php
+++ b/packages/framework/tests/Unit/HeadingRendererUnitTest.php
@@ -268,28 +268,39 @@ class HeadingRendererUnitTest extends UnitTestCase
     public static function headingIdentifierProvider(): array
     {
         return [
-            ['hello world', 'hello-world'],
-            ['hello-world', 'hello-world'],
-            ['hello_world', 'hello-world'],
-            ['user@host', 'user-at-host'],
-            ['', ''],
-            ['Introduction', 'introduction'],
-            ['Getting Started', 'getting-started'],
-            ['Installation Guide', 'installation-guide'],
-            ['API Reference', 'api-reference'],
-            ['Frequently Asked Questions', 'frequently-asked-questions'],
-            ['123 heading', '123-heading'],
-            ['heading with multiple spaces', 'heading-with-multiple-spaces'],
-            ['heading_with_underscores_and-dashes', 'heading-with-underscores-and-dashes'],
-            ['heading with special characters !@#$', 'heading-with-special-characters-at'],
-            ['heading with numbers 123', 'heading-with-numbers-123'],
-            ['UPPERCASE HEADING', 'uppercase-heading'],
-            ['heading with emoji 😊', 'heading-with-emoji'],
-            ['heading with mixed CASE and 123 numbers', 'heading-with-mixed-case-and-123-numbers'],
-            ['heading with punctuation, commas, and periods.', 'heading-with-punctuation-commas-and-periods'],
-            ['heading with quotes "double" and \'single\'', 'heading-with-quotes-double-and-single'],
-            ['heading with slashes / and \\', 'heading-with-slashes-and'],
-            ['heading with parentheses (and brackets) [and braces] {and more}', 'heading-with-parentheses-and-brackets-and-braces-and-more'],
+            // Basic cases
+            ['Hello World', 'hello-world'],
+            ['Simple Heading', 'simple-heading'],
+            ['Heading With Numbers 123', 'heading-with-numbers-123'],
+
+            // Special characters
+            ['Heading with & symbol', 'heading-with-amp-symbol'],
+            ['Heading with < > symbols', 'heading-with-lt-gt-symbols'],
+            ['Heading with "quotes"', 'heading-with-quot-quotes'],
+            ['Heading with / and \\', 'heading-with-and'],
+            ['Heading with punctuation!?!', 'heading-with-punctuation'],
+            ['Hyphenated-heading-name', 'hyphenated-heading-name'],
+
+            // Emojis
+            ['Heading with emoji 🎉', 'heading-with-emoji'],
+            ['Another emoji 🤔 test', 'another-emoji-test'],
+            ['Multiple emojis 🎉🤔✨', 'multiple-emojis'],
+
+            // Accented and non-ASCII characters
+            ['Accented é character', 'accented-e-character'],
+            ['Café Crème', 'cafe-creme'],
+            ['Łódź and święto', 'lodz-and-swieto'],
+            ['中文标题', ''],
+            ['日本語の見出し', ''],
+
+            // Edge cases
+            ['    Leading spaces', 'leading-spaces'],
+            ['Trailing spaces    ', 'trailing-spaces'],
+            ['  Surrounded by spaces  ', 'surrounded-by-spaces'],
+            ['----', ''], // All hyphens
+            ['%%%%%%%', ''], // All special characters
+            ['    ', ''], // Empty after trimming
+            ['1234567890', '1234567890'], // Numbers only
         ];
     }
 }

--- a/packages/framework/tests/Unit/HeadingRendererUnitTest.php
+++ b/packages/framework/tests/Unit/HeadingRendererUnitTest.php
@@ -273,6 +273,11 @@ class HeadingRendererUnitTest extends UnitTestCase
             ['hello_world', 'hello-world'],
             ['user@host', 'user-at-host'],
             ['', ''],
+            ['Introduction', 'introduction'],
+            ['Getting Started', 'getting-started'],
+            ['Installation Guide', 'installation-guide'],
+            ['API Reference', 'api-reference'],
+            ['Frequently Asked Questions', 'frequently-asked-questions'],
         ];
     }
 }

--- a/packages/framework/tests/Unit/HeadingRendererUnitTest.php
+++ b/packages/framework/tests/Unit/HeadingRendererUnitTest.php
@@ -290,8 +290,8 @@ class HeadingRendererUnitTest extends UnitTestCase
             ['Accented é character', 'accented-e-character'],
             ['Café Crème', 'cafe-creme'],
             ['Łódź and święto', 'lodz-and-swieto'],
-            ['中文标题', ''],
-            ['日本語の見出し', ''],
+            ['中文标题', 'zhong-wen-biao-ti'],
+            ['日本語の見出し', 'ri-ben-yu-nojian-chu-si'],
 
             // Edge cases
             ['    Leading spaces', 'leading-spaces'],

--- a/packages/framework/tests/Unit/HeadingRendererUnitTest.php
+++ b/packages/framework/tests/Unit/HeadingRendererUnitTest.php
@@ -276,7 +276,7 @@ class HeadingRendererUnitTest extends UnitTestCase
             // Special characters
             ['Heading with & symbol', 'heading-with-and-symbol'],
             ['Heading with < > symbols', 'heading-with-symbols'],
-            ['Heading with "quotes"', 'heading-with-quot-quotes'],
+            ['Heading with "quotes"', 'heading-with-quotes'],
             ['Heading with / and \\', 'heading-with-and'],
             ['Heading with punctuation!?!', 'heading-with-punctuation'],
             ['Hyphenated-heading-name', 'hyphenated-heading-name'],

--- a/packages/framework/tests/Unit/HeadingRendererUnitTest.php
+++ b/packages/framework/tests/Unit/HeadingRendererUnitTest.php
@@ -291,7 +291,7 @@ class HeadingRendererUnitTest extends UnitTestCase
             ['Café Crème', 'cafe-creme'],
             ['Łódź and święto', 'lodz-and-swieto'],
             ['中文标题', 'zhong-wen-biao-ti'],
-            ['日本語の見出し', 'ri-ben-yu-nojian-chu-si'],
+            ['日本語の見出し', 'ri-ben-yu-nojian-chu-shi'],
             ['한국어 제목', 'han-gug-eo-jemog'],
 
             // Edge cases

--- a/packages/framework/tests/Unit/HeadingRendererUnitTest.php
+++ b/packages/framework/tests/Unit/HeadingRendererUnitTest.php
@@ -25,6 +25,7 @@ class HeadingRendererUnitTest extends UnitTestCase
     use UsesRealBladeInUnitTests;
 
     protected static bool $needsConfig = true;
+    protected static bool $needsKernel = true;
     protected static ?array $cachedConfig = null;
 
     protected function setUp(): void

--- a/packages/framework/tests/Unit/HeadingRendererUnitTest.php
+++ b/packages/framework/tests/Unit/HeadingRendererUnitTest.php
@@ -14,6 +14,7 @@ use League\CommonMark\Extension\CommonMark\Node\Block\Heading;
 use League\CommonMark\Node\Node;
 use League\CommonMark\Renderer\ChildNodeRendererInterface;
 use Mockery;
+use PHPUnit\Framework\Attributes\TestWith;
 
 /**
  * @covers \Hyde\Markdown\Processing\HeadingRenderer
@@ -234,13 +235,14 @@ class HeadingRendererUnitTest extends UnitTestCase
         $this->assertSame('<p>Paragraph</p>', (new HeadingRenderer())->postProcess($html));
     }
 
-    public function testHeadingIdentifierGeneration()
+    #[TestWith(['hello world', 'hello-world'])]
+    #[TestWith(['hello-world', 'hello-world'])]
+    #[TestWith(['hello_world', 'hello-world'])]
+    #[TestWith(['user@host', 'user-at-host'])]
+    #[TestWith(['', ''])]
+    public function testHeadingIdentifierGeneration(string $input, string $expected): void
     {
-        $this->assertSame('hello-world', HeadingRenderer::makeIdentifier('hello world'));
-        $this->assertSame('hello-world', HeadingRenderer::makeIdentifier('hello-world'));
-        $this->assertSame('hello-world', HeadingRenderer::makeIdentifier('hello_world'));
-        $this->assertSame('user-at-host', HeadingRenderer::makeIdentifier('user@host'));
-        $this->assertSame('', HeadingRenderer::makeIdentifier(''));
+        $this->assertSame($expected, HeadingRenderer::makeIdentifier($input));
     }
 
     protected function mockChildNodeRenderer(string $contents = 'Test Heading'): ChildNodeRendererInterface

--- a/packages/framework/tests/Unit/HeadingRendererUnitTest.php
+++ b/packages/framework/tests/Unit/HeadingRendererUnitTest.php
@@ -292,7 +292,7 @@ class HeadingRendererUnitTest extends UnitTestCase
             ['Łódź and święto', 'lodz-and-swieto'],
             ['中文标题', 'zhong-wen-biao-ti'],
             ['日本語の見出し', 'ri-ben-yu-nojian-chu-shi'],
-            ['한국어 제목', 'han-gug-eo-jemog'],
+            ['한국어 제목', 'hangugeo-jemog'],
 
             // Edge cases
             ['    Leading spaces', 'leading-spaces'],

--- a/packages/framework/tests/Unit/HeadingRendererUnitTest.php
+++ b/packages/framework/tests/Unit/HeadingRendererUnitTest.php
@@ -14,7 +14,6 @@ use League\CommonMark\Extension\CommonMark\Node\Block\Heading;
 use League\CommonMark\Node\Node;
 use League\CommonMark\Renderer\ChildNodeRendererInterface;
 use Mockery;
-use PHPUnit\Framework\Attributes\TestWith;
 
 /**
  * @covers \Hyde\Markdown\Processing\HeadingRenderer
@@ -235,14 +234,13 @@ class HeadingRendererUnitTest extends UnitTestCase
         $this->assertSame('<p>Paragraph</p>', (new HeadingRenderer())->postProcess($html));
     }
 
-    #[TestWith(['hello world', 'hello-world'])]
-    #[TestWith(['hello-world', 'hello-world'])]
-    #[TestWith(['hello_world', 'hello-world'])]
-    #[TestWith(['user@host', 'user-at-host'])]
-    #[TestWith(['', ''])]
-    public function testHeadingIdentifierGeneration(string $input, string $expected): void
+    public function testHeadingIdentifierGeneration()
     {
-        $this->assertSame($expected, HeadingRenderer::makeIdentifier($input));
+        $this->assertSame('hello-world', HeadingRenderer::makeIdentifier('hello world'));
+        $this->assertSame('hello-world', HeadingRenderer::makeIdentifier('hello-world'));
+        $this->assertSame('hello-world', HeadingRenderer::makeIdentifier('hello_world'));
+        $this->assertSame('user-at-host', HeadingRenderer::makeIdentifier('user@host'));
+        $this->assertSame('', HeadingRenderer::makeIdentifier(''));
     }
 
     protected function mockChildNodeRenderer(string $contents = 'Test Heading'): ChildNodeRendererInterface


### PR DESCRIPTION
- Follow up to https://github.com/hydephp/develop/pull/2047
- Targets https://github.com/hydephp/develop/pull/2006

This pull request modifies the heading identifier generation to improve how heading slugs/IDs are created. The key changes include:

1. Replacing the simple `Str::slug()` method with a more robust `makeIdentifier()` method in the `HeadingRenderer` class.

2. Adding more comprehensive normalization of heading text:
   - Transliterate non-ASCII characters
   - Replace certain special characters (e.g., '&' becomes 'and', '<' and '>' are removed)
   - Handle emojis by removing them
   - Normalize accented characters
   - Trim and clean up various edge cases

3. Ensure the identifier works consistently across different types of input, including:
   - Special characters
   - Emojis
   - Accented characters
   - Non-Latin scripts
   - Headings with leading/trailing spaces

4. Added comprehensive unit tests to verify the new identifier generation works correctly for a wide range of input scenarios.

The goal is creating more predictable and clean URL-friendly identifiers for headings in markdown documents, while maintaining readability and handling internationalization.