### PR TITLE
Internal: Update documentation mirror workflow

### DIFF
--- a/.github/workflows/sync-documentation-mirror.yml
+++ b/.github/workflows/sync-documentation-mirror.yml
@@ -2,14 +2,16 @@ name: Sync documentation mirror
 
 on:
   push:
-    branches: [ master, '1.x' ]
+    branches: [ master ]
     paths:
       - 'docs/**'
       - '.github/workflows/sync-documentation-mirror.yml'
+  release:
+    types: [ published ]
 
-# Avoid overlapping runs trying to push at once
+# Serialize all runs since they push to the same target repo
 concurrency:
-  group: sync-docs-${{ github.ref }}
+  group: sync-docs
   cancel-in-progress: false
 
 jobs:
@@ -17,24 +19,45 @@ jobs:
     if: github.repository == 'hydephp/develop'
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout monorepo
-        uses: actions/checkout@v6
-        with:
-          fetch-depth: 0
-
-      - name: Determine target subdirectory (1.x vs 2.x)
+      - name: Determine target subdirectory
         id: vars
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          TAG_NAME: ${{ github.event.release.tag_name }}
+          IS_PRERELEASE: ${{ github.event.release.prerelease }}
         run: |
-          if [ "${GITHUB_REF_NAME}" = "master" ]; then
-            echo "TARGET_SUBDIR=2.x" >> "$GITHUB_OUTPUT"
-          elif [ "${GITHUB_REF_NAME}" = "1.x" ]; then
-            echo "TARGET_SUBDIR=1.x" >> "$GITHUB_OUTPUT"
-          else
-            echo "Unsupported branch: ${GITHUB_REF_NAME}"
-            exit 78
+          set -euo pipefail
+          if [ "$EVENT_NAME" = "push" ]; then
+            echo "TARGET_SUBDIR=master" >> "$GITHUB_OUTPUT"
+            echo "SOURCE_LABEL=${GITHUB_REF_NAME}@${GITHUB_SHA}" >> "$GITHUB_OUTPUT"
+          elif [ "$EVENT_NAME" = "release" ]; then
+            if [ "$IS_PRERELEASE" = "true" ]; then
+              echo "Skipping prerelease ${TAG_NAME}."
+              echo "SKIP=true" >> "$GITHUB_OUTPUT"
+              exit 0
+            fi
+            case "$TAG_NAME" in
+              v1.*|1.*)
+                echo "TARGET_SUBDIR=1.x" >> "$GITHUB_OUTPUT" ;;
+              v2.*|2.*)
+                echo "TARGET_SUBDIR=2.x" >> "$GITHUB_OUTPUT" ;;
+              *)
+                echo "Unrecognized release tag: ${TAG_NAME}, skipping."
+                echo "SKIP=true" >> "$GITHUB_OUTPUT"
+                exit 0 ;;
+            esac
+            echo "SOURCE_LABEL=release ${TAG_NAME}" >> "$GITHUB_OUTPUT"
           fi
 
+      - name: Checkout monorepo
+        if: steps.vars.outputs.SKIP != 'true'
+        uses: actions/checkout@v6
+        # For push events this checks out the pushed commit on master.
+        # For release events, github.ref is the release tag, so we check
+        # out exactly the code that was released.
+
       - name: Clone target repo (hydephp/docs)
+        if: steps.vars.outputs.SKIP != 'true'
         env:
           TOKEN: ${{ secrets.DOCS_SYNC_TOKEN }}
         run: |
@@ -46,22 +69,21 @@ jobs:
           git clone --depth 1 "https://x-access-token:${TOKEN}@github.com/hydephp/docs.git" target-docs
 
       - name: Replace target directory with monorepo /docs
+        if: steps.vars.outputs.SKIP != 'true'
         run: |
           set -euo pipefail
           DEST="target-docs/${{ steps.vars.outputs.TARGET_SUBDIR }}"
-          # Remove and recreate the target subdir to ensure a full replacement
           rm -rf "$DEST"
           mkdir -p "$DEST"
-          # Mirror monorepo docs into the dest (delete removed files)
           rsync -a --delete --exclude='.git' ./docs/ "$DEST/"
 
       - name: Commit & push if there are changes
+        if: steps.vars.outputs.SKIP != 'true'
         env:
           GIT_AUTHOR_NAME: hydephp-bot
           GIT_AUTHOR_EMAIL: bot@hydephp.com
           GIT_COMMITTER_NAME: hydephp-bot
           GIT_COMMITTER_EMAIL: bot@hydephp.com
-          TOKEN: ${{ secrets.DOCS_SYNC_TOKEN }}
         run: |
           set -euo pipefail
           cd target-docs
@@ -70,6 +92,5 @@ jobs:
             echo "✅ No changes to sync."
             exit 0
           fi
-          git commit -m "Sync docs from ${GITHUB_REPOSITORY}@${GITHUB_SHA} (${GITHUB_REF_NAME}) → ${{ steps.vars.outputs.TARGET_SUBDIR }}"
-          # Push to main on hydephp/docs
+          git commit -m "Sync docs from ${{ steps.vars.outputs.SOURCE_LABEL }} → ${{ steps.vars.outputs.TARGET_SUBDIR }}"
           git push origin HEAD:main


### PR DESCRIPTION
Key changes and reasoning:

**Release-driven versioned dirs.** The `release: published` trigger fires for both v1 and v2 releases regardless of which branch they were cut from. Since `github.ref` is the tag ref on release events, `actions/checkout` checks out the exact released commit — you don't need to figure out whether to check out `1.x` or `master`, the tag already points at the right tree. The tag name (`v1.*` vs `v2.*`) decides whether it lands in `1.x/` or `2.x/`.

**Push to master → `master/` dir only.** Unreleased changes now go to a `master` directory instead of polluting `2.x`. I dropped `1.x` from the push branches entirely since pushes to `1.x` no longer sync anything — only its releases do.

**Concurrency is now a single group** instead of per-ref. A release and a master push can land near-simultaneously and both push to `hydephp/docs`, which would previously race (they were in different groups). Note GitHub only queues one pending run per group; if three runs stack up, the middle one gets discarded. That's fine for master pushes (the latest push wins and syncs everything anyway) but if you cut releases in rapid succession you could theoretically drop one — rare enough that I wouldn't engineer around it, but re-running the workflow from the release fixes it.

A couple of things to be aware of:

- **Prereleases are skipped** (the `IS_PRERELEASE` guard). If you want release candidates to update the mirror, delete that block — or route them to their own dir.
- **Path filtering doesn't apply to release events**, so every release triggers a run even if docs didn't change. The "no changes" early exit makes that a cheap no-op commit-skip, so it's harmless.
- **One-time migration:** the current `2.x/` in hydephp/docs contains unreleased master content. The next v2 release will overwrite it with the released state, but until then it's stale-forward. If that matters, manually re-run this workflow against your latest v2 tag (or just wait for the next release).
- If you ever tag a v3, the `case` statement skips it silently — worth remembering to extend when that day comes.