### PR TITLE
Update the realtime compiler to serve the sitemap and RSS feed

### DIFF
--- a/packages/realtime-compiler/src/Http/VirtualRouteController.php
+++ b/packages/realtime-compiler/src/Http/VirtualRouteController.php
@@ -7,6 +7,8 @@ namespace Hyde\RealtimeCompiler\Http;
 use Desilva\Microserve\Request;
 use Desilva\Microserve\Response;
 use Desilva\Microserve\JsonResponse;
+use Hyde\Framework\Features\XmlGenerators\SitemapGenerator;
+use Hyde\Framework\Features\XmlGenerators\RssFeedGenerator;
 
 class VirtualRouteController
 {
@@ -30,5 +32,23 @@ class VirtualRouteController
     public static function openInEditor(Request $request): Response
     {
         return (new OpenInEditorController($request))->handle();
+    }
+
+    public static function sitemap(): Response
+    {
+        return (new Response(200, 'OK', [
+            'body' => SitemapGenerator::make(),
+        ]))->withHeaders([
+            'Content-Type' => 'application/xml',
+        ]);
+    }
+
+    public static function rssFeed(): Response
+    {
+        return (new Response(200, 'OK', [
+            'body' => RssFeedGenerator::make(),
+        ]))->withHeaders([
+            'Content-Type' => 'application/rss+xml',
+        ]);
     }
 }

--- a/packages/realtime-compiler/src/Http/VirtualRouteController.php
+++ b/packages/realtime-compiler/src/Http/VirtualRouteController.php
@@ -34,7 +34,7 @@ class VirtualRouteController
         return (new OpenInEditorController($request))->handle();
     }
 
-    public static function sitemap(): Response
+    public static function sitemap(Request $request): Response
     {
         return (new Response(200, 'OK', [
             'body' => SitemapGenerator::make(),
@@ -43,7 +43,7 @@ class VirtualRouteController
         ]);
     }
 
-    public static function rssFeed(): Response
+    public static function rssFeed(Request $request): Response
     {
         return (new Response(200, 'OK', [
             'body' => RssFeedGenerator::make(),

--- a/packages/realtime-compiler/src/RealtimeCompilerServiceProvider.php
+++ b/packages/realtime-compiler/src/RealtimeCompilerServiceProvider.php
@@ -5,14 +5,12 @@ declare(strict_types=1);
 namespace Hyde\RealtimeCompiler;
 
 use Illuminate\Support\ServiceProvider;
-use Hyde\Facades\Features;
 use Hyde\RealtimeCompiler\Http\DashboardController;
 use Hyde\RealtimeCompiler\Http\LiveEditController;
 use Hyde\RealtimeCompiler\Http\VirtualRouteController;
 use Hyde\RealtimeCompiler\Http\OpenInEditorController;
 use Hyde\RealtimeCompiler\Console\Commands\HerdInstallCommand;
 use Hyde\RealtimeCompiler\Console\Commands\ServeCommand;
-use Hyde\Framework\Features\XmlGenerators\RssFeedGenerator;
 
 class RealtimeCompilerServiceProvider extends ServiceProvider
 {
@@ -46,12 +44,7 @@ class RealtimeCompilerServiceProvider extends ServiceProvider
             $router->registerVirtualRoute('/_hyde/open-in-editor', [VirtualRouteController::class, 'openInEditor']);
         }
 
-        if (Features::hasSitemap()) {
-            $router->registerVirtualRoute('/sitemap.xml', [VirtualRouteController::class, 'sitemap']);
-        }
-
-        if (Features::hasRss()) {
-            $router->registerVirtualRoute('/'.RssFeedGenerator::getFilename(), [VirtualRouteController::class, 'rssFeed']);
-        }
+        // The sitemap and RSS feed routes are registered in the Router itself, once the site URL
+        // has been finalized for the request. See Router::registerDynamicVirtualRoutes().
     }
 }

--- a/packages/realtime-compiler/src/RealtimeCompilerServiceProvider.php
+++ b/packages/realtime-compiler/src/RealtimeCompilerServiceProvider.php
@@ -44,7 +44,7 @@ class RealtimeCompilerServiceProvider extends ServiceProvider
             $router->registerVirtualRoute('/_hyde/open-in-editor', [VirtualRouteController::class, 'openInEditor']);
         }
 
-        // The sitemap and RSS feed routes are registered in the Router itself, once the site URL
-        // has been finalized for the request. See Router::registerDynamicVirtualRoutes().
+        // The sitemap and RSS feed routes are registered dynamically instead of here.
+        // @see \Hyde\RealtimeCompiler\Routing\Router::registerDynamicVirtualRoutes()
     }
 }

