### PR TITLE
Revert "Bump tailwindcss from 3.4.17 to 4.0.12 in /packages/hyde"

### DIFF
--- a/packages/hyde/package.json
+++ b/packages/hyde/package.json
@@ -12,6 +12,6 @@
         "laravel-mix": "^6.0.49",
         "postcss": "^8.4.31",
         "prettier": "3.5.3",
-        "tailwindcss": "^4.0.12"
+        "tailwindcss": "^3.0.24"
     }
 }


### PR DESCRIPTION
Reverts hydephp/develop#2115 as Tailwind 4 is breaking and we'll save that for HydePHP v2.0.