### PR TITLE
[2.x] Create a new branch structure

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,6 +7,7 @@ version: 2
 updates:
   - package-ecosystem: "github-actions"
     directory: "/"
+    target-branch: "master"
     schedule:
       interval: "daily"
     groups:
@@ -20,6 +21,7 @@ updates:
 
   - package-ecosystem: "composer" # See documentation for possible values
     directory: "/" # Location of package manifests
+    target-branch: "master"
     schedule:
       interval: "daily"
 
@@ -28,5 +30,6 @@ updates:
       - "/"
       - "packages/hyde"
       - "packages/hydefront"
+    target-branch: "master"
     schedule:
       interval: "daily"

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -549,7 +549,7 @@ jobs:
         run: vendor/bin/psalm --shepherd > psalmout.txt|| true
 
       - name: Ping CI server with type coverage results
-        run: php monorepo/scripts/ping-ci-server-with-type-coverage.php ${{ secrets.CI_SERVER_TOKEN }} ${{ github.sha }} master ${{ github.run_id }}
+        run: php monorepo/scripts/ping-ci-server-with-type-coverage.php ${{ secrets.CI_SERVER_TOKEN }} ${{ github.sha }} ${{ github.ref_name }} ${{ github.run_id }}
 
 
   run-static-analysis-phpstan:

--- a/.github/workflows/deploy-documentation-preview.yml
+++ b/.github/workflows/deploy-documentation-preview.yml
@@ -2,7 +2,7 @@ name: Deploy Documentation Preview
 
 on:
   pull_request:
-    branches: [ "master" ]
+    branches: [ "1.x", "2.x", "master" ]
     paths:
       - 'docs/**'
       - '.github/workflows/deploy-documentation-preview.yml'

--- a/.github/workflows/end-to-end-tests.yml
+++ b/.github/workflows/end-to-end-tests.yml
@@ -2,9 +2,9 @@ name: End-to-End Testing
 
 on:
   push:
-    branches: [ "master" ]
+    branches: [ "1.x", "2.x", "master" ]
   pull_request:
-    branches: [ "master" ]
+    branches: [ "1.x", "2.x", "master" ]
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/hyde-stan.yml
+++ b/.github/workflows/hyde-stan.yml
@@ -2,7 +2,7 @@ name: 🔬 HydeStan
 
 on:
   push:
-    branches: [ "master" ]
+    branches: [ "1.x", "2.x", "master" ]
   pull_request:
 
 permissions:

--- a/.github/workflows/matrix-tests.yml
+++ b/.github/workflows/matrix-tests.yml
@@ -2,7 +2,7 @@ name: Matrix Tests
 
 on:
   pull_request:
-    branches: [ "master", "2.x-dev" ]
+    branches: [ "1.x", "2.x", "master" ]
     paths:
       - 'app/**'
       - 'packages/**'

--- a/.github/workflows/split-monorepo.yml
+++ b/.github/workflows/split-monorepo.yml
@@ -4,7 +4,7 @@ name: 🪓 Split monorepo
 
 on:
   push:
-    branches: [ "master" ]
+    branches: [ "1.x", "2.x", "master" ]
 
 # Cancels all previous workflow runs for the same branch that have not yet completed.
 concurrency:
@@ -16,10 +16,9 @@ jobs:
 
   hyde:
     runs-on: ubuntu-latest
-    continue-on-error: true
     environment:
       name: hydephp/hyde
-      url: https://github.com/hydephp/hyde/tree/master
+      url: https://github.com/hydephp/hyde/tree/${{ github.ref_name }}
 
     steps:
       - name: Checkout hydephp/develop
@@ -33,7 +32,7 @@ jobs:
         with:
           repository: hydephp/hyde
           path: hyde
-          ref: develop
+          ref: ${{ github.ref_name }}
           fetch-depth: 0
           persist-credentials: false
 
@@ -81,15 +80,14 @@ jobs:
           git add .
           git commit --author="$COMMIT_AUTHOR_NAME <$COMMIT_AUTHOR_EMAIL>" -m "$COMMIT_MESSAGE https://github.com/hydephp/develop/commit/${{ github.sha }}"
 
