### PR TITLE
Internal: Swap the headings on the documentation index page

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -1,4 +1,4 @@
-# Elegant and Powerful Static Site Generator
+# Welcome to HydePHP
 
 <style>.images-inline img { display: inline; margin: 4px 2px;}</style>
 
@@ -10,7 +10,7 @@
 ![License MIT](https://img.shields.io/github/license/hydephp/hyde)
 {.images-inline .not-prose}
 
-## About HydePHP
+## The Elegant and Powerful Static Site Generator
 
 HydePHP is a Static Site Generator focused on writing content, not markup. With Hyde, it is easy to create static
 websites, blogs, and documentation pages using Markdown and (optionally) Laravel's Blade.


### PR DESCRIPTION
This helps make the large heading a bit shorter which improves the layout as we got overflow after adding the buttons

<img width="989" height="489" alt="image" src="https://github.com/user-attachments/assets/268ee928-9389-4ad1-8c8d-2ceb8acf2ff1" />
