### PR TITLE
Fix build command using Vite dev server path when Vite is running

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ This serves two purposes:
 - Fixed bug causing errors in the build manifest task not showing in console in https://github.com/hydephp/develop/pull/2451
 - Fixed realtime compiler loading assets from production URL when configured in https://github.com/hydephp/develop/pull/2418
 - Updated the scroll to top button to smooth scroll to the top of the page in https://github.com/hydephp/develop/pull/2458
+- Fix build command trying to use Vite in site builds if server is running in https://github.com/hydephp/develop/issues/2483
 
 ### Security
 - in case of vulnerabilities.

--- a/packages/framework/src/Console/Commands/BuildSiteCommand.php
+++ b/packages/framework/src/Console/Commands/BuildSiteCommand.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Hyde\Console\Commands;
 
 use Hyde\Hyde;
+use Hyde\Facades\Vite;
 use Hyde\Facades\Config;
 use Hyde\Support\BuildWarnings;
 use Hyde\Console\Concerns\Command;
@@ -52,7 +53,15 @@ class BuildSiteCommand extends Command
 
         $this->runPreBuildActions();
 
-        $this->service->compileStaticPages();
+        // The static build should never reference the Vite dev server, even if it happens
+        // to be running in another process, as that would break the built site's assets.
+        Vite::forceDisable();
+
+        try {
+            $this->service->compileStaticPages();
+        } finally {
+            Vite::forceDisable(false);
+        }
 
         $this->runPostBuildActions();
 

--- a/packages/framework/src/Facades/Vite.php
+++ b/packages/framework/src/Facades/Vite.php
@@ -15,9 +15,21 @@ class Vite
     protected const CSS_EXTENSIONS = ['css', 'less', 'sass', 'scss', 'styl', 'stylus', 'pcss', 'postcss'];
     protected const JS_EXTENSIONS = ['js', 'jsx', 'ts', 'tsx'];
 
+    protected static bool $forceDisabled = false;
+
     public static function running(): bool
     {
+        if (static::$forceDisabled) {
+            return false;
+        }
+
         return Filesystem::exists('app/storage/framework/runtime/vite.hot');
+    }
+
+    /** @internal Force Vite to be treated as not running, regardless of the hot file. */
+    public static function forceDisable(bool $disable = true): void
+    {
+        static::$forceDisabled = $disable;
     }
 
     public static function asset(string $path): HtmlString

--- a/packages/framework/tests/Feature/StaticSiteServiceTest.php
+++ b/packages/framework/tests/Feature/StaticSiteServiceTest.php
@@ -106,6 +106,20 @@ class StaticSiteServiceTest extends TestCase
         rename(Hyde::path('_media/app.css.bak'), Hyde::path('_media/app.css'));
     }
 
+    public function testBuildCommandDoesNotUseViteDevServerPathEvenWhenViteIsRunning()
+    {
+        $this->file('app/storage/framework/runtime/vite.hot');
+
+        $this->artisan('build')
+            ->assertExitCode(0);
+
+        $contents = Filesystem::getContents('_site/index.html');
+
+        $this->assertStringNotContainsString('http://localhost:5173', $contents);
+
+        Filesystem::unlink('app/storage/framework/runtime/vite.hot');
+    }
+
     public function testAllPageTypesCanBeCompiled()
     {
         $this->file('_pages/html.html');

--- a/packages/framework/tests/Unit/Facades/ViteFacadeTest.php
+++ b/packages/framework/tests/Unit/Facades/ViteFacadeTest.php
@@ -19,6 +19,8 @@ class ViteFacadeTest extends UnitTestCase
 
     protected function tearDown(): void
     {
+        Vite::forceDisable(false);
+
         $this->cleanUpFilesystem();
     }
 
@@ -34,6 +36,26 @@ class ViteFacadeTest extends UnitTestCase
         $this->assertFileDoesNotExist('app/storage/framework/runtime/vite.hot');
 
         $this->assertFalse(Vite::running());
+    }
+
+    public function testRunningReturnsFalseWhenForceDisabledEvenIfHotFileExists()
+    {
+        $this->file('app/storage/framework/runtime/vite.hot');
+
+        Vite::forceDisable();
+
+        $this->assertFalse(Vite::running());
+    }
+
+    public function testForceDisableCanBeToggledBackOn()
+    {
+        $this->file('app/storage/framework/runtime/vite.hot');
+
+        Vite::forceDisable();
+        $this->assertFalse(Vite::running());
+
+        Vite::forceDisable(false);
+        $this->assertTrue(Vite::running());
     }
 
     public function testItAlwaysImportsClientModule()


### PR DESCRIPTION
The static build should never emit http://localhost:5173 asset URLs, even if a Vite dev server happens to be running in another process (detected via the vite.hot file), since the built site is served statically and browsers block cross-origin requests to the loopback dev server (CORS/private network access error).

Fixes #2483 and is considered a bugfix since there is no path where the code would actually work given the CORS issue.