-          git push upstream develop
+          git push upstream HEAD:${{ github.ref_name }}
           echo "No changes to this package. Exiting gracefully."
 
   framework:
     runs-on: ubuntu-latest
-    continue-on-error: true
     environment:
       name: hydephp/framework
-      url: https://github.com/hydephp/framework/tree/master
+      url: https://github.com/hydephp/framework/tree/${{ github.ref_name }}
 
     steps:
       - name: Checkout hydephp/develop
@@ -103,7 +101,7 @@ jobs:
         with:
           repository: hydephp/framework
           path: framework
-          ref: develop
+          ref: ${{ github.ref_name }}
           fetch-depth: 0
           persist-credentials: false
 
@@ -132,10 +130,11 @@ jobs:
           git add .
           git commit --author="$COMMIT_AUTHOR_NAME <$COMMIT_AUTHOR_EMAIL>" -m "$COMMIT_MESSAGE https://github.com/hydephp/develop/commit/${{ github.sha }}"
 
-          git push upstream develop
+          git push upstream HEAD:${{ github.ref_name }}
           echo "No changes to this package. Exiting gracefully."
 
   realtime-compiler:
+    if: github.ref_name == 'master'
     runs-on: ubuntu-latest
     continue-on-error: true
     environment:
@@ -186,6 +185,7 @@ jobs:
           git push upstream master
 
   hydefront:
+    if: github.ref_name == 'master'
     runs-on: ubuntu-latest
     continue-on-error: true
     environment:
@@ -236,6 +236,7 @@ jobs:
           git push upstream master
 
   docs:
+    if: github.ref_name == 'master'
     runs-on: ubuntu-latest
     continue-on-error: true
     environment:
@@ -291,6 +292,7 @@ jobs:
           echo "No changes to this package. Exiting gracefully."
 
   testing:
+    if: github.ref_name == 'master'
     runs-on: ubuntu-latest
     continue-on-error: true
     environment:
@@ -341,6 +343,7 @@ jobs:
           git push upstream master
 
   ui-kit:
+    if: github.ref_name == 'master'
     runs-on: ubuntu-latest
     continue-on-error: true
     environment:
@@ -392,6 +395,7 @@ jobs:
           git push upstream master
 
   vite-plugin:
+    if: github.ref_name == 'master'
     runs-on: ubuntu-latest
     continue-on-error: true
     environment:

--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -2,7 +2,7 @@ name: 🔎 Static Analysis
 
 on:
   pull_request:
-    branches: [ "master", "2.x-dev" ]
+    branches: [ "1.x", "2.x", "master" ]
 
 jobs:
 

--- a/.github/workflows/sync-documentation-mirror.yml
+++ b/.github/workflows/sync-documentation-mirror.yml
@@ -2,7 +2,7 @@ name: Sync documentation mirror
 
 on:
   push:
-    branches: [ master ]
+    branches: [ "1.x", "2.x", "master" ]
     paths:
       - 'docs/**'
       - '.github/workflows/sync-documentation-mirror.yml'
@@ -28,7 +28,7 @@ jobs:
         run: |
           set -euo pipefail
           if [ "$EVENT_NAME" = "push" ]; then
-            echo "TARGET_SUBDIR=master" >> "$GITHUB_OUTPUT"
+            echo "TARGET_SUBDIR=${GITHUB_REF_NAME}" >> "$GITHUB_OUTPUT"
             echo "SOURCE_LABEL=${GITHUB_REF_NAME}@${GITHUB_SHA}" >> "$GITHUB_OUTPUT"
           elif [ "$EVENT_NAME" = "release" ]; then
             if [ "$IS_PRERELEASE" = "true" ]; then
@@ -41,6 +41,8 @@ jobs:
                 echo "TARGET_SUBDIR=1.x" >> "$GITHUB_OUTPUT" ;;
               v2.*|2.*)
                 echo "TARGET_SUBDIR=2.x" >> "$GITHUB_OUTPUT" ;;
+              v3.*|3.*)
+                echo "TARGET_SUBDIR=3.x" >> "$GITHUB_OUTPUT" ;;
               *)
                 echo "Unrecognized release tag: ${TAG_NAME}, skipping."
                 echo "SKIP=true" >> "$GITHUB_OUTPUT"
