### PR TITLE
Internal: Retain commit authors for split monorepo packages

### DIFF
--- a/.github/workflows/split-monorepo.yml
+++ b/.github/workflows/split-monorepo.yml
@@ -65,6 +65,8 @@ jobs:
       - name: Commit and push changes
         env:
           COMMIT_MESSAGE: ${{ github.event.head_commit.message }}
+          COMMIT_AUTHOR_NAME: ${{ github.event.head_commit.author.name }}
+          COMMIT_AUTHOR_EMAIL: ${{ github.event.head_commit.author.email }}
         run: |
           cd hyde
           if ! [[ `git status --porcelain` ]]; then
@@ -72,8 +74,8 @@ jobs:
             exit 0;
           fi
 
-          git config user.name github-actions
-          git config user.email github-actions@github.com
+          git config user.name "$COMMIT_AUTHOR_NAME"
+          git config user.email "$COMMIT_AUTHOR_EMAIL"
           git remote add upstream https://oauth2:${{ secrets.SPLIT_MONOREPO_TOKEN }}@github.com/hydephp/hyde.git
 
           git add .
@@ -114,6 +116,8 @@ jobs:
       - name: Commit and push changes
         env:
           COMMIT_MESSAGE: ${{ github.event.head_commit.message }}
+          COMMIT_AUTHOR_NAME: ${{ github.event.head_commit.author.name }}
+          COMMIT_AUTHOR_EMAIL: ${{ github.event.head_commit.author.email }}
         run: |
           cd framework
           if ! [[ `git status --porcelain` ]]; then
@@ -121,8 +125,8 @@ jobs:
             exit 0;
           fi
 
-          git config user.name github-actions
-          git config user.email github-actions@github.com
+          git config user.name "$COMMIT_AUTHOR_NAME"
+          git config user.email "$COMMIT_AUTHOR_EMAIL"
           git remote add upstream https://oauth2:${{ secrets.SPLIT_MONOREPO_TOKEN }}@github.com/hydephp/framework.git
 
           git add .
@@ -163,6 +167,8 @@ jobs:
       - name: Commit and push changes
         env:
           COMMIT_MESSAGE: ${{ github.event.head_commit.message }}
+          COMMIT_AUTHOR_NAME: ${{ github.event.head_commit.author.name }}
+          COMMIT_AUTHOR_EMAIL: ${{ github.event.head_commit.author.email }}
         run: |
           cd realtime-compiler
           if ! [[ `git status --porcelain` ]]; then
@@ -170,8 +176,8 @@ jobs:
             exit 0;
           fi
 
-          git config user.name github-actions
-          git config user.email github-actions@github.com
+          git config user.name "$COMMIT_AUTHOR_NAME"
+          git config user.email "$COMMIT_AUTHOR_EMAIL"
           git remote add upstream https://oauth2:${{ secrets.SPLIT_MONOREPO_TOKEN }}@github.com/hydephp/realtime-compiler.git
 
           git add .
@@ -211,6 +217,8 @@ jobs:
       - name: Commit and push changes
         env:
           COMMIT_MESSAGE: ${{ github.event.head_commit.message }}
+          COMMIT_AUTHOR_NAME: ${{ github.event.head_commit.author.name }}
+          COMMIT_AUTHOR_EMAIL: ${{ github.event.head_commit.author.email }}
         run: |
           cd hydefront
           if ! [[ `git status --porcelain` ]]; then
@@ -218,8 +226,8 @@ jobs:
             exit 0;
           fi
 
-          git config user.name github-actions
-          git config user.email github-actions@github.com
+          git config user.name "$COMMIT_AUTHOR_NAME"
+          git config user.email "$COMMIT_AUTHOR_EMAIL"
           git remote add upstream https://oauth2:${{ secrets.SPLIT_MONOREPO_TOKEN }}@github.com/hydephp/hydefront.git
 
           git add .
@@ -263,6 +271,8 @@ jobs:
       - name: Commit and push changes
         env:
           COMMIT_MESSAGE: ${{ github.event.head_commit.message }}
+          COMMIT_AUTHOR_NAME: ${{ github.event.head_commit.author.name }}
+          COMMIT_AUTHOR_EMAIL: ${{ github.event.head_commit.author.email }}
         run: |
           cd website
           if ! [[ `git status --porcelain` ]]; then
@@ -270,8 +280,8 @@ jobs:
             exit 0;
           fi
 
