### PR TITLE
feat: forward method calls to DateTime in DateString

### DIFF
--- a/packages/framework/src/Support/Models/DateString.php
+++ b/packages/framework/src/Support/Models/DateString.php
@@ -46,4 +46,13 @@ class DateString implements Stringable
     {
         return $this->short;
     }
+
+    public function __call(string $method, array $arguments): mixed
+    {
+        if (method_exists($this->dateTimeObject, $method)) {
+            return $this->dateTimeObject->$method(...$arguments);
+        }
+
+        throw new \BadMethodCallException("Method {$method} does not exist on DateTime.");
+    } 
 }

--- a/packages/framework/tests/Unit/DateStringTest.php
+++ b/packages/framework/tests/Unit/DateStringTest.php
@@ -48,4 +48,36 @@ class DateStringTest extends UnitTestCase
         $dateString = new DateString('2022-01-01 UTC');
         $this->assertSame('Jan 1st, 2022', (string) $dateString);
     }
+
+    public function testItCanForwardGetTimestampMethodToDateTimeObject()
+    {
+        $dateString = new DateString('2020-01-01 00:00:00 UTC');
+        $expected = (new DateTime('2020-01-01 00:00:00 UTC'))->getTimestamp();
+        $this->assertSame($expected, $dateString->getTimestamp());
+    }
+
+    public function testItCanForwardModifyMethodToDateTimeObject()
+    {
+        $dateString = new DateString('2020-01-01 UTC');
+        $modified = $dateString->modify('+1 day');
+        $this->assertInstanceOf(DateTime::class, $modified);
+        $this->assertSame('2020-01-02', $modified->format('Y-m-d'));
+    }
+
+    public function testItCanForwardSetTimeMethodToDateTimeObject()
+    {
+        $dateString = new DateString('2020-01-01 UTC');
+        $modified = $dateString->setTime(15, 30);
+        $this->assertInstanceOf(DateTime::class, $modified);
+        $this->assertSame('15:30:00', $modified->format('H:i:s'));
+    }
+
+    public function testCallingUndefinedMethodThrowsException()
+    {
+        $this->expectException(\BadMethodCallException::class);
+        $this->expectExceptionMessage('Method nonExistentMethod does not exist on DateTime');
+
+        $dateString = new DateString('2020-01-01 UTC');
+        $dateString->nonExistentMethod();
+    }
 }


### PR DESCRIPTION
This PR adds support for forwarding method calls from the `DateString` class to its internal `DateTime` instance. This allows for more intuitive usage, such as calling `$post->date->format('Y-m-d')` directly instead of accessing `$post->date->dateTimeObject->format('Y-m-d')`.

- [ ] Implemented the __call() magic method to intercept and forward undefined method calls to the DateTime object.
- [ ] Throws a BadMethodCallException if a method does not exist on DateTime, maintaining robustness.
