### PR TITLE
[2.x] Fix rebuild command showing the wrong console output

### DIFF
--- a/packages/framework/src/Console/Commands/RebuildPageCommand.php
+++ b/packages/framework/src/Console/Commands/RebuildPageCommand.php
@@ -76,7 +76,7 @@ class RebuildPageCommand extends Command
             public function printFinishMessage(): void
             {
                 $this->createdSiteFile(Command::fileLink(
-                    Pages::getPage($this->path)->getOutputPath()
+                    Hyde::sitePath(Pages::getPage($this->path)->getOutputPath())
                 ))->withExecutionTime();
             }
 

--- a/packages/framework/tests/Feature/Commands/RebuildPageCommandTest.php
+++ b/packages/framework/tests/Feature/Commands/RebuildPageCommandTest.php
@@ -16,7 +16,9 @@ class RebuildPageCommandTest extends TestCase
     {
         $this->file('_pages/test-page.md', 'foo');
 
-        $this->artisan('rebuild _pages/test-page.md')->assertExitCode(0);
+        $this->artisan('rebuild _pages/test-page.md')
+            ->expectsOutputToContain('_site/test-page.html')
+            ->assertExitCode(0);
 
         $this->assertFileExists(Hyde::path('_site/test-page.html'));
 


### PR DESCRIPTION
output message about file location fixed

Closes: 288
(cherry picked from commit 08ea48bfb4ba2fea3dd8b28bbe31d3bd190fd52c)