### PR TITLE
[3.x] Remove check for deprecated Laravel Mix command flags

### DIFF
--- a/HYDEPHP_V3_PLANNING.md
+++ b/HYDEPHP_V3_PLANNING.md
@@ -16,6 +16,10 @@ Having this document in code lets us know the devlopment state at any given poin
 
 ### Feature Changes
 
+### Minor Changes and Cleanup
+
+- Removed the legacy `checkForDeprecatedRunMixCommandUsage` check and the placeholder `--run-dev`/`--run-prod` options from the `build` command, which were kept in v2 only to surface a helpful error message. ([#2461](https://github.com/hydephp/develop/pull/2461))
+
 ### Breaking Changes
 
 ### Upgrade guide

--- a/packages/framework/src/Console/Commands/BuildSiteCommand.php
+++ b/packages/framework/src/Console/Commands/BuildSiteCommand.php
@@ -28,9 +28,7 @@ class BuildSiteCommand extends Command
     protected $signature = 'build
         {--vite : Build frontend assets using Vite}
         {--pretty-urls : Should links in output use pretty URLs?}
-        {--no-api : Disable API calls, for example, Torchlight}
-        {--run-dev : [Removed] Use --vite instead}
-        {--run-prod : [Removed] Use --vite instead}';
+        {--no-api : Disable API calls, for example, Torchlight}';
 
     /** @var string */
     protected $description = 'Build the static site';
@@ -40,8 +38,6 @@ class BuildSiteCommand extends Command
 
     public function handle(): int
     {
-        $this->checkForDeprecatedRunMixCommandUsage();
-
         $timeStart = microtime(true);
 
         $this->title('Building your static site!');
@@ -147,24 +143,5 @@ class BuildSiteCommand extends Command
         }
 
         return Command::SUCCESS;
-    }
-
-    /**
-     * This method is called when the removed --run-dev or --run-prod options are used.
-     *
-     * @deprecated Use --vite instead
-     * @since v2.0 - This will be removed after 2-3 minor releases depending on the timeframe between them. (~v2.3)
-     *
-     * @codeCoverageIgnore
-     */
-    protected function checkForDeprecatedRunMixCommandUsage(): void
-    {
-        if ($this->option('run-dev') || $this->option('run-prod')) {
-            $this->error('The --run-dev and --run-prod options have been removed in HydePHP v2.0.');
-            $this->info('Please use --vite instead to build assets for production with Vite.');
-            $this->line('See https://github.com/hydephp/develop/pull/2013 for more information.');
-
-            exit(Command::INVALID);
-        }
     }
 }


### PR DESCRIPTION
Removed the `checkForDeprecatedRunMixCommandUsage` helper and deprecated --run-dev/--run-prod options

These Mix-era options were deprecated in v2.0 and are being fully removed for v3. The --vite flag supersedes them.