@@ -52,7 +54,7 @@ jobs:
       - name: Checkout monorepo
         if: steps.vars.outputs.SKIP != 'true'
         uses: actions/checkout@v6
-        # For push events this checks out the pushed commit on master.
+        # For push events this checks out the pushed commit on its version branch.
         # For release events, github.ref is the release tag, so we check
         # out exactly the code that was released.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -40,11 +40,11 @@ When thinking about a new feature, make sure it's intuitive and easy to understa
 
 ## Which Branch?
 
-All bug fixes should be sent to the latest version that supports bug fixes (currently 1.x). Bug fixes should never be sent to the master branch unless they fix features that exist only in the upcoming release.
+Bug fixes for the current stable release should be sent to the `2.x` branch. Fixes for v1 should be sent to `1.x` only when they apply to that supported release line. Bug fixes should never be sent to `master` unless they affect features that exist only in the upcoming v3 release.
 
-Minor features that are fully backward compatible with the current release may be sent to the latest stable branch (currently 1.x).
+Minor features that are fully backward compatible with the current release may be sent to `2.x`.
 
-Major new features or features with breaking changes should always be sent to the master branch, which contains the upcoming release.
+Major new features or features with breaking changes should be sent to `master`, which contains the upcoming v3 release.
 
 ## Procedure
 

