### PR TITLE
[2.x] Simplified front matter image schema

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -39,6 +39,7 @@ This serves two purposes:
 - Added Vite facade in https://github.com/hydephp/develop/pull/2016
 - Added a custom Blade-based heading renderer for Markdown conversions in https://github.com/hydephp/develop/pull/2047
 - The `publish:views` command is now interactive for Unix-like systems in https://github.com/hydephp/develop/pull/2062
+- Added a new simplified blog post image front matter schema using a new "caption" field in https://github.com/hydephp/develop/pull/2175
 
 ### Changed
 

--- a/docs/creating-content/blog-posts.md
+++ b/docs/creating-content/blog-posts.md
@@ -212,7 +212,7 @@ The image source will be used as-is, and no additional processing is done.
 image: https://cdn.example.com/image.jpg
 ```
 
-#### Data-rich image
+#### Data-rich image and captions
 
 You can also supply an array of data to construct a rich image with a fluent caption.
 
@@ -226,9 +226,20 @@ image:
     licenseUrl: https://example.com/license/
     authorUrl: https://photographer.example.com/
     authorName: "John Doe"
+    caption: "Overrides the fluent caption feature"
 ```
 
->info See [posts/introducing-images](https://hydephp.com/posts/introducing-images) for a detailed blog post with examples and schema information!
+The data will then be used for metadata and to render a fluently worded caption. If you just want to add a quick caption, you can instead simply set the "caption field" to override the caption; or if you simply want a caption and no metadata this is a quick option as well.
+```yaml
+image:
+    source: how-to-turn-your-github-readme-into-a-static-website-cropped.png
+    alt: Example of a static website created from a GitHub Readme
+    caption: Static website from GitHub Readme with **Markdown** support!
+```
+
+The caption field supports inline Markdown formatting like **bold**, *italic*, and [links](https://example.com). This makes it easy to add rich text formatting to your image captions.
+
+If the `alt` field is missing, the caption will be used as the alt text as well.
 
 ## Using Images in Posts
 

--- a/docs/creating-content/managing-assets.md
+++ b/docs/creating-content/managing-assets.md
@@ -183,4 +183,4 @@ To improve accessibility, you should always add an `alt` text. Here is a full ex
 
 Hyde offers great support for creating data-rich and accessible featured images for blog posts.
 
-You can read more about this on the [creating blog posts page](blog-posts#image).
+You can read more about this on the [creating blog posts page](blog-posts#data-rich-image-and-captions).

--- a/packages/framework/resources/views/components/post/image.blade.php
+++ b/packages/framework/resources/views/components/post/image.blade.php
@@ -6,6 +6,10 @@
 <figure aria-label="Cover image" itemprop="image" itemscope itemtype="https://schema.org/ImageObject" role="doc-cover">
     <img src="{{ $image->getSource() }}" alt="{{ $image->getAltText() ?? '' }}" title="{{ $image->getTitleText() ?? '' }}" itemprop="image" class="mb-0">
     <figcaption aria-label="Image caption" itemprop="caption">
+        @if($image->hasCaption())
+            <span>{{ $image->getCaption() }}</span>
+        @endif
+
         @if($image->hasAuthorName())
             <span>Image by</span>
             <span itemprop="creator" itemscope="" itemtype="https://schema.org/Person">

--- a/packages/framework/resources/views/components/post/image.blade.php
+++ b/packages/framework/resources/views/components/post/image.blade.php
@@ -2,12 +2,14 @@
     /** @var \Hyde\Pages\MarkdownPost $page  */
     /** @var \Hyde\Framework\Features\Blogging\Models\FeaturedImage $image  */
     $image = $page->image;
+    
+    use Illuminate\Support\Str;
 @endphp
 <figure aria-label="Cover image" itemprop="image" itemscope itemtype="https://schema.org/ImageObject" role="doc-cover">
     <img src="{{ $image->getSource() }}" alt="{{ $image->getAltText() ?? '' }}" title="{{ $image->getTitleText() ?? '' }}" itemprop="image" class="mb-0">
     <figcaption aria-label="Image caption" itemprop="caption">
         @if($image->hasCaption())
-            <span>{{ $image->getCaption() }}</span>
+            <span>{!! Str::inlineMarkdown($image->getCaption()) !!}</span>
         @endif
 
         @if($image->hasAuthorName())

--- a/packages/framework/resources/views/components/post/image.blade.php
+++ b/packages/framework/resources/views/components/post/image.blade.php
@@ -10,31 +10,31 @@
     <figcaption aria-label="Image caption" itemprop="caption">
         @if($image->hasCaption())
             <span>{!! Str::inlineMarkdown($image->getCaption()) !!}</span>
-        @endif
-
-        @if($image->hasAuthorName())
-            <span>Image by</span>
-            <span itemprop="creator" itemscope="" itemtype="https://schema.org/Person">
-                @if($image->hasAuthorUrl())
-                    <a href="{{ $image->getAuthorUrl() }}" rel="author noopener nofollow" itemprop="url">
+        @else
+            @if($image->hasAuthorName())
+                <span>Image by</span>
+                <span itemprop="creator" itemscope="" itemtype="https://schema.org/Person">
+                    @if($image->hasAuthorUrl())
+                        <a href="{{ $image->getAuthorUrl() }}" rel="author noopener nofollow" itemprop="url">
+                            <span itemprop="name">{{ $image->getAuthorName() }}</span>.
+                        </a>
+                    @else
                         <span itemprop="name">{{ $image->getAuthorName() }}</span>.
-                    </a>
+                    @endif
+                </span>
+            @endif
+
+            @if($image->hasCopyrightText())
+                <span itemprop="copyrightNotice">{{ $image->getCopyrightText() }}</span>.
+            @endif
+
+            @if($image->hasLicenseName())
+                <span>License</span>
+                @if($image->hasLicenseUrl())
+                    <a href="{{ $image->getLicenseUrl() }}" rel="license nofollow noopener" itemprop="license">{{ $image->getLicenseName() }}</a>.
                 @else
-                    <span itemprop="name">{{ $image->getAuthorName() }}</span>.
+                    <span itemprop="license">{{ $image->getLicenseName() }}</span>.
                 @endif
-            </span>
-        @endif
-
-        @if($image->hasCopyrightText())
-            <span itemprop="copyrightNotice">{{ $image->getCopyrightText() }}</span>.
-        @endif
-
-        @if($image->hasLicenseName())
-            <span>License</span>
-            @if($image->hasLicenseUrl())
-                <a href="{{ $image->getLicenseUrl() }}" rel="license nofollow noopener" itemprop="license">{{ $image->getLicenseName() }}</a>.
-            @else
-                <span itemprop="license">{{ $image->getLicenseName() }}</span>.
             @endif
         @endif
     </figcaption>

--- a/packages/framework/src/Framework/Factories/FeaturedImageFactory.php
+++ b/packages/framework/src/Framework/Factories/FeaturedImageFactory.php
@@ -28,23 +28,25 @@ class FeaturedImageFactory extends Concerns\PageDataFactory implements FeaturedI
     protected readonly ?string $copyrightText;
     protected readonly ?string $licenseName;
     protected readonly ?string $licenseUrl;
+    protected readonly ?string $caption;
 
     public function __construct(
         private readonly FrontMatter $matter,
         private readonly ?string $filePath = null,
     ) {
         $this->source = $this->makeSource();
-        $this->altText = $this->getStringMatter('image.altText');
+        $this->altText = $this->getStringMatter('image.altText') ?? $this->getStringMatter('image.alt');
         $this->titleText = $this->getStringMatter('image.titleText');
         $this->authorName = $this->getStringMatter('image.authorName');
         $this->authorUrl = $this->getStringMatter('image.authorUrl');
         $this->copyrightText = $this->getStringMatter('image.copyright');
         $this->licenseName = $this->getStringMatter('image.licenseName');
         $this->licenseUrl = $this->getStringMatter('image.licenseUrl');
+        $this->caption = $this->getStringMatter('image.caption');
     }
 
     /**
-     * @return array{source: string, altText: string|null, titleText: string|null, authorName: string|null, authorUrl: string|null, copyrightText: string|null, licenseName: string|null, licenseUrl: string|null}
+     * @return array{source: string, altText: string|null, titleText: string|null, authorName: string|null, authorUrl: string|null, copyrightText: string|null, licenseName: string|null, licenseUrl: string|null, caption: string|null}
      */
     public function toArray(): array
     {
@@ -57,6 +59,7 @@ class FeaturedImageFactory extends Concerns\PageDataFactory implements FeaturedI
             'copyrightText' => $this->copyrightText,
             'licenseName' => $this->licenseName,
             'licenseUrl' => $this->licenseUrl,
+            'caption' => $this->caption,
         ];
     }
 

--- a/packages/framework/src/Framework/Features/Blogging/Models/FeaturedImage.php
+++ b/packages/framework/src/Framework/Features/Blogging/Models/FeaturedImage.php
@@ -58,7 +58,8 @@ class FeaturedImage implements Stringable, FeaturedImageSchema
         protected readonly ?string $authorUrl = null,
         protected readonly ?string $licenseName = null,
         protected readonly ?string $licenseUrl = null,
-        protected readonly ?string $copyrightText = null
+        protected readonly ?string $copyrightText = null,
+        protected readonly ?string $caption = null
     ) {
         $this->type = Hyperlinks::isRemote($source) ? self::TYPE_REMOTE : self::TYPE_LOCAL;
         $this->source = $this->setSource($source);
@@ -127,6 +128,10 @@ class FeaturedImage implements Stringable, FeaturedImageSchema
             $metadata['name'] = $this->getTitleText();
         }
 
+        if ($this->hasCaption()) {
+            $metadata['caption'] = $this->getCaption();
+        }
+
         $metadata['url'] = $this->getSource();
         $metadata['contentUrl'] = $this->getSource();
 
@@ -135,7 +140,7 @@ class FeaturedImage implements Stringable, FeaturedImageSchema
 
     public function getAltText(): ?string
     {
-        return $this->altText;
+        return $this->altText ?? $this->caption;
     }
 
     public function getTitleText(): ?string
@@ -166,6 +171,11 @@ class FeaturedImage implements Stringable, FeaturedImageSchema
     public function getLicenseUrl(): ?string
     {
         return $this->licenseUrl;
+    }
+
+    public function getCaption(): ?string
+    {
+        return $this->caption;
     }
 
     public function hasAltText(): bool
@@ -201,6 +211,11 @@ class FeaturedImage implements Stringable, FeaturedImageSchema
     public function hasLicenseUrl(): bool
     {
         return $this->has('licenseUrl');
+    }
+
+    public function hasCaption(): bool
+    {
+        return $this->has('caption');
     }
 
     protected function has(string $property): bool

--- a/packages/framework/src/Markdown/Contracts/FrontMatter/SubSchemas/FeaturedImageSchema.php
+++ b/packages/framework/src/Markdown/Contracts/FrontMatter/SubSchemas/FeaturedImageSchema.php
@@ -14,8 +14,10 @@ interface FeaturedImageSchema extends BlogPostSchema
 {
     public const FEATURED_IMAGE_SCHEMA = [
         'source' => 'string', // Name of a file in _media/ or a remote URL (required)
-        'altText' => 'string', // The alt text (important for accessibility) // todo: Support alt, description
-        'titleText' => 'string', // The title text (hover tooltip & metadata) // todo: Support title, caption
+        'altText' => 'string', // The alt text (important for accessibility)
+        'alt' => 'string',     // Alternative to altText (simplified schema)
+        'titleText' => 'string', // The title text (hover tooltip & metadata)
+        'caption' => 'string', // The caption text (simplified schema)
         'licenseName' => 'string', // The name of the license (e.g. "CC BY 4.0")
         'licenseUrl' => 'string', // The URL of the license (e.g. "https://creativecommons.org/licenses/by/4.0/")
         'authorName' => 'string', // The name of the author/photographer of the image (e.g. "John Doe", Wikimedia Commons)

--- a/packages/framework/tests/Feature/FeaturedImageFactoryTest.php
+++ b/packages/framework/tests/Feature/FeaturedImageFactoryTest.php
@@ -47,6 +47,7 @@ class FeaturedImageFactoryTest extends TestCase
             'copyrightText' => 'copyright',
             'licenseName' => 'license',
             'licenseUrl' => 'licenseUrl',
+            'caption' => null,
         ];
 
         $factory = new FeaturedImageFactory(new FrontMatter($array));
@@ -144,6 +145,43 @@ class FeaturedImageFactoryTest extends TestCase
         $this->assertSourceIsSame('media/foo?v=00000000', ['image' => ['source' => 'foo']]);
         $this->assertSourceIsSame('media/foo?v=00000000', ['image' => ['source' => 'media/foo']]);
         $this->assertSourceIsSame('media/foo?v=00000000', ['image' => ['source' => '_media/foo']]);
+    }
+
+    public function testSupportsSimplifiedImageSchema()
+    {
+        $array = [
+            'image' => [
+                'source' => 'source',
+                'alt' => 'Alternative text',
+                'caption' => 'Static website from GitHub Readme',
+            ],
+        ];
+
+        $factory = new FeaturedImageFactory(new FrontMatter($array));
+        $image = FeaturedImageFactory::make(new FrontMatter($array));
+
+        $this->assertSame('source', $factory->toArray()['source']);
+        $this->assertSame('Alternative text', $factory->toArray()['altText']);
+        $this->assertSame('Static website from GitHub Readme', $factory->toArray()['caption']);
+
+        $this->assertSame('Alternative text', $image->getAltText());
+        $this->assertSame('Static website from GitHub Readme', $image->getCaption());
+    }
+
+    public function testFallsBackToCaptionWhenAltIsMissing()
+    {
+        $array = [
+            'image' => [
+                'source' => 'source',
+                'caption' => 'This caption should be used as alt text',
+            ],
+        ];
+
+        $image = FeaturedImageFactory::make(new FrontMatter($array));
+
+        $this->assertFalse($image->hasAltText());
+        $this->assertSame('This caption should be used as alt text', $image->getAltText());
+        $this->assertSame('This caption should be used as alt text', $image->getCaption());
     }
 
     protected function makeFromArray(array $matter): FeaturedImage

--- a/packages/framework/tests/Feature/FeaturedImageTest.php
+++ b/packages/framework/tests/Feature/FeaturedImageTest.php
@@ -41,6 +41,15 @@ class FeaturedImageTest extends TestCase
             'contentUrl' => 'media/source',
         ], (new FilledImage)->getMetadataArray());
 
