### PR TITLE
Fix Content-Type header for JSON/XML in the realtime compiler

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ This serves two purposes:
 - Fixed realtime compiler loading assets from production URL when configured in https://github.com/hydephp/develop/pull/2418
 - Updated the scroll to top button to smooth scroll to the top of the page in https://github.com/hydephp/develop/pull/2458
 - Fix build command trying to use Vite in site builds if server is running in https://github.com/hydephp/develop/issues/2483
+- Fixed missing content type headers for JSON and XML in the realtime compiler in https://github.com/hydephp/develop/pull/2496
 
 ### Security
 - in case of vulnerabilities.

--- a/packages/realtime-compiler/src/Routing/PageRouter.php
+++ b/packages/realtime-compiler/src/Routing/PageRouter.php
@@ -33,9 +33,38 @@ class PageRouter
 
     protected function handlePageRequest(): Response
     {
+        $page = $this->getPageFromRoute();
+        $body = $this->getHtml($page);
+
+        $contentType = $this->getContentType($page);
+
+        if ($contentType !== 'text/html') {
+            return (new Response(200, 'OK', [
+                'body' => $body,
+            ]))->withHeaders([
+                'Content-Type' => $contentType,
+                'Content-Length' => (string) strlen($body),
+            ]);
+        }
+
         return new HtmlResponse(200, 'OK', [
-            'body' => $this->getHtml($this->getPageFromRoute()),
+            'body' => $body,
         ]);
+    }
+
+    /**
+     * Determine the response content type based on the compiled page's output file extension.
+     */
+    protected function getContentType(HydePage $page): string
+    {
+        $extension = pathinfo($page->getOutputPath(), PATHINFO_EXTENSION);
+
+        return match ($extension) {
+            'json' => 'application/json',
+            'xml' => 'application/xml',
+            'txt' => 'text/plain',
+            default => 'text/html',
+        };
     }
 
     protected function normalizePath(string $path): string

--- a/packages/realtime-compiler/tests/RealtimeCompilerTest.php
+++ b/packages/realtime-compiler/tests/RealtimeCompilerTest.php
@@ -7,10 +7,12 @@ use Desilva\Microserve\JsonResponse;
 use Desilva\Microserve\Request;
 use Desilva\Microserve\Response;
 use Hyde\Facades\Filesystem;
+use Hyde\Pages\InMemoryPage;
 use Hyde\Framework\Exceptions\RouteNotFoundException;
 use Hyde\RealtimeCompiler\Http\ExceptionHandler;
 use Desilva\Microserve\HtmlResponse;
 use Hyde\RealtimeCompiler\Http\HttpKernel;
+use Hyde\RealtimeCompiler\Routing\PageRouter;
 use Hyde\RealtimeCompiler\Routing\Router;
 
 class RealtimeCompilerTest extends TestCase
@@ -197,6 +199,63 @@ class RealtimeCompilerTest extends TestCase
         Filesystem::unlink('_docs/index.md');
     }
 
+    public function testDocsSearchJsonRendersSearchIndexWithJsonContentType()
+    {
+        $this->mockCompilerRoute('docs/search.json');
+        Filesystem::put('_docs/index.md', '# Hello World!');
+
+        $kernel = new HttpKernel();
+        $response = $kernel->handle(new Request());
+
+        $this->assertInstanceOf(Response::class, $response);
+        $this->assertNotInstanceOf(HtmlResponse::class, $response);
+        $this->assertSame(200, $response->statusCode);
+        $this->assertSame('OK', $response->statusMessage);
+
+        $headers = $this->getResponseHeaders($response);
+        $this->assertSame('application/json', $headers['Content-Type']);
+        $this->assertSame((string) strlen($response->body), $headers['Content-Length']);
+
+        $this->assertIsArray(json_decode($response->body, true));
+
+        Filesystem::unlink('_docs/index.md');
+    }
+
+    public function testGetContentTypeReturnsApplicationJsonForJsonOutputPath()
+    {
+        $page = $this->makePageWithOutputPath('foo.json');
+
+        $this->assertSame('application/json', $this->invokeGetContentType($page));
+    }
+
+    public function testGetContentTypeReturnsApplicationXmlForXmlOutputPath()
+    {
+        $page = $this->makePageWithOutputPath('foo.xml');
+
+        $this->assertSame('application/xml', $this->invokeGetContentType($page));
+    }
+
+    public function testGetContentTypeReturnsTextPlainForTxtOutputPath()
+    {
+        $page = $this->makePageWithOutputPath('foo.txt');
+
+        $this->assertSame('text/plain', $this->invokeGetContentType($page));
+    }
+
+    public function testGetContentTypeReturnsTextHtmlForHtmlOutputPath()
+    {
+        $page = $this->makePageWithOutputPath('foo.html');
+
+        $this->assertSame('text/html', $this->invokeGetContentType($page));
+    }
+
+    public function testGetContentTypeDefaultsToTextHtmlForUnknownExtension()
+    {
+        $page = $this->makePageWithOutputPath('foo');
+
+        $this->assertSame('text/html', $this->invokeGetContentType($page));
+    }
+
     public function testPingRouteReturnsPingResponse()
     {
         $this->mockCompilerRoute('ping');
@@ -329,5 +388,46 @@ class RealtimeCompilerTest extends TestCase
         $method = new ReflectionMethod(Router::class, 'overrideSiteUrl');
         $method->setAccessible(true);
         $method->invoke(new Router(new Request()));
+    }
+
+    protected function invokeGetContentType(InMemoryPage $page): string
+    {
+        $this->mockCompilerRoute('foo');
+
+        $method = new ReflectionMethod(PageRouter::class, 'getContentType');
+        $method->setAccessible(true);
+
+        return $method->invoke(new PageRouter(new Request()), $page);
+    }
+
+    protected function makePageWithOutputPath(string $outputPath): InMemoryPage
+    {
+        return new class('foo', [], 'contents', '', $outputPath) extends InMemoryPage
+        {
+            protected string $customOutputPath;
+
+            public function __construct(string $identifier, array $matter, string $contents, string $view, string $outputPath)
+            {
+                // The custom output path must be assigned before calling the parent
+                // constructor, as it triggers factory data construction which calls
+                // getOutputPath() before this constructor body would otherwise run.
+                $this->customOutputPath = $outputPath;
+
+                parent::__construct($identifier, $matter, $contents, $view);
+            }
+
+            public function getOutputPath(): string
+            {
+                return $this->customOutputPath;
+            }
+        };
+    }
+
+    protected function getResponseHeaders(Response $response): array
+    {
+        $property = new ReflectionProperty(Response::class, 'headers');
+        $property->setAccessible(true);
+
+        return $property->getValue($response);
     }
 }


### PR DESCRIPTION
**Before:**

```
curl -I http://localhost:8080/docs/search.json
HTTP/1.1 200 OK
Host: localhost:8080
Date: Fri, 03 Jul 2026 23:04:52 GMT
Connection: close
X-Powered-By: PHP/8.5.7
X-Server: Hyde/RealtimeCompiler
Content-type: text/html;charset=UTF-8
Content-Length: 165
```

**After:**
```
curl -I http://localhost:8080/docs/search.json
HTTP/1.1 200 OK
Host: localhost:8080
Date: Fri, 03 Jul 2026 23:05:17 GMT
Connection: close
X-Powered-By: PHP/8.5.7
X-Server: Hyde/RealtimeCompiler
Content-Type: application/json
Content-Length: 165
```