--- a/README.md
+++ b/README.md
@@ -4,8 +4,8 @@
 <div align=center>
 
 [![Test & Build](https://github.com/hydephp/develop/actions/workflows/continuous-integration.yml/badge.svg)](https://github.com/hydephp/develop/actions/workflows/continuous-integration.yml)
-[![Framework Tests (Matrix)](https://github.com/hydephp/framework/actions/workflows/run-tests.yml/badge.svg?branch=develop)](https://github.com/hydephp/framework/actions/workflows/run-tests.yml)
-[![Hyde Tests](https://github.com/hydephp/hyde/actions/workflows/run-tests.yml/badge.svg?branch=develop)](https://github.com/hydephp/hyde/actions/workflows/run-tests.yml)
+[![Framework Tests (Matrix)](https://github.com/hydephp/framework/actions/workflows/run-tests.yml/badge.svg?branch=master)](https://github.com/hydephp/framework/actions/workflows/run-tests.yml)
+[![Hyde Tests](https://github.com/hydephp/hyde/actions/workflows/run-tests.yml/badge.svg?branch=master)](https://github.com/hydephp/hyde/actions/workflows/run-tests.yml)
 </div>
 
 <div align=center>
@@ -60,11 +60,13 @@ The two most important components are **Hyde** and **Framework**. We also use **
 
 ### How the monorepo works
 
-Changes to HydePHP including some first-party packages are made here. The changes are then pushed to the `develop` or `master` branches of the readonly repositories seen in the table above.
+Changes to HydePHP including some first-party packages are made here. Changes to the core Hyde and Framework packages are mirrored to the matching `1.x`, `2.x`, or `master` branch in their read-only repositories. Other first-party packages continue to be mirrored from `master`.
 
 ### Releases
 
 The versioning between the Framework and Hyde packages are linked together, meaning that if Hyde gets a major release, so must Framework, and vice versa. To make this easier, we also publish major and minor releases in the monorepo. Patch releases are not published in the monorepo, and are instead handled by the individual packages, as the changes therein are generally self-contained.
+
+The release helper targets `master` by default. Pass the maintained version branch when preparing a release from another line, for example `php hyde monorepo:release --base=2.x`. Once the monorepo release pull request is merged, the matching branch is synchronized to the Hyde and Framework repositories before their releases are published.
 
 ## Contributing
 

--- a/monorepo/DevTools/src/MonorepoReleaseCommand.php
+++ b/monorepo/DevTools/src/MonorepoReleaseCommand.php
@@ -13,7 +13,7 @@ use Hyde\Console\Concerns\Command;
 class MonorepoReleaseCommand extends Command
 {
     /** @var string */
-    protected $signature = 'monorepo:release {--dry-run}';
+    protected $signature = 'monorepo:release {--base=master : Version branch to release from (1.x, 2.x, or master)} {--dry-run}';
 
     /** @var string */
     protected $description = 'Prepare a new syndicated HydePHP release';
@@ -29,6 +29,7 @@ class MonorepoReleaseCommand extends Command
     protected string $newVersion;
 
     protected bool $failed = false;
+    protected string $baseBranch;
     protected string $branch;
     protected string $releaseBody;
 
@@ -36,8 +37,15 @@ class MonorepoReleaseCommand extends Command
     {
         $this->title('Preparing a new syndicated HydePHP release!');
         $this->dryRun = $this->option('dry-run');
+        $this->baseBranch = (string) $this->option('base');
 
-        $this->fetchAndCheckoutMaster();
+        if (! in_array($this->baseBranch, ['1.x', '2.x', 'master'], true)) {
+            $this->failCommand('The release base must be one of: 1.x, 2.x, master.');
+
+            return Command::FAILURE;
+        }
+
+        $this->fetchAndCheckoutBaseBranch();
         $this->getCurrentVersion();
         $this->askForNewVersion();
         $this->newLine();
@@ -64,16 +72,9 @@ class MonorepoReleaseCommand extends Command
             $this->makeMonorepoCommit();
         }
 
-        $this->prepareFrameworkPR();
-
-        if ($this->isNotPatch()) {
-            $this->prepareHydePR();
-            $this->prepareDocsPR();
-        }
-
         $this->prepareMonorepoPR();
 
-        $this->confirm('Once the pull requests are merged and propagated, press enter to proceed and draft the releases.', true);
+        $this->confirm('Once the monorepo pull request is merged and the package mirrors are synced, press enter to proceed and draft the releases.', true);
 
         $this->prepareFrameworkRelease();
 
@@ -87,13 +88,13 @@ class MonorepoReleaseCommand extends Command
         return Command::SUCCESS;
     }
 
-    protected function fetchAndCheckoutMaster(): void
+    protected function fetchAndCheckoutBaseBranch(): void
     {
-        $this->info('Fetching and checking out master branch...');
+        $this->info("Fetching and checking out $this->baseBranch branch...");
 
-        $this->runUnlessDryRun('echo hi');
-        $this->runUnlessDryRun('git checkout master');
-        $this->runUnlessDryRun('git pull');
+        $this->runUnlessDryRun('git fetch origin '.escapeshellarg($this->baseBranch));
+        $this->runUnlessDryRun('git checkout '.escapeshellarg($this->baseBranch));
+        $this->runUnlessDryRun('git pull --ff-only origin '.escapeshellarg($this->baseBranch));
 
         $this->exitIfFailed();
 
@@ -322,42 +323,10 @@ This serves two purposes:
         $this->line('Done.');
     }
 
-    protected function prepareFrameworkPR(): void
-    {
-        $this->preparePackagePR('framework');
-    }
-
-    protected function prepareHydePR(): void
-    {
-        $this->preparePackagePR('hyde');
-    }
-
-    protected function prepareDocsPR(): void
-    {
-        $this->preparePackagePR('hydephp.com', 'upcoming', 'Merge upcoming documentation', 'This PR merges the upcoming documentation for `v'.$this->newVersion.'` into the master branch.');
-    }
-
-    protected function getTitle(): string
-    {
-        return "HydePHP v$this->newVersion - ".date('Y-m-d');
-    }
-
     protected function getCompanionBody(): string
     {
         // return sprintf('Please see the release notes in the development monorepo [`Release v%s`](https://github.com/hydephp/develop/releases/tag/v%s)', $this->newVersion, $this->newVersion);
         return sprintf('Please see the release notes in the development monorepo https://github.com/hydephp/develop/releases/tag/v%s', $this->newVersion);
-    }
-
-    protected function preparePackagePR(string $package, string $branch = 'develop', ?string $title = null, ?string $body = null): void
-    {
-        // Create link to draft pull request merging develop into master
-        $link = sprintf('https://github.com/hydephp/'.$package.'/compare/master...'.$branch.'?expand=1&draft=1&title=%s&body=%s',
-            urlencode($title ?? $this->getTitle()),
-            $body ?? ($this->isPatch() ? '' : $this->getCompanionBody())
-        );
-
-        $this->info("Opening $package pull request link in browser. Please review and submit the PR once all changes are propagated.");
-        $this->runUnlessDryRun((PHP_OS_FAMILY === 'Windows' ? 'explorer' : 'open').' '.escapeshellarg($link), true);
     }
 
     protected function prepareMonorepoPR(): void
@@ -373,7 +342,7 @@ This serves two purposes:
         // Inject "version" before version in PR body
         $body = preg_replace('/## \[(.*)]/', '## Version [v$1]', $body, 1);
 
-        $link = sprintf('https://github.com/hydephp/develop/compare/master...'.$this->branch.'?expand=1&draft=1&title=%s&body=%s',
+        $link = sprintf('https://github.com/hydephp/develop/compare/'.$this->baseBranch.'...'.$this->branch.'?expand=1&draft=1&title=%s&body=%s',
             urlencode($title),
             $this->isPatch() ? 'Framework patch release' : urlencode($body)
         );

--- a/packages/hyde/CONTRIBUTING.md
+++ b/packages/hyde/CONTRIBUTING.md
@@ -44,9 +44,10 @@ Development happens in the [HydePHP/Develop](https://github.com/hydephp/develop)
 
 ## Which Branch?
 
-- **Bug fixes** should be sent to the latest stable branch (currently 1.x)
-- **Minor features** that are fully backward compatible should go to the latest stable branch
-- **Major features** or breaking changes should be sent to the master branch
+- **Bug fixes for the current stable release** should be sent to `2.x`
+- **Fixes for the supported v1 release line** should be sent to `1.x`
+- **Minor features** that are fully backward compatible with v2 should be sent to `2.x`
+- **Major features** or breaking changes for v3 should be sent to `master`
 
 ## Project Goals
 


### PR DESCRIPTION
## Overview

This updates the monorepo for HydePHP’s new version branch model:

- `1.x` contains the supported v1/LTS release line.
- `2.x` contains the current stable release.
- `master` contains the upcoming v3 release.

Previously, changes from the monorepo were synchronized to `develop` branches in the read-only Hyde and Framework repositories. With matching version branches now available across `hydephp/develop`, `hydephp/hyde`, and `hydephp/framework`, synchronization can follow the source branch directly.

## Changes

- Synchronize `1.x`, `2.x`, and `master` from the monorepo to the matching Hyde and Framework branches.
- Keep other first-party package splits restricted to `master`.
- Synchronize documentation changes into matching `1.x`, `2.x`, and `master` directories.
- Add documentation snapshot handling for published v3 releases.
- Update CI and PR validation policies to recognize all three release branches.
- Update contribution documentation to identify:
  - `1.x` as the v1 maintenance/LTS branch.
  - `2.x` as the current stable branch.
  - `master` as the upcoming v3 branch.
- Explicitly keep dependency update PRs targeting `master`.
- Update the release helper to accept `--base=1.x`, `--base=2.x`, or `--base=master`.
- Remove obsolete package-side `develop -> master` release PR preparation.

## Context

This removes the need for a long-running v3 base PR and allows `master` to contain the upcoming release directly, following the versioning model used by projects such as Laravel.

Setting `2.x` as the repository’s default branch keeps ordinary pull requests focused on the current stable release, while v3 development can continue independently on `master`.

The `master` branch is intentionally not being renamed as part of this change. This avoids combining the version branch migration with changes to existing URLs, automation references, and Composer development constraints.

## Release Process

The release helper targets `master` by default. Releases for maintained versions must specify their base branch:

```bash
php hyde monorepo:release --base=2.x
```

After the monorepo release pull request is merged, the split workflow synchronizes the matching branch to Hyde and Framework before package releases are published.

## Validation

- Workflow and Dependabot YAML files parse successfully.
- The release command passes PHP syntax validation.
- Invalid release base branches are rejected.
- The changes pass Git whitespace validation.

## Syncronized changes

- https://github.com/hydephp/develop/pull/2512
- https://github.com/hydephp/develop/pull/2513
- https://github.com/hydephp/develop/pull/2514