### PR TITLE
[2.x] Move internal Vite hot file to runtime directory for better semantics

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -558,7 +558,7 @@ jobs:
 
 
   devskim-lint:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     permissions:
       actions: read
       contents: read

--- a/app/storage/framework/runtime/.gitignore
+++ b/app/storage/framework/runtime/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore

--- a/packages/framework/src/Console/Commands/ServeCommand.php
+++ b/packages/framework/src/Console/Commands/ServeCommand.php
@@ -192,7 +192,7 @@ class ServeCommand extends Command
             );
         }
 
-        Filesystem::touch('app/storage/framework/cache/vite.hot');
+        Filesystem::touch('app/storage/framework/runtime/vite.hot');
 
         $this->vite = Process::forever()->start('npm run dev');
     }

--- a/packages/framework/src/Facades/Vite.php
+++ b/packages/framework/src/Facades/Vite.php
@@ -17,7 +17,7 @@ class Vite
 
     public static function running(): bool
     {
-        return Filesystem::exists('app/storage/framework/cache/vite.hot');
+        return Filesystem::exists('app/storage/framework/runtime/vite.hot');
     }
 
     public static function asset(string $path): HtmlString

--- a/packages/framework/tests/Feature/Commands/ServeCommandTest.php
+++ b/packages/framework/tests/Feature/Commands/ServeCommandTest.php
@@ -182,7 +182,7 @@ class ServeCommandTest extends TestCase
 
     public function testHydeServeCommandWithViteOption()
     {
-        $this->cleanUpWhenDone('app/storage/framework/cache/vite.hot');
+        $this->cleanUpWhenDone('app/storage/framework/runtime/vite.hot');
 
         $mockViteProcess = mock(InvokedProcess::class);
         $mockViteProcess->shouldReceive('running')
@@ -227,12 +227,12 @@ class ServeCommandTest extends TestCase
             ->expectsOutput('vite latest output')
             ->assertExitCode(0);
 
-        $this->assertFileExists('app/storage/framework/cache/vite.hot');
+        $this->assertFileExists('app/storage/framework/runtime/vite.hot');
     }
 
     public function testHydeServeCommandWithViteOptionButViteNotRunning()
     {
-        $this->cleanUpWhenDone('app/storage/framework/cache/vite.hot');
+        $this->cleanUpWhenDone('app/storage/framework/runtime/vite.hot');
 
         $mockViteProcess = mock(InvokedProcess::class);
         $mockViteProcess->shouldReceive('running')
@@ -270,7 +270,7 @@ class ServeCommandTest extends TestCase
             ->expectsOutput('Starting the HydeRC server... Use Ctrl+C to stop')
             ->assertExitCode(0);
 
-        $this->assertFileExists('app/storage/framework/cache/vite.hot');
+        $this->assertFileExists('app/storage/framework/runtime/vite.hot');
     }
 
     public function testHydeServeCommandWithViteOptionThrowsWhenPortIsInUse()

--- a/packages/framework/tests/Unit/Facades/ViteFacadeTest.php
+++ b/packages/framework/tests/Unit/Facades/ViteFacadeTest.php
@@ -26,14 +26,14 @@ class ViteFacadeTest extends UnitTestCase
 
     public function testRunningReturnsTrueWhenViteHotFileExists()
     {
-        $this->file('app/storage/framework/cache/vite.hot');
+        $this->file('app/storage/framework/runtime/vite.hot');
 
         $this->assertTrue(Vite::running());
     }
 
     public function testRunningReturnsFalseWhenViteHotFileDoesNotExist()
     {
-        $this->assertFileDoesNotExist('app/storage/framework/cache/vite.hot');
+        $this->assertFileDoesNotExist('app/storage/framework/runtime/vite.hot');
 
         $this->assertFalse(Vite::running());
     }

--- a/packages/hyde/vite.config.mjs
+++ b/packages/hyde/vite.config.mjs
@@ -14,12 +14,12 @@ const hydeVitePlugin = () => ({
     name: 'hyde-vite',
     configureServer(server) {
         // Create hot file when Vite server starts
-        fs.writeFileSync(path.resolve(process.cwd(), 'app/storage/framework/cache/vite.hot'), '');
+        fs.writeFileSync(path.resolve(process.cwd(), 'app/storage/framework/runtime/vite.hot'), '');
 
         // Remove hot file when Vite server closes
         ['SIGINT', 'SIGTERM'].forEach(signal => {
             process.on(signal, () => {
-                fs.rmSync(path.resolve(process.cwd(), 'app/storage/framework/cache/vite.hot'));
+                fs.rmSync(path.resolve(process.cwd(), 'app/storage/framework/runtime/vite.hot'));
                 process.exit();
             });
         });

--- a/vite.config.mjs
+++ b/vite.config.mjs
@@ -14,12 +14,12 @@ const hydeVitePlugin = () => ({
     name: 'hyde-vite',
     configureServer(server) {
         // Create hot file when Vite server starts
-        fs.writeFileSync(path.resolve(process.cwd(), 'app/storage/framework/cache/vite.hot'), '');
+        fs.writeFileSync(path.resolve(process.cwd(), 'app/storage/framework/runtime/vite.hot'), '');
 
         // Remove hot file when Vite server closes
         ['SIGINT', 'SIGTERM'].forEach(signal => {
             process.on(signal, () => {
-                fs.rmSync(path.resolve(process.cwd(), 'app/storage/framework/cache/vite.hot'));
+                fs.rmSync(path.resolve(process.cwd(), 'app/storage/framework/runtime/vite.hot'));
                 process.exit();
             });
         });


### PR DESCRIPTION
### Summary
Moves the Vite hot file from the cache directory to a new runtime directory under storage/framework. This aligns better with its actual purpose, as the file is used for runtime signaling, not caching.

### Details
- The hot file is now located at storage/framework/runtime/vite.hot.
- The Vite::running() method has been updated to reflect the new path.
- No external user-facing behavior is changed. Framework storage is internal.
- This change prepares the system for potential future runtime or IPC features.

### Reasoning
The cache directory is intended for optimizing repeated computations, not for interprocess signaling or ephemeral runtime flags. Using a dedicated runtime directory makes internal filesystem structure clearer and more maintainable over time.