-          git config user.name github-actions
-          git config user.email github-actions@github.com
+          git config user.name "$COMMIT_AUTHOR_NAME"
+          git config user.email "$COMMIT_AUTHOR_EMAIL"
           git remote add upstream https://oauth2:${{ secrets.SPLIT_MONOREPO_TOKEN }}@github.com/hydephp/hydephp.com.git
 
           git add .
@@ -312,6 +322,8 @@ jobs:
       - name: Commit and push changes
         env:
           COMMIT_MESSAGE: ${{ github.event.head_commit.message }}
+          COMMIT_AUTHOR_NAME: ${{ github.event.head_commit.author.name }}
+          COMMIT_AUTHOR_EMAIL: ${{ github.event.head_commit.author.email }}
         run: |
           cd testing
           if ! [[ `git status --porcelain` ]]; then
@@ -319,8 +331,8 @@ jobs:
             exit 0;
           fi
 
-          git config user.name github-actions
-          git config user.email github-actions@github.com
+          git config user.name "$COMMIT_AUTHOR_NAME"
+          git config user.email "$COMMIT_AUTHOR_EMAIL"
           git remote add upstream https://oauth2:${{ secrets.SPLIT_MONOREPO_TOKEN }}@github.com/hydephp/testing.git
 
           git add .
@@ -360,6 +372,8 @@ jobs:
       - name: Commit and push changes
         env:
           COMMIT_MESSAGE: ${{ github.event.head_commit.message }}
+          COMMIT_AUTHOR_NAME: ${{ github.event.head_commit.author.name }}
+          COMMIT_AUTHOR_EMAIL: ${{ github.event.head_commit.author.email }}
         run: |
           cd ui-kit
 
@@ -368,8 +382,8 @@ jobs:
             exit 0;
           fi
 
-          git config user.name github-actions
-          git config user.email github-actions@github.com
+          git config user.name "$COMMIT_AUTHOR_NAME"
+          git config user.email "$COMMIT_AUTHOR_EMAIL"
           git remote add upstream https://oauth2:${{ secrets.SPLIT_MONOREPO_TOKEN }}@github.com/hydephp/ui-kit.git
 
           git add .

--- a/.github/workflows/split-monorepo.yml
+++ b/.github/workflows/split-monorepo.yml
@@ -74,12 +74,12 @@ jobs:
             exit 0;
           fi
 
-          git config user.name "$COMMIT_AUTHOR_NAME"
-          git config user.email "$COMMIT_AUTHOR_EMAIL"
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git remote add upstream https://oauth2:${{ secrets.SPLIT_MONOREPO_TOKEN }}@github.com/hydephp/hyde.git
 
           git add .
-          git commit -m "$COMMIT_MESSAGE https://github.com/hydephp/develop/commit/${{ github.sha }}"
+          git commit --author="$COMMIT_AUTHOR_NAME <$COMMIT_AUTHOR_EMAIL>" -m "$COMMIT_MESSAGE https://github.com/hydephp/develop/commit/${{ github.sha }}"
 
           git push upstream develop
           echo "No changes to this package. Exiting gracefully."
@@ -125,12 +125,12 @@ jobs:
             exit 0;
           fi
 
-          git config user.name "$COMMIT_AUTHOR_NAME"
-          git config user.email "$COMMIT_AUTHOR_EMAIL"
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git remote add upstream https://oauth2:${{ secrets.SPLIT_MONOREPO_TOKEN }}@github.com/hydephp/framework.git
 
           git add .
-          git commit -m "$COMMIT_MESSAGE https://github.com/hydephp/develop/commit/${{ github.sha }}"
+          git commit --author="$COMMIT_AUTHOR_NAME <$COMMIT_AUTHOR_EMAIL>" -m "$COMMIT_MESSAGE https://github.com/hydephp/develop/commit/${{ github.sha }}"
 
           git push upstream develop
           echo "No changes to this package. Exiting gracefully."
@@ -176,12 +176,12 @@ jobs:
             exit 0;
           fi
 
-          git config user.name "$COMMIT_AUTHOR_NAME"
-          git config user.email "$COMMIT_AUTHOR_EMAIL"
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git remote add upstream https://oauth2:${{ secrets.SPLIT_MONOREPO_TOKEN }}@github.com/hydephp/realtime-compiler.git
 
           git add .
