### PR TITLE
[3.x] Enable HTML in Markdown by default in v3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ This serves two purposes:
 
 ### Changed
 - Blade in Markdown is now enabled by default. The `markdown.enable_blade` option controls both `[Blade]:` directives and executable Blade Blocks; set it to `false` when compiling untrusted or unreviewed Markdown.
+- Raw HTML in Markdown is now enabled by default. Set `markdown.allow_html` to `false` when compiling untrusted or unreviewed Markdown to strip potentially unsafe HTML tags.
 
 ### Deprecated
 - for changes that will be removed in upcoming releases.

--- a/HYDEPHP_V3_PLANNING.md
+++ b/HYDEPHP_V3_PLANNING.md
@@ -27,6 +27,7 @@ Having this document in code lets us know the devlopment state at any given poin
 ### Feature Changes
 
 - Blade in Markdown is now enabled by default. The `markdown.enable_blade` option controls both `[Blade]:` directives and executable Blade Blocks. Hyde sites generally treat project content as trusted and reviewed; sites that compile untrusted or unreviewed Markdown can disable both forms with this option.
+- Raw HTML in Markdown is now enabled by default. Hyde sites generally treat project content as trusted and reviewed; sites that compile untrusted or unreviewed Markdown can set `markdown.allow_html` to `false` to strip potentially unsafe HTML tags.
 
 ### Minor Changes and Cleanup
 
@@ -47,5 +48,6 @@ Having this document in code lets us know the devlopment state at any given poin
 Please fill in UPGRADE.md as you make changes.
 
 - Blade in Markdown is now enabled by default, including `[Blade]:` directives and the new executable `blade render` and `blade component(name)` fenced code blocks. Existing projects with a published `config/markdown.php` retain their current `markdown.enable_blade` setting; set it to `true` to adopt the v3 default, or keep it `false` to disable both forms when compiling untrusted or unreviewed Markdown.
