### PR TITLE
[2.x] Merge route helper methods

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -121,6 +121,7 @@ This serves two purposes:
 - Markdown headings are now compiled using our custom Blade-based heading renderer in https://github.com/hydephp/develop/pull/2047
     - The `id` attributes for heading permalinks have been moved from the anchor to the heading element in https://github.com/hydephp/develop/pull/2052
 - Colored Markdown blockquotes are now rendered using Blade and TailwindCSS, this change is not visible in the rendered result, but the HTML output has changed in https://github.com/hydephp/develop/pull/2056
+- **Breaking:** The Routes facade's API has been simplified by merging the `get()` and `getOrFail()` methods into a single `get()` method that always throws a `RouteNotFoundException` when a route doesn't exist in https://github.com/hydephp/develop/pull/1743.
 
 ### Deprecated
 
@@ -686,3 +687,37 @@ navigation:
 ```
 
 These changes provide more flexibility and control over your site's navigation structure. Make sure to update your configuration files and any custom code that interacts with navigation items to align with these new formats and features.
+
+### Routes facade API changes
+
+The Routes facade's API has been simplified by merging the `get()` and `getOrFail()` methods into a single `get()` method that always throws a `RouteNotFoundException` when a route doesn't exist.
+
+#### Instead of:
+```php
+// Try to get a route, returns null if not found
+$route = Routes::get('some-route');
+if ($route !== null) {
+    // Use the route
+}
+
+// Get a route or throw an exception
+$route = Routes::getOrFail('some-route');
+```
+
+#### Use instead:
+```php
+// Check if a route exists first
+if (Routes::exists('some-route')) {
+    // Get the route (will never be null)
+    $route = Routes::get('some-route');
+}
+
+// Or handle the exception
+try {
+    $route = Routes::get('some-route');
+} catch (RouteNotFoundException $e) {
+    // Handle the exception
+}
+```
+
+This change makes the API more predictable and better aligned with Laravel's conventions.

--- a/_pages/404.blade.php
+++ b/_pages/404.blade.php
@@ -31,7 +31,7 @@
                     Sorry, the page you are looking for could not be found.
                 </p>
 
-                <a href="{{ Routes::get('index') ?? '/' }}">
+                <a href="{{ Routes::exists('index') ? Routes::get('index') : '/' }}">
                     <button class="bg-transparent text-grey-darkest font-bold uppercase tracking-wide py-3 px-6 border-2 border-grey-light hover:border-grey rounded-lg">
                         Go Home
                     </button>

--- a/docs/architecture-concepts/autodiscovery.md
+++ b/docs/architecture-concepts/autodiscovery.md
@@ -34,7 +34,7 @@ discovery process and stores the discovered data in memory.
 
 Usually, you will interact with the collection data through intermediaries.
 * For example, if you call `MarkdownPost::get('my-post')`, Hyde will retrieve that page from the page collection.
-* If you call `Routes::get('index')`, Hyde will retrieve that route from the route collection.
+* If you call `Routes::get('index')`, Hyde will retrieve that route from the route collection. If the route doesn't exist, an exception will be thrown. You can use `Routes::exists('index')` to check if a route exists before trying to retrieve it.
 
 ## The HydeKernel
 

--- a/docs/architecture-concepts/automatic-routing.md
+++ b/docs/architecture-concepts/automatic-routing.md
@@ -25,7 +25,9 @@ php hyde route:list
 
 Each route in your site is represented by a Route object. It's very easy to get a Route object instance from the Router's index.
 There are a few ways to do this, but most commonly you'll use the Routes facade's `get()` method where you provide a route key,
-and it will return the Route object. The route key is generally `<page-output-directory/page-identifier>`. Here are some examples:
+and it will return the Route object. If the route doesn't exist, an exception will be thrown. You can use `Routes::exists()` to check if a route exists before trying to retrieve it. 
+
+The route key is generally `<page-output-directory/page-identifier>`. Here are some examples:
 
 ```php
 // Source file: _pages/index.md/index.blade.php
@@ -54,11 +56,11 @@ You can of course use it just like a normal anchor tag like so:
 But where it really shines is when you supply a route. This will then resolve the proper relative link, and format it to use pretty URLs if your site is configured to use them.
 
 ```blade
-<x-link :href="Routes::get('index')">Home</x-link>
+<x-link :href="Routes::exists('index') ? Routes::get('index') : '/'">Home</x-link>
 ```
 
 You can of course, also supply extra attributes like classes:
 
 ```blade
-<x-link :href="Routes::get('index')" class="btn btn-primary">Home</x-link>
+<x-link :href="Routes::exists('index') ? Routes::get('index') : '/'" class="btn btn-primary">Home</x-link>
 ```

