### PR TITLE
[1.x] Remove strict Composer validation from 1.x branch

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -17,9 +17,6 @@ jobs:
 
       - uses: actions/checkout@v4
 
-      - name: Validate composer.json and composer.lock
-        run: composer validate --strict --no-check-all
-
       - name: Cache Composer packages
         id: composer-cache
         uses: actions/cache@v4

--- a/.github/workflows/coverage-tests.yml
+++ b/.github/workflows/coverage-tests.yml
@@ -14,9 +14,6 @@ jobs:
           extensions: fileinfo
       - uses: actions/checkout@v4
 
-      - name: Validate composer.json and composer.lock
-        run: composer validate --strict --no-check-all
-
       - name: Cache Composer packages
         id: composer-cache
         uses: actions/cache@v4


### PR DESCRIPTION
HydePHP v1 officially supports PHP 8.1, however that version is nearing end of life and it is no longer possible to reliably update Composer dependencies on that version due to other downstream packages requiring later versions. For that reason it is now not possible to create a valid composer.lock file with PHP 8.1