### PR TITLE
Internal: Fix GitHub action that switched to ESM

### DIFF
--- a/.github/scripts/RemoveStateLabels.js
+++ b/.github/scripts/RemoveStateLabels.js
@@ -1,4 +1,4 @@
-module.exports = async ({github, context}) => {
+export default async function ({github, context}) {
     const { data: labels } = await github.rest.issues.listLabelsOnIssue({
         issue_number: context.issue.number,
         owner: context.repo.owner,

--- a/.github/workflows/label-pull-requests.yml
+++ b/.github/workflows/label-pull-requests.yml
@@ -22,8 +22,8 @@ jobs:
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
-            const script = require('./.github/scripts/LabelInternal.js');
-            console.log(script({github, context}));
+            const { default: script } = await import('./.github/scripts/RemoveStateLabels.js');
+            await script({github, context});
 
       # Remove "run-visual-tests" labels and similar when the pull request is closed
       - name: Remove state control labels
@@ -32,5 +32,5 @@ jobs:
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
-            const script = require('./.github/scripts/RemoveStateLabels.js');
+            const { default: script } = await import('./.github/scripts/RemoveStateLabels.js');
             await script({github, context});


### PR DESCRIPTION
Previous versions of actions/github-script (v6 and earlier) used CommonJS internally, where require() worked fine. Now it uses ESM, so the action fails.