--- a/packages/framework/resources/views/components/navigation/navigation-brand.blade.php
+++ b/packages/framework/resources/views/components/navigation/navigation-brand.blade.php
@@ -1,3 +1,3 @@
-<a href="{{ Routes::get('index') }}" class="font-bold px-4" aria-label="Home page">
+<a href="{{ Routes::exists('index') ? Routes::get('index') : '/' }}" class="font-bold px-4" aria-label="Home page">
     {{ config('hyde.name', 'HydePHP') }}
 </a>

--- a/packages/framework/resources/views/pages/404.blade.php
+++ b/packages/framework/resources/views/pages/404.blade.php
@@ -31,7 +31,7 @@
                     Sorry, the page you are looking for could not be found.
                 </p>
 
-                <a href="{{ Routes::get('index') ?? '/' }}">
+                <a href="{{ Routes::exists('index') ? Routes::get('index') : '/' }}">
                     <button class="bg-transparent text-grey-darkest font-bold uppercase tracking-wide py-3 px-6 border-2 border-grey-light hover:border-grey rounded-lg">
                         Go Home
                     </button>

--- a/packages/framework/src/Foundation/Facades/Routes.php
+++ b/packages/framework/src/Foundation/Facades/Routes.php
@@ -29,13 +29,8 @@ class Routes extends Facade
         return static::getFacadeRoot()->has($routeKey);
     }
 
-    public static function get(string $routeKey): ?Route
-    {
-        return static::getFacadeRoot()->get($routeKey);
-    }
-
     /** @throws \Hyde\Framework\Exceptions\RouteNotFoundException */
-    public static function getOrFail(string $routeKey): Route
+    public static function get(string $routeKey): Route
     {
         return static::getFacadeRoot()->getRoute($routeKey);
     }

