### PR TITLE
[2.x] Improve the Vite integration

### DIFF
--- a/docs/creating-content/managing-assets.md
+++ b/docs/creating-content/managing-assets.md
@@ -18,6 +18,57 @@ Some extra component styles are organized into modular files in the HydeFront pa
 To get you started quickly, all the styles are already compiled and minified into `_media/app.css`,
 which will be copied to the `_site/media/app.css` directory when you run `php hyde build`.
 
+## Vite
+
+Hyde uses [Vite](https://vitejs.dev/) to compile assets. Vite is a build tool that aims to provide a faster and more efficient development experience for modern web projects.
+
+### Why Vite?
+
+HydePHP integrates Vite to compile assets such as CSS and JavaScript files. This integration ensures that your assets are processed efficiently, enhancing the development workflow by leveraging Vite's rapid build system.
+
+#### Asset Management
+
+**Development and Production Modes**
+
+- **Development Mode**: Use `npm run dev` to start the Vite development HMR server, which provides fast live reloading and efficient compilation during development.
+- **Production Mode**: Use `npm run build` for creating optimized, minified asset bundles ready for production deployment.
+
+**Asset Compilation**:
+
+- Assets are compiled from the `resources/assets` directory. The primary CSS file, `app.css`, is processed with TailwindCSS and other specified tools like PostCSS.
+- Vite automatically processes all scripts and styles, outputting compiled files to the `_media` directory. These are copied to `_site/media` when the static site is built with `php hyde build`.
+
+>warn Note that the HydePHP Vite integration only supports CSS and JavaScript files, if you try to load other file types, they will not be processed by Vite.
+
+**Configuration**:
+- You can customize Vite's behavior and output paths by modifying the pre-configured `vite.config.js` file in the project root directory.
+
+### Blade Integration
+
+Hyde effortlessly integrates Vite with Blade views, allowing you to include compiled assets in your templates. The Blade components `hyde::layouts.styles` and `hyde::layouts.scripts` are already set up to load the compiled CSS and JavaScript files.
+
+You can check if the Vite HMR server is running with `Vite::running()`, and you can include CSS and JavaScript resources with `Vite::asset('path')`, or `Vite::assets([])` to supply an array of paths.
+
+**Example: Using Vite if the HMR server is enabled, or loading the compiled CSS file if not:**
+
+```blade
+@if(Vite::running())
+    {{ Vite::assets(['resources/assets/app.css']) }}
+@else
+    <link rel="stylesheet" href="{{ asset('media/app.css') }}">
+@endif
+```
+
+### Hot Module Replacement (HMR)
+
+Vite's HMR feature allows for instant updates to the browser without requiring a full page reload. This **only works** through the realtime compiler when the Vite development server is also running.
+
+You can start both of these by running `npm run dev` and `php hyde serve` in separate terminals, or using the `--vite` flag with the serve command:
+
+```bash
+php hyde serve --vite
+```
+
 ## Additional Information and Answers to Common Questions
 
 ### Is NodeJS/NPM Required for Using Hyde?

--- a/docs/creating-content/managing-assets.md
+++ b/docs/creating-content/managing-assets.md
@@ -43,6 +43,16 @@ HydePHP integrates Vite to compile assets such as CSS and JavaScript files. This
 **Configuration**:
 - You can customize Vite's behavior and output paths by modifying the pre-configured `vite.config.js` file in the project root directory.
 
+### Hot Module Replacement (HMR)
+
+Vite's HMR feature allows for instant updates to the browser without requiring a full page reload. This **only works** through the realtime compiler when the Vite development server is also running.
+
+You can start both of these by running `npm run dev` and `php hyde serve` in separate terminals, or using the `--vite` flag with the serve command:
+
+```bash
+php hyde serve --vite
+```
+
 ### Blade Integration
 
 Hyde effortlessly integrates Vite with Blade views, allowing you to include compiled assets in your templates. The Blade components `hyde::layouts.styles` and `hyde::layouts.scripts` are already set up to load the compiled CSS and JavaScript files.
@@ -57,16 +67,6 @@ You can check if the Vite HMR server is running with `Vite::running()`, and you 
 @else
     <link rel="stylesheet" href="{{ asset('media/app.css') }}">
 @endif
-```
-
-### Hot Module Replacement (HMR)
-
-Vite's HMR feature allows for instant updates to the browser without requiring a full page reload. This **only works** through the realtime compiler when the Vite development server is also running.
-
-You can start both of these by running `npm run dev` and `php hyde serve` in separate terminals, or using the `--vite` flag with the serve command:
-
-```bash
-php hyde serve --vite
 ```
 
 ## Additional Information and Answers to Common Questions

--- a/packages/framework/src/Console/Commands/ServeCommand.php
+++ b/packages/framework/src/Console/Commands/ServeCommand.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Hyde\Console\Commands;
 
 use Closure;
+use Hyde\Facades\Filesystem;
 use Hyde\Hyde;
 use Hyde\Facades\Config;
 use Illuminate\Contracts\Process\InvokedProcess;
@@ -112,7 +113,6 @@ class ServeCommand extends Command
             'HYDE_SERVER_DASHBOARD' => $this->parseEnvironmentOption('dashboard'),
             'HYDE_PRETTY_URLS' => $this->parseEnvironmentOption('pretty-urls'),
             'HYDE_PLAY_CDN' => $this->parseEnvironmentOption('play-cdn'),
-            'HYDE_SERVER_VITE' => $this->option('vite') ? 'enabled' : null,
         ]);
     }
 
@@ -203,6 +203,8 @@ class ServeCommand extends Command
                 'Please stop any other Vite processes and try again.'
             );
         }
+
+        Filesystem::touch('app/storage/framework/cache/vite.hot');
 
         $this->vite = Process::forever()->start('npm run dev');
     }

--- a/packages/framework/src/Facades/Vite.php
+++ b/packages/framework/src/Facades/Vite.php
@@ -22,11 +22,11 @@ class Vite
 
         foreach ($paths as $path) {
             if (str_ends_with($path, '.css')) {
-                $html .= sprintf('<link rel="stylesheet" href="http://localhost:5173/%s">', $path);
+                $html .= static::formatStylesheetLink($path);
             }
 
             if (str_ends_with($path, '.js')) {
-                $html .= sprintf('<script src="http://localhost:5173/%s" type="module"></script>', $path);
+                $html .= static::formatScriptInclude($path);
             }
         }
 
@@ -36,5 +36,15 @@ class Vite
     protected static function checkIfViteWasEnabledViaTheServeCommand(): bool
     {
         return env('HYDE_SERVER_VITE') === 'enabled';
+    }
+
+    protected static function formatStylesheetLink(string $path): string
+    {
+        return sprintf('<link rel="stylesheet" href="http://localhost:5173/%s">', $path);
+    }
+
+    protected static function formatScriptInclude(string $path): string
+    {
+        return sprintf('<script src="http://localhost:5173/%s" type="module"></script>', $path);
     }
 }

--- a/packages/framework/src/Facades/Vite.php
+++ b/packages/framework/src/Facades/Vite.php
@@ -42,7 +42,7 @@ class Vite
 
     protected static function isCssPath(string $path): bool
     {
-        return str_ends_with($path, '.css');
+        return preg_match('/\.(css|less|sass|scss|styl|stylus|pcss|postcss)$/', $path) === 1;
     }
 
     protected static function isJsPath(string $path): bool

--- a/packages/framework/src/Facades/Vite.php
+++ b/packages/framework/src/Facades/Vite.php
@@ -14,7 +14,7 @@ class Vite
 {
     public static function running(): bool
     {
-        return static::checkIfViteWasEnabledViaTheServeCommand() || Filesystem::exists('app/storage/framework/cache/vite.hot');
+        return Filesystem::exists('app/storage/framework/cache/vite.hot');
     }
 
     public static function asset(string $path): HtmlString
@@ -47,12 +47,6 @@ class Vite
 
         // We don't know how to handle other asset types, so we throw an exception to let the user know.
         throw new InvalidArgumentException("Unsupported asset type for path: '$path'");
-    }
-
-    protected static function checkIfViteWasEnabledViaTheServeCommand(): bool
-    {
-        // TODO: Do we actually need this? Hotfile should be enough.
-        return env('HYDE_SERVER_VITE') === 'enabled';
     }
 
     protected static function isCssPath(string $path): bool

--- a/packages/framework/src/Facades/Vite.php
+++ b/packages/framework/src/Facades/Vite.php
@@ -24,9 +24,7 @@ class Vite
         foreach ($paths as $path) {
             if (self::isCssPath($path)) {
                 $html .= static::formatStylesheetLink($path);
-            }
-
-            if (self::isJsPath($path)) {
+            } elseif (self::isJsPath($path)) {
                 $html .= static::formatScriptInclude($path);
             }
         }

--- a/packages/framework/src/Facades/Vite.php
+++ b/packages/framework/src/Facades/Vite.php
@@ -18,7 +18,6 @@ class Vite
             return true;
         }
 
-        // Check for Vite hot file
         return Filesystem::exists('app/storage/framework/cache/vite.hot');
     }
 

--- a/packages/framework/src/Facades/Vite.php
+++ b/packages/framework/src/Facades/Vite.php
@@ -35,6 +35,7 @@ class Vite
 
     protected static function checkIfViteWasEnabledViaTheServeCommand(): bool
     {
+        // TODO: Do we actually need this? Hotfile should be enough.
         return env('HYDE_SERVER_VITE') === 'enabled';
     }
 

--- a/packages/framework/src/Facades/Vite.php
+++ b/packages/framework/src/Facades/Vite.php
@@ -16,6 +16,7 @@ class Vite
         return self::checkIfViteWasEnabledViaTheServeCommand() || Filesystem::exists('app/storage/framework/cache/vite.hot');
     }
 
+    /** @param array<string> $paths */
     public static function assets(array $paths): HtmlString
     {
         $html = '<script src="http://localhost:5173/@vite/client" type="module"></script>';

--- a/packages/framework/src/Facades/Vite.php
+++ b/packages/framework/src/Facades/Vite.php
@@ -54,12 +54,17 @@ class Vite
 
     protected static function isCssPath(string $path): bool
     {
-        return preg_match('/\.('.implode('|', static::CSS_EXTENSIONS).')$/', $path) === 1;
+        return static::checkFileExtensionForPath($path, static::CSS_EXTENSIONS);
     }
 
     protected static function isJsPath(string $path): bool
     {
-        return preg_match('/\.('.implode('|', static::JS_EXTENSIONS).')$/', $path) === 1;
+        return static::checkFileExtensionForPath($path, static::JS_EXTENSIONS);
+    }
+
+    protected static function checkFileExtensionForPath(string $path, array $extensions): bool
+    {
+        return preg_match('/\.('.implode('|', $extensions).')$/', $path) === 1;
     }
 
     protected static function formatStylesheetLink(string $path): string

--- a/packages/framework/src/Facades/Vite.php
+++ b/packages/framework/src/Facades/Vite.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Hyde\Facades;
 
 use Illuminate\Support\HtmlString;
+use InvalidArgumentException;
 
 /**
  * Vite facade for handling Vite-related operations.
@@ -33,6 +34,7 @@ class Vite
         return new HtmlString($html);
     }
 
+    /** @throws InvalidArgumentException If the asset type is not supported. */
     protected static function formatAssetPath(string $path): string
     {
         if (static::isCssPath($path)) {
@@ -43,7 +45,8 @@ class Vite
             return static::formatScriptInclude($path);
         }
 
-        return ''; // TODO: Throw an exception?
+        // We don't know how to handle other asset types, so we throw an exception to let the user know.
+        throw new InvalidArgumentException("Unsupported asset type for path: '$path'");
     }
 
     protected static function checkIfViteWasEnabledViaTheServeCommand(): bool

--- a/packages/framework/src/Facades/Vite.php
+++ b/packages/framework/src/Facades/Vite.php
@@ -12,6 +12,8 @@ use InvalidArgumentException;
  */
 class Vite
 {
+    protected const CSS_EXTENSIONS = ['css', 'less', 'sass', 'scss', 'styl', 'stylus', 'pcss', 'postcss'];
+
     public static function running(): bool
     {
         return Filesystem::exists('app/storage/framework/cache/vite.hot');
@@ -51,7 +53,7 @@ class Vite
 
     protected static function isCssPath(string $path): bool
     {
-        return preg_match('/\.(css|less|sass|scss|styl|stylus|pcss|postcss)$/', $path) === 1;
+        return preg_match('/\.('.implode('|', static::CSS_EXTENSIONS).')$/', $path) === 1;
     }
 
     protected static function isJsPath(string $path): bool

--- a/packages/framework/src/Facades/Vite.php
+++ b/packages/framework/src/Facades/Vite.php
@@ -16,6 +16,11 @@ class Vite
         return static::checkIfViteWasEnabledViaTheServeCommand() || Filesystem::exists('app/storage/framework/cache/vite.hot');
     }
 
+    public static function asset(string $path): HtmlString
+    {
+        return static::assets([$path]);
+    }
+
     /** @param array<string> $paths */
     public static function assets(array $paths): HtmlString
     {

--- a/packages/framework/src/Facades/Vite.php
+++ b/packages/framework/src/Facades/Vite.php
@@ -22,16 +22,23 @@ class Vite
         $html = '<script src="http://localhost:5173/@vite/client" type="module"></script>';
 
         foreach ($paths as $path) {
-            if (self::isCssPath($path)) {
-                $html .= static::formatStylesheetLink($path);
-            }
-
-            if (self::isJsPath($path)) {
-                $html .= static::formatScriptInclude($path);
-            }
+            $html .= static::formatAssetPath($path);
         }
 
         return new HtmlString($html);
+    }
+
+    protected static function formatAssetPath(string $path): string
+    {
+        if (self::isCssPath($path)) {
+            return static::formatStylesheetLink($path);
+        }
+
+        if (self::isJsPath($path)) {
+            return static::formatScriptInclude($path);
+        }
+
+        return ''; // TODO: Throw an exception?
     }
 
     protected static function checkIfViteWasEnabledViaTheServeCommand(): bool

--- a/packages/framework/src/Facades/Vite.php
+++ b/packages/framework/src/Facades/Vite.php
@@ -13,7 +13,7 @@ class Vite
 {
     public static function running(): bool
     {
-        return self::checkIfViteWasEnabledViaTheServeCommand() || Filesystem::exists('app/storage/framework/cache/vite.hot');
+        return static::checkIfViteWasEnabledViaTheServeCommand() || Filesystem::exists('app/storage/framework/cache/vite.hot');
     }
 
     /** @param array<string> $paths */
@@ -30,11 +30,11 @@ class Vite
 
     protected static function formatAssetPath(string $path): string
     {
-        if (self::isCssPath($path)) {
+        if (static::isCssPath($path)) {
             return static::formatStylesheetLink($path);
         }
 
-        if (self::isJsPath($path)) {
+        if (static::isJsPath($path)) {
             return static::formatScriptInclude($path);
         }
 

--- a/packages/framework/src/Facades/Vite.php
+++ b/packages/framework/src/Facades/Vite.php
@@ -24,7 +24,9 @@ class Vite
         foreach ($paths as $path) {
             if (self::isCssPath($path)) {
                 $html .= static::formatStylesheetLink($path);
-            } elseif (self::isJsPath($path)) {
+            }
+
+            if (self::isJsPath($path)) {
                 $html .= static::formatScriptInclude($path);
             }
         }

--- a/packages/framework/src/Facades/Vite.php
+++ b/packages/framework/src/Facades/Vite.php
@@ -13,6 +13,7 @@ use InvalidArgumentException;
 class Vite
 {
     protected const CSS_EXTENSIONS = ['css', 'less', 'sass', 'scss', 'styl', 'stylus', 'pcss', 'postcss'];
+    protected const JS_EXTENSIONS = ['js', 'jsx', 'ts', 'tsx'];
 
     public static function running(): bool
     {
@@ -58,7 +59,7 @@ class Vite
 
     protected static function isJsPath(string $path): bool
     {
-        return str_ends_with($path, '.js');
+        return preg_match('/\.('.implode('|', static::JS_EXTENSIONS).')$/', $path) === 1;
     }
 
     protected static function formatStylesheetLink(string $path): string

--- a/packages/framework/src/Facades/Vite.php
+++ b/packages/framework/src/Facades/Vite.php
@@ -13,12 +13,7 @@ class Vite
 {
     public static function running(): bool
     {
-        // Check if Vite was enabled via the serve command
-        if (env('HYDE_SERVER_VITE') === 'enabled') {
-            return true;
-        }
-
-        return Filesystem::exists('app/storage/framework/cache/vite.hot');
+        return self::checkIfViteWasEnabledViaTheServeCommand() || Filesystem::exists('app/storage/framework/cache/vite.hot');
     }
 
     public static function assets(array $paths): HtmlString
@@ -36,5 +31,10 @@ class Vite
         }
 
         return new HtmlString($html);
+    }
+
+    protected static function checkIfViteWasEnabledViaTheServeCommand(): bool
+    {
+        return env('HYDE_SERVER_VITE') === 'enabled';
     }
 }

--- a/packages/framework/src/Facades/Vite.php
+++ b/packages/framework/src/Facades/Vite.php
@@ -22,11 +22,11 @@ class Vite
         $html = '<script src="http://localhost:5173/@vite/client" type="module"></script>';
 
         foreach ($paths as $path) {
-            if (str_ends_with($path, '.css')) {
+            if (self::isCssPath($path)) {
                 $html .= static::formatStylesheetLink($path);
             }
 
-            if (str_ends_with($path, '.js')) {
+            if (self::isJsPath($path)) {
                 $html .= static::formatScriptInclude($path);
             }
         }
@@ -38,6 +38,16 @@ class Vite
     {
         // TODO: Do we actually need this? Hotfile should be enough.
         return env('HYDE_SERVER_VITE') === 'enabled';
+    }
+
+    protected static function isCssPath(string $path): bool
+    {
+        return str_ends_with($path, '.css');
+    }
+
+    protected static function isJsPath(string $path): bool
+    {
+        return str_ends_with($path, '.js');
     }
 
     protected static function formatStylesheetLink(string $path): string

--- a/packages/framework/src/Facades/Vite.php
+++ b/packages/framework/src/Facades/Vite.php
@@ -23,7 +23,7 @@ class Vite
 
     public static function assets(array $paths): HtmlString
     {
-        $html = sprintf('<script src="http://localhost:5173/@vite/client" type="module"></script>');
+        $html = '<script src="http://localhost:5173/@vite/client" type="module"></script>';
 
         foreach ($paths as $path) {
             if (str_ends_with($path, '.css')) {

--- a/packages/framework/tests/Feature/Commands/ServeCommandTest.php
+++ b/packages/framework/tests/Feature/Commands/ServeCommandTest.php
@@ -182,6 +182,8 @@ class ServeCommandTest extends TestCase
 
     public function testHydeServeCommandWithViteOption()
     {
+        $this->cleanUpWhenDone('app/storage/framework/cache/vite.hot');
+
         $mockViteProcess = mock(InvokedProcess::class);
         $mockViteProcess->shouldReceive('running')
             ->once()
@@ -202,7 +204,7 @@ class ServeCommandTest extends TestCase
 
         Process::shouldReceive('env')
             ->once()
-            ->with(['HYDE_SERVER_REQUEST_OUTPUT' => false, 'HYDE_SERVER_VITE' => 'enabled'])
+            ->with(['HYDE_SERVER_REQUEST_OUTPUT' => false])
             ->andReturnSelf();
 
         Process::shouldReceive('start')
@@ -224,10 +226,14 @@ class ServeCommandTest extends TestCase
             ->expectsOutput('server output')
             ->expectsOutput('vite latest output')
             ->assertExitCode(0);
+
+        $this->assertFileExists('app/storage/framework/cache/vite.hot');
     }
 
     public function testHydeServeCommandWithViteOptionButViteNotRunning()
     {
+        $this->cleanUpWhenDone('app/storage/framework/cache/vite.hot');
+
         $mockViteProcess = mock(InvokedProcess::class);
         $mockViteProcess->shouldReceive('running')
             ->once()
@@ -245,7 +251,7 @@ class ServeCommandTest extends TestCase
 
         Process::shouldReceive('env')
             ->once()
-            ->with(['HYDE_SERVER_REQUEST_OUTPUT' => false, 'HYDE_SERVER_VITE' => 'enabled'])
+            ->with(['HYDE_SERVER_REQUEST_OUTPUT' => false])
             ->andReturnSelf();
 
         Process::shouldReceive('start')
@@ -263,6 +269,8 @@ class ServeCommandTest extends TestCase
         $this->artisan('serve --no-ansi --vite')
             ->expectsOutput('Starting the HydeRC server... Use Ctrl+C to stop')
             ->assertExitCode(0);
+
+        $this->assertFileExists('app/storage/framework/cache/vite.hot');
     }
 
     public function testHydeServeCommandWithViteOptionThrowsWhenPortIsInUse()

--- a/packages/framework/tests/Unit/Facades/ViteFacadeTest.php
+++ b/packages/framework/tests/Unit/Facades/ViteFacadeTest.php
@@ -59,6 +59,15 @@ class ViteFacadeTest extends UnitTestCase
         $this->assertFalse(Vite::running());
     }
 
+    public function testAssetsMethodReturnsHtmlString()
+    {
+        $this->assertInstanceOf(HtmlString::class, Vite::assets([]));
+        $this->assertInstanceOf(HtmlString::class, Vite::assets(['foo.js']));
+
+        $this->assertEquals(new HtmlString('<script src="http://localhost:5173/@vite/client" type="module"></script>'), Vite::assets([]));
+        $this->assertEquals(new HtmlString('<script src="http://localhost:5173/@vite/client" type="module"></script><script src="http://localhost:5173/foo.js" type="module"></script>'), Vite::assets(['foo.js']));
+    }
+
     public function testAssetsMethodGeneratesCorrectHtmlForJavaScriptFiles()
     {
         $html = Vite::assets(['resources/js/app.js']);
@@ -88,10 +97,5 @@ class ViteFacadeTest extends UnitTestCase
         $expected = '<script src="http://localhost:5173/@vite/client" type="module"></script><script src="http://localhost:5173/resources/js/app.js" type="module"></script><link rel="stylesheet" href="http://localhost:5173/resources/css/app.css"><script src="http://localhost:5173/resources/js/other.js" type="module"></script>';
 
         $this->assertSame($expected, (string) $html);
-    }
-
-    public function testAssetsMethodReturnsHtmlString()
-    {
-        $this->assertInstanceOf(HtmlString::class, Vite::assets([]));
     }
 }

--- a/packages/framework/tests/Unit/Facades/ViteFacadeTest.php
+++ b/packages/framework/tests/Unit/Facades/ViteFacadeTest.php
@@ -31,6 +31,19 @@ class ViteFacadeTest extends UnitTestCase
 
         putenv('HYDE_SERVER_VITE');
     }
+    
+    public function testRunningReturnsFalseWhenEnvironmentVariableIsNotSetOrDisabled()
+    {
+        $this->assertFalse(Vite::running());
+
+        putenv('HYDE_SERVER_VITE=disabled');
+
+        $this->assertFalse(Vite::running());
+
+        putenv('HYDE_SERVER_VITE');
+
+        $this->assertFalse(Vite::running());
+    }
 
     public function testRunningReturnsTrueWhenViteHotFileExists()
     {

--- a/packages/framework/tests/Unit/Facades/ViteFacadeTest.php
+++ b/packages/framework/tests/Unit/Facades/ViteFacadeTest.php
@@ -47,8 +47,7 @@ class ViteFacadeTest extends UnitTestCase
     {
         $html = Vite::assets(['resources/js/app.js']);
 
-        $expected = '<script src="http://localhost:5173/@vite/client" type="module"></script>'
-            .'<script src="http://localhost:5173/resources/js/app.js" type="module"></script>';
+        $expected = '<script src="http://localhost:5173/@vite/client" type="module"></script><script src="http://localhost:5173/resources/js/app.js" type="module"></script>';
 
         $this->assertSame($expected, (string) $html);
     }
@@ -57,8 +56,7 @@ class ViteFacadeTest extends UnitTestCase
     {
         $html = Vite::assets(['resources/css/app.css']);
 
-        $expected = '<script src="http://localhost:5173/@vite/client" type="module"></script>'
-            .'<link rel="stylesheet" href="http://localhost:5173/resources/css/app.css">';
+        $expected = '<script src="http://localhost:5173/@vite/client" type="module"></script><link rel="stylesheet" href="http://localhost:5173/resources/css/app.css">';
 
         $this->assertSame($expected, (string) $html);
     }
@@ -71,10 +69,7 @@ class ViteFacadeTest extends UnitTestCase
             'resources/js/other.js',
         ]);
 
-        $expected = '<script src="http://localhost:5173/@vite/client" type="module"></script>'
-            .'<script src="http://localhost:5173/resources/js/app.js" type="module"></script>'
-            .'<link rel="stylesheet" href="http://localhost:5173/resources/css/app.css">'
-            .'<script src="http://localhost:5173/resources/js/other.js" type="module"></script>';
+        $expected = '<script src="http://localhost:5173/@vite/client" type="module"></script><script src="http://localhost:5173/resources/js/app.js" type="module"></script><link rel="stylesheet" href="http://localhost:5173/resources/css/app.css"><script src="http://localhost:5173/resources/js/other.js" type="module"></script>';
 
         $this->assertSame($expected, (string) $html);
     }

--- a/packages/framework/tests/Unit/Facades/ViteFacadeTest.php
+++ b/packages/framework/tests/Unit/Facades/ViteFacadeTest.php
@@ -24,28 +24,6 @@ class ViteFacadeTest extends UnitTestCase
         $this->cleanUpFilesystem();
     }
 
-    public function testRunningReturnsTrueWhenEnvironmentVariableIsSet()
-    {
-        putenv('HYDE_SERVER_VITE=enabled');
-
-        $this->assertTrue(Vite::running());
-
-        putenv('HYDE_SERVER_VITE');
-    }
-
-    public function testRunningReturnsFalseWhenEnvironmentVariableIsNotSetOrDisabled()
-    {
-        $this->assertFalse(Vite::running());
-
-        putenv('HYDE_SERVER_VITE=disabled');
-
-        $this->assertFalse(Vite::running());
-
-        putenv('HYDE_SERVER_VITE');
-
-        $this->assertFalse(Vite::running());
-    }
-
     public function testRunningReturnsTrueWhenViteHotFileExists()
     {
         $this->file('app/storage/framework/cache/vite.hot');

--- a/packages/framework/tests/Unit/Facades/ViteFacadeTest.php
+++ b/packages/framework/tests/Unit/Facades/ViteFacadeTest.php
@@ -100,19 +100,33 @@ class ViteFacadeTest extends UnitTestCase
     }
 
     /**
-     * @dataProvider cssFileExtensions
+     * @dataProvider cssFileExtensionsProvider
      */
-    public function testAssetsMethodSupportsAllCssFileExtensions(string $extension)
+    public function testAssetsMethodSupportsAllCssFileExtensions(string $extension, bool $shouldBeUsed)
     {
         $html = Vite::assets(["resources/css/app.$extension"]);
 
-        $expected = '<script src="http://localhost:5173/@vite/client" type="module"></script><link rel="stylesheet" href="http://localhost:5173/resources/css/app.'.$extension.'">';
+        $expected = $shouldBeUsed
+            ? '<script src="http://localhost:5173/@vite/client" type="module"></script><link rel="stylesheet" href="http://localhost:5173/resources/css/app.'.$extension.'">'
+            : '<script src="http://localhost:5173/@vite/client" type="module"></script>';
 
         $this->assertSame($expected, (string) $html);
     }
 
-    public static function cssFileExtensions(): array
+    public static function cssFileExtensionsProvider(): array
     {
-        return array_map(fn (string $ext): array => [$ext], ['css', 'less', 'sass', 'scss', 'styl', 'stylus', 'pcss', 'postcss']);
+        return [
+            ['css', true],
+            ['less', true],
+            ['sass', true],
+            ['scss', true],
+            ['styl', true],
+            ['stylus', true],
+            ['pcss', true],
+            ['postcss', true],
+            ['foo', false],
+            ['txt', false],
+            ['html', false],
+        ];
     }
 }

--- a/packages/framework/tests/Unit/Facades/ViteFacadeTest.php
+++ b/packages/framework/tests/Unit/Facades/ViteFacadeTest.php
@@ -8,6 +8,7 @@ use Hyde\Testing\UnitTestCase;
 use Hyde\Facades\Vite;
 use Hyde\Testing\CreatesTemporaryFiles;
 use Illuminate\Support\HtmlString;
+use InvalidArgumentException;
 
 /**
  * @covers \Hyde\Facades\Vite
@@ -70,9 +71,20 @@ class ViteFacadeTest extends UnitTestCase
         $this->assertStringContainsString('<script src="http://localhost:5173/@vite/client" type="module"></script>', (string) $html);
     }
 
-    public function testItDoesNotIncludeUnknownExtensions()
+    public function testAssetMethodThrowsExceptionForUnknownExtensions()
     {
-        $this->assertSame((string) Vite::assets([]), (string) Vite::assets(['foo.txt']));
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage("Unsupported asset type for path: 'foo.txt'");
+
+        Vite::asset('foo.txt');
+    }
+
+    public function testAssetsMethodThrowsExceptionForUnknownExtensions()
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage("Unsupported asset type for path: 'foo.txt'");
+
+        Vite::assets(['foo.txt']);
     }
 
     public function testAssetsMethodReturnsHtmlString()
@@ -151,15 +163,6 @@ class ViteFacadeTest extends UnitTestCase
         $html = Vite::asset('resources/css/app.css');
 
         $expected = '<script src="http://localhost:5173/@vite/client" type="module"></script><link rel="stylesheet" href="http://localhost:5173/resources/css/app.css">';
-
-        $this->assertSame($expected, (string) $html);
-    }
-
-    public function testAssetMethodDoesNotIncludeUnknownExtensions()
-    {
-        $html = Vite::asset('unknown.ext');
-
-        $expected = '<script src="http://localhost:5173/@vite/client" type="module"></script>';
 
         $this->assertSame($expected, (string) $html);
     }

--- a/packages/framework/tests/Unit/Facades/ViteFacadeTest.php
+++ b/packages/framework/tests/Unit/Facades/ViteFacadeTest.php
@@ -129,6 +129,38 @@ class ViteFacadeTest extends UnitTestCase
         $this->assertSame($expected, (string) $html);
     }
 
+    public function testAssetMethodReturnsHtmlString()
+    {
+        $this->assertInstanceOf(HtmlString::class, Vite::asset('foo.js'));
+    }
+
+    public function testAssetMethodGeneratesCorrectHtmlForJavaScriptFile()
+    {
+        $html = Vite::asset('resources/js/app.js');
+
+        $expected = '<script src="http://localhost:5173/@vite/client" type="module"></script><script src="http://localhost:5173/resources/js/app.js" type="module"></script>';
+
+        $this->assertSame($expected, (string) $html);
+    }
+
+    public function testAssetMethodGeneratesCorrectHtmlForCssFile()
+    {
+        $html = Vite::asset('resources/css/app.css');
+
+        $expected = '<script src="http://localhost:5173/@vite/client" type="module"></script><link rel="stylesheet" href="http://localhost:5173/resources/css/app.css">';
+
+        $this->assertSame($expected, (string) $html);
+    }
+
+    public function testAssetMethodDoesNotIncludeUnknownExtensions()
+    {
+        $html = Vite::asset('unknown.ext');
+
+        $expected = '<script src="http://localhost:5173/@vite/client" type="module"></script>';
+
+        $this->assertSame($expected, (string) $html);
+    }
+
     public static function cssFileExtensionsProvider(): array
     {
         return [

--- a/packages/framework/tests/Unit/Facades/ViteFacadeTest.php
+++ b/packages/framework/tests/Unit/Facades/ViteFacadeTest.php
@@ -59,6 +59,22 @@ class ViteFacadeTest extends UnitTestCase
         $this->assertFalse(Vite::running());
     }
 
+    public function testItAlwaysImportsClientModule()
+    {
+        $html = Vite::assets([]);
+
+        $this->assertStringContainsString('<script src="http://localhost:5173/@vite/client" type="module"></script>', (string) $html);
+
+        $html = Vite::assets(['foo.js']);
+
+        $this->assertStringContainsString('<script src="http://localhost:5173/@vite/client" type="module"></script>', (string) $html);
+    }
+
+    public function testItDoesNotIncludeUnknownExtensions()
+    {
+        $this->assertSame((string) Vite::assets([]), (string) Vite::assets(['foo.txt']));
+    }
+
     public function testAssetsMethodReturnsHtmlString()
     {
         $this->assertInstanceOf(HtmlString::class, Vite::assets([]));

--- a/packages/framework/tests/Unit/Facades/ViteFacadeTest.php
+++ b/packages/framework/tests/Unit/Facades/ViteFacadeTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Hyde\Framework\Testing\Unit\Facades;
 
 use Hyde\Testing\UnitTestCase;

--- a/packages/framework/tests/Unit/Facades/ViteFacadeTest.php
+++ b/packages/framework/tests/Unit/Facades/ViteFacadeTest.php
@@ -54,6 +54,8 @@ class ViteFacadeTest extends UnitTestCase
 
     public function testRunningReturnsFalseWhenViteHotFileDoesNotExist()
     {
+        $this->assertFileDoesNotExist('app/storage/framework/cache/vite.hot');
+
         $this->assertFalse(Vite::running());
     }
 

--- a/packages/framework/tests/Unit/Facades/ViteFacadeTest.php
+++ b/packages/framework/tests/Unit/Facades/ViteFacadeTest.php
@@ -31,7 +31,7 @@ class ViteFacadeTest extends UnitTestCase
 
         putenv('HYDE_SERVER_VITE');
     }
-    
+
     public function testRunningReturnsFalseWhenEnvironmentVariableIsNotSetOrDisabled()
     {
         $this->assertFalse(Vite::running());

--- a/packages/framework/tests/Unit/Facades/ViteFacadeTest.php
+++ b/packages/framework/tests/Unit/Facades/ViteFacadeTest.php
@@ -98,4 +98,21 @@ class ViteFacadeTest extends UnitTestCase
 
         $this->assertSame($expected, (string) $html);
     }
+
+    /**
+     * @dataProvider cssFileExtensions
+     */
+    public function testAssetsMethodSupportsAllCssFileExtensions(string $extension)
+    {
+        $html = Vite::assets(["resources/css/app.$extension"]);
+
+        $expected = '<script src="http://localhost:5173/@vite/client" type="module"></script><link rel="stylesheet" href="http://localhost:5173/resources/css/app.'.$extension.'">';
+
+        $this->assertSame($expected, (string) $html);
+    }
+
+    public static function cssFileExtensions(): array
+    {
+        return array_map(fn (string $ext): array => [$ext], ['css', 'less', 'sass', 'scss', 'styl', 'stylus', 'pcss', 'postcss']);
+    }
 }

--- a/packages/framework/tests/Unit/Facades/ViteFacadeTest.php
+++ b/packages/framework/tests/Unit/Facades/ViteFacadeTest.php
@@ -118,15 +118,18 @@ class ViteFacadeTest extends UnitTestCase
     /**
      * @dataProvider cssFileExtensionsProvider
      */
-    public function testAssetsMethodSupportsAllCssFileExtensions(string $extension, bool $shouldBeUsed)
+    public function testAssetsMethodSupportsAllCssFileExtensions(string $extension)
     {
         $html = Vite::assets(["resources/css/app.$extension"]);
 
-        $expected = $shouldBeUsed
-            ? '<script src="http://localhost:5173/@vite/client" type="module"></script><link rel="stylesheet" href="http://localhost:5173/resources/css/app.'.$extension.'">'
-            : '<script src="http://localhost:5173/@vite/client" type="module"></script>';
+        if ($extension !== 'js') {
+            $expected = '<script src="http://localhost:5173/@vite/client" type="module"></script><link rel="stylesheet" href="http://localhost:5173/resources/css/app.'.$extension.'">';
 
-        $this->assertSame($expected, (string) $html);
+            $this->assertStringContainsString('stylesheet', (string) $html);
+            $this->assertSame($expected, (string) $html);
+        } else {
+            $this->assertStringNotContainsString('stylesheet', (string) $html);
+        }
     }
 
     public function testAssetMethodReturnsHtmlString()
@@ -164,17 +167,15 @@ class ViteFacadeTest extends UnitTestCase
     public static function cssFileExtensionsProvider(): array
     {
         return [
-            ['css', true],
-            ['less', true],
-            ['sass', true],
-            ['scss', true],
-            ['styl', true],
-            ['stylus', true],
-            ['pcss', true],
-            ['postcss', true],
-            ['foo', false],
-            ['txt', false],
-            ['html', false],
+            ['css'],
+            ['less'],
+            ['sass'],
+            ['scss'],
+            ['styl'],
+            ['stylus'],
+            ['pcss'],
+            ['postcss'],
+            ['js'],
         ];
     }
 }

--- a/packages/framework/tests/Unit/Facades/ViteFacadeTest.php
+++ b/packages/framework/tests/Unit/Facades/ViteFacadeTest.php
@@ -122,6 +122,23 @@ class ViteFacadeTest extends UnitTestCase
         }
     }
 
+    /**
+     * @dataProvider jsFileExtensionsProvider
+     */
+    public function testAssetsMethodSupportsAllJsFileExtensions(string $extension)
+    {
+        $html = Vite::assets(["resources/js/app.$extension"]);
+
+        if ($extension !== 'css') {
+            $expected = '<script src="http://localhost:5173/@vite/client" type="module"></script><script src="http://localhost:5173/resources/js/app.'.$extension.'" type="module"></script>';
+
+            $this->assertStringNotContainsString('stylesheet', (string) $html);
+            $this->assertSame($expected, (string) $html);
+        } else {
+            $this->assertStringContainsString('stylesheet', (string) $html);
+        }
+    }
+
     public function testAssetMethodReturnsHtmlString()
     {
         $this->assertInstanceOf(HtmlString::class, Vite::asset('foo.js'));
@@ -157,6 +174,17 @@ class ViteFacadeTest extends UnitTestCase
             ['pcss'],
             ['postcss'],
             ['js'],
+        ];
+    }
+
+    public static function jsFileExtensionsProvider(): array
+    {
+        return [
+            ['js'],
+            ['jsx'],
+            ['ts'],
+            ['tsx'],
+            ['css'],
         ];
     }
 }

--- a/packages/framework/tests/Unit/Facades/ViteFacadeTest.php
+++ b/packages/framework/tests/Unit/Facades/ViteFacadeTest.php
@@ -7,6 +7,7 @@ namespace Hyde\Framework\Testing\Unit\Facades;
 use Hyde\Testing\UnitTestCase;
 use Hyde\Facades\Vite;
 use Hyde\Testing\CreatesTemporaryFiles;
+use Illuminate\Support\HtmlString;
 
 /**
  * @covers \Hyde\Facades\Vite
@@ -76,6 +77,6 @@ class ViteFacadeTest extends UnitTestCase
 
     public function testAssetsMethodReturnsHtmlString()
     {
-        $this->assertInstanceOf(\Illuminate\Support\HtmlString::class, Vite::assets([]));
+        $this->assertInstanceOf(HtmlString::class, Vite::assets([]));
     }
 }

--- a/packages/framework/tests/Unit/ServeCommandOptionsUnitTest.php
+++ b/packages/framework/tests/Unit/ServeCommandOptionsUnitTest.php
@@ -335,18 +335,6 @@ class ServeCommandOptionsUnitTest extends UnitTestCase
         $this->assertNull($this->getMock()->getOpenCommand('UnknownOS'));
     }
 
-    public function testViteOptionPropagatesToEnvironmentVariables()
-    {
-        $command = $this->getMock(['vite' => true]);
-        $this->assertSame('enabled', $command->getEnvironmentVariables()['HYDE_SERVER_VITE']);
-
-        $command = $this->getMock(['vite' => false]);
-        $this->assertFalse(isset($command->getEnvironmentVariables()['HYDE_SERVER_VITE']));
-
-        $command = $this->getMock();
-        $this->assertFalse(isset($command->getEnvironmentVariables()['HYDE_SERVER_VITE']));
-    }
-
     public function testWithViteArgument()
     {
         HydeKernel::setInstance(new HydeKernel());

--- a/packages/realtime-compiler/src/ConsoleOutput.php
+++ b/packages/realtime-compiler/src/ConsoleOutput.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Hyde\RealtimeCompiler;
 
 use Closure;
+use Hyde\Facades\Vite;
 use Hyde\Hyde;
 use Illuminate\Support\Str;
 use Illuminate\Support\Arr;
@@ -35,7 +36,7 @@ class ConsoleOutput
             sprintf('<span class="text-white">Listening on:</span> <a href="%s" class="text-yellow-500">%s</a>', $url, $url),
             (config('hyde.server.dashboard.enabled') || Arr::has($environment, 'HYDE_SERVER_DASHBOARD')) && Arr::get($environment, 'HYDE_SERVER_DASHBOARD') === 'enabled' ?
                 sprintf('<span class="text-white">Live dashboard:</span> <a href="%s/dashboard" class="text-yellow-500">%s/dashboard</a>', $url, $url) : null,
-            Arr::get($environment, 'HYDE_SERVER_VITE') === 'enabled' ?
+            Vite::running() ?
                 sprintf('<span class="text-white">Vite HMR server:</span> <a href="http://%s:5173" class="text-yellow-500">http://%s:5173</a>', $host, $host) : null,
             '',
         ]);


### PR DESCRIPTION
Targets https://github.com/hydephp/develop/pull/2006

- Refactors code
- Adds documentation
- Adds more tests
- Throws if the path is not a supported extension (Laravel assumes non-CSS is JavaScript... I'd rather be explicit)
- Removes the internal `HYDE_SERVER_VITE` environment variable
  - The complexity this adds to microoptimize things is not warranted yet
  - The Vite server configuration already manages adding and removing the hotfile.
  - <s>**We need this to print the start message. Instead, it renames the variable to be more clear it's internal**</s> Edit: Fixed by just touching the hotfile right away