### PR TITLE
[2.x] Normalize @ and & in makeSlug helper 

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -414,6 +414,10 @@ If you have used any of the following selectors in custom code you wrote yoursel
 - Rename HTML ID `#searchMenuButton` to `#search-menu-button`
 - Rename HTML ID `#searchMenuButtonMobile` to `#search-menu-button-mobile`
 
+### Edge case changes to slug generation
+
+Slug generation now normalizes two symbols before slugging (@ → at, & → and). This may change permalinks for titles containing these symbols. (https://github.com/hydephp/develop/pull/2314)
+
 ### New documentation search implementation
 
 As the new documentation search implementation brings changes to their code API you may need to adapt your code

--- a/packages/framework/src/Foundation/Concerns/ImplementsStringHelpers.php
+++ b/packages/framework/src/Foundation/Concerns/ImplementsStringHelpers.php
@@ -46,7 +46,11 @@ trait ImplementsStringHelpers
         // Transliterate international characters to ASCII
         $value = Str::transliterate($value);
 
-        // Todo: In v2.0 we will use the following dictionary: ['@' => 'at', '&' => 'and']
+        // Normalize a couple of common symbols before slugging (since v2)
+        $value = strtr($value, [
+            '@' => ' at ',
+            '&' => ' and ',
+        ]);
 
         return Str::slug($value);
     }

--- a/packages/framework/tests/Unit/HydeHelperFacadeMakeSlugTest.php
+++ b/packages/framework/tests/Unit/HydeHelperFacadeMakeSlugTest.php
@@ -43,7 +43,7 @@ class HydeHelperFacadeMakeSlugTest extends UnitTestCase
 
     public function testMakeSlugHelperHandlesSpecialCharacters()
     {
-        $this->assertSame('hello-world', Hyde::makeSlug('Hello & World!'));
+        $this->assertSame('hello-and-world', Hyde::makeSlug('Hello & World!'));
     }
 
     public function testMakeSlugHelperConvertsUppercaseToLowercase()
@@ -111,7 +111,7 @@ class HydeHelperFacadeMakeSlugTest extends UnitTestCase
     public function testMakeSlugHelperHandlesEdgeCases()
     {
         $this->assertSame('', Hyde::makeSlug(''));
-        $this->assertSame('at', Hyde::makeSlug('!@#$%^&*()'));
+        $this->assertSame('at-and', Hyde::makeSlug('!@#$%^&*()'));
         $this->assertSame('', Hyde::makeSlug('...   ...'));
         $this->assertSame('multiple-dashes', Hyde::makeSlug('multiple---dashes'));
     }


### PR DESCRIPTION
Updated the makeSlug helper to replace '@' with 'at' and '&' with 'and' before slugging. Adjusted related unit tests to reflect the new normalization behavior.