+        // Test with caption
+        $this->assertSame([
+            'text' => 'alt',
+            'name' => 'title',
+            'caption' => 'This is a caption',
+            'url' => 'media/source',
+            'contentUrl' => 'media/source',
+        ], (new FeaturedImage('source', 'alt', 'title', null, null, null, null, null, 'This is a caption'))->getMetadataArray());
+
         $this->assertSame([
             'url' => 'media/source',
             'contentUrl' => 'media/source',

--- a/packages/framework/tests/Unit/SchemaContractsTest.php
+++ b/packages/framework/tests/Unit/SchemaContractsTest.php
@@ -69,7 +69,9 @@ class SchemaContractsTest extends UnitTestCase
         $this->assertSame([
             'source' => 'string',
             'altText' => 'string',
+            'alt' => 'string',
             'titleText' => 'string',
+            'caption' => 'string',
             'licenseName' => 'string',
             'licenseUrl' => 'string',
             'authorName' => 'string',

--- a/packages/framework/tests/Unit/Views/FeaturedImageViewTest.php
+++ b/packages/framework/tests/Unit/Views/FeaturedImageViewTest.php
@@ -334,7 +334,7 @@ class FeaturedImageViewTest extends TestCase
     public function testCaptionWithSimplifiedSchemaSupportsMarkdown()
     {
         $this->file('_media/markdown.jpg', 'test content');
-        
+
         $image = new FeaturedImage(
             'markdown.jpg',
             null, // altText
@@ -346,9 +346,9 @@ class FeaturedImageViewTest extends TestCase
             null, // copyrightText
             'Caption with **bold** and *italic* text' // caption with markdown
         );
-        
+
         $component = $this->renderComponent($image);
-        
+
         $this->assertStringContainsString('<strong>bold</strong>', $component);
         $this->assertStringContainsString('<em>italic</em>', $component);
     }
@@ -364,14 +364,14 @@ class FeaturedImageViewTest extends TestCase
 
         // The caption should be present
         $this->assertStringContainsString('This custom caption should override the fluent caption', $component);
-        
+
         // The fluent caption elements should NOT be present
         $this->assertStringNotContainsString('Image by', $component);
         $this->assertStringNotContainsString('John Doe', $component);
         $this->assertStringNotContainsString('License', $component);
         $this->assertStringNotContainsString('MIT License', $component);
     }
-    
+
     public function testFluentCaptionUsedWhenNoCaptionIsSet()
     {
         $component = $this->renderComponent([

--- a/packages/framework/tests/Unit/Views/FeaturedImageViewTest.php
+++ b/packages/framework/tests/Unit/Views/FeaturedImageViewTest.php
@@ -318,6 +318,41 @@ class FeaturedImageViewTest extends TestCase
         $this->assertStringContainsString('alt="Static website from GitHub Readme"', $component);
     }
 
+    public function testCaptionSupportsMarkdown()
+    {
+        $component = $this->renderComponent([
+            'image.source' => 'foo.jpg',
+            'image.caption' => 'This is a caption with **bold** and *italic* text and [a link](https://example.com)',
+        ]);
+
+        // Check that Markdown is rendered correctly
+        $this->assertStringContainsString('<strong>bold</strong>', $component);
+        $this->assertStringContainsString('<em>italic</em>', $component);
+        $this->assertStringContainsString('<a href="https://example.com">a link</a>', $component);
+    }
+
+    public function testCaptionWithSimplifiedSchemaSupportsMarkdown()
+    {
+        $this->file('_media/markdown.jpg', 'test content');
+        
+        $image = new FeaturedImage(
+            'markdown.jpg',
+            null, // altText
+            null, // titleText
+            null, // authorName
+            null, // authorUrl
+            null, // licenseName
+            null, // licenseUrl
+            null, // copyrightText
+            'Caption with **bold** and *italic* text' // caption with markdown
+        );
+        
+        $component = $this->renderComponent($image);
+        
+        $this->assertStringContainsString('<strong>bold</strong>', $component);
+        $this->assertStringContainsString('<em>italic</em>', $component);
+    }
+
     protected function stripHtml(string $string): string
     {
         return trim($this->stripWhitespace(strip_tags($string)), "\t ");

--- a/packages/framework/tests/Unit/Views/FeaturedImageViewTest.php
+++ b/packages/framework/tests/Unit/Views/FeaturedImageViewTest.php
@@ -353,6 +353,40 @@ class FeaturedImageViewTest extends TestCase
         $this->assertStringContainsString('<em>italic</em>', $component);
     }
 
+    public function testCaptionOverridesFeaturedImage()
+    {
+        $component = $this->renderComponent([
+            'image.source' => 'foo.jpg',
+            'image.caption' => 'This custom caption should override the fluent caption',
+            'image.authorName' => 'John Doe',
+            'image.licenseName' => 'MIT License',
+        ]);
+
+        // The caption should be present
+        $this->assertStringContainsString('This custom caption should override the fluent caption', $component);
+        
+        // The fluent caption elements should NOT be present
+        $this->assertStringNotContainsString('Image by', $component);
+        $this->assertStringNotContainsString('John Doe', $component);
+        $this->assertStringNotContainsString('License', $component);
+        $this->assertStringNotContainsString('MIT License', $component);
+    }
+    
+    public function testFluentCaptionUsedWhenNoCaptionIsSet()
+    {
+        $component = $this->renderComponent([
+            'image.source' => 'foo.jpg',
+            'image.authorName' => 'John Doe',
+            'image.licenseName' => 'MIT License',
+        ]);
+
+        // The fluent caption elements should be present
+        $this->assertStringContainsString('Image by', $component);
+        $this->assertStringContainsString('John Doe', $component);
+        $this->assertStringContainsString('License', $component);
+        $this->assertStringContainsString('MIT License', $component);
+    }
+
     protected function stripHtml(string $string): string
     {
         return trim($this->stripWhitespace(strip_tags($string)), "\t ");

--- a/packages/framework/tests/Unit/Views/FeaturedImageViewTest.php
+++ b/packages/framework/tests/Unit/Views/FeaturedImageViewTest.php
@@ -273,6 +273,51 @@ class FeaturedImageViewTest extends TestCase
         $this->assertStringContainsString('src="custom_media/bar.png"', $component);
     }
 
+    public function testCaptionIsRenderedWhenPresent()
+    {
+        $component = $this->renderComponent([
+            'image.source' => 'foo.jpg',
+            'image.caption' => 'This is a caption for the image',
+            'image.altText' => 'Alt text for the image',
+        ]);
+
+        $this->assertStringContainsString('This is a caption for the image', $component);
+        $this->assertStringContainsString('alt="Alt text for the image"', $component);
+    }
+
+    public function testAltTextFallsBackToCaptionWhenMissing()
+    {
+        $component = $this->renderComponent([
+            'image.source' => 'foo.jpg',
+            'image.caption' => 'This caption is used as alt text',
+        ]);
+
+        $this->assertStringContainsString('This caption is used as alt text', $component);
+        $this->assertStringContainsString('alt="This caption is used as alt text"', $component);
+    }
+
+    public function testSupportsSimplifiedImageSchema()
+    {
+        $this->file('_media/simple.jpg', 'test content');
+
+        $image = new FeaturedImage(
+            'simple.jpg',
+            null, // altText
+            null, // titleText
+            null, // authorName
+            null, // authorUrl
+            null, // licenseName
+            null, // licenseUrl
+            null, // copyrightText
+            'Static website from GitHub Readme' // caption
+        );
+
+        $component = $this->renderComponent($image);
+
+        $this->assertStringContainsString('Static website from GitHub Readme', $component);
+        $this->assertStringContainsString('alt="Static website from GitHub Readme"', $component);
+    }
+
     protected function stripHtml(string $string): string
     {
         return trim($this->stripWhitespace(strip_tags($string)), "\t ");


### PR DESCRIPTION
Fixes https://github.com/hydephp/develop/issues/1718 by introducing a new "caption" field to just control the caption without having to remember the full syntax.