### PR TITLE
[2.x] Remove experimental annotations from codebase

### DIFF
--- a/docs/getting-started/core-concepts.md
+++ b/docs/getting-started/core-concepts.md
@@ -134,7 +134,7 @@ Lorem ipsum dolor sit amet, etc.
 
 ### Front Matter in Blade
 
-HydePHP has experimental support for creating front-matter in Blade templates, called [BladeMatter](front-matter#front-matter-in-blade),
+HydePHP has basic support for creating front-matter in Blade templates, called [BladeMatter](front-matter#front-matter-in-blade),
 where code in `@php` directives are statically parsed into page object's front matter data where it can be accessed in your templates.
 
 ```blade

--- a/docs/getting-started/front-matter.md
+++ b/docs/getting-started/front-matter.md
@@ -58,7 +58,7 @@ Lorem ipsum dolor sit amet, etc.
 
 ### Front Matter in Blade
 
-HydePHP has experimental support for creating front-matter in Blade templates, called BladeMatter.
+HydePHP has basic support for creating front-matter in Blade templates, called BladeMatter.
 
 The actual syntax does not use YAML; but instead PHP. However, the parsed end result is the same. Please note that
 BladeMatter currently does not support multidimensional arrays or multi-line directives as the data is statically parsed.

--- a/monorepo/gh-pages/gh-pages-config-dev-docs/config/hyde.php
+++ b/monorepo/gh-pages/gh-pages-config-dev-docs/config/hyde.php
@@ -209,14 +209,14 @@ return [
 
     /*
     |--------------------------------------------------------------------------
-    | Site Output Directory (Experimental 🧪)
+    | Site Output Directory
     |--------------------------------------------------------------------------
     |
     | If you want to store your compiled website in a different directory than
     | the default `_pages`, you can change the path here. The Hyde::path()
     | helper ensures the path is relative to your Hyde project. While
     | you can set the path to an absolute path outside the project,
-    | this is not officially supported and may be unstable.
+    | that is not officially supported and may be unstable.
     |
     */
 

--- a/monorepo/gh-pages/gh-pages-config/config/hyde.php
+++ b/monorepo/gh-pages/gh-pages-config/config/hyde.php
@@ -208,14 +208,14 @@ return [
 
     /*
     |--------------------------------------------------------------------------
-    | Site Output Directory (Experimental 🧪)
+    | Site Output Directory
     |--------------------------------------------------------------------------
     |
     | If you want to store your compiled website in a different directory than
     | the default `_pages`, you can change the path here. The Hyde::path()
     | helper ensures the path is relative to your Hyde project. While
     | you can set the path to an absolute path outside the project,
-    | this is not officially supported and may be unstable.
+    | that is not officially supported and may be unstable.
     |
     */
 

--- a/packages/framework/src/Facades/Config.php
+++ b/packages/framework/src/Facades/Config.php
@@ -44,7 +44,7 @@ class Config extends \Illuminate\Support\Facades\Config
         return (float) self::validated(static::get($key, $default), 'float', $key);
     }
 
-    /** @experimental Could possibly be merged by allowing null returns if default is null? Preferably with generics so the type is matched by IDE support. */
+    /** @experimental */
     public static function getNullableString(string $key, ?string $default = null): ?string
     {
         /** @var array|string|int|bool|float|null $value */

--- a/packages/framework/src/Framework/Concerns/RegistersFileLocations.php
+++ b/packages/framework/src/Framework/Concerns/RegistersFileLocations.php
@@ -104,7 +104,7 @@ trait RegistersFileLocations
 
     private function getPageConfiguration(string $option, string $class, string $default): string
     {
-        return Config::getNullableString("hyde.$option.".Str::kebab(class_basename($class))) /** @experimental Support for using kebab-case class names */
+        return Config::getNullableString("hyde.$option.".Str::kebab(class_basename($class)))
             ?? Config::getNullableString("hyde.$option.$class")
             ?? $default;
     }

--- a/packages/framework/src/Framework/Exceptions/InvalidConfigurationException.php
+++ b/packages/framework/src/Framework/Exceptions/InvalidConfigurationException.php
@@ -48,8 +48,6 @@ class InvalidConfigurationException extends InvalidArgumentException
 
     /**
      * @internal
-     *
-     * @experimental
      */
     public static function try(callable $callback, ?string $message = null): mixed
     {

--- a/packages/framework/src/Framework/Exceptions/ParseException.php
+++ b/packages/framework/src/Framework/Exceptions/ParseException.php
@@ -12,7 +12,6 @@ use function rtrim;
 use function sprintf;
 use function explode;
 
-/** @experimental This class may change significantly before its release. */
 class ParseException extends RuntimeException
 {
     /** @var int */

--- a/packages/framework/src/Framework/Features/Navigation/NavigationGroup.php
+++ b/packages/framework/src/Framework/Features/Navigation/NavigationGroup.php
@@ -57,7 +57,6 @@ class NavigationGroup extends NavigationMenu
         });
     }
 
-    /** @experimental This method is subject to change before its release. */
     public static function normalizeGroupKey(string $group): string
     {
         return Str::slug($group);

--- a/packages/framework/src/Framework/Features/Navigation/NavigationMenuGenerator.php
+++ b/packages/framework/src/Framework/Features/Navigation/NavigationMenuGenerator.php
@@ -19,9 +19,6 @@ use function collect;
 use function in_array;
 use function strtolower;
 
-/**
- * @experimental This class may change significantly before its release.
- */
 class NavigationMenuGenerator
 {
     /** @var \Illuminate\Support\Collection<string, \Hyde\Framework\Features\Navigation\NavigationItem|\Hyde\Framework\Features\Navigation\NavigationGroup> */

--- a/packages/framework/src/Support/Internal/RouteListItem.php
+++ b/packages/framework/src/Support/Internal/RouteListItem.php
@@ -45,7 +45,6 @@ class RouteListItem
 
         $page = $this->route->getPage();
 
-        /** @experimental The typeLabel macro is experimental */
         if ($page instanceof InMemoryPage && $page->hasMacro('typeLabel')) {
             $type .= sprintf(' <fg=gray>(%s)</>', (string) $page->__call('typeLabel', []));
         }

--- a/packages/framework/src/Support/Models/RouteKey.php
+++ b/packages/framework/src/Support/Models/RouteKey.php
@@ -57,8 +57,6 @@ final class RouteKey implements Stringable
     }
 
     /**
-     * @experimental
-     *
      * @param  class-string<\Hyde\Pages\Concerns\HydePage>  $pageClass
      * */
     protected static function stripPrefixIfNeeded(string $pageClass, string $identifier): string

--- a/packages/realtime-compiler/src/Console/Commands/ServeCommand.php
+++ b/packages/realtime-compiler/src/Console/Commands/ServeCommand.php
@@ -230,7 +230,6 @@ class ServeCommand extends Command
         }
     }
 
-    /** @experimental This feature may be removed before the final release. */
     protected function isPortAvailable(int $port): bool
     {
         $addresses = ['localhost', '127.0.0.1'];

--- a/packages/realtime-compiler/src/ConsoleOutput.php
+++ b/packages/realtime-compiler/src/ConsoleOutput.php
@@ -64,7 +64,6 @@ class ConsoleOutput
         };
     }
 
-    /** @experimental */
     public function printMessage(string $message, string $context): void
     {
         $this->output->writeln(sprintf('%s ::context=[%s]', $message, $context));

--- a/packages/testing/src/FluentTestingHelpers.php
+++ b/packages/testing/src/FluentTestingHelpers.php
@@ -63,9 +63,6 @@ trait FluentTestingHelpers
         }
     }
 
-    /**
-     * @experimental Helper to print and die.
-     */
     protected function dd($var): void
     {
         if (is_string($var)) {
@@ -83,9 +80,6 @@ trait FluentTestingHelpers
         exit;
     }
 
-    /**
-     * @experimental Helper function to format an array as a plain PHP array with [] syntax.
-     */
     private function formatArray(array $array): string
     {
         $json = json_encode($array, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES);


### PR DESCRIPTION
Removed various @experimental comments and annotations from documentation, configuration, and source files to reflect stabilization of features and APIs. Updated documentation to indicate 'basic' rather than 'experimental' support for Blade front matter. No functional code changes were made. This is because either these changes are now stable after being experimental for a while, or because we are committing to them for the v2 release.