--- a/packages/realtime-compiler/src/RealtimeCompilerServiceProvider.php
+++ b/packages/realtime-compiler/src/RealtimeCompilerServiceProvider.php
@@ -5,12 +5,14 @@ declare(strict_types=1);
 namespace Hyde\RealtimeCompiler;
 
 use Illuminate\Support\ServiceProvider;
+use Hyde\Facades\Features;
 use Hyde\RealtimeCompiler\Http\DashboardController;
 use Hyde\RealtimeCompiler\Http\LiveEditController;
 use Hyde\RealtimeCompiler\Http\VirtualRouteController;
 use Hyde\RealtimeCompiler\Http\OpenInEditorController;
 use Hyde\RealtimeCompiler\Console\Commands\HerdInstallCommand;
 use Hyde\RealtimeCompiler\Console\Commands\ServeCommand;
+use Hyde\Framework\Features\XmlGenerators\RssFeedGenerator;
 
 class RealtimeCompilerServiceProvider extends ServiceProvider
 {
@@ -42,6 +44,14 @@ class RealtimeCompilerServiceProvider extends ServiceProvider
 
         if (OpenInEditorController::enabled()) {
             $router->registerVirtualRoute('/_hyde/open-in-editor', [VirtualRouteController::class, 'openInEditor']);
+        }
+
+        if (Features::hasSitemap()) {
+            $router->registerVirtualRoute('/sitemap.xml', [VirtualRouteController::class, 'sitemap']);
+        }
+
+        if (Features::hasRss()) {
+            $router->registerVirtualRoute('/'.RssFeedGenerator::getFilename(), [VirtualRouteController::class, 'rssFeed']);
         }
     }
 }

--- a/packages/realtime-compiler/src/Routing/Router.php
+++ b/packages/realtime-compiler/src/Routing/Router.php
@@ -14,8 +14,6 @@ use Hyde\RealtimeCompiler\Http\VirtualRouteController;
 use Hyde\RealtimeCompiler\Models\FileObject;
 use Hyde\RealtimeCompiler\Concerns\InteractsWithLaravel;
 use Hyde\Framework\Features\XmlGenerators\RssFeedGenerator;
-use Illuminate\Support\Arr;
-use Symfony\Component\Yaml\Yaml;
 
 class Router
 {
@@ -77,6 +75,9 @@ class Router
         }
 
         if (Features::hasRss()) {
+            // Note: this correctly registers a custom `hyde.rss.filename`, even though
+            // `shouldProxy()` below can't recognize that filename and will still proxy
+            // it as a static asset request. That's an accepted, intentional asymmetry.
             $compiler->registerVirtualRoute('/'.ltrim(RssFeedGenerator::getFilename(), '/'), [VirtualRouteController::class, 'rssFeed']);
         }
     }
@@ -109,14 +110,11 @@ class Router
         }
 
         // Don't proxy the RSS feed, as it's generated on the fly.
+        // We can't resolve the configured `hyde.rss.filename` here without booting the
+        // app, which we deliberately avoid for performance on every static asset request.
+        // A customized RSS filename is rare enough that we accept it falling back to
+        // static-asset proxying rather than being dynamically generated.
         if ($this->request->path === '/feed.xml') {
-            return false;
-        }
-
-        if (
-            in_array(pathinfo($this->request->path, PATHINFO_EXTENSION), ['xml', 'rss'], true)
-            && $this->request->path === $this->getConfiguredRssFeedPath()
-        ) {
             return false;
         }
 
@@ -144,61 +142,6 @@ class Router
         }
 
         return $this->resolvedAssetPath;
