### PR TITLE
Fix realtime compiler loading assets from production URL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ This serves two purposes:
 - Improved documentation page detection in MarkdownService so it works for child classes in https://github.com/hydephp/develop/pull/2332
 - Fixed bug causing build manifest to not generate when a site has dynamic pages in https://github.com/hydephp/develop/pull/2450
 - Fixed bug causing errors in the build manifest task not showing in console in https://github.com/hydephp/develop/pull/2451
+- Fixed realtime compiler loading assets from production URL when configured in https://github.com/hydephp/develop/pull/2418
 
 ### Security
 - in case of vulnerabilities.

--- a/packages/realtime-compiler/src/Routing/Router.php
+++ b/packages/realtime-compiler/src/Routing/Router.php
@@ -89,9 +89,65 @@ class Router
         }
 
         $scheme = (! empty($_SERVER['HTTPS']) && $_SERVER['HTTPS'] !== 'off') ? 'https' : 'http';
-        $host = $_SERVER['HTTP_HOST'] ?? 'localhost';
+
+        $host = $this->sanitizeHost($_SERVER['HTTP_HOST'] ?? null)
+            ?? $this->getConfiguredServerHost($scheme);
 
         config(['hyde.url' => "$scheme://$host"]);
+    }
+
+    /**
+     * Sanitize a host header value before using it in generated URLs.
+     */
+    protected function sanitizeHost(?string $host): ?string
+    {
+        if ($host === null) {
+            return null;
+        }
+
+        $host = trim($host);
+
+        if ($host === '') {
+            return null;
+        }
+
+        // Reject whitespace, path separators, and other obvious host-header injection vectors.
+        if (preg_match('/[\s\/\\\\@]/', $host)) {
+            return null;
+        }
+
+        // Allow normal hostnames with optional ports, plus localhost.
+        if (! preg_match('/^[A-Za-z0-9.-]+(?::[0-9]{1,5})?$/', $host)) {
+            return null;
+        }
+
+        if (str_contains($host, ':')) {
+            $port = (int) substr(strrchr($host, ':'), 1);
+
+            if ($port < 1 || $port > 65535) {
+                return null;
+            }
+        }
+
+        return $host;
+    }
+
+    /**
+     * Get the configured local server host, including the port when non-default.
+     */
+    protected function getConfiguredServerHost(string $scheme): string
+    {
+        $host = $this->sanitizeHost(config('hyde.server.host', 'localhost')) ?? 'localhost';
+        $port = (int) config('hyde.server.port', 0);
+
+        $isDefaultPort = ($scheme === 'https' && $port === 443)
+            || ($scheme === 'http' && $port === 80);
+
+        if ($port > 0 && $port <= 65535 && ! $isDefaultPort && ! str_contains($host, ':')) {
+            return "$host:$port";
+        }
+
+        return $host;
     }
 
     /**

--- a/packages/realtime-compiler/src/Routing/Router.php
+++ b/packages/realtime-compiler/src/Routing/Router.php
@@ -32,6 +32,8 @@ class Router
 
         $this->bootApplication();
 
+        $this->overrideSiteUrl();
+
         $virtualRoutes = app(RealtimeCompiler::class)->getVirtualRoutes();
 
         if (isset($virtualRoutes[$this->request->path])) {
@@ -69,6 +71,27 @@ class Router
 
         // The page is not a web page, so we assume it should be proxied.
         return true;
+    }
+
+    /**
+     * Override the configured site URL so compiled pages reference the local
+     * server instead of the production URL. Without this, assets such as
+     * media files would be loaded from the production host when previewing
+     * the site locally.
+     */
+    protected function overrideSiteUrl(): void
+    {
+        // When save_preview is enabled, the compiled page is written to disk,
+        // so we leave the configured site URL alone to avoid baking the local
+        // preview URL into the persisted output.
+        if (config('hyde.server.save_preview')) {
+            return;
+        }
+
+        $scheme = (! empty($_SERVER['HTTPS']) && $_SERVER['HTTPS'] !== 'off') ? 'https' : 'http';
+        $host = $_SERVER['HTTP_HOST'] ?? 'localhost';
+
+        config(['hyde.url' => "$scheme://$host"]);
     }
 
     /**

--- a/packages/realtime-compiler/tests/RealtimeCompilerTest.php
+++ b/packages/realtime-compiler/tests/RealtimeCompilerTest.php
@@ -11,6 +11,7 @@ use Hyde\Framework\Exceptions\RouteNotFoundException;
 use Hyde\RealtimeCompiler\Http\ExceptionHandler;
 use Desilva\Microserve\HtmlResponse;
 use Hyde\RealtimeCompiler\Http\HttpKernel;
+use Hyde\RealtimeCompiler\Routing\Router;
 
 class RealtimeCompilerTest extends TestCase
 {
@@ -211,9 +212,66 @@ class RealtimeCompilerTest extends TestCase
         $this->assertSame('Internal Server Error', $response->statusMessage);
     }
 
+    public function testOverridesSiteUrlWithRequestUrl()
+    {
+        $this->mockCompilerRoute('');
+        $_SERVER['HTTP_HOST'] = 'localhost:8080';
+
+        config(['hyde.url' => 'https://hydephp.com']);
+
+        $this->invokeOverrideSiteUrl();
+
+        $this->assertSame('http://localhost:8080', config('hyde.url'));
+    }
+
+    public function testOverridesSiteUrlUsesHttpsSchemeForSecureRequests()
+    {
+        $this->mockCompilerRoute('');
+        $_SERVER['HTTP_HOST'] = 'hyde.test';
+        $_SERVER['HTTPS'] = 'on';
+
+        $this->invokeOverrideSiteUrl();
+
+        $this->assertSame('https://hyde.test', config('hyde.url'));
+
+        unset($_SERVER['HTTPS']);
+    }
+
+    public function testOverridesSiteUrlFallsBackToLocalhostWhenHostIsMissing()
+    {
+        $this->mockCompilerRoute('');
+        unset($_SERVER['HTTP_HOST']);
+
+        $this->invokeOverrideSiteUrl();
+
+        $this->assertSame('http://localhost', config('hyde.url'));
+    }
+
+    public function testDoesNotOverrideSiteUrlWhenSavePreviewIsEnabled()
+    {
+        $this->mockCompilerRoute('');
+        $_SERVER['HTTP_HOST'] = 'localhost:8080';
+
+        config([
+            'hyde.server.save_preview' => true,
+            'hyde.url' => 'https://hydephp.com',
+        ]);
+
+        $this->invokeOverrideSiteUrl();
+
+        $this->assertSame('https://hydephp.com', config('hyde.url'));
+    }
+
     protected function mockCompilerRoute(string $route, $method = 'GET'): void
     {
         $_SERVER['REQUEST_METHOD'] = $method;
         $_SERVER['REQUEST_URI'] = "/$route";
+    }
+
+    protected function invokeOverrideSiteUrl(): void
+    {
+        $method = new ReflectionMethod(Router::class, 'overrideSiteUrl');
+        $method->setAccessible(true);
+        $method->invoke(new Router(new Request()));
     }
 }

--- a/packages/realtime-compiler/tests/RealtimeCompilerTest.php
+++ b/packages/realtime-compiler/tests/RealtimeCompilerTest.php
@@ -15,6 +15,8 @@ use Hyde\RealtimeCompiler\Routing\Router;
 
 class RealtimeCompilerTest extends TestCase
 {
+    protected array $serverBackup = [];
+
     public static function setUpBeforeClass(): void
     {
         putenv('SERVER_LIVE_EDIT=false');
@@ -30,10 +32,14 @@ class RealtimeCompilerTest extends TestCase
     {
         parent::setUp();
         ob_start();
+
+        $this->serverBackup = $_SERVER;
     }
 
     protected function tearDown(): void
     {
+        $_SERVER = $this->serverBackup;
+
         parent::tearDown();
         ob_end_clean();
     }
@@ -71,6 +77,7 @@ class RealtimeCompilerTest extends TestCase
 
     public function testHandlesRoutesPagesWithHtmlExtension()
     {
+        $this->mockCompilerRoute('foo.html');
         Filesystem::put('_pages/foo.md', '# Hello World!');
 
         $kernel = new HttpKernel();
@@ -233,18 +240,36 @@ class RealtimeCompilerTest extends TestCase
         $this->invokeOverrideSiteUrl();
 
         $this->assertSame('https://hyde.test', config('hyde.url'));
-
-        unset($_SERVER['HTTPS']);
     }
 
-    public function testOverridesSiteUrlFallsBackToLocalhostWhenHostIsMissing()
+    public function testOverridesSiteUrlFallsBackToConfiguredServerWhenHostIsMissing()
     {
         $this->mockCompilerRoute('');
         unset($_SERVER['HTTP_HOST']);
 
+        config([
+            'hyde.server.host' => 'hyde.test',
+            'hyde.server.port' => 8080,
+        ]);
+
         $this->invokeOverrideSiteUrl();
 
-        $this->assertSame('http://localhost', config('hyde.url'));
+        $this->assertSame('http://hyde.test:8080', config('hyde.url'));
+    }
+
+    public function testOverridesSiteUrlFallsBackToConfiguredServerWhenHostHeaderIsInvalid()
+    {
+        $this->mockCompilerRoute('');
+        $_SERVER['HTTP_HOST'] = 'evil.test/path';
+
+        config([
+            'hyde.server.host' => 'localhost',
+            'hyde.server.port' => 8080,
+        ]);
+
+        $this->invokeOverrideSiteUrl();
+
+        $this->assertSame('http://localhost:8080', config('hyde.url'));
     }
 
     public function testDoesNotOverrideSiteUrlWhenSavePreviewIsEnabled()

--- a/packages/realtime-compiler/tests/RealtimeCompilerTest.php
+++ b/packages/realtime-compiler/tests/RealtimeCompilerTest.php
@@ -287,6 +287,37 @@ class RealtimeCompilerTest extends TestCase
         $this->assertSame('https://hydephp.com', config('hyde.url'));
     }
 
+    public function testRouterHandleOverridesSiteUrlForPageRequest()
+    {
+        putenv('SERVER_DASHBOARD=false');
+        $this->mockCompilerRoute('');
+        $_SERVER['HTTP_HOST'] = 'localhost:8080';
+
+        config(['hyde.url' => 'https://hydephp.com']);
+
+        $kernel = new HttpKernel();
+        $kernel->handle(new Request());
+
+        $this->assertSame('http://localhost:8080', config('hyde.url'));
+    }
+
+    public function testRouterHandleDoesNotOverrideSiteUrlWhenSavePreviewIsEnabled()
+    {
+        putenv('SERVER_DASHBOARD=false');
+        putenv('SERVER_SAVE_PREVIEW=true');
+        $this->mockCompilerRoute('');
+        $_SERVER['HTTP_HOST'] = 'localhost:8080';
+
+        $kernel = new HttpKernel();
+        $kernel->handle(new Request());
+
+        // When save_preview is enabled, overrideSiteUrl() must not replace the
+        // configured URL with the local server address.
+        $this->assertNotSame('http://localhost:8080', config('hyde.url'));
+
+        putenv('SERVER_SAVE_PREVIEW=');
+    }
+
     protected function mockCompilerRoute(string $route, $method = 'GET'): void
     {
         $_SERVER['REQUEST_METHOD'] = $method;


### PR DESCRIPTION
When the realtime compiler served pages with a configured site URL (e.g. hydephp.com), asset and media file references were generated as absolute URLs pointing to the production host, causing the browser to request files from production instead of the local server.

Override the configured site URL to the current request's host:port when booting the application for page compilation. This ensures all generated asset links resolve against localhost (or the configured dev server) rather than production.

Skip the override when save_preview is enabled to avoid baking the local URL into persisted output files.

Closes #2327