+- Raw HTML in Markdown is now enabled by default. Existing projects with a published `config/markdown.php` retain their current `markdown.allow_html` setting; set it to `true` to adopt the v3 default, or keep it `false` when compiling untrusted or unreviewed Markdown.
 - The `rebuild` command has been removed. If you need to build a single page programmatically, use `Hyde\Framework\Actions\StaticPageBuilder::handle()` instead.
 - Move any calls to `Redirect::create()` or `Redirect::store()` into the `redirects` array in `config/hyde.php`, using the old path as the key and the destination as the value.

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -52,17 +52,18 @@ Then run `npm install` (or your package manager's equivalent) to pick up the upd
 
 If you have a custom `vite.config.js` that overrides `build.rollupOptions`, note that Vite 8 builds with Rolldown by default. The `hyde-vite-plugin` now configures its own build options under `build.rolldownOptions` rather than `build.rollupOptions` — if your custom config only sets `rollupOptions`, double check your output still ends up where you expect after upgrading.
 
-## Step 2: Review the Blade in Markdown Default
+## Step 2: Review the Markdown Trust Defaults
 
-HydePHP v3 enables Blade in Markdown by default. The existing `markdown.enable_blade` setting now controls both
+HydePHP v3 enables both raw HTML and Blade in Markdown by default. The existing `markdown.enable_blade` setting controls both
 `[Blade]:` directives and the new executable `blade render` and `blade component(name)` fenced code blocks. New
-projects and projects without an explicit setting can execute PHP from either syntax during a build.
+projects and projects without explicit settings can render arbitrary HTML and execute PHP during a build.
 
 Existing projects normally keep their published `config/markdown.php` file during a dependency update. If yours
-currently sets `enable_blade` to `false`, both forms will remain disabled until you change it:
+currently sets either option to `false`, that behavior remains disabled until you change it:
 
 ```php
 // filepath: config/markdown.php
+'allow_html' => true,
 'enable_blade' => true,
 ```
 
@@ -72,16 +73,17 @@ code sample.
 - `blade render`
 - `blade component(name)`
 
-The v3 default is intended for sites where Markdown is part of the trusted, reviewed project source. If you ingest
-Markdown from users or another untrusted source, or your CI builds pull requests before review, keep all Blade in
-Markdown disabled:
+The v3 defaults are intended for sites where Markdown is part of the trusted, reviewed project source. If you ingest
+Markdown from users or another untrusted source, or your CI builds pull requests before review, disable raw HTML and
+Blade in Markdown:
 
 ```php
 // filepath: config/markdown.php
+'allow_html' => false,
 'enable_blade' => false,
 ```
 
-This setting is not a security boundary for contributors who can add arbitrary project files, since they could add a
+These settings are not a security boundary for contributors who can add arbitrary project files, since they could add a
 malicious `.blade.php` file instead. Review source changes before building them in a privileged environment.
 
 ## Step 3: Replace the Removed `rebuild` Command
@@ -168,7 +170,7 @@ from navigation menus and the sitemap. Redirect pages always include a visible f
 
 Use this checklist to track your upgrade progress:
 
-- [ ] Reviewed `markdown.enable_blade` and explicitly selected the appropriate trust policy
+- [ ] Reviewed `markdown.allow_html` and `markdown.enable_blade` and explicitly selected the appropriate trust policy
 - [ ] Replaced any `php hyde rebuild <path>` usage with `StaticPageBuilder::handle()` or a full `php hyde build`
 - [ ] Moved calls to `Redirect::create()` or `Redirect::store()` into the `hyde.redirects` configuration array
 

--- a/config/markdown.php
+++ b/config/markdown.php
@@ -56,13 +56,13 @@ return [
     |--------------------------------------------------------------------------
     |
     | HydePHP uses the GitHub Flavored Markdown extension to convert Markdown.
-    | This, by default strips out some HTML tags. If you want to allow all
-    | arbitrary HTML tags, and understand the risks involved, you can
-    | use this config setting to enable all HTML tags.
+    | Raw HTML is enabled by default because source files in Hyde projects are
+    | generally trusted and reviewed. Disable this when compiling untrusted or
+    | unreviewed Markdown to strip potentially unsafe HTML tags.
     |
     */
 
-    'allow_html' => false,
+    'allow_html' => true,
 
     /*
     |--------------------------------------------------------------------------

--- a/docs/digging-deeper/advanced-markdown.md
+++ b/docs/digging-deeper/advanced-markdown.md
@@ -190,8 +190,8 @@ If you have a newline after the filepath, like in the first example, it will be 
 
 ### Advanced usage
 
-If you have enabled HTML in Markdown by setting the `allow_html` option to true in your `config/markdown.php` file,
-anything within the path label will be rendered as HTML. This means you can add links, or even images to the label.
+Since HTML in Markdown is enabled by default, anything within the path label will be rendered as HTML. This means you
+can add links, or even images to the label. This requires `allow_html` to remain `true` in `config/markdown.php`.
 
 ````markdown
 // filepath: <a href="https://github.com/hydephp/develop/blob/master/docs/digging-deeper/advanced-markdown.md" rel="nofollow noopener" target="_blank">View file on Github</a>
@@ -290,16 +290,16 @@ You can find the full reference on the [Customization](customization#markdown-co
 
 ### Raw HTML Tags
 
-To convert Markdown, HydePHP uses the GitHub Flavored Markdown extension, which strips out potentially unsafe HTML.
-If you want to allow all arbitrary HTML tags, and understand the risks involved, you can enable all HTML tags by setting
-the `allow_html` option to `true` in your `config/markdown.php` file.
+To convert Markdown, HydePHP uses the GitHub Flavored Markdown extension. HydePHP v3 allows raw HTML by default because
+project source is normally trusted and reviewed. If you process Markdown from outside your trusted review process, set
+the `allow_html` option to `false` in your `config/markdown.php` file to strip potentially unsafe HTML tags.
 
 ```php
 // filepath: config/markdown.php
-'allow_html' => true,
+'allow_html' => false,
 ```
 
-This will add and configure the `DisallowedRawHtml` CommonMark extension so that no HTML tags are stripped out.
+When HTML is allowed, Hyde configures the `DisallowedRawHtml` CommonMark extension so that no HTML tags are stripped out.
 
 ### Tailwind Typography Prose Classes
 

--- a/docs/digging-deeper/customization.md
+++ b/docs/digging-deeper/customization.md
@@ -457,12 +457,12 @@ Any custom options will be merged with the defaults.
 ### Allow Raw HTML
 
 Since Hyde uses [GitHub Flavored Markdown](https://commonmark.thephpleague.com/2.3/extensions/github-flavored-markdown/),
-some HTML tags are stripped out by default. If you want to allow all arbitrary HTML tags, and understand the risks involved,
-you can use the `allow_html` setting to enable all HTML tags.
+it can strip potentially unsafe HTML tags. Raw HTML is enabled by default in HydePHP v3 because project source is
+normally trusted and reviewed. Disable it when processing Markdown from outside your trusted review process.
 
 ```php
 // filepath: config/markdown.php
-'allow_html' => true,
+'allow_html' => false,
 ```
 
 ### Allow Blade Code

--- a/packages/framework/config/markdown.php
+++ b/packages/framework/config/markdown.php
@@ -56,13 +56,13 @@ return [
     |--------------------------------------------------------------------------
     |
     | HydePHP uses the GitHub Flavored Markdown extension to convert Markdown.
-    | This, by default strips out some HTML tags. If you want to allow all
-    | arbitrary HTML tags, and understand the risks involved, you can
-    | use this config setting to enable all HTML tags.
+    | Raw HTML is enabled by default because source files in Hyde projects are
+    | generally trusted and reviewed. Disable this when compiling untrusted or
+    | unreviewed Markdown to strip potentially unsafe HTML tags.
     |
     */
 
-    'allow_html' => false,
+    'allow_html' => true,
 
     /*
     |--------------------------------------------------------------------------

--- a/packages/framework/src/Framework/Concerns/Internal/SetsUpMarkdownConverter.php
+++ b/packages/framework/src/Framework/Concerns/Internal/SetsUpMarkdownConverter.php
@@ -30,7 +30,7 @@ trait SetsUpMarkdownConverter
             $this->addExtension(TorchlightExtension::class);
         }
 
-        if (Config::getBool('markdown.allow_html', false)) {
+        if (Config::getBool('markdown.allow_html', true)) {
             $this->enableAllHtmlElements();
         }
     }

--- a/packages/framework/src/Markdown/Processing/CodeblockFilepathProcessor.php
+++ b/packages/framework/src/Markdown/Processing/CodeblockFilepathProcessor.php
@@ -131,7 +131,7 @@ class CodeblockFilepathProcessor implements MarkdownPreProcessorContract, Markdo
     protected static function resolveTemplate(string $path, bool $highlightedByTorchlight): string
     {
         return View::make('hyde::components.filepath-label', [
-            'path' => Config::getBool('markdown.allow_html', false) ? new HtmlString($path) : $path,
+            'path' => Config::getBool('markdown.allow_html', true) ? new HtmlString($path) : $path,
             'highlightedByTorchlight' => $highlightedByTorchlight,
         ])->render();
     }

--- a/packages/framework/tests/Feature/MarkdownHeadingRendererTest.php
+++ b/packages/framework/tests/Feature/MarkdownHeadingRendererTest.php
@@ -205,8 +205,29 @@ class MarkdownHeadingRendererTest extends TestCase
         HTML, $html);
     }
 
-    public function testHeadingsAllowBasicHtmlButEscapesDangerousInput()
+    public function testHeadingsAllowRawHtmlByDefault()
     {
+        $markdown = <<<'MARKDOWN'
+        ## Heading with <strong>HTML</strong>
+        ### Heading with <script>alert('XSS')</script>
+        MARKDOWN;
+
+        $html = (new MarkdownService($markdown, MarkdownPage::class))->parse();
+
+        $this->assertStringContainsString('Heading with <strong>HTML</strong>', $html);
+        $this->assertStringContainsString("Heading with <script>alert('XSS')</script>", $html);
+
+        $this->assertSame(<<<'HTML'
+        <h2>Heading with <strong>HTML</strong></h2>
+        <h3>Heading with <script>alert('XSS')</script></h3>
+
+        HTML, $html);
+    }
+
+    public function testHeadingsEscapeDisallowedRawHtmlWhenHtmlIsDisabled()
+    {
+        config(['markdown.allow_html' => false]);
+
         $markdown = <<<'MARKDOWN'
         ## Heading with <strong>HTML</strong>
         ### Heading with <script>alert('XSS')</script>

--- a/packages/framework/tests/Feature/MarkdownServiceTest.php
+++ b/packages/framework/tests/Feature/MarkdownServiceTest.php
@@ -153,21 +153,21 @@ class MarkdownServiceTest extends TestCase
         $this->assertSame("<p>[Blade]: {{ &quot;Hello World!&quot; }}</p>\n", $service->parse());
     }
 
-    public function testRawHtmlTagsAreStrippedByDefault()
+    public function testRawHtmlTagsAreAllowedByDefault()
     {
-        $markdown = '<p>foo</p><style>bar</style><script>hat</script>';
-        $service = new MarkdownService($markdown);
-        $html = $service->parse();
-        $this->assertSame("<p>foo</p>&lt;style>bar&lt;/style>&lt;script>hat&lt;/script>\n", $html);
-    }
-
-    public function testRawHtmlTagsAreNotStrippedWhenExplicitlyEnabled()
-    {
-        config(['markdown.allow_html' => true]);
         $markdown = '<p>foo</p><style>bar</style><script>hat</script>';
         $service = new MarkdownService($markdown);
         $html = $service->parse();
         $this->assertSame("<p>foo</p><style>bar</style><script>hat</script>\n", $html);
+    }
+
+    public function testRawHtmlTagsCanBeStrippedWhenExplicitlyDisabled()
+    {
+        config(['markdown.allow_html' => false]);
+        $markdown = '<p>foo</p><style>bar</style><script>hat</script>';
+        $service = new MarkdownService($markdown);
+        $html = $service->parse();
+        $this->assertSame("<p>foo</p>&lt;style>bar&lt;/style>&lt;script>hat&lt;/script>\n", $html);
     }
 
     public function testHasFeaturesArray()

--- a/packages/framework/tests/Feature/Services/Markdown/CodeblockFilepathProcessorTest.php
+++ b/packages/framework/tests/Feature/Services/Markdown/CodeblockFilepathProcessorTest.php
@@ -219,8 +219,24 @@ class CodeblockFilepathProcessorTest extends TestCase
         $this->assertSame($expected, CodeblockFilepathProcessor::postprocess($html));
     }
 
-    public function testProcessorEscapesHtmlByDefault()
+    public function testProcessorDoesNotEscapeHtmlByDefault()
     {
+        $html = <<<'HTML'
+        <!-- HYDE[Filepath]<a href="">Link</a> -->
+        <pre><code class="language-html"></code></pre>
+        HTML;
+
+        $expected = <<<'HTML'
+        <pre><code class="language-html"><small class="relative float-right opacity-50 hover:opacity-100 transition-opacity duration-250 not-prose hidden md:block top-0 right-0"><span class="sr-only">Filepath: </span><a href="">Link</a></small></code></pre>
+        HTML;
+
+        $this->assertSame($expected, CodeblockFilepathProcessor::postprocess($html));
+    }
+
+    public function testProcessorEscapesHtmlWhenExplicitlyDisabled()
+    {
+        config(['markdown.allow_html' => false]);
+
         $html = <<<'HTML'
         <!-- HYDE[Filepath]<a href="">Link</a> -->
         <pre><code class="language-html"></code></pre>
@@ -229,22 +245,6 @@ class CodeblockFilepathProcessorTest extends TestCase
         $escaped = e('<a href="">Link</a>');
         $expected = <<<HTML
         <pre><code class="language-html"><small class="relative float-right opacity-50 hover:opacity-100 transition-opacity duration-250 not-prose hidden md:block top-0 right-0"><span class="sr-only">Filepath: </span>$escaped</small></code></pre>
-        HTML;
-
-        $this->assertSame($expected, CodeblockFilepathProcessor::postprocess($html));
-    }
-
-    public function testProcessorDoesNotEscapeHtmlIfConfigured()
-    {
-        config(['markdown.allow_html' => true]);
-
-        $html = <<<'HTML'
-        <!-- HYDE[Filepath]<a href="">Link</a> -->
-        <pre><code class="language-html"></code></pre>
-        HTML;
-
-        $expected = <<<'HTML'
-        <pre><code class="language-html"><small class="relative float-right opacity-50 hover:opacity-100 transition-opacity duration-250 not-prose hidden md:block top-0 right-0"><span class="sr-only">Filepath: </span><a href="">Link</a></small></code></pre>
         HTML;
 
         $this->assertSame($expected, CodeblockFilepathProcessor::postprocess($html));


### PR DESCRIPTION
## Summary

- enable raw HTML in Markdown by default for HydePHP v3
- align runtime fallbacks and code-block filepath rendering with the new default
- document the trusted-source policy and the `markdown.allow_html` opt-out
- update the changelog, v3 planning notes, upgrade guide, and tests

## Security

Raw HTML and Blade are enabled for Hyde projects because project Markdown is normally trusted and reviewed. Sites processing untrusted or unreviewed Markdown should set both `markdown.allow_html` and `markdown.enable_blade` to `false`.

## Tests

- `vendor/bin/phpunit packages/framework/tests/Feature/MarkdownServiceTest.php packages/framework/tests/Feature/Services/Markdown/CodeblockFilepathProcessorTest.php packages/framework/tests/Unit/HydeConfigFilesAreMatchingTest.php`
- 49 tests, 86 assertions