### PR TITLE
[3.x] Use attribute syntax for the Blade Block component directive

### DIFF
--- a/HYDEPHP_V3_PLANNING.md
+++ b/HYDEPHP_V3_PLANNING.md
@@ -23,7 +23,7 @@ Having this document in code lets us know the devlopment state at any given poin
 - Added native support for versioned documentation pages. Register versions in the new `docs.versions` configuration option, and store the pages for each version in a matching subdirectory of the documentation source directory (like `_docs/1.x` and `_docs/2.x`). Each version is compiled to a matching subdirectory of the documentation output directory, and gets its own sidebar, search index, and search page. A version switcher dropdown is shown in the documentation sidebar, the main navigation links to the default version's index page, and a redirect page is generated at the documentation root pointing to the default version. Sidebar and search configuration entries (`docs.sidebar.order`, `docs.sidebar.labels`, `docs.sidebar.exclude`, and `docs.exclude_from_search`) match version-agnostic identifiers and route keys, so a single entry applies to the page in every version, while full versioned keys allow version-specific overrides. Enabling the feature is all or nothing: documentation source files stored outside the version directories are ignored, so pages that should live at the documentation root belong in the normal page source directory (like `_pages/docs/index.md`). Versioning is disabled by default, and single-version sites are unaffected. ([#2516](https://github.com/hydephp/develop/pull/2516))
 - Redirects can now be declared as source and destination path pairs in the `hyde.redirects` configuration array. Hyde registers them with the kernel, includes them in `route:list`, and generates them through the normal site build.
 - Blog posts can now be kept out of the published site through two zero-configuration publication states. Setting `draft: true` in front matter excludes a post indefinitely, until the property is removed or set to `false`, which suits content that is unfinished or awaiting approval. Setting a date in the future schedules a post, excluding it until that date has passed. Drafts and scheduled posts are skipped during auto-discovery when building the site: they get no route, are not present in the kernel's page and route collections, and are left out of post listings, the sitemap, and the RSS feed. The date rule supports both front matter dates and filename date prefixes, and an explicit draft outranks the date, so a draft stays excluded even after its date passes. Posts are published by default, making `draft: false` a no-op. Both states remain served by the realtime compiler, which is treated as an authoring preview, so posts can be written and proofread at their normal URL without editing their front matter: `serve` shows everything you are working on, while `build` publishes only what is eligible. Since Hyde is a static site generator, a scheduled post does not publish itself once its date passes: it is included in the first site build run after that point, so recurring builds (for example a cron-scheduled GitHub Actions workflow) are needed for a post to go live on its own. The new `MarkdownPost::isDraft()` and `MarkdownPost::isScheduled()` methods expose the checks. ([#2441](https://github.com/hydephp/develop/issues/2441), [#2572](https://github.com/hydephp/develop/pull/2572))