--- a/packages/framework/src/Framework/Views/Components/BreadcrumbsComponent.php
+++ b/packages/framework/src/Framework/Views/Components/BreadcrumbsComponent.php
@@ -31,7 +31,7 @@ class BreadcrumbsComponent extends Component
     protected function makeBreadcrumbs(): array
     {
         $identifier = Hyde::currentRoute()->getPage()->getIdentifier();
-        $breadcrumbs = [(Routes::get('index')?->getLink() ?? '/') => 'Home'];
+        $breadcrumbs = [(Routes::exists('index') ? Routes::get('index')->getLink() : '/') => 'Home'];
 
         if ($identifier === 'index') {
             return $breadcrumbs;

--- a/packages/framework/src/Pages/Concerns/HydePage.php
+++ b/packages/framework/src/Pages/Concerns/HydePage.php
@@ -309,7 +309,7 @@ abstract class HydePage implements PageSchema, SerializableContract
      */
     public function getRoute(): Route
     {
-        return Routes::get($this->getRouteKey()) ?? new Route($this);
+        return Routes::exists($this->getRouteKey()) ? Routes::get($this->getRouteKey()) : new Route($this);
     }
 
     /**

--- a/packages/framework/src/Pages/DocumentationPage.php
+++ b/packages/framework/src/Pages/DocumentationPage.php
@@ -30,7 +30,9 @@ class DocumentationPage extends BaseMarkdownPage
 
     public static function home(): ?Route
     {
-        return Routes::get(static::homeRouteName());
+        return Routes::exists(static::homeRouteName())
+            ? Routes::get(static::homeRouteName())
+            : null;
     }
 
     public static function homeRouteName(): string

--- a/packages/framework/src/Support/Paginator.php
+++ b/packages/framework/src/Support/Paginator.php
@@ -85,7 +85,10 @@ class Paginator
 
         if (isset($this->routeBasename)) {
             foreach ($pageRange as $number) {
-                $array[$number] = Routes::get("$this->routeBasename/page-$number") ?? Hyde::formatLink("$this->routeBasename/page-$number");
+                $routeKey = "$this->routeBasename/page-$number";
+                $array[$number] = Routes::exists($routeKey)
+                    ? Routes::get($routeKey)
+                    : Hyde::formatLink("$this->routeBasename/page-$number");
             }
         } else {
             foreach ($pageRange as $number) {
@@ -204,7 +207,11 @@ class Paginator
 
     protected function getRoute(int $offset): Route|string
     {
-        return Routes::get("$this->routeBasename/{$this->formatPageName($offset)}") ?? Hyde::formatLink("$this->routeBasename/{$this->formatPageName($offset)}");
+        $routeKey = "$this->routeBasename/{$this->formatPageName($offset)}";
+
+        return Routes::exists($routeKey)
+            ? Routes::get($routeKey)
+            : Hyde::formatLink("$this->routeBasename/{$this->formatPageName($offset)}");
     }
 
     protected function firstPage(): int

--- a/packages/framework/tests/Feature/PaginatorTest.php
+++ b/packages/framework/tests/Feature/PaginatorTest.php
@@ -257,6 +257,30 @@ class PaginatorTest extends TestCase
         ], $paginator->getPageLinks());
     }
 
+    public function testGetPageLinksWithBaseRouteWithMixedExistentAndNonExistentRoutes()
+    {
+        // Register only the first two pages in the Routes
+        $pages[1] = new InMemoryPage('articles/page-1');
+        $pages[2] = new InMemoryPage('articles/page-2');
+
+        foreach ($pages as $page) {
+            Hyde::routes()->put($page->getRouteKey(), $page->getRoute());
+        }
+
+        // Create a paginator with 5 items, using 'articles' as the route basename
+        $paginator = new Paginator(range(1, 50), 10, paginationRouteBasename: 'articles');
+
+        $expected = [
+            1 => $pages[1]->getRoute(),
+            2 => $pages[2]->getRoute(),
+            3 => Hyde::formatLink('articles/page-3'),
+            4 => Hyde::formatLink('articles/page-4'),
+            5 => Hyde::formatLink('articles/page-5'),
+        ];
+
+        $this->assertSame($expected, $paginator->getPageLinks());
+    }
+
     public function testFirstItemNumberOnPage()
     {
         $paginator = $this->makePaginator();

--- a/packages/framework/tests/Unit/Facades/RouteFacadeTest.php
+++ b/packages/framework/tests/Unit/Facades/RouteFacadeTest.php
@@ -9,7 +9,6 @@ use Hyde\Framework\Exceptions\RouteNotFoundException;
 use Hyde\Hyde;
 use Hyde\Pages\BladePage;
 use Hyde\Pages\MarkdownPage;
-use Hyde\Pages\MarkdownPost;
 use Hyde\Support\Models\Route;
 use Hyde\Testing\UnitTestCase;
 
@@ -26,11 +25,11 @@ class RouteFacadeTest extends UnitTestCase
         $this->assertSame(Hyde::routes(), Routes::all());
     }
 
-    public function testGetOrFailThrowsExceptionIfRouteIsNotFound()
+    public function testGetThrowsExceptionIfRouteIsNotFound()
     {
         $this->expectException(RouteNotFoundException::class);
 
-        Routes::getOrFail('not-found');
+        Routes::get('not-found');
     }
 
     public function testGetReturnsRouteFromRouterIndex()
@@ -41,11 +40,6 @@ class RouteFacadeTest extends UnitTestCase
     public function testGetReturnsRouteFromRouterIndexForTheRightPage()
     {
         $this->assertEquals(new Route(BladePage::parse('index')), Routes::get('index'));
-    }
-
-    public function testGetFromReturnsNullIfRouteIsNotFound()
-    {
-        $this->assertNull(Routes::get('not-found'));
     }
 
     public function testCurrentReturnsCurrentRoute()

--- a/packages/realtime-compiler/src/Http/DashboardController.php
+++ b/packages/realtime-compiler/src/Http/DashboardController.php
@@ -296,7 +296,7 @@ class DashboardController extends BaseController
     protected function openPageInEditor(): void
     {
         $routeKey = $this->request->data['routeKey'] ?? $this->abort(400, 'Must provide routeKey');
-        $page = Routes::getOrFail($routeKey)->getPage();
+        $page = Routes::get($routeKey)->getPage();
 
         $binary = $this->findGeneralOpenBinary();
         $path = Hyde::path($page->getSourcePath());

--- a/packages/realtime-compiler/src/Routing/PageRouter.php
+++ b/packages/realtime-compiler/src/Routing/PageRouter.php
@@ -82,12 +82,10 @@ class PageRouter
     protected function getPageFromRoute(): HydePage
     {
         try {
-            return Routes::getOrFail($this->normalizePath($this->request->path))->getPage();
+            return Routes::get($this->normalizePath($this->request->path))->getPage();
         } catch (RouteNotFoundException $exception) {
-            $index = Routes::get($this->normalizePath($this->request->path).'/index');
-
-            if ($index) {
-                return $index->getPage();
+            if (Routes::exists($this->normalizePath($this->request->path).'/index')) {
+                return Routes::get($this->normalizePath($this->request->path).'/index')->getPage();
             }
 
             throw $exception;


### PR DESCRIPTION
# PR Description:
This PR simplifies the Routes facade API by merging the `get()` and `getOrFail()` methods into a single `get()` method that always throws a `RouteNotFoundException` when a route doesn't exist. This aligns with Laravel's conventions and makes the API more predictable. While we lose the ability to use null coalesces, the benefit in predictability and uniformity outweighs that syntax sugar.

## Changes:

- Merged `get` and `getOrFail` into a single `get` method that throws an exception on failure
- Updated code that relied on the null return behavior to use `Routes::exists()` checks first
- Updated tests and documentation to reflect the new behavior

## Benefits:
- More predictable API - `get()` will always throw if the route doesn't exist
- Better alignment with Laravel's conventions
- Encourages explicit existence checks using `Routes::exists()` rather than null coalescing
- Removes redundancy in the API

## Breaking Changes:
- Code that relied on `Routes::get()` returning null for non-existent routes needs to be updated to use `Routes::exists()` first
- A complete upgrade guide is provided in the documentation

This implements the proposal from #1743.