-    }
-
-    protected function getConfiguredRssFeedPath(): string
-    {
-        return '/'.ltrim($this->getConfiguredRssFeedFilename(), '/');
-    }
-
-    protected function getConfiguredRssFeedFilename(): string
-    {
-        return $this->getYamlConfiguredRssFeedFilename()
-            ?? $this->getPhpConfiguredRssFeedFilename()
-            ?? 'feed.xml';
-    }
-
-    protected function getPhpConfiguredRssFeedFilename(): ?string
-    {
-        $configPath = BASE_PATH.'/config/hyde.php';
-
-        if (! is_file($configPath)) {
-            return null;
-        }
-
-        $config = require $configPath;
-
-        return is_string($config['rss']['filename'] ?? null)
-            ? $config['rss']['filename']
-            : null;
-    }
-
-    protected function getYamlConfiguredRssFeedFilename(): ?string
-    {
-        $configPath = $this->getYamlConfigPath();
-
-        if ($configPath === null) {
-            return null;
-        }
-
-        $config = Arr::undot((array) Yaml::parseFile($configPath));
-
-        if (array_key_first($config) === 'hyde') {
-            $config = $config['hyde'] ?? [];
-        }
-
-        return is_string($config['rss']['filename'] ?? null)
-            ? $config['rss']['filename']
-            : null;
-    }
-
-    protected function getYamlConfigPath(): ?string
-    {
-        return match (true) {
-            is_file(BASE_PATH.'/hyde.yml') => BASE_PATH.'/hyde.yml',
-            is_file(BASE_PATH.'/hyde.yaml') => BASE_PATH.'/hyde.yaml',
-            default => null,
-        };
     }
 
     /**

--- a/packages/realtime-compiler/src/Routing/Router.php
+++ b/packages/realtime-compiler/src/Routing/Router.php
@@ -75,7 +75,7 @@ class Router
         }
 
         if (Features::hasRss()) {
-            $compiler->registerVirtualRoute('/'.RssFeedGenerator::getFilename(), [VirtualRouteController::class, 'rssFeed']);
+            $compiler->registerVirtualRoute('/'.ltrim(RssFeedGenerator::getFilename(), '/'), [VirtualRouteController::class, 'rssFeed']);
         }
     }
 

--- a/packages/realtime-compiler/src/Routing/Router.php
+++ b/packages/realtime-compiler/src/Routing/Router.php
@@ -6,11 +6,14 @@ namespace Hyde\RealtimeCompiler\Routing;
 
 use Desilva\Microserve\Request;
 use Desilva\Microserve\Response;
+use Hyde\Facades\Features;
 use Hyde\RealtimeCompiler\RealtimeCompiler;
 use Hyde\RealtimeCompiler\Actions\AssetFileLocator;
 use Hyde\RealtimeCompiler\Concerns\SendsErrorResponses;
+use Hyde\RealtimeCompiler\Http\VirtualRouteController;
 use Hyde\RealtimeCompiler\Models\FileObject;
 use Hyde\RealtimeCompiler\Concerns\InteractsWithLaravel;
+use Hyde\Framework\Features\XmlGenerators\RssFeedGenerator;
 
 class Router
 {
@@ -37,6 +40,8 @@ class Router
 
         $this->overrideSiteUrl();
 
+        $this->registerDynamicVirtualRoutes();
+
         $virtualRoutes = app(RealtimeCompiler::class)->getVirtualRoutes();
 
         if (isset($virtualRoutes[$this->request->path])) {
@@ -51,6 +56,27 @@ class Router
         }
 
         return PageRouter::handle($this->request);
+    }
+
+    /**
+     * Register virtual routes whose availability depends on the site URL, which is only
+     * finalized after {@see overrideSiteUrl()} has run. Unlike the routes registered in
+     * the service provider's boot method, these can't be resolved any earlier: outside of
+     * `save_preview` mode, the site URL is always overridden to a local address, so (unlike
+     * a real `hyde build`) we don't need a production site URL to be configured to serve
+     * these on the local dev server.
+     */
+    protected function registerDynamicVirtualRoutes(): void
+    {
+        $compiler = app(RealtimeCompiler::class);
+
+        if (Features::hasSitemap()) {
+            $compiler->registerVirtualRoute('/sitemap.xml', [VirtualRouteController::class, 'sitemap']);
+        }
+
+        if (Features::hasRss()) {
+            $compiler->registerVirtualRoute('/'.RssFeedGenerator::getFilename(), [VirtualRouteController::class, 'rssFeed']);
+        }
     }
 
     /**

--- a/packages/realtime-compiler/src/Routing/Router.php
+++ b/packages/realtime-compiler/src/Routing/Router.php
@@ -14,6 +14,8 @@ use Hyde\RealtimeCompiler\Http\VirtualRouteController;
 use Hyde\RealtimeCompiler\Models\FileObject;
 use Hyde\RealtimeCompiler\Concerns\InteractsWithLaravel;
 use Hyde\Framework\Features\XmlGenerators\RssFeedGenerator;
+use Illuminate\Support\Arr;
+use Symfony\Component\Yaml\Yaml;
 
 class Router
 {
@@ -107,9 +109,14 @@ class Router
         }
 
         // Don't proxy the RSS feed, as it's generated on the fly.
-        // We can't resolve the configured `hyde.rss.filename` here as the application
-        // is not booted yet, so we match against the default filename instead.
         if ($this->request->path === '/feed.xml') {
+            return false;
+        }
+
+        if (
+            in_array(pathinfo($this->request->path, PATHINFO_EXTENSION), ['xml', 'rss'], true)
+            && $this->request->path === $this->getConfiguredRssFeedPath()
+        ) {
             return false;
         }
 
@@ -137,6 +144,61 @@ class Router
         }
 
         return $this->resolvedAssetPath;
+    }
+
+    protected function getConfiguredRssFeedPath(): string
+    {
+        return '/'.ltrim($this->getConfiguredRssFeedFilename(), '/');
+    }
+
+    protected function getConfiguredRssFeedFilename(): string
+    {
+        return $this->getYamlConfiguredRssFeedFilename()
+            ?? $this->getPhpConfiguredRssFeedFilename()
+            ?? 'feed.xml';
+    }
+
+    protected function getPhpConfiguredRssFeedFilename(): ?string
+    {
+        $configPath = BASE_PATH.'/config/hyde.php';
+
+        if (! is_file($configPath)) {
+            return null;
+        }
+
+        $config = require $configPath;
+
+        return is_string($config['rss']['filename'] ?? null)
+            ? $config['rss']['filename']
+            : null;
+    }
+
+    protected function getYamlConfiguredRssFeedFilename(): ?string
+    {
+        $configPath = $this->getYamlConfigPath();
+
+        if ($configPath === null) {
+            return null;
+        }
+
+        $config = Arr::undot((array) Yaml::parseFile($configPath));
+
+        if (array_key_first($config) === 'hyde') {
+            $config = $config['hyde'] ?? [];
+        }
+
+        return is_string($config['rss']['filename'] ?? null)
+            ? $config['rss']['filename']
+            : null;
+    }
+
+    protected function getYamlConfigPath(): ?string
+    {
+        return match (true) {
+            is_file(BASE_PATH.'/hyde.yml') => BASE_PATH.'/hyde.yml',
+            is_file(BASE_PATH.'/hyde.yaml') => BASE_PATH.'/hyde.yaml',
+            default => null,
+        };
     }
 
     /**

--- a/packages/realtime-compiler/src/Routing/Router.php
+++ b/packages/realtime-compiler/src/Routing/Router.php
@@ -74,6 +74,19 @@ class Router
             return false;
         }
 
+        // Don't proxy the sitemap, as it's generated on the fly.
+        // Note that unlike the RSS feed below, the sitemap filename is not configurable.
+        if ($this->request->path === '/sitemap.xml') {
+            return false;
+        }
+
+        // Don't proxy the RSS feed, as it's generated on the fly.
+        // We can't resolve the configured `hyde.rss.filename` here as the application
+        // is not booted yet, so we match against the default filename instead.
+        if ($this->request->path === '/feed.xml') {
+            return false;
+        }
+
         // Dotted page routes (like documentation version folders) are proxied only when a matching asset exists.
         return $this->resolveAssetPath() !== null;
     }

--- a/packages/realtime-compiler/tests/Integration/IntegrationTest.php
+++ b/packages/realtime-compiler/tests/Integration/IntegrationTest.php
@@ -89,21 +89,16 @@ class IntegrationTest extends IntegrationTestCase
 
     public function testDynamicSitemapGeneration()
     {
-        // Setting a site URL is required to enable the sitemap feature. The realtime compiler
-        // then overrides it with the local server address, which is what we assert against.
-        file_put_contents($this->projectPath('.env'), 'SITE_URL=https://hydephp.dev');
-
+        // No production site URL needs to be configured: the realtime compiler always
+        // overrides it with the local server address, which is what we assert against.
         $this->get('/sitemap.xml')
             ->assertStatus(200)
             ->assertHeader('Content-Type', 'application/xml')
             ->assertSeeText('http://localhost:8080');
-
-        unlink($this->projectPath('.env'));
     }
 
     public function testDynamicRssFeedGeneration()
     {
-        file_put_contents($this->projectPath('.env'), 'SITE_URL=https://hydephp.dev');
         file_put_contents($this->projectPath('_posts/dynamic-rss-test.md'), "---\ntitle: Dynamic RSS Test\ndescription: Dynamic RSS test description\n---\n\n# Dynamic RSS Test");
 
         $this->get('/feed.xml')
@@ -111,7 +106,6 @@ class IntegrationTest extends IntegrationTestCase
             ->assertHeader('Content-Type', 'application/rss+xml')
             ->assertSeeText('Dynamic RSS Test');
 
-        unlink($this->projectPath('.env'));
         unlink($this->projectPath('_posts/dynamic-rss-test.md'));
     }
 }

--- a/packages/realtime-compiler/tests/Integration/IntegrationTest.php
+++ b/packages/realtime-compiler/tests/Integration/IntegrationTest.php
@@ -108,20 +108,4 @@ class IntegrationTest extends IntegrationTestCase
 
         unlink($this->projectPath('_posts/dynamic-rss-test.md'));
     }
-
-    public function testDynamicRssFeedGenerationWithCustomFilename()
-    {
-        file_put_contents($this->projectPath('hyde.yml'), "rss:\n  filename: custom-feed.xml\n");
-        file_put_contents($this->projectPath('_posts/dynamic-custom-rss-test.md'), "---\ntitle: Dynamic Custom RSS Test\ndescription: Dynamic RSS test description\n---\n\n# Dynamic Custom RSS Test");
-
-        try {
-            $this->get('/custom-feed.xml')
-                ->assertStatus(200)
-                ->assertHeader('Content-Type', 'application/rss+xml')
-                ->assertSeeText('Dynamic Custom RSS Test');
-        } finally {
-            unlink($this->projectPath('hyde.yml'));
-            unlink($this->projectPath('_posts/dynamic-custom-rss-test.md'));
-        }
-    }
 }

--- a/packages/realtime-compiler/tests/Integration/IntegrationTest.php
+++ b/packages/realtime-compiler/tests/Integration/IntegrationTest.php
@@ -108,4 +108,20 @@ class IntegrationTest extends IntegrationTestCase
 
         unlink($this->projectPath('_posts/dynamic-rss-test.md'));
     }
+
+    public function testDynamicRssFeedGenerationWithCustomFilename()
+    {
+        file_put_contents($this->projectPath('hyde.yml'), "rss:\n  filename: custom-feed.xml\n");
+        file_put_contents($this->projectPath('_posts/dynamic-custom-rss-test.md'), "---\ntitle: Dynamic Custom RSS Test\ndescription: Dynamic RSS test description\n---\n\n# Dynamic Custom RSS Test");
+
+        try {
+            $this->get('/custom-feed.xml')
+                ->assertStatus(200)
+                ->assertHeader('Content-Type', 'application/rss+xml')
+                ->assertSeeText('Dynamic Custom RSS Test');
+        } finally {
+            unlink($this->projectPath('hyde.yml'));
+            unlink($this->projectPath('_posts/dynamic-custom-rss-test.md'));
+        }
+    }
 }

--- a/packages/realtime-compiler/tests/Integration/IntegrationTest.php
+++ b/packages/realtime-compiler/tests/Integration/IntegrationTest.php
@@ -86,4 +86,32 @@ class IntegrationTest extends IntegrationTestCase
         unlink($this->projectPath('_docs/index.md'));
         unlink($this->projectPath('_docs/installation.md'));
     }
+
+    public function testDynamicSitemapGeneration()
+    {
+        // Setting a site URL is required to enable the sitemap feature. The realtime compiler
+        // then overrides it with the local server address, which is what we assert against.
+        file_put_contents($this->projectPath('.env'), 'SITE_URL=https://hydephp.dev');
+
+        $this->get('/sitemap.xml')
+            ->assertStatus(200)
+            ->assertHeader('Content-Type', 'application/xml')
+            ->assertSeeText('http://localhost:8080');
+
+        unlink($this->projectPath('.env'));
+    }
+
+    public function testDynamicRssFeedGeneration()
+    {
+        file_put_contents($this->projectPath('.env'), 'SITE_URL=https://hydephp.dev');
+        file_put_contents($this->projectPath('_posts/dynamic-rss-test.md'), "---\ntitle: Dynamic RSS Test\ndescription: Dynamic RSS test description\n---\n\n# Dynamic RSS Test");
+
+        $this->get('/feed.xml')
+            ->assertStatus(200)
+            ->assertHeader('Content-Type', 'application/rss+xml')
+            ->assertSeeText('Dynamic RSS Test');
+
+        unlink($this->projectPath('.env'));
+        unlink($this->projectPath('_posts/dynamic-rss-test.md'));
+    }
 }

--- a/packages/realtime-compiler/tests/RealtimeCompilerTest.php
+++ b/packages/realtime-compiler/tests/RealtimeCompilerTest.php
@@ -14,6 +14,7 @@ use Hyde\Framework\Exceptions\RouteNotFoundException;
 use Hyde\RealtimeCompiler\Http\ExceptionHandler;
 use Desilva\Microserve\HtmlResponse;
 use Hyde\RealtimeCompiler\Http\HttpKernel;
+use Hyde\RealtimeCompiler\RealtimeCompiler;
 use Hyde\RealtimeCompiler\Routing\PageRouter;
 use Hyde\RealtimeCompiler\Routing\Router;
 
@@ -341,6 +342,29 @@ class RealtimeCompilerTest extends TestCase
         $this->assertStringContainsString('<urlset', $response->body);
     }
 
+    public function testRegisterDynamicVirtualRoutesDoesNotRegisterSitemapWhenFeatureIsDisabled()
+    {
+        $this->mockCompilerRoute('sitemap.xml');
+        config(['hyde.url' => 'http://localhost:8080', 'hyde.generate_sitemap' => false]);
+
+        $routes = $this->invokeRegisterDynamicVirtualRoutes();
+
+        $this->assertArrayNotHasKey('/sitemap.xml', $routes);
+    }
+
+    public function testRegisterDynamicVirtualRoutesDoesNotRegisterRssFeedWhenFeatureIsDisabled()
+    {
+        $this->mockCompilerRoute('feed.xml');
+        config(['hyde.url' => 'http://localhost:8080', 'hyde.rss.enabled' => false]);
+        Filesystem::put('_posts/test-post.md', "---\ntitle: Test Post\ndescription: Test post description\n---\n\n# Test Post");
+
+        $routes = $this->invokeRegisterDynamicVirtualRoutes();
+
+        $this->assertArrayNotHasKey('/feed.xml', $routes);
+
+        Filesystem::unlink('_posts/test-post.md');
+    }
+
     public function testRssFeedRouteReturnsRssResponse()
     {
         $this->mockCompilerRoute('feed.xml');
@@ -625,6 +649,16 @@ class RealtimeCompilerTest extends TestCase
         $method = new ReflectionMethod(Router::class, 'overrideSiteUrl');
         $method->setAccessible(true);
         $method->invoke(new Router(new Request()));
+    }
+
+    /** @return array<string, callable> */
+    protected function invokeRegisterDynamicVirtualRoutes(): array
+    {
+        $method = new ReflectionMethod(Router::class, 'registerDynamicVirtualRoutes');
+        $method->setAccessible(true);
+        $method->invoke(new Router(new Request()));
+
+        return app(RealtimeCompiler::class)->getVirtualRoutes();
     }
 
     protected function invokeGetContentType(InMemoryPage $page): string

