### PR TITLE
[2.x] Rename --run-vite flag to --vite in build command

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -73,7 +73,7 @@ This serves two purposes:
 - **Breaking:** Renamed class `DataCollections` to `DataCollection` in [#1732](https://github.com/hydephp/develop/pull/1732)  For more information, see below.
 - **Breaking:** Renamed the `hyde.enable_cache_busting` configuration option to `hyde.cache_busting` in [#1980](https://github.com/hydephp/develop/pull/1980)
 - **Breaking:** Renamed the `hyde.navigation.subdirectories` configuration option to `hyde.navigation.subdirectory_display` in [#1818](https://github.com/hydephp/develop/pull/1818)
-- **Breaking:** Replaced `--run-dev` and `--run-prod` build command flags with a single `--run-vite` flag that uses Vite to build assets in [#2013](https://github.com/hydephp/develop/pull/2013)
+- **Breaking:** Replaced `--run-dev` and `--run-prod` build command flags with a single `--vite` flag that uses Vite to build assets in [#2013](https://github.com/hydephp/develop/pull/2013)
 - **Breaking:** The `Author::create()` method now returns an array instead of a `PostAuthor` instance in [#1798](https://github.com/hydephp/develop/pull/1798) For more information, see below.
 - **Breaking:** The `Author::get()` method now returns `null` if an author is not found, rather than creating a new instance in [#1798](https://github.com/hydephp/develop/pull/1798)  For more information, see below.
 - **Breaking:** The `hyde.authors` config setting should now be keyed by the usernames in [#1782](https://github.com/hydephp/develop/pull/1782) For more information, see below.
@@ -555,7 +555,7 @@ The new asset system is a complete rewrite of the HydeFront asset handling syste
     - Added a new `npm run build` command for compiling frontend assets with Vite.
     - Added Vite facade for Blade templates.
     - Added Vite Hot Module Replacement (HMR) support to the realtime compiler.
-    - Build command now uses Vite to compile assets when the `--run-vite` flag is passed.
+    - Build command now uses Vite to compile assets when the `--vite` flag is passed.
 
 - **Improved HydeFront integration.** ([#2024], [#2029], [#2031], [#2036], [#2037], [#2038], [#2039])
     - HydeFront styles are now refactored into Tailwind.
@@ -576,7 +576,7 @@ The new asset system is a complete rewrite of the HydeFront asset handling syste
 
 - Replaced Laravel Mix with Vite. ([#2010])
     - You must now use `npm run build` to compile your assets, instead of `npm run prod`.
-- Removed `--run-dev` and `--run-prod` build command flags, replaced by `--run-vite`. ([#2013])
+- Removed `--run-dev` and `--run-prod` build command flags, replaced by `--vite`. ([#2013])
 - Removed `DocumentationPage::getTableOfContents()` method. Table of contents are now generated using a Blade component. ([#2045])
 - Removed `hyde.css` from HydeFront, requiring recompilation of assets if you were extending it. ([#2037])
 - Changed how HydeFront is included in projects.  Instead of separate `hyde.css` and `app.css`, all styles are now in `app.css`. ([#2024])

--- a/docs/getting-started/console-commands.md
+++ b/docs/getting-started/console-commands.md
@@ -66,7 +66,7 @@ Here is a quick reference of all the available commands. You can also run `php h
 <a name="build" style="display: inline-block; position: absolute; margin-top: -5rem;"></a>
 
 ```bash
-php hyde build [--run-vite] [--run-prettier] [--pretty-urls] [--no-api]
+php hyde build [--vite] [--run-prettier] [--pretty-urls] [--no-api]
 ```
 
 Build the static site
@@ -75,7 +75,7 @@ Build the static site
 
 |                  |                                            |
 |------------------|--------------------------------------------|
-| `--run-vite`     | Build frontend assets using Vite           |
+| `--vite`         | Build frontend assets using Vite           |
 | `--run-prettier` | Format the output using NPM Prettier       |
 | `--pretty-urls`  | Should links in output use pretty URLs?    |
 | `--no-api`       | Disable API calls, for example, Torchlight |

--- a/packages/framework/src/Console/Commands/BuildSiteCommand.php
+++ b/packages/framework/src/Console/Commands/BuildSiteCommand.php
@@ -26,12 +26,12 @@ class BuildSiteCommand extends Command
 {
     /** @var string */
     protected $signature = 'build
-        {--run-vite : Build frontend assets using Vite}
+        {--vite : Build frontend assets using Vite}
         {--run-prettier : Format the output using NPM Prettier}
         {--pretty-urls : Should links in output use pretty URLs?}
         {--no-api : Disable API calls, for example, Torchlight}
-        {--run-dev : [Removed] Use --run-vite instead}
-        {--run-prod : [Removed] Use --run-vite instead}';
+        {--run-dev : [Removed] Use --vite instead}
+        {--run-prod : [Removed] Use --vite instead}';
 
     /** @var string */
     protected $description = 'Build the static site';
@@ -88,7 +88,7 @@ class BuildSiteCommand extends Command
             Config::set(['hyde.pretty_urls' => true]);
         }
 
-        if ($this->option('run-vite')) {
+        if ($this->option('vite')) {
             $this->runNodeCommand('npm run build', 'Building frontend assets for production!');
         }
 
@@ -161,7 +161,7 @@ class BuildSiteCommand extends Command
     /**
      * This method is called when the removed --run-dev or --run-prod options are used.
      *
-     * @deprecated Use --run-vite instead
+     * @deprecated Use --vite instead
      * @since v2.0 - This will be removed after 2-3 minor releases depending on the timeframe between them. (~v2.3)
      *
      * @codeCoverageIgnore
@@ -170,7 +170,7 @@ class BuildSiteCommand extends Command
     {
         if ($this->option('run-dev') || $this->option('run-prod')) {
             $this->error('The --run-dev and --run-prod options have been removed in HydePHP v2.0.');
-            $this->info('Please use --run-vite instead to build assets for production with Vite.');
+            $this->info('Please use --vite instead to build assets for production with Vite.');
             $this->line('See https://github.com/hydephp/develop/pull/2013 for more information.');
 
             exit(Command::INVALID);

--- a/packages/framework/tests/Feature/StaticSiteServiceTest.php
+++ b/packages/framework/tests/Feature/StaticSiteServiceTest.php
@@ -158,7 +158,7 @@ class StaticSiteServiceTest extends TestCase
     {
         Process::fake();
 
-        $this->artisan('build --run-prettier --run-vite')
+        $this->artisan('build --run-prettier --vite')
             ->expectsOutput('Building frontend assets for production! This may take a second.')
             ->expectsOutput('Prettifying code! This may take a second.')
             ->assertExitCode(0);


### PR DESCRIPTION
Replaces all occurrences of the --run-vite flag with --vite in documentation, command signature, implementation, and tests for consistency and clarity. Updates deprecation messages and related documentation to reflect the new flag name. This is not breaking as HydePHP v2 has not been released yet