### PR TITLE
[2.x] Improve Routes facade method naming with find() and get()

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -121,6 +121,10 @@ This serves two purposes:
 - Markdown headings are now compiled using our custom Blade-based heading renderer in https://github.com/hydephp/develop/pull/2047
     - The `id` attributes for heading permalinks have been moved from the anchor to the heading element in https://github.com/hydephp/develop/pull/2052
 - Colored Markdown blockquotes are now rendered using Blade and TailwindCSS, this change is not visible in the rendered result, but the HTML output has changed in https://github.com/hydephp/develop/pull/2056
+- **Improved Routes facade API with more intuitive method names** in https://github.com/hydephp/develop/pull/2179
+    - **Breaking:** Renamed `Routes::get()` to `Routes::find()` to better indicate it may return null
+    - **Breaking:** Renamed `Routes::getOrFail()` to `Routes::get()` to make the exception-throwing behavior the default and match Laravel conventions
+    - This change requires code updates if you were using these methods - see upgrade guide below
 
 ### Deprecated
 
@@ -535,6 +539,33 @@ Hyperlinks::isRemote($source);
 ```
 
 This change was implemented in https://github.com/hydephp/develop/pull/1883. Make sure to update any instances of `FeaturedImage::isRemote()` in your codebase to ensure compatibility with HydePHP v2.0.
+
+### Routes facade API changes
+
+The Routes facade API has been improved to better follow Laravel naming conventions and make the API more intuitive. This change affects code that directly uses the Routes facade methods.
+
+#### Changes
+
+- The `Routes::get()` method has been renamed to `Routes::find()` to better indicate that it may return null if a route is not found
+- The `Routes::getOrFail()` method has been renamed to `Routes::get()` to make the exception-throwing behavior the default, matching Laravel conventions
+
+#### Upgrade guide
+
+If you have used the Routes facade in your custom code, update it as follows:
+
+```php
+// Old code:
+$route = Routes::get('some-route'); // Returns null if not found
+$route = Routes::getOrFail('some-route'); // Throws exception if not found
+
+// New code:
+$route = Routes::find('some-route'); // Returns null if not found
+$route = Routes::get('some-route'); // Throws exception if not found
+```
+
+This change provides more intuitive method names and better type safety, with `find()` returning `?Route` and `get()` returning `Route`.
+
+This change was implemented in https://github.com/hydephp/develop/pull/2179.
 
 ## New Asset System
 

--- a/_pages/404.blade.php
+++ b/_pages/404.blade.php
@@ -31,7 +31,7 @@
                     Sorry, the page you are looking for could not be found.
                 </p>
 
-                <a href="{{ Routes::get('index') ?? '/' }}">
+                <a href="{{ Routes::find('index') ?? '/' }}">
                     <button class="bg-transparent text-grey-darkest font-bold uppercase tracking-wide py-3 px-6 border-2 border-grey-light hover:border-grey rounded-lg">
                         Go Home
                     </button>

--- a/packages/framework/resources/views/components/navigation/navigation-brand.blade.php
+++ b/packages/framework/resources/views/components/navigation/navigation-brand.blade.php
@@ -1,3 +1,3 @@
-<a href="{{ Routes::get('index') }}" class="font-bold px-4" aria-label="Home page">
+<a href="{{ Routes::find('index') }}" class="font-bold px-4" aria-label="Home page">
     {{ config('hyde.name', 'HydePHP') }}
 </a>

--- a/packages/framework/resources/views/pages/404.blade.php
+++ b/packages/framework/resources/views/pages/404.blade.php
@@ -31,7 +31,7 @@
                     Sorry, the page you are looking for could not be found.
                 </p>
 
-                <a href="{{ Routes::get('index') ?? '/' }}">
+                <a href="{{ Routes::find('index') ?? '/' }}">
                     <button class="bg-transparent text-grey-darkest font-bold uppercase tracking-wide py-3 px-6 border-2 border-grey-light hover:border-grey rounded-lg">
                         Go Home
                     </button>

--- a/packages/framework/src/Foundation/Facades/Routes.php
+++ b/packages/framework/src/Foundation/Facades/Routes.php
@@ -29,7 +29,7 @@ class Routes extends Facade
         return static::getFacadeRoot()->has($routeKey);
     }
 
-    public static function get(string $routeKey): ?Route
+    public static function find(string $routeKey): ?Route
     {
         return static::getFacadeRoot()->get($routeKey);
     }

--- a/packages/framework/src/Foundation/Facades/Routes.php
+++ b/packages/framework/src/Foundation/Facades/Routes.php
@@ -35,7 +35,7 @@ class Routes extends Facade
     }
 
     /** @throws \Hyde\Framework\Exceptions\RouteNotFoundException */
-    public static function getOrFail(string $routeKey): Route
+    public static function get(string $routeKey): Route
     {
         return static::getFacadeRoot()->getRoute($routeKey);
     }

--- a/packages/framework/src/Foundation/Facades/Routes.php
+++ b/packages/framework/src/Foundation/Facades/Routes.php
@@ -24,28 +24,46 @@ class Routes extends Facade
         return HydeKernel::getInstance()->routes();
     }
 
+    /**
+     * Check if a route exists by its route key.
+     */
     public static function exists(string $routeKey): bool
     {
         return static::getFacadeRoot()->has($routeKey);
     }
 
+    /**
+     * Try to get a route by its route key. If it doesn't exist, null is returned.
+     */
     public static function find(string $routeKey): ?Route
     {
         return static::getFacadeRoot()->get($routeKey);
     }
 
-    /** @throws \Hyde\Framework\Exceptions\RouteNotFoundException */
+    /**
+     * Get a route by its route key. If it doesn't exist, an exception is thrown.
+     *
+     * @throws \Hyde\Framework\Exceptions\RouteNotFoundException
+     */
     public static function get(string $routeKey): Route
     {
         return static::getFacadeRoot()->getRoute($routeKey);
     }
 
+    /**
+     * Get all the routes for the site as a collection of route instances, keyed by route key.
+     *
+     * @return \Hyde\Foundation\Kernel\RouteCollection<string, \Hyde\Support\Models\Route>
+     */
     public static function all(): RouteCollection
     {
         return static::getFacadeRoot()->getRoutes();
     }
 
-    /** Get the current route for the page being rendered. */
+    /**
+     * Get the route instance for the page currently being rendered.
+     * If a render is not in progress, this will return null.
+     */
     public static function current(): ?Route
     {
         return Hyde::currentRoute();

--- a/packages/framework/src/Framework/Views/Components/BreadcrumbsComponent.php
+++ b/packages/framework/src/Framework/Views/Components/BreadcrumbsComponent.php
@@ -31,7 +31,7 @@ class BreadcrumbsComponent extends Component
     protected function makeBreadcrumbs(): array
     {
         $identifier = Hyde::currentRoute()->getPage()->getIdentifier();
-        $breadcrumbs = [(Routes::get('index')?->getLink() ?? '/') => 'Home'];
+        $breadcrumbs = [(Routes::find('index')?->getLink() ?? '/') => 'Home'];
 
         if ($identifier === 'index') {
             return $breadcrumbs;

--- a/packages/framework/src/Pages/Concerns/HydePage.php
+++ b/packages/framework/src/Pages/Concerns/HydePage.php
@@ -309,7 +309,7 @@ abstract class HydePage implements PageSchema, SerializableContract
      */
     public function getRoute(): Route
     {
-        return Routes::get($this->getRouteKey()) ?? new Route($this);
+        return Routes::find($this->getRouteKey()) ?? new Route($this);
     }
 
     /**

--- a/packages/framework/src/Pages/DocumentationPage.php
+++ b/packages/framework/src/Pages/DocumentationPage.php
@@ -30,7 +30,7 @@ class DocumentationPage extends BaseMarkdownPage
 
     public static function home(): ?Route
     {
-        return Routes::get(static::homeRouteName());
+        return Routes::find(static::homeRouteName());
     }
 
     public static function homeRouteName(): string

--- a/packages/framework/tests/Unit/Facades/RouteFacadeTest.php
+++ b/packages/framework/tests/Unit/Facades/RouteFacadeTest.php
@@ -44,7 +44,7 @@ class RouteFacadeTest extends UnitTestCase
 
     public function testGetFromReturnsNullIfRouteIsNotFound()
     {
-        $this->assertNull(Routes::get('not-found'));
+        $this->assertNull(Routes::find('not-found'));
     }
 
     public function testCurrentReturnsCurrentRoute()

--- a/packages/framework/tests/Unit/Facades/RouteFacadeTest.php
+++ b/packages/framework/tests/Unit/Facades/RouteFacadeTest.php
@@ -29,7 +29,7 @@ class RouteFacadeTest extends UnitTestCase
     {
         $this->expectException(RouteNotFoundException::class);
 
-        Routes::getOrFail('not-found');
+        Routes::get('not-found');
     }
 
     public function testGetReturnsRouteFromRouterIndex()

--- a/packages/realtime-compiler/src/Http/DashboardController.php
+++ b/packages/realtime-compiler/src/Http/DashboardController.php
@@ -296,7 +296,7 @@ class DashboardController extends BaseController
     protected function openPageInEditor(): void
     {
         $routeKey = $this->request->data['routeKey'] ?? $this->abort(400, 'Must provide routeKey');
-        $page = Routes::getOrFail($routeKey)->getPage();
+        $page = Routes::get($routeKey)->getPage();
 
         $binary = $this->findGeneralOpenBinary();
         $path = Hyde::path($page->getSourcePath());

--- a/packages/realtime-compiler/src/Routing/PageRouter.php
+++ b/packages/realtime-compiler/src/Routing/PageRouter.php
@@ -84,7 +84,7 @@ class PageRouter
         try {
             return Routes::getOrFail($this->normalizePath($this->request->path))->getPage();
         } catch (RouteNotFoundException $exception) {
-            $index = Routes::get($this->normalizePath($this->request->path).'/index');
+            $index = Routes::find($this->normalizePath($this->request->path).'/index');
 
             if ($index) {
                 return $index->getPage();

--- a/packages/realtime-compiler/src/Routing/PageRouter.php
+++ b/packages/realtime-compiler/src/Routing/PageRouter.php
@@ -82,7 +82,7 @@ class PageRouter
     protected function getPageFromRoute(): HydePage
     {
         try {
-            return Routes::getOrFail($this->normalizePath($this->request->path))->getPage();
+            return Routes::get($this->normalizePath($this->request->path))->getPage();
         } catch (RouteNotFoundException $exception) {
             $index = Routes::find($this->normalizePath($this->request->path).'/index');
 


### PR DESCRIPTION
### Description
This PR improves the Routes facade API by renaming methods to better communicate their behavior:

1. Renames `Routes::get()` (which returns null for missing routes) to `Routes::find()` to better indicate its trying to find, but is null safe
2. Renames `Routes::getOrFail()` to `Routes::get()` to make the exception-throwing behavior the default

**Benefits:**
- More predictable API: `get()` now fails fast with clear exceptions, matching Laravel conventions
- More descriptive naming: `find()` indicates it may return null
- Complete type safety: `find()` returns `?Route`, `get()` returns `Route`

**Breaking changes:**
- Code using `Routes::get('some-route')` needs to be updated to `Routes::find('some-route')` _if_ it needs to handle missing routes nullably
- Code using `Routes::getOrFail('some-route')` needs to be updated to `Routes::get('some-route')`

**Migration guide:**
```php
// Old code:
$route = Routes::get('some-route'); // Returns null if not found
$route = Routes::getOrFail('some-route'); // Throws exception if not found

// New code:
$route = Routes::find('some-route'); // Returns null if not found
$route = Routes::get('some-route'); // Throws exception if not found
```

All internal uses have been updated to use the new method names.

**Relations:**
- Replaces https://github.com/hydephp/develop/pull/2176.
- Fixes https://github.com/hydephp/develop/issues/1743