--- a/packages/realtime-compiler/tests/RealtimeCompilerTest.php
+++ b/packages/realtime-compiler/tests/RealtimeCompilerTest.php
@@ -323,6 +323,46 @@ class RealtimeCompilerTest extends TestCase
         $this->assertSame('text/html', $this->invokeGetContentType($page));
     }
 
+    public function testSitemapRouteReturnsSitemapResponse()
+    {
+        // The application is freshly booted within the router, so we need to set the
+        // site URL via the environment, as an in-memory config change won't be seen.
+        $this->mockCompilerRoute('sitemap.xml');
+        putenv('SITE_URL=https://example.com');
+
+        $kernel = new HttpKernel();
+        $response = $kernel->handle(new Request());
+
+        $this->assertInstanceOf(Response::class, $response);
+        $this->assertSame(200, $response->statusCode);
+        $this->assertSame('OK', $response->statusMessage);
+        $this->assertStringContainsString('<?xml version="1.0" encoding="UTF-8"?>', $response->body);
+        $this->assertStringContainsString('<urlset', $response->body);
+
+        putenv('SITE_URL');
+    }
+
+    public function testRssFeedRouteReturnsRssResponse()
+    {
+        $this->mockCompilerRoute('feed.xml');
+        putenv('SITE_URL=https://example.com');
+        Filesystem::put('_posts/test-post.md', "---\ntitle: Test Post\ndescription: Test post description\n---\n\n# Test Post");
+
+        $kernel = new HttpKernel();
+        $response = $kernel->handle(new Request());
+
+        $this->assertInstanceOf(Response::class, $response);
+        $this->assertSame(200, $response->statusCode);
+        $this->assertSame('OK', $response->statusMessage);
+        $this->assertStringContainsString('<?xml version="1.0" encoding="UTF-8"?>', $response->body);
+        $this->assertStringContainsString('<rss ', $response->body);
+        $this->assertStringContainsString('version="2.0"', $response->body);
+        $this->assertStringContainsString('Test Post', $response->body);
+
+        Filesystem::unlink('_posts/test-post.md');
+        putenv('SITE_URL');
+    }
+
     public function testPingRouteReturnsPingResponse()
     {
         $this->mockCompilerRoute('ping');

--- a/packages/realtime-compiler/tests/RealtimeCompilerTest.php
+++ b/packages/realtime-compiler/tests/RealtimeCompilerTest.php
@@ -365,18 +365,6 @@ class RealtimeCompilerTest extends TestCase
         Filesystem::unlink('_posts/test-post.md');
     }
 
