### PR TITLE
HydePHP v2 Release Candidate One

### DIFF
--- a/packages/framework/src/Foundation/HydeKernel.php
+++ b/packages/framework/src/Foundation/HydeKernel.php
@@ -50,7 +50,7 @@ class HydeKernel implements SerializableContract
     use Serializable;
     use Macroable;
 
-    final public const VERSION = '1.8.0';
+    final public const VERSION = '2.0.0';
 
     protected static self $instance;
 

--- a/packages/hyde/composer.json
+++ b/packages/hyde/composer.json
@@ -24,12 +24,12 @@
         }
     ],
     "require": {
-        "php": "^8.1",
-        "hyde/framework": "^1.8",
-        "laravel-zero/framework": "^10.0"
+        "php": "^8.2",
+        "hyde/framework": "^2.0",
+        "laravel-zero/framework": "^11.0"
     },
     "require-dev": {
-        "hyde/realtime-compiler": "^3.6"
+        "hyde/realtime-compiler": "^4.0"
     },
     "autoload": {
         "psr-4": {

--- a/packages/ui-kit/docs/composer.json
+++ b/packages/ui-kit/docs/composer.json
@@ -30,7 +30,7 @@
         "laravel-zero/framework": "^11.0"
     },
     "require-dev": {
-        "hyde/realtime-compiler": "^3.0"
+        "hyde/realtime-compiler": "^4.0"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
At long last, this is the first release candidate for HydePHP v2.0. Please stay tuned for the official release which will contain the finalized changeset and release notes with upgrade guide. However, for those who are curious - feel free to start testing this right now!