-          git commit -m "$COMMIT_MESSAGE https://github.com/hydephp/develop/commit/${{ github.sha }}"
+          git commit --author="$COMMIT_AUTHOR_NAME <$COMMIT_AUTHOR_EMAIL>" -m "$COMMIT_MESSAGE https://github.com/hydephp/develop/commit/${{ github.sha }}"
 
           git push upstream master
 
@@ -226,12 +226,12 @@ jobs:
             exit 0;
           fi
 
-          git config user.name "$COMMIT_AUTHOR_NAME"
-          git config user.email "$COMMIT_AUTHOR_EMAIL"
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git remote add upstream https://oauth2:${{ secrets.SPLIT_MONOREPO_TOKEN }}@github.com/hydephp/hydefront.git
 
           git add .
-          git commit -m "$COMMIT_MESSAGE https://github.com/hydephp/develop/commit/${{ github.sha }}"
+          git commit --author="$COMMIT_AUTHOR_NAME <$COMMIT_AUTHOR_EMAIL>" -m "$COMMIT_MESSAGE https://github.com/hydephp/develop/commit/${{ github.sha }}"
 
           git push upstream master
 
@@ -280,12 +280,12 @@ jobs:
             exit 0;
           fi
 
-          git config user.name "$COMMIT_AUTHOR_NAME"
-          git config user.email "$COMMIT_AUTHOR_EMAIL"
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git remote add upstream https://oauth2:${{ secrets.SPLIT_MONOREPO_TOKEN }}@github.com/hydephp/hydephp.com.git
 
           git add .
-          git commit -m "$COMMIT_MESSAGE https://github.com/hydephp/develop/commit/${{ github.sha }}"
+          git commit --author="$COMMIT_AUTHOR_NAME <$COMMIT_AUTHOR_EMAIL>" -m "$COMMIT_MESSAGE https://github.com/hydephp/develop/commit/${{ github.sha }}"
 
           git push upstream upcoming
           echo "No changes to this package. Exiting gracefully."
@@ -331,12 +331,12 @@ jobs:
             exit 0;
           fi
 
-          git config user.name "$COMMIT_AUTHOR_NAME"
-          git config user.email "$COMMIT_AUTHOR_EMAIL"
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git remote add upstream https://oauth2:${{ secrets.SPLIT_MONOREPO_TOKEN }}@github.com/hydephp/testing.git
 
           git add .
-          git commit -m "$COMMIT_MESSAGE https://github.com/hydephp/develop/commit/${{ github.sha }}"
+          git commit --author="$COMMIT_AUTHOR_NAME <$COMMIT_AUTHOR_EMAIL>" -m "$COMMIT_MESSAGE https://github.com/hydephp/develop/commit/${{ github.sha }}"
 
           git push upstream master
 
@@ -382,11 +382,11 @@ jobs:
             exit 0;
           fi
 
-          git config user.name "$COMMIT_AUTHOR_NAME"
-          git config user.email "$COMMIT_AUTHOR_EMAIL"
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git remote add upstream https://oauth2:${{ secrets.SPLIT_MONOREPO_TOKEN }}@github.com/hydephp/ui-kit.git
 
           git add .
-          git commit -m "$COMMIT_MESSAGE https://github.com/hydephp/develop/commit/${{ github.sha }}"
+          git commit --author="$COMMIT_AUTHOR_NAME <$COMMIT_AUTHOR_EMAIL>" -m "$COMMIT_MESSAGE https://github.com/hydephp/develop/commit/${{ github.sha }}"
 
           git push upstream master


### PR DESCRIPTION
**Key changes made:**

1.  Added new environment variables for author name and email from the head commit
2.  Updated Git config to use the original author's name and email instead of github-actions
3.  Experimental: Makes it so that it says that the original user authored and GitHub Actions committed

This will now attribute the split repository commits to the original author of the commit being synced.

---

**Background**

This workflow currently makes the split commit as the GitHub Actions user. This was originally so that if there are multiple commits, we may not want to attribute unrelated commits to authors. But I had an idea:

First, I was thinking that if the commit is a merge commit (like from a pull request), we can use the commit author then. Because if an author merges a PR, they are presumed to be responsible for all commits in that PR, so we can safely attribute the merge to them (as in essence, this split is like a squash merge).

The same if it's just a single commit we are syncing, we can keep the user.

But then, after looking at the commit history, I realized we only ever really have single changes because the merge queue makes so only one change goes through at a time, so the split monorepo job will just run on the last pushed/merged code. So, we can use the author of the last commit.

So, this updates all jobs in the workflow to use the original commit author for the latest commit (the one we're basing the message on).