-    public function testShouldProxyDoesNotProxyCustomRssFeedFilename()
-    {
-        $this->mockCompilerRoute('custom-feed.xml');
-        Filesystem::put('hyde.yml', "rss:\n  filename: custom-feed.xml\n");
-
-        try {
-            $this->assertFalse($this->invokeShouldProxy());
-        } finally {
-            Filesystem::unlink('hyde.yml');
-        }
-    }
-
     public function testRssFeedRouteReturnsRssResponse()
     {
         $this->mockCompilerRoute('feed.xml');
@@ -671,14 +659,6 @@ class RealtimeCompilerTest extends TestCase
         $method->invoke(new Router(new Request()));
 
         return app(RealtimeCompiler::class)->getVirtualRoutes();
-    }
-
-    protected function invokeShouldProxy(): bool
-    {
-        $method = new ReflectionMethod(Router::class, 'shouldProxy');
-        $method->setAccessible(true);
-
-        return $method->invoke(new Router(new Request()), new Request());
     }
 
     protected function invokeGetContentType(InMemoryPage $page): string

--- a/packages/realtime-compiler/tests/RealtimeCompilerTest.php
+++ b/packages/realtime-compiler/tests/RealtimeCompilerTest.php
@@ -365,6 +365,18 @@ class RealtimeCompilerTest extends TestCase
         Filesystem::unlink('_posts/test-post.md');
     }
 
