### PR TITLE
Update scroll to top button to smooth scroll to top

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ This serves two purposes:
 - Fixed bug causing build manifest to not generate when a site has dynamic pages in https://github.com/hydephp/develop/pull/2450
 - Fixed bug causing errors in the build manifest task not showing in console in https://github.com/hydephp/develop/pull/2451
 - Fixed realtime compiler loading assets from production URL when configured in https://github.com/hydephp/develop/pull/2418
+- Updated the scroll to top button to smooth scroll to the top of the page in https://github.com/hydephp/develop/pull/2458
 
 ### Security
 - in case of vulnerabilities.

--- a/packages/framework/resources/views/layouts/footer.blade.php
+++ b/packages/framework/resources/views/layouts/footer.blade.php
@@ -3,7 +3,7 @@
         <div class="prose dark:prose-invert text-center mx-auto">
             {!! \Hyde\Support\Includes::markdown('footer', config('hyde.footer', 'Site proudly built with [HydePHP](https://github.com/hydephp/hyde) 🎩')) !!}
         </div>
-        <a href="#app" aria-label="Go to top of page" class="float-right">
+        <a href="#app" aria-label="Go to top of page" class="float-right" @click.prevent="document.querySelector('#app').scrollIntoView({ behavior: 'smooth' })">
             <button title="Scroll to top">
                 <svg width="1.5rem" height="1.5rem" role="presentation" class="fill-current text-gray-500 h-6 w-6" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20">
                     <path d="M7.41 15.41L12 10.83l4.59 4.58L18 14l-6-6-6 6z" />


### PR DESCRIPTION
Adds a progressive enhancement to scroll smoothly to the top of the page, and without adding the hash to the url

Fixes part two of https://github.com/hydephp/develop/issues/2275