### PR TITLE
[2.x] Support "excerpt" as alias for "description" in blog posts

### DIFF
--- a/packages/framework/src/Framework/Factories/BlogPostDataFactory.php
+++ b/packages/framework/src/Framework/Factories/BlogPostDataFactory.php
@@ -74,7 +74,7 @@ class BlogPostDataFactory extends Concerns\PageDataFactory implements BlogPostSc
 
     protected function makeDescription(): string
     {
-        return $this->getMatter('description') ?? $this->makeDescriptionFromMarkdownBody();
+        return $this->getMatter('description') ?? $this->getMatter('excerpt') ?? $this->makeDescriptionFromMarkdownBody();
     }
 
     protected function makeCategory(): ?string

--- a/packages/framework/src/Markdown/Contracts/FrontMatter/BlogPostSchema.php
+++ b/packages/framework/src/Markdown/Contracts/FrontMatter/BlogPostSchema.php
@@ -14,7 +14,7 @@ interface BlogPostSchema extends PageSchema
 {
     public const BLOG_POST_SCHEMA = [
         'title' => 'string',
-        'description' => 'string',
+        'description' => 'string',  // Excerpt is also supported
         'category' => 'string',
         'date' => 'string',
         'author' => ['string', AuthorSchema::AUTHOR_SCHEMA],

--- a/packages/framework/tests/Feature/MarkdownPostTest.php
+++ b/packages/framework/tests/Feature/MarkdownPostTest.php
@@ -190,6 +190,25 @@ class MarkdownPostTest extends TestCase
         Filesystem::unlink('_site/feed-test.html');
     }
 
+    public function testConstructorCanUseExcerptAsAliasForDescription()
+    {
+        $post = new MarkdownPost(matter: FrontMatter::fromArray([
+            'excerpt' => 'This is the excerpt content',
+        ]));
+
+        $this->assertSame('This is the excerpt content', $post->description);
+    }
+
+    public function testConstructorPrioritizesDescriptionOverExcerptWhenBothAreSet()
+    {
+        $post = new MarkdownPost(matter: FrontMatter::fromArray([
+            'description' => 'This is the description',
+            'excerpt' => 'This is the excerpt',
+        ]));
+
+        $this->assertSame('This is the description', $post->description);
+    }
+
     protected function setupMediaFileAndCacheBusting(bool $enableCacheBusting = false): void
     {
         $this->file('_media/foo.png', 'test content');


### PR DESCRIPTION
You can also use `excerpt` as an alias for `description`. If both are set, `description` takes priority.

```yaml
excerpt: "A short description used in previews and SEO"
```

- Fixes https://github.com/hydephp/hyde/issues/285

I'm not adding this to release notes or docs because I don't want to bloat it. The idea is not that people should use this as I want to encourage sticking with the canonical convention, but this is a way to fall back if one uses the wrong one (like I've tried). It's also good for interop. We can add a validator to encourage using canonical fields if we want, but only if it becomes an actual problem.