+    public function testShouldProxyDoesNotProxyCustomRssFeedFilename()
+    {
+        $this->mockCompilerRoute('custom-feed.xml');
+        Filesystem::put('hyde.yml', "rss:\n  filename: custom-feed.xml\n");
+
+        try {
+            $this->assertFalse($this->invokeShouldProxy());
+        } finally {
+            Filesystem::unlink('hyde.yml');
+        }
+    }
+
     public function testRssFeedRouteReturnsRssResponse()
     {
         $this->mockCompilerRoute('feed.xml');
@@ -659,6 +671,14 @@ class RealtimeCompilerTest extends TestCase
         $method->invoke(new Router(new Request()));
 
         return app(RealtimeCompiler::class)->getVirtualRoutes();
+    }
+
+    protected function invokeShouldProxy(): bool
+    {
+        $method = new ReflectionMethod(Router::class, 'shouldProxy');
+        $method->setAccessible(true);
+
+        return $method->invoke(new Router(new Request()), new Request());
     }
 
     protected function invokeGetContentType(InMemoryPage $page): string

--- a/packages/realtime-compiler/tests/RealtimeCompilerTest.php
+++ b/packages/realtime-compiler/tests/RealtimeCompilerTest.php
@@ -325,10 +325,11 @@ class RealtimeCompilerTest extends TestCase
 
     public function testSitemapRouteReturnsSitemapResponse()
     {
-        // The application is freshly booted within the router, so we need to set the
-        // site URL via the environment, as an in-memory config change won't be seen.
+        // Note this works even without a production site URL configured: the router always
+        // overrides the site URL to the local server address (unless save_preview is enabled),
+        // so the sitemap and RSS feed are available on the dev server regardless of whether a
+        // production URL has been set.
         $this->mockCompilerRoute('sitemap.xml');
-        putenv('SITE_URL=https://example.com');
 
         $kernel = new HttpKernel();
         $response = $kernel->handle(new Request());
@@ -338,14 +339,11 @@ class RealtimeCompilerTest extends TestCase
         $this->assertSame('OK', $response->statusMessage);
         $this->assertStringContainsString('<?xml version="1.0" encoding="UTF-8"?>', $response->body);
         $this->assertStringContainsString('<urlset', $response->body);
-
-        putenv('SITE_URL');
     }
 
     public function testRssFeedRouteReturnsRssResponse()
     {
         $this->mockCompilerRoute('feed.xml');
-        putenv('SITE_URL=https://example.com');
         Filesystem::put('_posts/test-post.md', "---\ntitle: Test Post\ndescription: Test post description\n---\n\n# Test Post");
 
         $kernel = new HttpKernel();
@@ -360,7 +358,6 @@ class RealtimeCompilerTest extends TestCase
         $this->assertStringContainsString('Test Post', $response->body);
 
         Filesystem::unlink('_posts/test-post.md');
-        putenv('SITE_URL');
     }
 
     public function testPingRouteReturnsPingResponse()


