### PR TITLE
[2.x] Improve documentation page detection in MarkdownService

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,7 +29,7 @@ This serves two purposes:
 - for now removed features.
 
 ### Fixed
-- for any bug fixes.
+- Improved documentation page detection in MarkdownService so it works for child classes in https://github.com/hydephp/develop/pull/2332
 
 ### Security
 - in case of vulnerabilities.

--- a/packages/framework/src/Framework/Services/MarkdownService.php
+++ b/packages/framework/src/Framework/Services/MarkdownService.php
@@ -149,7 +149,7 @@ class MarkdownService
 
     public function isDocumentationPage(): bool
     {
-        return isset($this->pageClass) && $this->pageClass === DocumentationPage::class;
+        return isset($this->pageClass) && is_a($this->pageClass, DocumentationPage::class, true);
     }
 
     public function withTableOfContents(): static

--- a/packages/framework/tests/Feature/MarkdownServiceTest.php
+++ b/packages/framework/tests/Feature/MarkdownServiceTest.php
@@ -89,6 +89,57 @@ class MarkdownServiceTest extends TestCase
                 .'rel="noopener nofollow">Torchlight.dev</a>', $html);
     }
 
+    public function testTorchlightAttributionIsNotInjectedForDocumentationPages()
+    {
+        $markdown = '# Hello World! <!-- Syntax highlighted by torchlight.dev -->';
+
+        $service = new MarkdownService($markdown, DocumentationPage::class);
+
+        $html = $service->parse();
+
+        $this->assertStringNotContainsString('Syntax highlighting by <a href="https://torchlight.dev/" '
+                .'rel="noopener nofollow">Torchlight.dev</a>', $html,
+            'Torchlight attribution should not be injected for documentation pages as it is handled by SemanticDocumentationArticle');
+    }
+
+    public function testTorchlightAttributionIsNotInjectedForDocumentationPageSubclasses()
+    {
+        $markdown = '# Hello World! <!-- Syntax highlighted by torchlight.dev -->';
+
+        $service = new MarkdownService($markdown, TestDocumentationPageSubclass::class);
+
+        $html = $service->parse();
+
+        $this->assertStringNotContainsString('Syntax highlighting by <a href="https://torchlight.dev/" '
+                .'rel="noopener nofollow">Torchlight.dev</a>', $html,
+            'Torchlight attribution should not be injected for documentation page subclasses as it is handled by SemanticDocumentationArticle');
+    }
+
+    public function testIsDocumentationPageReturnsTrueForDocumentationPageClass()
+    {
+        $service = new MarkdownService('', DocumentationPage::class);
+        $this->assertTrue($service->isDocumentationPage());
+    }
+
+    public function testIsDocumentationPageReturnsTrueForDocumentationPageSubclass()
+    {
+        $service = new MarkdownService('', TestDocumentationPageSubclass::class);
+        $this->assertTrue($service->isDocumentationPage(),
+            'isDocumentationPage should return true for subclasses of DocumentationPage using instanceof check');
+    }
+
+    public function testIsDocumentationPageReturnsFalseForOtherPageClasses()
+    {
+        $service = new MarkdownService('', MarkdownPage::class);
+        $this->assertFalse($service->isDocumentationPage());
+    }
+
+    public function testIsDocumentationPageReturnsFalseWhenNoPageClassIsSet()
+    {
+        $service = new MarkdownService('');
+        $this->assertFalse($service->isDocumentationPage());
+    }
+
     public function testBladedownIsNotEnabledByDefault()
     {
         $service = new MarkdownService('[Blade]: {{ "Hello World!" }}');
@@ -286,4 +337,12 @@ class MarkdownServiceTestClass extends MarkdownService
     {
         parent::__construct($markdown, $pageClass);
     }
+}
+
+/**
+ * Mock subclass of DocumentationPage for testing instanceof checks.
+ */
+class TestDocumentationPageSubclass extends DocumentationPage
+{
+    //
 }


### PR DESCRIPTION
Updated isDocumentationPage to use is_a for class and subclass detection. Added tests to verify correct attribution handling and isDocumentationPage behavior for DocumentationPage and its subclasses. This is so that this works for child classes.