-- Added Blade Blocks for rendering Blade and Blade components from fenced code blocks in Markdown pages. The supported directives are `blade render` and `blade component(name)`, and the feature is controlled by `markdown.enable_blade`. ([#2504](https://github.com/hydephp/develop/pull/2504))
+- Added Blade Blocks for rendering Blade and Blade components from fenced code blocks in Markdown pages. The supported directives are `blade render` and `blade component="name"`, and the feature is controlled by `markdown.enable_blade`. ([#2504](https://github.com/hydephp/develop/pull/2504))
 - Added built-in terminal code blocks using the `terminal` fence language. Command prompts are styled for selection-free copying, and `terminal xml` supports four Symfony-style Console formatter tags. ([#2188](https://github.com/hydephp/develop/issues/2188), [#2485](https://github.com/hydephp/develop/issues/2485))
 
 ### Feature Changes
@@ -53,7 +53,7 @@ Having this document in code lets us know the devlopment state at any given poin
 
 Please fill in UPGRADE.md as you make changes.
 
-- Blade in Markdown is now enabled by default, including `[Blade]:` directives and the new executable `blade render` and `blade component(name)` fenced code blocks. Existing projects with a published `config/markdown.php` retain their current `markdown.enable_blade` setting; set it to `true` to adopt the v3 default, or keep it `false` to disable both forms when compiling untrusted or unreviewed Markdown.
+- Blade in Markdown is now enabled by default, including `[Blade]:` directives and the new executable `blade render` and `blade component="name"` fenced code blocks. Existing projects with a published `config/markdown.php` retain their current `markdown.enable_blade` setting; set it to `true` to adopt the v3 default, or keep it `false` to disable both forms when compiling untrusted or unreviewed Markdown.
 - Raw HTML in Markdown is now enabled by default. Existing projects with a published `config/markdown.php` retain their current `markdown.allow_html` setting; set it to `true` to adopt the v3 default, or keep it `false` when compiling untrusted or unreviewed Markdown.
 - Blog posts marked `draft: true` or dated in the future are no longer built, though they remain visible when serving the site. Check `_posts` for both, correcting any mistyped dates and reviewing any existing `draft: true` annotations, which now gain built-in publication behavior. If you want to schedule posts, set up recurring builds, as a scheduled post is only published by a build run after its date has passed.
 - The `rebuild` command has been removed. If you need to build a single page programmatically, use `Hyde\Framework\Actions\StaticPageBuilder::handle()` instead.
@@ -75,3 +75,20 @@ mutually exclusive alternatives and ambiguous construction fails immediately.
 Both arguments use `null` as the omission sentinel so an explicitly empty literal remains distinguishable from an
 omitted contents argument. Their names and order remain unchanged to keep the upgrade mechanical: existing named calls
 are unaffected, while positional view calls replace their old `''` placeholder with `null`.
+
+## Blade Block component syntax motivation
+
+The Blade Block component directive was initially prototyped as a function call, `blade component(name)`, before being
+settled as an HTML-style attribute, `blade component="name"`. Since neither form shipped in a release, the released
+documentation only describes the attribute form.
+
+The attribute form was chosen because it matches how component names are already written in Blade itself, most
+directly in Laravel's `<x-dynamic-component component="name" />`, so the directive reads like the Blade it renders
+rather than like a PHP call. It also extends cleanly: fenced code block info strings conventionally carry
+space-separated attributes, so future directives can add options next to the existing one without inventing an
+argument list or changing the shape of what is already documented.
+
+Double quotes are canonical, since that is the prevailing convention in both HTML and Blade component tags. Single
+quotes are accepted as an equivalent alternative, matching HTML's tolerance for either, while an unquoted or partially
+quoted value is rejected rather than guessed at. The name may not contain whitespace, keeping the info string
+parseable as space-separated tokens for the extensibility noted above.

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -55,7 +55,7 @@ If you have a custom `vite.config.js` that overrides `build.rollupOptions`, note
 ## Step 2: Review the Markdown Trust Defaults
 
 HydePHP v3 enables both raw HTML and Blade in Markdown by default. The existing `markdown.enable_blade` setting controls both
-`[Blade]:` directives and the new executable `blade render` and `blade component(name)` fenced code blocks. New
+`[Blade]:` directives and the new executable `blade render` and `blade component="name"` fenced code blocks. New
 projects and projects without explicit settings can render arbitrary HTML and execute PHP during a build.
 
 Existing projects normally keep their published `config/markdown.php` file during a dependency update. If yours
@@ -71,7 +71,7 @@ When enabled, the following fences are executable. A fence using only `blade` re
 code sample.
 
 - `blade render`
-- `blade component(name)`
+- `blade component="name"`
 
 The v3 defaults are intended for sites where Markdown is part of the trusted, reviewed project source. If you ingest
 Markdown from users or another untrusted source, or your CI builds pull requests before review, disable raw HTML and

--- a/docs/digging-deeper/advanced-markdown.md
+++ b/docs/digging-deeper/advanced-markdown.md
@@ -49,11 +49,12 @@ For multi-line Blade, use an executable `blade render` fenced block:
 The Blade is evaluated at build time, and the rendered output is wrapped in a
 `<div class="blade-block not-prose">` element. When compiling a page, the `$page` variable is available to the block.
 
-You can also render a Blade component using the `blade component(name)` directive. Component data is passed using YAML
-front matter at the start of the block:
+You can also render a Blade component using the `blade component="name"` directive. The component name is given as an
+HTML-style attribute, mirroring Laravel's own `<x-dynamic-component component="name" />` syntax. Component data is
+passed using YAML front matter at the start of the block:
 
 ````markdown
-```blade component(alert)
+```blade component="alert"
 ---
 type: warning
 title: Check this
@@ -65,7 +66,7 @@ If the block does not start with YAML front matter, its content is rendered as M
 component slot. This is useful when the component does not need any data:
 
 ````markdown
-```blade component(alert)
+```blade component="alert"
 This content is passed to the component **slot**.
 ```
 ````
@@ -74,7 +75,7 @@ To pass both component data and Markdown slot content, enclose the data in YAML 
 it:
 
 ````markdown
-```blade component(alert)
+```blade component="alert"
 ---
 type: warning
 title: Check this
@@ -83,6 +84,9 @@ title: Check this
 This content is passed to the component **slot**.
 ```
 ````
+
+Double quotes are the canonical style, but single quotes are accepted as well, so `blade component='alert'` is
+equivalent. The name must be quoted and cannot contain whitespace.
 
 A fence using only `blade` is an ordinary syntax-highlighted code sample and is not executed. Unsupported Blade block
 directives, including `blade component` without a component name, throw an exception.

--- a/docs/digging-deeper/composable-markdown-blocks.md
+++ b/docs/digging-deeper/composable-markdown-blocks.md
@@ -57,7 +57,7 @@ loops, `@include`, config calls, and the full Tailwind class set inside them.
 | [Coloured blockquotes](#coloured-blockquotes) | `>info Text`            | `colored-blockquote.blade.php`     | Markdown pre-processor |
 | [Headings](#headings)                   | `## Heading`                  | `markdown-heading.blade.php`       | CommonMark renderer  |
 | [Filepath labels](#code-block-filepath-labels) | `// filepath: foo.php` | `filepath-label.blade.php`         | Markdown post-processor |
-| [Blade component blocks](#blade-component-blocks) | ` ```blade component(x) ` | *any component you write*     | Markdown pre-processor |
+| [Blade component blocks](#blade-component-blocks) | ` ```blade component="x" ` | *any component you write*    | Markdown pre-processor |
 
 All view paths are relative to `resources/views/components/` in the framework package, and to
 `resources/views/vendor/hyde/components/` once published into your project.
@@ -124,7 +124,7 @@ phases, orchestrated by the `MarkdownService`:
 
 **1. Pre-processors** run against the raw Markdown string, before the parser sees it.
 
-- `BladeBlockProcessor` — extracts ` ```blade render ` and ` ```blade component(name) ` blocks, replacing each with a
+- `BladeBlockProcessor` — extracts ` ```blade render ` and ` ```blade component="name" ` blocks, replacing each with a
   placeholder comment so nothing downstream tries to parse their contents.
 - `BladeDownProcessor` — handles single-line `[Blade]:` directives.
 - `ShortcodeProcessor` — expands coloured blockquotes into rendered HTML.
@@ -398,11 +398,11 @@ than a wrapper around the code block.
 
 ## Blade Component Blocks
 
-The blocks above are Hyde's own. The `blade component(name)` fenced block is the escape hatch that lets *any* component
+The blocks above are Hyde's own. The `blade component="name"` fenced block is the escape hatch that lets *any* component
 you write become a Markdown block:
 
 ````markdown
-```blade component(alert)
+```blade component="alert"
 ---
 type: warning
 title: Check this
@@ -625,7 +625,7 @@ fine; block-level Markdown inside the blockquote does not.
 
 ### Blade blocks depend on configuration
 
-`blade render` and `blade component(name)` blocks are gated behind `markdown.enable_blade`. If your site builds Markdown
+`blade render` and `blade component="name"` blocks are gated behind `markdown.enable_blade`. If your site builds Markdown
 from outside your trusted review process, that setting should be off — and any block you built on top of Blade blocks
 will stop rendering with it. Custom CommonMark extensions are unaffected.
 

--- a/docs/digging-deeper/customization.md
+++ b/docs/digging-deeper/customization.md
@@ -470,7 +470,7 @@ normally trusted and reviewed. Disable it when processing Markdown from outside 
 
 HydePHP also allows you to use Blade code in your Markdown files. This is enabled by default in HydePHP v3 because
 project source is normally trusted and reviewed. The `enable_blade` setting controls both `[Blade]:` directives and
-executable `blade render` and `blade component(name)` fenced code blocks.
+executable `blade render` and `blade component="name"` fenced code blocks.
 
 Blade code can execute arbitrary PHP during the build. Disable it when processing Markdown from outside your trusted
 review process:

--- a/packages/framework/src/Markdown/Processing/BladeBlocks/BladeBlockExtractor.php
+++ b/packages/framework/src/Markdown/Processing/BladeBlocks/BladeBlockExtractor.php
@@ -178,7 +178,7 @@ class BladeBlockExtractor
         }
 
         throw new InvalidArgumentException(
-            'Invalid Blade block syntax. Expected ```blade render``` or ```blade component(component-name)```.'
+            'Invalid Blade block syntax. Expected ```blade render``` or ```blade component="component-name"```.'
         );
     }
 
@@ -187,10 +187,11 @@ class BladeBlockExtractor
         return $tokens[0] === 'blade' && count($tokens) > 1;
     }
 
+    /** Extract the component name from an HTML-style attribute, using either double (canonical) or single quotes. */
     protected function extractComponentName(string $directive): ?string
     {
-        if (preg_match('/^component\((?<name>[^)]+)\)$/', $directive, $matches)) {
-            return trim($matches['name']);
+        if (preg_match('/^component=(?<quote>["\'])(?<name>[^"\'\s]+)\k<quote>$/', $directive, $matches)) {
+            return $matches['name'];
         }
 
         return null;

--- a/packages/framework/tests/Feature/BladeBlocksTest.php
+++ b/packages/framework/tests/Feature/BladeBlocksTest.php
@@ -111,11 +111,11 @@ class BladeBlocksTest extends TestCase
         $this->assertStringContainsString('&lt;h1&gt;Hello&lt;/h1&gt;', $html);
     }
 
-    // Test `blade component(name)`
+    // Test `blade component="name"`
 
     public function testComponentBlockWithFrontMatterAndMarkdownSlot()
     {
-        $html = $this->render("```blade component(blade-block-fixture)\n---\nfoo: bar\n---\n\n# Heading\n\nSome **bold** text\n```");
+        $html = $this->render("```blade component=\"blade-block-fixture\"\n---\nfoo: bar\n---\n\n# Heading\n\nSome **bold** text\n```");
 
         $this->assertStringContainsString('data=[bar]', $html);
         $this->assertStringContainsString('<h1>Heading</h1>', $html);
@@ -124,7 +124,7 @@ class BladeBlocksTest extends TestCase
 
     public function testComponentWithMarkdownBodyUsesContentAsMarkdownSlot()
     {
-        $html = $this->render("```blade component(blade-block-fixture)\nThis is just a simple alert message.\n\nIt supports **Markdown** without front matter.\n```");
+        $html = $this->render("```blade component=\"blade-block-fixture\"\nThis is just a simple alert message.\n\nIt supports **Markdown** without front matter.\n```");
 
         $this->assertStringContainsString('data=[]', $html);
         $this->assertStringContainsString('<p>This is just a simple alert message.</p>', $html);
@@ -134,7 +134,7 @@ class BladeBlocksTest extends TestCase
     public function testTextLookingLikeYamlIsTreatedAsMarkdownSlot()
     {
         $markdown = <<<'MARKDOWN'
-```blade component(blade-block-fixture)
+```blade component="blade-block-fixture"
 Warning: This is an alert
 - Item 1
 - Item 2
@@ -153,7 +153,7 @@ MARKDOWN;
 
     public function testFrontMatterMustStartTheComponentBlock()
     {
-        $html = $this->render("```blade component(blade-block-fixture)\n\n---\nfoo: bar\n---\n```");
+        $html = $this->render("```blade component=\"blade-block-fixture\"\n\n---\nfoo: bar\n---\n```");
 
         $this->assertStringContainsString('data=[]', $html);
         $this->assertStringContainsString('foo: bar', $html);
@@ -161,9 +161,16 @@ MARKDOWN;
 
     public function testComponentDataIsAvailableAsViewVariables()
     {
-        $html = $this->render("```blade component(blade-block-props-fixture)\n---\nfoo: bar\n---\n```");
+        $html = $this->render("```blade component=\"blade-block-props-fixture\"\n---\nfoo: bar\n---\n```");
 
         $this->assertStringContainsString('value=[bar]', $html);
+    }
+
+    public function testComponentNameCanBeSingleQuoted()
+    {
+        $html = $this->render("```blade component='blade-block-fixture'\n---\nfoo: bar\n---\n```");
+
+        $this->assertStringContainsString('data=[bar]', $html);
     }
 
     // Error handling
@@ -176,25 +183,32 @@ MARKDOWN;
         $this->render("```blade foo\ncontent\n```");
     }
 
-    public function testComponentWithoutParenthesesThrows()
+    public function testComponentWithoutAttributeThrows()
     {
         $this->expectException(InvalidArgumentException::class);
 
         $this->render("```blade component\ncontent\n```");
     }
 
-    public function testComponentWithEmptyParenthesesThrows()
+    public function testComponentWithEmptyAttributeValueThrows()
     {
         $this->expectException(InvalidArgumentException::class);
 
-        $this->render("```blade component()\ncontent\n```");
+        $this->render("```blade component=\"\"\ncontent\n```");
+    }
+
+    public function testComponentNameWithoutQuotesThrows()
+    {
+        $this->expectException(InvalidArgumentException::class);
+
+        $this->render("```blade component=foo\ncontent\n```");
     }
 
     public function testComponentNameWithWhitespaceThrows()
     {
         $this->expectException(InvalidArgumentException::class);
 
-        $this->render("```blade component(foo bar)\ncontent\n```");
+        $this->render("```blade component=\"foo bar\"\ncontent\n```");
     }
 
     // Fence parsing behavior (through the real pipeline)
@@ -254,14 +268,14 @@ MARKDOWN;
 
     public function testBladeBlocksNestedInComponentSlotAreProcessed()
     {
-        $html = $this->render("````blade component(blade-block-fixture)\n---\nfoo: bar\n---\n\n```blade render\n{{ \"Nested\" }}\n```\n````");
+        $html = $this->render("````blade component=\"blade-block-fixture\"\n---\nfoo: bar\n---\n\n```blade render\n{{ \"Nested\" }}\n```\n````");
 
         $this->assertStringContainsString('<div class="blade-block not-prose">Nested</div>', $html);
     }
 
     public function testComponentSlotUsesPageClassWhenCompiledWithinPage()
     {
-        $page = MarkdownPage::make('blade-block-slot-page', [], "```blade component(blade-block-fixture)\n---\nfoo: bar\n---\n\n# Heading\n```");
+        $page = MarkdownPage::make('blade-block-slot-page', [], "```blade component=\"blade-block-fixture\"\n---\nfoo: bar\n---\n\n# Heading\n```");
 
         Hyde::shareViewData($page);
 

--- a/packages/framework/tests/Feature/Documentation/ComposableMarkdownBlocksDocumentationTest.php
+++ b/packages/framework/tests/Feature/Documentation/ComposableMarkdownBlocksDocumentationTest.php
@@ -354,7 +354,7 @@ class ComposableMarkdownBlocksDocumentationTest extends TestCase
         $this->assertStringContainsString('Rendered by Blade', BladeBlockProcessor::postprocess($preprocessed));
 
         // Component blocks are extracted the same way
-        $preprocessed = BladeBlockProcessor::preprocess("Intro paragraph.\n\n```blade component(alert)\nSlot content\n```");
+        $preprocessed = BladeBlockProcessor::preprocess("Intro paragraph.\n\n```blade component=\"alert\"\nSlot content\n```");
 
         $this->assertStringContainsString('<!-- HYDE[BladeBlock]', $preprocessed);
         $this->assertStringNotContainsString('Slot content', $preprocessed);
@@ -887,7 +887,7 @@ class ComposableMarkdownBlocksDocumentationTest extends TestCase
         $this->publishAlertComponent();
 
         $html = Markdown::render(<<<'MARKDOWN'
-        ```blade component(alert)
+        ```blade component="alert"
         ---
         type: warning
         title: Check this
@@ -910,13 +910,13 @@ class ComposableMarkdownBlocksDocumentationTest extends TestCase
         $this->publishAlertComponent();
 
         // Front matter alone
-        $html = Markdown::render("```blade component(alert)\n---\ntype: warning\ntitle: Front matter alone\n---\n```");
+        $html = Markdown::render("```blade component=\"alert\"\n---\ntype: warning\ntitle: Front matter alone\n---\n```");
 
         $this->assertStringContainsString('<strong>Front matter alone</strong>', $html);
         $this->assertStringContainsString('border-amber-500', $html);
 
         // Slot content alone
-        $html = Markdown::render("```blade component(alert)\nSlot content alone\n```");
+        $html = Markdown::render("```blade component=\"alert\"\nSlot content alone\n```");
 
         $this->assertStringContainsString('Slot content alone', $html);
         $this->assertStringNotContainsString('border-amber-500', $html);
@@ -928,7 +928,7 @@ class ComposableMarkdownBlocksDocumentationTest extends TestCase
 
         config(['markdown.enable_blade' => false]);
 
-        $html = Markdown::render("```blade component(alert)\nSlot content\n```");
+        $html = Markdown::render("```blade component=\"alert\"\nSlot content\n```");
 
         $this->assertStringNotContainsString('rounded border-l-4 p-4', $html);
         $this->assertStringContainsString('<pre><code class="language-blade">', $html);

--- a/packages/framework/tests/Unit/BladeBlockExtractorTest.php
+++ b/packages/framework/tests/Unit/BladeBlockExtractorTest.php
@@ -55,7 +55,15 @@ class BladeBlockExtractorTest extends UnitTestCase
 
     public function testExtractsComponentBlock()
     {
-        [$blocks] = (new BladeBlockExtractor())->handle("```blade component(x)\ncontent\n```");
+        [$blocks] = (new BladeBlockExtractor())->handle("```blade component=\"x\"\ncontent\n```");
+
+        $this->assertCount(1, $blocks);
+        $this->assertInstanceOf(BladeComponentBlock::class, array_values($blocks)[0]);
+    }
+
+    public function testExtractsComponentBlockUsingSingleQuotes()
+    {
+        [$blocks] = (new BladeBlockExtractor())->handle("```blade component='x'\ncontent\n```");
 
         $this->assertCount(1, $blocks);
         $this->assertInstanceOf(BladeComponentBlock::class, array_values($blocks)[0]);
@@ -158,10 +166,31 @@ class BladeBlockExtractorTest extends UnitTestCase
         (new BladeBlockExtractor())->handle("```blade component\ncontent\n```");
     }
 
-    public function testThrowsOnComponentWithEmptyParentheses()
+    public function testThrowsOnComponentWithEmptyAttributeValue()
     {
         $this->expectException(InvalidArgumentException::class);
 
-        (new BladeBlockExtractor())->handle("```blade component()\ncontent\n```");
+        (new BladeBlockExtractor())->handle("```blade component=\"\"\ncontent\n```");
+    }
+
+    public function testThrowsOnUnquotedComponentName()
+    {
+        $this->expectException(InvalidArgumentException::class);
+
+        (new BladeBlockExtractor())->handle("```blade component=x\ncontent\n```");
+    }
+
+    public function testThrowsOnMismatchedQuotes()
+    {
+        $this->expectException(InvalidArgumentException::class);
+
+        (new BladeBlockExtractor())->handle("```blade component=\"x'\ncontent\n```");
+    }
+
+    public function testThrowsOnUnterminatedQuote()
+    {
+        $this->expectException(InvalidArgumentException::class);
+
+        (new BladeBlockExtractor())->handle("```blade component=\"x\ncontent\n```");
     }
 }


### PR DESCRIPTION
Replaces the function-call form `blade component(name)` with an HTML-style attribute, `blade component="name"`.

````markdown
```blade component="alert"
---
type: warning
---
This content is passed to the component **slot**.
```
````

## Why

The attribute form matches how component names are already written in Blade itself, most directly in Laravel's `<x-dynamic-component component="name" />`, so the directive reads like the Blade it renders rather than like a PHP call.

It also extends cleanly: fenced code block info strings conventionally carry space-separated attributes, so future directives can add options next to the existing one without inventing an argument list or changing the shape of what is already documented.

## Quoting rules

Double quotes are canonical, since that is the prevailing convention in both HTML and Blade component tags. Single quotes are accepted as an equivalent alternative, matching HTML's tolerance for either. Unquoted, partially quoted, and unterminated values are rejected rather than guessed at, and the name may not contain whitespace, keeping the info string parseable as space-separated tokens.

| Input | Result |
|---|---|
| `blade component="alert"` | Canonical |
| `blade component='alert'` | Accepted |
| `blade component=alert` | Throws |
| `blade component="alert'` | Throws |
| `blade component=""` | Throws |
| `blade component="foo bar"` | Throws |

## Notes

Neither form has shipped in a release, so this is not a breaking change and the documentation describes only the attribute form rather than presenting it as a migration.

The commits are split so each one stands on its own: the syntax change with its tests, the documentation, then the planning note recording the rationale.

🤖 Generated with [Claude Code](https://claude.com/claude-code)