### PR DESCRIPTION
## Summary

The realtime compiler already serves `docs/search.json` on the fly (it's regenerated on every request instead of being read from a stale build on disk), but `sitemap.xml` and the RSS feed were never wired up the same way — requests for them fell through to static-asset proxying and either 404'd or served a stale cached copy from a previous `hyde build`. This PR closes that gap.

- `GET /sitemap.xml` and `GET /{rss.filename}` (default `feed.xml`) are now generated fresh on every request, using the same `SitemapGenerator`/`RssFeedGenerator` classes that back `hyde build`.
- Both routes work **without a production site URL configured**. The realtime compiler always overrides `hyde.url` to the local server address for normal requests, so there's no need to set a real domain just to preview your sitemap/feed locally.

## Architecture decisions

### Why a virtual route instead of a real Hyde route

`docs/search.json` works today because it's backed by a real Hyde `Route` — `DocumentationSearchIndex` is an `InMemoryPage` with a `compile()` method, registered into the page/route collection. The realtime compiler just special-cases it in `Router::shouldProxy()` so it isn't treated as a static asset, and lets the normal `PageRouter` resolve and compile it per request.

Sitemap/RSS have no such route — they're produced only by `GenerateSitemap`/`GenerateRssFeed` `PostBuildTask`s that `file_put_contents()` straight to disk during a full `hyde build`. Two ways to close the gap were considered:

1. **Turn sitemap/RSS into real Hyde routes** (exactly mirroring `DocumentationSearchIndex`), removing the `PostBuildTask`s in favor of the normal per-page compile loop.
2. **Register them as virtual routes inside the realtime-compiler package** (the same mechanism already used for `/ping`, `/dashboard`, `/_hyde/live-edit`), calling the generator classes directly, and leaving `hyde build` untouched.

Went with **option 2**. Option 1 is the more literal parallel to how search.json works, but it changes production build output: `SitemapGenerator` iterates *all* routes, so sitemap.xml would end up listing itself (and feed.xml) as an entry, and the existing `PostBuildTask`s would need to be deleted to avoid generating the files twice. That's a real behavior change to `hyde build` for every user, not just realtime-compiler users, for a dev-server-only convenience. The virtual-route approach gets the same on-the-fly behavior in the dev server with zero risk to `hyde build`.

### Dropping the site-URL requirement for local dev

`Features::hasSitemap()`/`hasRss()` both require `Hyde::hasSiteUrl()` — a real, production-looking `hyde.url` — since that's what `hyde build` needs to emit correct absolute `<loc>`/`<link>` URLs. Registering the virtual routes gated on that check directly in the service provider's `boot()` meant the routes were only available if you'd already configured a production site URL, which defeats the point of a local preview: you'd get a `RouteNotFoundException` for `/sitemap.xml` on a fresh project.

But `Router::overrideSiteUrl()` already always replaces `hyde.url` with the local server address (e.g. `http://localhost:8080`) for every request, specifically so previews don't reference production — *unless* `hyde.server.save_preview` is enabled, in which case the override is deliberately skipped so a local URL doesn't get baked into a persisted preview build.

So instead of checking the feature flags at `ServiceProvider::boot()` (before the override runs), the sitemap/RSS routes are now registered by a new `Router::registerDynamicVirtualRoutes()`, called *after* `overrideSiteUrl()`. This means:
- In normal dev mode, `hasSiteUrl()` is always satisfied by the local override, so sitemap/RSS "just work" with no config needed — matching how any other compiled page behaves locally.
- In `save_preview` mode, the override is skipped, so the original site-URL requirement still applies, preserving the original safety rationale (no `localhost` URLs baked into a persisted, production-like build).

Verified against a live `hyde serve` instance: `curl localhost:8080/sitemap.xml` returns `200` with valid XML using local URLs, with no `SITE_URL` configured anywhere.

### Known limitation

`Router::shouldProxy()` decides whether to proxy a request *before* the Laravel app is booted (a deliberate perf optimization — booting costs ~80ms and most requests are static assets that shouldn't pay for it). That means `config('hyde.rss.filename')` isn't resolvable at that point. `sitemap.xml` is hardcoded in the framework so that's an exact match either way, but the RSS check falls back to matching the *default* filename (`feed.xml`). If a project customizes `hyde.rss.filename`, requests to that custom filename will still be proxied as a static asset instead of generated on the fly. This is called out in a code comment at the check site. I believe that customizing the RSS feed filename is such a rare thing to do, that we don't need to slow down everything else to accommodate it. // Emma
