### PR TITLE
Improve build task exception handling to fix silently absorbed errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ This serves two purposes:
 ### Fixed
 - Improved documentation page detection in MarkdownService so it works for child classes in https://github.com/hydephp/develop/pull/2332
 - Fixed bug causing build manifest to not generate when a site has dynamic pages in https://github.com/hydephp/develop/pull/2450
+- Fixed bug causing errors in the build manifest task not showing in console in https://github.com/hydephp/develop/pull/2451
 
 ### Security
 - in case of vulnerabilities.

--- a/packages/framework/src/Framework/Actions/PostBuildTasks/GenerateBuildManifest.php
+++ b/packages/framework/src/Framework/Actions/PostBuildTasks/GenerateBuildManifest.php
@@ -8,8 +8,8 @@ use Hyde\Hyde;
 use Hyde\Facades\Config;
 use Hyde\Pages\Concerns\HydePage;
 use Hyde\Framework\Features\BuildTasks\PostBuildTask;
-use Illuminate\Console\OutputStyle;
 use Illuminate\Support\Collection;
+use Throwable;
 
 use function Hyde\unixsum_file;
 use function file_put_contents;
@@ -79,8 +79,19 @@ class GenerateBuildManifest extends PostBuildTask
         ], JSON_PRETTY_PRINT);
     }
 
-    public function setOutput(OutputStyle $output): void
+    public function printStartMessage(): void
     {
-        // Disable output
+        // Deferred to failure handler
+    }
+
+    public function printFinishMessage(): void
+    {
+        // Silent
+    }
+
+    protected function handleExceptionReporting(Throwable $exception): void
+    {
+        $this->write("<comment>{$this->getMessage()}...</comment> ");
+        parent::handleExceptionReporting($exception);
     }
 }

--- a/packages/framework/src/Framework/Features/BuildTasks/BuildTask.php
+++ b/packages/framework/src/Framework/Features/BuildTasks/BuildTask.php
@@ -49,13 +49,7 @@ abstract class BuildTask
             $this->handle();
             $this->printFinishMessage();
         } catch (Throwable $exception) {
-            if ($exception instanceof BuildTaskSkippedException) {
-                $this->write("<bg=yellow>Skipped</>\n");
-                $this->write("<fg=gray> > {$exception->getMessage()}</>");
-            } else {
-                $this->write("<error>Failed</error>\n");
-                $this->write("<error>{$exception->getMessage()}</error>");
-            }
+            $this->handleExceptionReporting($exception);
 
             $this->exitCode = $exception->getCode();
         }
@@ -122,5 +116,16 @@ abstract class BuildTask
         $this->write(" in {$this->getExecutionTimeString()}");
 
         return $this;
+    }
+
+    protected function handleExceptionReporting(Throwable $exception): void
+    {
+        if ($exception instanceof BuildTaskSkippedException) {
+            $this->write("<bg=yellow>Skipped</>\n");
+            $this->write("<fg=gray> > {$exception->getMessage()}</>");
+        } else {
+            $this->write("<error>Failed</error>\n");
+            $this->write("<error>{$exception->getMessage()}</error>");
+        }
     }
 }

--- a/packages/framework/tests/Unit/GenerateBuildManifestTest.php
+++ b/packages/framework/tests/Unit/GenerateBuildManifestTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Hyde\Framework\Testing\Unit;
 
+use Exception;
 use Hyde\Framework\Actions\PostBuildTasks\GenerateBuildManifest;
 use Hyde\Framework\Features\Documentation\DocumentationSearchIndex;
 use Hyde\Hyde;
@@ -50,5 +51,31 @@ class GenerateBuildManifestTest extends UnitTestCase
         $this->assertSame(unixsum_file(Hyde::path('_pages/404.blade.php')), $manifest['pages'][404]['source_hash']);
         $this->assertNull($manifest['pages'][404]['output_hash']);
         $this->assertNull($manifest['pages']['docs/search.json']['source_hash']);
+    }
+
+    public function testExceptionHandlingPrintsDeferredStartMessage()
+    {
+        $task = new FailingGenerateBuildManifest();
+
+        $this->assertSame(123, $task->run());
+
+        $this->assertSame('<comment>Generating build manifest...</comment> ', $task->buffer[0]);
+        $this->assertSame("<error>Failed</error>\n", $task->buffer[1]);
+        $this->assertSame('<error>Test exception</error>', $task->buffer[2]);
+    }
+}
+
+class FailingGenerateBuildManifest extends GenerateBuildManifest
+{
+    public array $buffer = [];
+
+    public function handle(): void
+    {
+        throw new Exception('Test exception', 123);
+    }
+
+    public function write(string $message): void
+    {
+        $this->buffer[] = $message;
     }
 }


### PR DESCRIPTION
This fixes https://github.com/hydephp/develop/issues/2449 by adding a hook to customize the exception handling so that the build task can specifically disable what output we don't need but still report errors.