### PR TITLE
[3.x] Support setting titles in terminal code blocks

### DIFF
--- a/HYDEPHP_V3_PLANNING.md
+++ b/HYDEPHP_V3_PLANNING.md
@@ -114,7 +114,14 @@ space-separated tokens.
 Rejecting a malformed title departs from how the block treats an unknown modifier, which is ignored so that a modifier
 added in a future version does not break a page rendered by an older one. The asymmetry is deliberate: `title=Build` is
 not a modifier this version doesn't know about, it is one it does know about, written wrong, and silently discarding it
-would leave an author looking at a window still labelled `Terminal` with nothing to explain why.
+would leave an author looking at a window still labelled `Terminal` with nothing to explain why. The same reasoning
+covers a bare `title`, a space around the `=`, and a second title on the same block: each is a title written wrong
+rather than a modifier from the future, so each is reported instead of ignored.
+
+The info string is tokenized by walking a cursor through it, requiring each token to end where the next one begins,
+rather than searching it for modifiers wherever they appear. That is what makes the rejections above reliable:
+`title="One"xml` is one malformed token instead of two valid modifiers, and a modifier is only recognized when it
+stands on its own, exactly as the documented grammar describes it.
 
 The title is passed to the view verbatim as a nullable string rather than pre-resolved to the default label, so that a
 published view can define its own fallback for untitled blocks, which the shipped view demonstrates with

--- a/HYDEPHP_V3_PLANNING.md
+++ b/HYDEPHP_V3_PLANNING.md
@@ -24,7 +24,7 @@ Having this document in code lets us know the devlopment state at any given poin
 - Redirects can now be declared as source and destination path pairs in the `hyde.redirects` configuration array. Hyde registers them with the kernel, includes them in `route:list`, and generates them through the normal site build.
 - Blog posts can now be kept out of the published site through two zero-configuration publication states. Setting `draft: true` in front matter excludes a post indefinitely, until the property is removed or set to `false`, which suits content that is unfinished or awaiting approval. Setting a date in the future schedules a post, excluding it until that date has passed. Drafts and scheduled posts are skipped during auto-discovery when building the site: they get no route, are not present in the kernel's page and route collections, and are left out of post listings, the sitemap, and the RSS feed. The date rule supports both front matter dates and filename date prefixes, and an explicit draft outranks the date, so a draft stays excluded even after its date passes. Posts are published by default, making `draft: false` a no-op. Both states remain served by the realtime compiler, which is treated as an authoring preview, so posts can be written and proofread at their normal URL without editing their front matter: `serve` shows everything you are working on, while `build` publishes only what is eligible. Since Hyde is a static site generator, a scheduled post does not publish itself once its date passes: it is included in the first site build run after that point, so recurring builds (for example a cron-scheduled GitHub Actions workflow) are needed for a post to go live on its own. The new `MarkdownPost::isDraft()` and `MarkdownPost::isScheduled()` methods expose the checks. ([#2441](https://github.com/hydephp/develop/issues/2441), [#2572](https://github.com/hydephp/develop/pull/2572))
 - Added Blade Blocks for rendering Blade and Blade components from fenced code blocks in Markdown pages. The supported directives are `blade render` and `blade component="name"`, and the feature is controlled by `markdown.enable_blade`. ([#2504](https://github.com/hydephp/develop/pull/2504))
-- Added built-in terminal code blocks using the `terminal` fence language. Command prompts are styled for selection-free copying, and `terminal xml` supports four Symfony-style Console formatter tags. ([#2188](https://github.com/hydephp/develop/issues/2188), [#2485](https://github.com/hydephp/develop/issues/2485))
+- Added built-in terminal code blocks using the `terminal` fence language. Command prompts are styled for selection-free copying, and `terminal xml` supports four Symfony-style Console formatter tags. The window's title bar can be titled per block with `terminal title="Installing Hyde"`, which the terminal view receives as a `$title` variable, falling back to the `Terminal` label when a block sets no title. The modifiers are order-independent, so they can be combined as either `terminal xml title="Build output"` or `terminal title="Build output" xml`. ([#2188](https://github.com/hydephp/develop/issues/2188), [#2485](https://github.com/hydephp/develop/issues/2485))
 
 ### Feature Changes
 
@@ -92,3 +92,31 @@ Double quotes are canonical, since that is the prevailing convention in both HTM
 quotes are accepted as an equivalent alternative, matching HTML's tolerance for either, while an unquoted or partially
 quoted value is rejected rather than guessed at. The name may not contain whitespace, keeping the info string
 parseable as space-separated tokens for the extensibility noted above.
+
+## Terminal block title syntax motivation
+
+The terminal block title uses the same attribute syntax as the Blade Block component directive, `title="Build output"`,
+which is what the extensibility argument above anticipated: the info string grammar is now `terminal [xml] [title="…"]`,
+with the title sitting next to the existing modifier instead of replacing or reshaping it.
+
+Beyond the internal consistency, `title="…"` is the established convention for this exact thing elsewhere. Docusaurus
+uses it for titled fenced code blocks, and Expressive Code uses it specifically for terminal window titles, so readers
+coming from other documentation generators recognize it without being taught. It also fits CommonMark, which treats the
+first word of the info string as the language and deliberately leaves the rest for implementations to interpret.
+
+Modifiers are order-independent, since there is no reason for one arbitrary order to be correct when both read equally
+well, and an author combining two independent options should not have to remember which came first. Quoting follows the
+component directive: double quotes canonical, single quotes equivalent (useful when the title itself contains a double
+quote), and an unquoted or unterminated value rejected rather than guessed at. Unlike a component name, a title may
+contain whitespace, which is exactly why it is quoted; the quotes keep the rest of the info string parseable as
+space-separated tokens.
+
+Rejecting a malformed title departs from how the block treats an unknown modifier, which is ignored so that a modifier
+added in a future version does not break a page rendered by an older one. The asymmetry is deliberate: `title=Build` is
+not a modifier this version doesn't know about, it is one it does know about, written wrong, and silently discarding it
+would leave an author looking at a window still labelled `Terminal` with nothing to explain why.
+
+The title is passed to the view verbatim as a nullable string rather than pre-resolved to the default label, so that a
+published view can define its own fallback for untitled blocks, which the shipped view demonstrates with
+`{{ $title ?? 'Terminal' }}`. An explicitly empty title is therefore distinguishable from an omitted one, and renders
+an empty title bar as written.

--- a/HYDEPHP_V3_PLANNING.md
+++ b/HYDEPHP_V3_PLANNING.md
@@ -114,7 +114,9 @@ space-separated tokens.
 Rejecting a malformed title departs from how the block treats an unknown modifier, which is ignored so that a modifier
 added in a future version does not break a page rendered by an older one. The asymmetry is deliberate: `title=Build` is
 not a modifier this version doesn't know about, it is one it does know about, written wrong, and silently discarding it
-would leave an author looking at a window still labelled `Terminal` with nothing to explain why.
+would leave an author looking at a window still labelled `Terminal` with nothing to explain why. The same goes for a
+bare `title` and for a space around the `=`, which is why tokens are matched only between whitespace boundaries: it
+keeps a modifier from being recognized inside a larger typo like `title="One"xml`.
 
 The title is passed to the view verbatim as a nullable string rather than pre-resolved to the default label, so that a
 published view can define its own fallback for untitled blocks, which the shipped view demonstrates with

--- a/HYDEPHP_V3_PLANNING.md
+++ b/HYDEPHP_V3_PLANNING.md
@@ -114,9 +114,10 @@ space-separated tokens.
 Rejecting a malformed title departs from how the block treats an unknown modifier, which is ignored so that a modifier
 added in a future version does not break a page rendered by an older one. The asymmetry is deliberate: `title=Build` is
 not a modifier this version doesn't know about, it is one it does know about, written wrong, and silently discarding it
-would leave an author looking at a window still labelled `Terminal` with nothing to explain why. The same goes for a
-bare `title` and for a space around the `=`, which is why tokens are matched only between whitespace boundaries: it
-keeps a modifier from being recognized inside a larger typo like `title="One"xml`.
+would leave an author looking at a window still labelled `Terminal` with nothing to explain why. Malformed forms such
+as `title`, `title=Build`, and `title = "Build"` are rejected explicitly because they are recognizable attempts to use
+a supported modifier. Tokens are also matched only at whitespace boundaries, preventing a modifier from being
+recognized inside a larger malformed token such as `title="One"xml`.
 
 The title is passed to the view verbatim as a nullable string rather than pre-resolved to the default label, so that a
 published view can define its own fallback for untitled blocks, which the shipped view demonstrates with

--- a/HYDEPHP_V3_PLANNING.md
+++ b/HYDEPHP_V3_PLANNING.md
@@ -114,14 +114,7 @@ space-separated tokens.
 Rejecting a malformed title departs from how the block treats an unknown modifier, which is ignored so that a modifier
 added in a future version does not break a page rendered by an older one. The asymmetry is deliberate: `title=Build` is
 not a modifier this version doesn't know about, it is one it does know about, written wrong, and silently discarding it
-would leave an author looking at a window still labelled `Terminal` with nothing to explain why. The same reasoning
-covers a bare `title`, a space around the `=`, and a second title on the same block: each is a title written wrong
-rather than a modifier from the future, so each is reported instead of ignored.
-
-The info string is tokenized by walking a cursor through it, requiring each token to end where the next one begins,
-rather than searching it for modifiers wherever they appear. That is what makes the rejections above reliable:
-`title="One"xml` is one malformed token instead of two valid modifiers, and a modifier is only recognized when it
-stands on its own, exactly as the documented grammar describes it.
+would leave an author looking at a window still labelled `Terminal` with nothing to explain why.
 
 The title is passed to the view verbatim as a nullable string rather than pre-resolved to the default label, so that a
 published view can define its own fallback for untitled blocks, which the shipped view demonstrates with

--- a/docs/digging-deeper/advanced-markdown.md
+++ b/docs/digging-deeper/advanced-markdown.md
@@ -161,10 +161,8 @@ $ composer require hyde/framework
 ```
 
 Double quotes are canonical, but single quotes work just as well, which helps when the title contains a double quote.
-The title is escaped when rendered, so any characters other than the enclosing quote are safe to use.
-
-A block can only have one title, and anything that reads as a title but isn't a quoted `title="…"` attribute — an
-unquoted value, an unclosed quote, or a space around the `=` — is reported as an error instead of being guessed at.
+The title is escaped when rendered, so any characters other than the enclosing quote are safe to use. A title that is
+unquoted, or that never closes its quote, is reported as an error instead of being guessed at.
 
 ### Symfony Console formatting
 
@@ -190,8 +188,8 @@ theme:
 The formatter only recognizes these four tags. All other terminal content, including HTML, is escaped and displayed
 as text. Without the `xml` modifier, the formatter tags are also displayed as ordinary terminal output.
 
-Modifiers can be combined in any order, as long as they are separated by whitespace, so
-`terminal xml title="Build output"` and `terminal title="Build output" xml` are the same thing.
+Modifiers can be combined in any order, so `terminal xml title="Build output"` and `terminal title="Build output" xml`
+are the same thing.
 
 The terminal markup provides stable styling hooks for customization. Use `hyde-terminal-body` to change the output
 area's default text and background colors, and `hyde-terminal` to style the outer container. The

--- a/docs/digging-deeper/advanced-markdown.md
+++ b/docs/digging-deeper/advanced-markdown.md
@@ -144,6 +144,26 @@ $ php hyde publish
 Lines beginning with a `$ ` prompt are highlighted as commands. The prompt is excluded from text selection, so you
 can select and copy the command without including it.
 
+### Window titles
+
+Add the `title` modifier to replace the default `Terminal` label in the window's title bar:
+
+````markdown
+```terminal title="Installing Hyde"
+$ composer require hyde/framework
+```
+````
+
+Which renders as:
+
+```terminal title="Installing Hyde"
+$ composer require hyde/framework
+```
+
+Double quotes are canonical, but single quotes work just as well, which helps when the title contains a double quote.
+The title is escaped when rendered, so any characters other than the enclosing quote are safe to use. A title that is
+unquoted, or that never closes its quote, is reported as an error instead of being guessed at.
+
 ### Symfony Console formatting
 
 Add the `xml` modifier to style four commonly used Symfony Console formatter tags using colors from Hyde's terminal
@@ -167,6 +187,9 @@ theme:
 
 The formatter only recognizes these four tags. All other terminal content, including HTML, is escaped and displayed
 as text. Without the `xml` modifier, the formatter tags are also displayed as ordinary terminal output.
+
+Modifiers can be combined in any order, so `terminal xml title="Build output"` and `terminal title="Build output" xml`
+are the same thing.
 
 The terminal markup provides stable styling hooks for customization. Use `hyde-terminal-body` to change the output
 area's default text and background colors, and `hyde-terminal` to style the outer container. The

--- a/docs/digging-deeper/advanced-markdown.md
+++ b/docs/digging-deeper/advanced-markdown.md
@@ -160,10 +160,11 @@ Which renders as:
 $ composer require hyde/framework
 ```
 
-Double quotes are canonical, but single quotes work just as well, which helps when the title contains a double quote.
-The title is escaped when rendered, so any characters other than the enclosing quote are safe to use. A title that
-isn't a quoted value — unquoted, never closing its quote, or spaced around the `=` — is reported as an error instead
-of being guessed at.
+Double quotes are canonical, but single quotes are also accepted, which is useful when the title contains a double
+quote. The title is HTML-escaped when rendered.
+
+The `title` modifier must use a quoted value with no whitespace around the `=`, such as `title="Build output"`.
+Unquoted values, unclosed quotes, and whitespace around the `=` are reported as errors instead of being guessed at.
 
 ### Symfony Console formatting
 

--- a/docs/digging-deeper/advanced-markdown.md
+++ b/docs/digging-deeper/advanced-markdown.md
@@ -161,8 +161,9 @@ $ composer require hyde/framework
 ```
 
 Double quotes are canonical, but single quotes work just as well, which helps when the title contains a double quote.
-The title is escaped when rendered, so any characters other than the enclosing quote are safe to use. A title that is
-unquoted, or that never closes its quote, is reported as an error instead of being guessed at.
+The title is escaped when rendered, so any characters other than the enclosing quote are safe to use. A title that
+isn't a quoted value — unquoted, never closing its quote, or spaced around the `=` — is reported as an error instead
+of being guessed at.
 
 ### Symfony Console formatting
 

--- a/docs/digging-deeper/advanced-markdown.md
+++ b/docs/digging-deeper/advanced-markdown.md
@@ -161,8 +161,10 @@ $ composer require hyde/framework
 ```
 
 Double quotes are canonical, but single quotes work just as well, which helps when the title contains a double quote.
-The title is escaped when rendered, so any characters other than the enclosing quote are safe to use. A title that is
-unquoted, or that never closes its quote, is reported as an error instead of being guessed at.
+The title is escaped when rendered, so any characters other than the enclosing quote are safe to use.
+
+A block can only have one title, and anything that reads as a title but isn't a quoted `title="…"` attribute — an
+unquoted value, an unclosed quote, or a space around the `=` — is reported as an error instead of being guessed at.
 
 ### Symfony Console formatting
 
@@ -188,8 +190,8 @@ theme:
 The formatter only recognizes these four tags. All other terminal content, including HTML, is escaped and displayed
 as text. Without the `xml` modifier, the formatter tags are also displayed as ordinary terminal output.
 
-Modifiers can be combined in any order, so `terminal xml title="Build output"` and `terminal title="Build output" xml`
-are the same thing.
+Modifiers can be combined in any order, as long as they are separated by whitespace, so
+`terminal xml title="Build output"` and `terminal title="Build output" xml` are the same thing.
 
 The terminal markup provides stable styling hooks for customization. Use `hyde-terminal-body` to change the output
 area's default text and background colors, and `hyde-terminal` to style the outer container. The

--- a/docs/digging-deeper/composable-markdown-blocks.md
+++ b/docs/digging-deeper/composable-markdown-blocks.md
@@ -199,8 +199,9 @@ an equivalent alternative, which is useful when the title itself contains a doub
 is rendered, so it is safe to use any characters in it, apart from the quote character enclosing it.
 
 An empty title (`title=""`) is respected as written, leaving the title bar with just the window buttons. A `title`
-value that is unquoted, or that never closes its quote, is rejected with an exception instead of being guessed at, so
-that a typo surfaces during the build rather than silently dropping the title.
+that isn't a quoted value — unquoted, never closing its quote, or spaced around the `=` — is rejected with an
+exception instead of being guessed at, so that a typo surfaces during the build rather than silently dropping the
+title.
 
 #### Symfony formatting
 

--- a/docs/digging-deeper/composable-markdown-blocks.md
+++ b/docs/digging-deeper/composable-markdown-blocks.md
@@ -194,14 +194,12 @@ $ composer require hyde/framework
 $ composer require hyde/framework
 ```
 
-Double quotes are canonical, matching how attributes are written in HTML and Blade, but single quotes are accepted as
-an equivalent alternative, which is useful when the title itself contains a double quote. The title is escaped when it
-is rendered, so it is safe to use any characters in it, apart from the quote character enclosing it.
+Double quotes are canonical, matching how attributes are written in HTML and Blade, but single quotes are also
+accepted, which is useful when the title contains a double quote. The title is HTML-escaped when rendered.
 
-An empty title (`title=""`) is respected as written, leaving the title bar with just the window buttons. A `title`
-that isn't a quoted value — unquoted, never closing its quote, or spaced around the `=` — is rejected with an
-exception instead of being guessed at, so that a typo surfaces during the build rather than silently dropping the
-title.
+An empty title (`title=""`) is respected as written, leaving the title bar with only the window controls. The `title`
+modifier must otherwise use a quoted value with no whitespace around the `=`. Malformed title syntax causes the build
+to fail rather than being silently ignored.
 
 #### Symfony formatting
 

--- a/docs/digging-deeper/composable-markdown-blocks.md
+++ b/docs/digging-deeper/composable-markdown-blocks.md
@@ -198,14 +198,9 @@ Double quotes are canonical, matching how attributes are written in HTML and Bla
 an equivalent alternative, which is useful when the title itself contains a double quote. The title is escaped when it
 is rendered, so it is safe to use any characters in it, apart from the quote character enclosing it.
 
-An empty title (`title=""`) is respected as written, leaving the title bar with just the window buttons. A block can
-only carry one title, and modifiers have to be separated by whitespace, so `title="One" title="Two"` and
-`title="One"xml` are both errors rather than a guess at what was meant.
-
-Anything else that reads as a title but isn't a quoted `title="…"` attribute — an unquoted value, a quote that is
-never closed, or a space around the `=` — is rejected with an exception, so that a typo surfaces during the build
-rather than silently dropping the title. Unknown modifiers are still ignored, since a modifier added in a future
-version should not break a page rendered by an older one.
+An empty title (`title=""`) is respected as written, leaving the title bar with just the window buttons. A `title`
+value that is unquoted, or that never closes its quote, is rejected with an exception instead of being guessed at, so
+that a typo surfaces during the build rather than silently dropping the title.
 
 #### Symfony formatting
 

--- a/docs/digging-deeper/composable-markdown-blocks.md
+++ b/docs/digging-deeper/composable-markdown-blocks.md
@@ -198,9 +198,14 @@ Double quotes are canonical, matching how attributes are written in HTML and Bla
 an equivalent alternative, which is useful when the title itself contains a double quote. The title is escaped when it
 is rendered, so it is safe to use any characters in it, apart from the quote character enclosing it.
 
-An empty title (`title=""`) is respected as written, leaving the title bar with just the window buttons. A `title`
-value that is unquoted, or that never closes its quote, is rejected with an exception instead of being guessed at, so
-that a typo surfaces during the build rather than silently dropping the title.
+An empty title (`title=""`) is respected as written, leaving the title bar with just the window buttons. A block can
+only carry one title, and modifiers have to be separated by whitespace, so `title="One" title="Two"` and
+`title="One"xml` are both errors rather than a guess at what was meant.
+
+Anything else that reads as a title but isn't a quoted `title="…"` attribute — an unquoted value, a quote that is
+never closed, or a space around the `=` — is rejected with an exception, so that a typo surfaces during the build
+rather than silently dropping the title. Unknown modifiers are still ignored, since a modifier added in a future
+version should not break a page rendered by an older one.
 
 #### Symfony formatting
 

--- a/docs/digging-deeper/composable-markdown-blocks.md
+++ b/docs/digging-deeper/composable-markdown-blocks.md
@@ -212,7 +212,7 @@ view and edit it:
             <span class="size-2.5 rounded-full bg-[#FEBC2E]"></span>
             <span class="size-2.5 rounded-full bg-[#28C840]"></span>
         </span>
-        <span>~/my-project</span>
+        <span>{{ $title ?? '~/my-project' }}</span>
     </figcaption>
     <pre class="hyde-terminal-body m-0 overflow-x-auto rounded-none bg-[#292D3E] p-4 text-[#A6ACCD]"><code class="block whitespace-pre font-mono text-sm leading-relaxed">{!! $contents !!}</code></pre>
 </figure>

--- a/docs/digging-deeper/composable-markdown-blocks.md
+++ b/docs/digging-deeper/composable-markdown-blocks.md
@@ -169,17 +169,72 @@ $ php hyde build
 
 Terminal blocks are a built-in Markdown feature and do not require a Torchlight API token.
 
+### Modifiers
+
+The language can be followed by optional modifiers:
+
+```
+terminal [xml] [title="…"]
+```
+
+Modifiers are order-independent, so `terminal xml title="Build output"` and `terminal title="Build output" xml` mean
+the same thing.
+
+#### Window titles
+
+The `title` modifier replaces the `Terminal` label in the window's title bar.
+
+````markdown
+```terminal title="Installing Hyde"
+$ composer require hyde/framework
+```
+````
+
+```terminal title="Installing Hyde"
+$ composer require hyde/framework
+```
+
+Double quotes are canonical, matching how attributes are written in HTML and Blade, but single quotes are accepted as
+an equivalent alternative, which is useful when the title itself contains a double quote. The title is escaped when it
+is rendered, so it is safe to use any characters in it, apart from the quote character enclosing it.
+
+An empty title (`title=""`) is respected as written, leaving the title bar with just the window buttons. A `title`
+value that is unquoted, or that never closes its quote, is rejected with an exception instead of being guessed at, so
+that a typo surfaces during the build rather than silently dropping the title.
+
+#### Symfony formatting
+
+The `xml` modifier renders the four [Symfony Console formatter tags](https://symfony.com/doc/current/console/coloring.html)
+(`<info>`, `<comment>`, `<question>`, and `<error>`) as coloured output, letting you paste console output verbatim.
+
+````markdown
+```terminal xml title="Build output"
+<info>Hyde was installed successfully.</info>
+```
+````
+
+```terminal xml title="Build output"
+<info>Hyde was installed successfully.</info>
+```
+
+Tags are only interpreted with the modifier present; without it, they stay literal text. Everything else is escaped as
+usual, including unknown tags and tags that are not closed in the order they were opened.
+
 ### View contract
 
 **View:** `hyde::components.markdown.terminal`
 
-| Variable    | Type     | Description                                                                    |
-|-------------|----------|--------------------------------------------------------------------------------|
-| `$contents` | `string` | The pre-rendered, already-escaped HTML for the terminal body. Echo with `{!! !!}`. |
+| Variable    | Type            | Description                                                                    |
+|-------------|-----------------|--------------------------------------------------------------------------------|
+| `$contents` | `string`        | The pre-rendered, already-escaped HTML for the terminal body. Echo with `{!! !!}`. |
+| `$title`    | `string`/`null` | The title set by the block, or `null` when it did not set one.                  |
 
 The renderer does the per-line work before the view is involved: it escapes the raw text, wraps `$ ` prompts in
 `hyde-terminal-command`/`hyde-terminal-prompt` spans, and — when the `xml` modifier is present — converts Symfony
 Console formatter tags into coloured spans. The view receives a single finished string.
+
+The title is passed through as it was written, so the view is what decides both how it is displayed and what an
+untitled block falls back to. The shipped view escapes it with `{{ }}` and falls back to `Terminal`.
 
 >danger `$contents` is already escaped by the renderer, which is why the view echoes it unescaped. If you build your own view, do not re-escape it with `{{ }}` (you will see markup as text), and do not pass unescaped user content into it from elsewhere.
 
@@ -200,8 +255,8 @@ Console formatter tags into coloured spans. The view receives a single finished 
 
 ### Customization example
 
-Say you want the window's title bar to show the current working directory instead of the word "Terminal". Publish the
-view and edit it:
+Say you want blocks that set no title of their own to show the current working directory instead of the word
+"Terminal". Publish the view and edit its fallback:
 
 ```blade
 <!-- filepath: resources/views/vendor/hyde/components/markdown/terminal.blade.php -->

--- a/packages/framework/resources/views/components/markdown/terminal.blade.php
+++ b/packages/framework/resources/views/components/markdown/terminal.blade.php
@@ -5,7 +5,7 @@
             <span class="size-2.5 rounded-full bg-[#FEBC2E]"></span>
             <span class="size-2.5 rounded-full bg-[#28C840]"></span>
         </span>
-        <span>Terminal</span>
+        <span>{{ $title ?? 'Terminal' }}</span>
     </figcaption>
     <pre class="hyde-terminal-body m-0 overflow-x-auto rounded-none bg-[#292D3E] p-4 text-[#A6ACCD]"><code class="block whitespace-pre font-mono text-sm leading-relaxed">{!! $contents !!}</code></pre>
 </figure>

--- a/packages/framework/src/Markdown/Extensions/Nodes/TerminalBlock.php
+++ b/packages/framework/src/Markdown/Extensions/Nodes/TerminalBlock.php
@@ -12,6 +12,7 @@ class TerminalBlock extends AbstractBlock
     public function __construct(
         public readonly string $literal,
         public readonly bool $usesSymfonyFormatting = false,
+        public readonly ?string $title = null,
     ) {
         parent::__construct();
     }

--- a/packages/framework/src/Markdown/Extensions/Processing/TerminalBlockRenderer.php
+++ b/packages/framework/src/Markdown/Extensions/Processing/TerminalBlockRenderer.php
@@ -34,6 +34,7 @@ class TerminalBlockRenderer implements NodeRendererInterface
 
         return view('hyde::components.markdown.terminal', [
             'contents' => $this->renderContents($node),
+            'title' => $node->title,
         ])->render();
     }
 

--- a/packages/framework/src/Markdown/Extensions/Processing/TransformTerminalBlocks.php
+++ b/packages/framework/src/Markdown/Extensions/Processing/TransformTerminalBlocks.php
@@ -97,8 +97,11 @@ class TransformTerminalBlocks
         $tokens = [];
         $cursor = 0;
 
-        // Each match is anchored to the cursor, so the walk ends as soon as a token doesn't start there.
-        while (preg_match(static::TOKEN_PATTERN, $info, $matches, PREG_UNMATCHED_AS_NULL, $cursor)) {
+        while ($cursor < strlen($info)) {
+            if (! preg_match(static::TOKEN_PATTERN, $info, $matches, PREG_UNMATCHED_AS_NULL, $cursor)) {
+                break; // Nothing but trailing whitespace is left.
+            }
+
             $tokens[] = $matches;
             $cursor += strlen($matches[0]);
         }

--- a/packages/framework/src/Markdown/Extensions/Processing/TransformTerminalBlocks.php
+++ b/packages/framework/src/Markdown/Extensions/Processing/TransformTerminalBlocks.php
@@ -97,11 +97,8 @@ class TransformTerminalBlocks
         $tokens = [];
         $cursor = 0;
 
-        while ($cursor < strlen($info)) {
-            if (! preg_match(static::TOKEN_PATTERN, $info, $matches, PREG_UNMATCHED_AS_NULL, $cursor)) {
-                break; // Nothing but trailing whitespace is left.
-            }
-
+        // Each match is anchored to the cursor, so the walk ends as soon as a token doesn't start there.
+        while (preg_match(static::TOKEN_PATTERN, $info, $matches, PREG_UNMATCHED_AS_NULL, $cursor)) {
             $tokens[] = $matches;
             $cursor += strlen($matches[0]);
         }

--- a/packages/framework/src/Markdown/Extensions/Processing/TransformTerminalBlocks.php
+++ b/packages/framework/src/Markdown/Extensions/Processing/TransformTerminalBlocks.php
@@ -10,23 +10,22 @@ use League\CommonMark\Event\DocumentParsedEvent;
 use League\CommonMark\Extension\CommonMark\Node\Block\FencedCode;
 
 use function array_slice;
-use function preg_match;
+use function preg_match_all;
 use function sprintf;
 use function str_starts_with;
-use function strlen;
 use function strtolower;
 
+use const PREG_SET_ORDER;
 use const PREG_UNMATCHED_AS_NULL;
 
 /** @internal */
 class TransformTerminalBlocks
 {
     /**
-     * Matches the next info string token: either an HTML-style attribute with a quoted value
-     * (which may contain spaces), or a bare space-free word. Anchored to the cursor, and
-     * required to end at a token boundary, so that tokens must be separated by whitespace.
+     * Matches one info string token: either an HTML-style attribute with a
+     * quoted value (which may contain spaces), or a bare space-free word.
      */
-    protected const TOKEN_PATTERN = '/\G\s*(?:(?<key>[\w-]+)=(?:"(?<double>[^"]*)"|\'(?<single>[^\']*)\')|(?<word>\S+))(?=\s|$)/';
+    protected const TOKEN_PATTERN = '/(?<key>[\w-]+)=(?:"(?<double>[^"]*)"|\'(?<single>[^\']*)\')|(?<word>\S+)/';
 
     public function __invoke(DocumentParsedEvent $event): void
     {
@@ -54,73 +53,33 @@ class TransformTerminalBlocks
     {
         $usesSymfonyFormatting = false;
         $title = null;
-        $titled = false;
 
-        // The first token is the language, which is what got us here in the first place.
-        foreach (array_slice($this->tokenize($info), 1) as $token) {
-            if ($token['word'] !== null) {
-                if (strtolower($token['word']) === 'xml') {
-                    $usesSymfonyFormatting = true;
+        preg_match_all(static::TOKEN_PATTERN, $info, $matches, PREG_SET_ORDER | PREG_UNMATCHED_AS_NULL);
 
-                    continue;
+        foreach (array_slice($matches, 1) as $token) {
+            if ($token['word'] === null) {
+                if (strtolower($token['key']) === 'title') {
+                    $title = $token['double'] ?? $token['single'];
                 }
 
-                $this->rejectMalformedTitles($token['word']);
-
-                // Any other modifier may mean something in a future version, so it is ignored.
                 continue;
             }
 
-            if (strtolower($token['key']) !== 'title') {
+            if (strtolower($token['word']) === 'xml') {
+                $usesSymfonyFormatting = true;
+
                 continue;
             }
 
-            if ($titled) {
-                throw new InvalidArgumentException('A terminal block can only have one title.');
+            // A modifier we don't know about may mean something in a future version, so it is ignored.
+            // A malformed title, on the other hand, is a typo we should not silently discard.
+            if (str_starts_with(strtolower($token['word']), 'title=')) {
+                throw new InvalidArgumentException(sprintf(
+                    'Invalid terminal block title [%s]. Expected a quoted value, like title="My title".', $token['word']
+                ));
             }
-
-            $title = $token['double'] ?? $token['single'];
-            $titled = true;
         }
 
         return [$usesSymfonyFormatting, $title];
-    }
-
-    /**
-     * Split the info string into its tokens, walking a cursor through it so that each
-     * token has to end where the next one begins, instead of being found anywhere.
-     *
-     * @return array<int, array{key: string|null, double: string|null, single: string|null, word: string|null}>
-     */
-    protected function tokenize(string $info): array
-    {
-        $tokens = [];
-        $cursor = 0;
-
-        while ($cursor < strlen($info)) {
-            if (! preg_match(static::TOKEN_PATTERN, $info, $matches, PREG_UNMATCHED_AS_NULL, $cursor)) {
-                break; // Nothing but trailing whitespace is left.
-            }
-
-            $tokens[] = $matches;
-            $cursor += strlen($matches[0]);
-        }
-
-        return $tokens;
-    }
-
-    /**
-     * A modifier we don't know about is ignored, since it may mean something in a future version.
-     * A title we can't read, on the other hand, is a typo we should not silently discard.
-     */
-    protected function rejectMalformedTitles(string $word): void
-    {
-        $normalized = strtolower($word);
-
-        if ($normalized === 'title' || str_starts_with($normalized, 'title=')) {
-            throw new InvalidArgumentException(sprintf(
-                'Invalid terminal block title [%s]. Expected a quoted value, like title="My title".', $word
-            ));
-        }
     }
 }

--- a/packages/framework/src/Markdown/Extensions/Processing/TransformTerminalBlocks.php
+++ b/packages/framework/src/Markdown/Extensions/Processing/TransformTerminalBlocks.php
@@ -10,22 +10,23 @@ use League\CommonMark\Event\DocumentParsedEvent;
 use League\CommonMark\Extension\CommonMark\Node\Block\FencedCode;
 
 use function array_slice;
-use function preg_match_all;
+use function preg_match;
 use function sprintf;
 use function str_starts_with;
+use function strlen;
 use function strtolower;
 
-use const PREG_SET_ORDER;
 use const PREG_UNMATCHED_AS_NULL;
 
 /** @internal */
 class TransformTerminalBlocks
 {
     /**
-     * Matches one info string token: either an HTML-style attribute with a
-     * quoted value (which may contain spaces), or a bare space-free word.
+     * Matches the next info string token: either an HTML-style attribute with a quoted value
+     * (which may contain spaces), or a bare space-free word. Anchored to the cursor, and
+     * required to end at a token boundary, so that tokens must be separated by whitespace.
      */
-    protected const TOKEN_PATTERN = '/(?<key>[\w-]+)=(?:"(?<double>[^"]*)"|\'(?<single>[^\']*)\')|(?<word>\S+)/';
+    protected const TOKEN_PATTERN = '/\G\s*(?:(?<key>[\w-]+)=(?:"(?<double>[^"]*)"|\'(?<single>[^\']*)\')|(?<word>\S+))(?=\s|$)/';
 
     public function __invoke(DocumentParsedEvent $event): void
     {
@@ -53,33 +54,73 @@ class TransformTerminalBlocks
     {
         $usesSymfonyFormatting = false;
         $title = null;
+        $titled = false;
 
-        preg_match_all(static::TOKEN_PATTERN, $info, $matches, PREG_SET_ORDER | PREG_UNMATCHED_AS_NULL);
+        // The first token is the language, which is what got us here in the first place.
+        foreach (array_slice($this->tokenize($info), 1) as $token) {
+            if ($token['word'] !== null) {
+                if (strtolower($token['word']) === 'xml') {
+                    $usesSymfonyFormatting = true;
 
-        foreach (array_slice($matches, 1) as $token) {
-            if ($token['word'] === null) {
-                if (strtolower($token['key']) === 'title') {
-                    $title = $token['double'] ?? $token['single'];
+                    continue;
                 }
 
+                $this->rejectMalformedTitles($token['word']);
+
+                // Any other modifier may mean something in a future version, so it is ignored.
                 continue;
             }
 
-            if (strtolower($token['word']) === 'xml') {
-                $usesSymfonyFormatting = true;
-
+            if (strtolower($token['key']) !== 'title') {
                 continue;
             }
 
-            // A modifier we don't know about may mean something in a future version, so it is ignored.
-            // A malformed title, on the other hand, is a typo we should not silently discard.
-            if (str_starts_with(strtolower($token['word']), 'title=')) {
-                throw new InvalidArgumentException(sprintf(
-                    'Invalid terminal block title [%s]. Expected a quoted value, like title="My title".', $token['word']
-                ));
+            if ($titled) {
+                throw new InvalidArgumentException('A terminal block can only have one title.');
             }
+
+            $title = $token['double'] ?? $token['single'];
+            $titled = true;
         }
 
         return [$usesSymfonyFormatting, $title];
+    }
+
+    /**
+     * Split the info string into its tokens, walking a cursor through it so that each
+     * token has to end where the next one begins, instead of being found anywhere.
+     *
+     * @return array<int, array{key: string|null, double: string|null, single: string|null, word: string|null}>
+     */
+    protected function tokenize(string $info): array
+    {
+        $tokens = [];
+        $cursor = 0;
+
+        while ($cursor < strlen($info)) {
+            if (! preg_match(static::TOKEN_PATTERN, $info, $matches, PREG_UNMATCHED_AS_NULL, $cursor)) {
+                break; // Nothing but trailing whitespace is left.
+            }
+
+            $tokens[] = $matches;
+            $cursor += strlen($matches[0]);
+        }
+
+        return $tokens;
+    }
+
+    /**
+     * A modifier we don't know about is ignored, since it may mean something in a future version.
+     * A title we can't read, on the other hand, is a typo we should not silently discard.
+     */
+    protected function rejectMalformedTitles(string $word): void
+    {
+        $normalized = strtolower($word);
+
+        if ($normalized === 'title' || str_starts_with($normalized, 'title=')) {
+            throw new InvalidArgumentException(sprintf(
+                'Invalid terminal block title [%s]. Expected a quoted value, like title="My title".', $word
+            ));
+        }
     }
 }

--- a/packages/framework/src/Markdown/Extensions/Processing/TransformTerminalBlocks.php
+++ b/packages/framework/src/Markdown/Extensions/Processing/TransformTerminalBlocks.php
@@ -22,10 +22,11 @@ use const PREG_UNMATCHED_AS_NULL;
 class TransformTerminalBlocks
 {
     /**
-     * Matches one info string token: either an HTML-style attribute with a
-     * quoted value (which may contain spaces), or a bare space-free word.
+     * Matches one info string token: either an HTML-style attribute with a quoted value
+     * (which may contain spaces), or a bare space-free word. The surrounding assertions
+     * keep a token from being found inside another one, as modifiers are whitespace separated.
      */
-    protected const TOKEN_PATTERN = '/(?<key>[\w-]+)=(?:"(?<double>[^"]*)"|\'(?<single>[^\']*)\')|(?<word>\S+)/';
+    protected const TOKEN_PATTERN = '/(?<!\S)(?:(?<key>[\w-]+)=(?:"(?<double>[^"]*)"|\'(?<single>[^\']*)\')|(?<word>\S+))(?=\s|$)/';
 
     public function __invoke(DocumentParsedEvent $event): void
     {
@@ -65,7 +66,9 @@ class TransformTerminalBlocks
                 continue;
             }
 
-            if (strtolower($token['word']) === 'xml') {
+            $word = strtolower($token['word']);
+
+            if ($word === 'xml') {
                 $usesSymfonyFormatting = true;
 
                 continue;
@@ -73,7 +76,7 @@ class TransformTerminalBlocks
 
             // A modifier we don't know about may mean something in a future version, so it is ignored.
             // A malformed title, on the other hand, is a typo we should not silently discard.
-            if (str_starts_with(strtolower($token['word']), 'title=')) {
+            if ($word === 'title' || str_starts_with($word, 'title=')) {
                 throw new InvalidArgumentException(sprintf(
                     'Invalid terminal block title [%s]. Expected a quoted value, like title="My title".', $token['word']
                 ));

--- a/packages/framework/src/Markdown/Extensions/Processing/TransformTerminalBlocks.php
+++ b/packages/framework/src/Markdown/Extensions/Processing/TransformTerminalBlocks.php
@@ -5,17 +5,28 @@ declare(strict_types=1);
 namespace Hyde\Markdown\Extensions\Processing;
 
 use Hyde\Markdown\Extensions\Nodes\TerminalBlock;
+use InvalidArgumentException;
 use League\CommonMark\Event\DocumentParsedEvent;
 use League\CommonMark\Extension\CommonMark\Node\Block\FencedCode;
 
-use function array_map;
 use function array_slice;
-use function in_array;
+use function preg_match_all;
+use function sprintf;
+use function str_starts_with;
 use function strtolower;
+
+use const PREG_SET_ORDER;
+use const PREG_UNMATCHED_AS_NULL;
 
 /** @internal */
 class TransformTerminalBlocks
 {
+    /**
+     * Matches one info string token: either an HTML-style attribute with a
+     * quoted value (which may contain spaces), or a bare space-free word.
+     */
+    protected const TOKEN_PATTERN = '/(?<key>[\w-]+)=(?:"(?<double>[^"]*)"|\'(?<single>[^\']*)\')|(?<word>\S+)/';
+
     public function __invoke(DocumentParsedEvent $event): void
     {
         $terminalBlocks = [];
@@ -27,12 +38,48 @@ class TransformTerminalBlocks
         }
 
         foreach ($terminalBlocks as $node) {
-            $info = array_map('strtolower', $node->getInfoWords());
+            [$usesSymfonyFormatting, $title] = $this->parseModifiers($node->getInfo() ?? '');
 
-            $node->replaceWith(new TerminalBlock(
-                $node->getLiteral(),
-                in_array('xml', array_slice($info, 1), true),
-            ));
+            $node->replaceWith(new TerminalBlock($node->getLiteral(), $usesSymfonyFormatting, $title));
         }
+    }
+
+    /**
+     * Parse the modifiers following the language, which are order-independent.
+     *
+     * @return array{0: bool, 1: string|null} Whether Symfony formatting is used, and the window title.
+     */
+    protected function parseModifiers(string $info): array
+    {
+        $usesSymfonyFormatting = false;
+        $title = null;
+
+        preg_match_all(static::TOKEN_PATTERN, $info, $matches, PREG_SET_ORDER | PREG_UNMATCHED_AS_NULL);
+
+        foreach (array_slice($matches, 1) as $token) {
+            if ($token['word'] === null) {
+                if (strtolower($token['key']) === 'title') {
+                    $title = $token['double'] ?? $token['single'];
+                }
+
+                continue;
+            }
+
+            if (strtolower($token['word']) === 'xml') {
+                $usesSymfonyFormatting = true;
+
+                continue;
+            }
+
+            // A modifier we don't know about may mean something in a future version, so it is ignored.
+            // A malformed title, on the other hand, is a typo we should not silently discard.
+            if (str_starts_with(strtolower($token['word']), 'title=')) {
+                throw new InvalidArgumentException(sprintf(
+                    'Invalid terminal block title [%s]. Expected a quoted value, like title="My title".', $token['word']
+                ));
+            }
+        }
+
+        return [$usesSymfonyFormatting, $title];
     }
 }

--- a/packages/framework/src/Markdown/Extensions/Processing/TransformTerminalBlocks.php
+++ b/packages/framework/src/Markdown/Extensions/Processing/TransformTerminalBlocks.php
@@ -78,7 +78,7 @@ class TransformTerminalBlocks
             // A malformed title, on the other hand, is a typo we should not silently discard.
             if ($word === 'title' || str_starts_with($word, 'title=')) {
                 throw new InvalidArgumentException(sprintf(
-                    'Invalid terminal block title [%s]. Expected a quoted value, like title="My title".', $token['word']
+                    'Invalid terminal block title [%s]. Expected syntax like title="My title".', $token['word']
                 ));
             }
         }

--- a/packages/framework/tests/Feature/Documentation/ComposableMarkdownBlocksDocumentationTest.php
+++ b/packages/framework/tests/Feature/Documentation/ComposableMarkdownBlocksDocumentationTest.php
@@ -594,11 +594,9 @@ class ComposableMarkdownBlocksDocumentationTest extends TestCase
         $this->assertStringContainsString('<span class="hyde-terminal-controls ', $html);
     }
 
-    public function testAnythingThatReadsAsATitleButIsNotAQuotedAttributeIsRejectedInsteadOfBeingGuessedAt()
+    public function testAnUnquotedOrUnclosedTitleIsRejectedInsteadOfBeingGuessedAt()
     {
-        $malformed = ['title=Build', 'title="Build output', "title='Build output", 'title = "Build"', 'title'];
-
-        foreach ($malformed as $modifier) {
+        foreach (['title=Build', 'title="Build output', "title='Build output"] as $modifier) {
             try {
                 Markdown::render("```terminal $modifier\nDone!\n```");
 
@@ -606,29 +604,6 @@ class ComposableMarkdownBlocksDocumentationTest extends TestCase
             } catch (InvalidArgumentException $exception) {
                 $this->assertStringContainsString('Invalid terminal block title', $exception->getMessage());
             }
-        }
-
-        // While an unknown modifier is still ignored, so that a future one does not break an older renderer
-        $this->assertStringContainsString('<span>Terminal</span>', Markdown::render("```terminal future\nDone!\n```"));
-        $this->assertStringContainsString('<span>Terminal</span>', Markdown::render("```terminal future=\"yes\"\nDone!\n```"));
-    }
-
-    public function testABlockCanOnlyCarryOneTitleAndModifiersHaveToBeSeparatedByWhitespace()
-    {
-        try {
-            Markdown::render("```terminal title=\"One\" title=\"Two\"\nDone!\n```");
-
-            $this->fail('A block with two titles was not rejected.');
-        } catch (InvalidArgumentException $exception) {
-            $this->assertSame('A terminal block can only have one title.', $exception->getMessage());
-        }
-
-        try {
-            Markdown::render("```terminal title=\"One\"xml\nDone!\n```");
-
-            $this->fail('A title running into the next modifier was not rejected.');
-        } catch (InvalidArgumentException $exception) {
-            $this->assertStringContainsString('Invalid terminal block title', $exception->getMessage());
         }
     }
 

--- a/packages/framework/tests/Feature/Documentation/ComposableMarkdownBlocksDocumentationTest.php
+++ b/packages/framework/tests/Feature/Documentation/ComposableMarkdownBlocksDocumentationTest.php
@@ -594,9 +594,9 @@ class ComposableMarkdownBlocksDocumentationTest extends TestCase
         $this->assertStringContainsString('<span class="hyde-terminal-controls ', $html);
     }
 
-    public function testAnUnquotedOrUnclosedTitleIsRejectedInsteadOfBeingGuessedAt()
+    public function testATitleThatIsNotAQuotedValueIsRejectedInsteadOfBeingGuessedAt()
     {
-        foreach (['title=Build', 'title="Build output', "title='Build output"] as $modifier) {
+        foreach (['title=Build', 'title="Build output', "title='Build output", 'title', 'title = "Build"'] as $modifier) {
             try {
                 Markdown::render("```terminal $modifier\nDone!\n```");
 

--- a/packages/framework/tests/Feature/Documentation/ComposableMarkdownBlocksDocumentationTest.php
+++ b/packages/framework/tests/Feature/Documentation/ComposableMarkdownBlocksDocumentationTest.php
@@ -536,6 +536,93 @@ class ComposableMarkdownBlocksDocumentationTest extends TestCase
 
         // Without the modifier the tags are just escaped text
         $this->assertStringContainsString('&lt;info&gt;Info&lt;/info&gt;', Markdown::render("```terminal\n<info>Info</info>\n```"));
+
+        // Everything else is escaped as usual, including unknown tags and tags closed out of order
+        $html = Markdown::render("```terminal xml\n<unknown>Text</unknown> <info>Info</comment>\n```");
+
+        $this->assertStringContainsString('&lt;unknown&gt;Text&lt;/unknown&gt;', $html);
+        $this->assertStringContainsString('<span class="hyde-terminal-info text-[#C3E88D]">Info&lt;/comment&gt;</span>', $html);
+    }
+
+    public function testTheTitleModifierReplacesTheDefaultLabelInTheWindowTitleBar()
+    {
+        $html = Markdown::render("```terminal title=\"Installing Hyde\"\n\$ composer require hyde/framework\n```");
+
+        $this->assertStringContainsString('<span>Installing Hyde</span>', $html);
+        $this->assertStringNotContainsString('<span>Terminal</span>', $html);
+
+        // The label is only replaced for the blocks that set a title
+        $this->assertStringContainsString('<span>Terminal</span>', Markdown::render("```terminal\n\$ php hyde build\n```"));
+    }
+
+    public function testModifiersAreOrderIndependent()
+    {
+        foreach (['xml title="Build output"', 'title="Build output" xml'] as $modifiers) {
+            $html = Markdown::render("```terminal $modifiers\n<info>Hyde was installed successfully.</info>\n```");
+
+            $this->assertStringContainsString('<span>Build output</span>', $html, "The modifiers [$modifiers] did not set the title.");
+            $this->assertStringContainsString('<span class="hyde-terminal-info', $html, "The modifiers [$modifiers] did not enable Symfony formatting.");
+        }
+    }
+
+    public function testSingleQuotedTitlesAreAcceptedAsAnEquivalentAlternative()
+    {
+        $this->assertStringContainsString('<span>Build output</span>', Markdown::render("```terminal title='Build output'\nDone!\n```"));
+
+        // Which is useful when the title itself contains a double quote
+        $this->assertStringContainsString('<span>The &quot;build&quot; command</span>',
+            Markdown::render("```terminal title='The \"build\" command'\nDone!\n```")
+        );
+    }
+
+    public function testTheTitleIsEscapedWhenItIsRendered()
+    {
+        $html = Markdown::render("```terminal title=\"<script>alert(1)</script> & 'more'\"\nDone!\n```");
+
+        $this->assertStringNotContainsString('<script>', $html);
+        $this->assertStringContainsString('&lt;script&gt;alert(1)&lt;/script&gt; &amp; &#039;more&#039;', $html);
+    }
+
+    public function testAnEmptyTitleIsRespectedAsWritten()
+    {
+        $html = Markdown::render("```terminal title=\"\"\nDone!\n```");
+
+        $this->assertStringContainsString('<span></span>', $html);
+        $this->assertStringNotContainsString('<span>Terminal</span>', $html);
+
+        // The window buttons are still there
+        $this->assertStringContainsString('<span class="hyde-terminal-controls ', $html);
+    }
+
+    public function testAnUnquotedOrUnclosedTitleIsRejectedInsteadOfBeingGuessedAt()
+    {
+        foreach (['title=Build', 'title="Build output', "title='Build output"] as $modifier) {
+            try {
+                Markdown::render("```terminal $modifier\nDone!\n```");
+
+                $this->fail("The malformed title [$modifier] was not rejected.");
+            } catch (InvalidArgumentException $exception) {
+                $this->assertStringContainsString('Invalid terminal block title', $exception->getMessage());
+            }
+        }
+    }
+
+    public function testTheTerminalViewReceivesTheTitleAsItWasWrittenOrNull()
+    {
+        $this->publishView('vendor/hyde/components/markdown/terminal.blade.php', '[title={{ $title }}][type={{ gettype($title) }}]');
+
+        $this->assertStringContainsString('[title=Build output][type=string]', Markdown::render("```terminal title=\"Build output\"\nDone!\n```"));
+        $this->assertStringContainsString('[title=][type=NULL]', Markdown::render("```terminal\nDone!\n```"));
+    }
+
+    public function testTheShippedViewIsWhatFallsBackToTheDefaultTitle()
+    {
+        $this->assertStringContainsString("{{ \$title ?? 'Terminal' }}", $this->frameworkViewContents('markdown/terminal.blade.php'));
+
+        // So a view that does not implement the fallback simply renders nothing for an untitled block
+        $this->publishView('vendor/hyde/components/markdown/terminal.blade.php', '[title={{ $title }}]');
+
+        $this->assertStringContainsString('[title=]', Markdown::render("```terminal\nDone!\n```"));
     }
 
     public function testEveryDocumentedTerminalClassHookTargetsTheDocumentedElement()

--- a/packages/framework/tests/Feature/Documentation/ComposableMarkdownBlocksDocumentationTest.php
+++ b/packages/framework/tests/Feature/Documentation/ComposableMarkdownBlocksDocumentationTest.php
@@ -1027,7 +1027,7 @@ class ComposableMarkdownBlocksDocumentationTest extends TestCase
     public function testTheBuiltInBlocksPassDataRatherThanMarkupToTheirViews()
     {
         // The blocks give the view their type, level, or path, rather than a pre-baked class string
-        $this->assertSame(['literal', 'usesSymfonyFormatting'], $this->constructorParameters(TerminalBlock::class));
+        $this->assertSame(['literal', 'usesSymfonyFormatting', 'title'], $this->constructorParameters(TerminalBlock::class));
 
         $this->publishView('vendor/hyde/components/colored-blockquote.blade.php', '{{ $class }}');
         $this->publishView('vendor/hyde/components/markdown-heading.blade.php', '{{ $level }}');

--- a/packages/framework/tests/Feature/Documentation/ComposableMarkdownBlocksDocumentationTest.php
+++ b/packages/framework/tests/Feature/Documentation/ComposableMarkdownBlocksDocumentationTest.php
@@ -594,9 +594,11 @@ class ComposableMarkdownBlocksDocumentationTest extends TestCase
         $this->assertStringContainsString('<span class="hyde-terminal-controls ', $html);
     }
 
-    public function testAnUnquotedOrUnclosedTitleIsRejectedInsteadOfBeingGuessedAt()
+    public function testAnythingThatReadsAsATitleButIsNotAQuotedAttributeIsRejectedInsteadOfBeingGuessedAt()
     {
-        foreach (['title=Build', 'title="Build output', "title='Build output"] as $modifier) {
+        $malformed = ['title=Build', 'title="Build output', "title='Build output", 'title = "Build"', 'title'];
+
+        foreach ($malformed as $modifier) {
             try {
                 Markdown::render("```terminal $modifier\nDone!\n```");
 
@@ -604,6 +606,29 @@ class ComposableMarkdownBlocksDocumentationTest extends TestCase
             } catch (InvalidArgumentException $exception) {
                 $this->assertStringContainsString('Invalid terminal block title', $exception->getMessage());
             }
+        }
+
+        // While an unknown modifier is still ignored, so that a future one does not break an older renderer
+        $this->assertStringContainsString('<span>Terminal</span>', Markdown::render("```terminal future\nDone!\n```"));
+        $this->assertStringContainsString('<span>Terminal</span>', Markdown::render("```terminal future=\"yes\"\nDone!\n```"));
+    }
+
+    public function testABlockCanOnlyCarryOneTitleAndModifiersHaveToBeSeparatedByWhitespace()
+    {
+        try {
+            Markdown::render("```terminal title=\"One\" title=\"Two\"\nDone!\n```");
+
+            $this->fail('A block with two titles was not rejected.');
+        } catch (InvalidArgumentException $exception) {
+            $this->assertSame('A terminal block can only have one title.', $exception->getMessage());
+        }
+
+        try {
+            Markdown::render("```terminal title=\"One\"xml\nDone!\n```");
+
+            $this->fail('A title running into the next modifier was not rejected.');
+        } catch (InvalidArgumentException $exception) {
+            $this->assertStringContainsString('Invalid terminal block title', $exception->getMessage());
         }
     }
 

--- a/packages/framework/tests/Feature/TerminalCodeBlocksTest.php
+++ b/packages/framework/tests/Feature/TerminalCodeBlocksTest.php
@@ -212,7 +212,7 @@ class TerminalCodeBlocksTest extends TestCase
                 $this->fail("The malformed title [$modifier] was not rejected.");
             } catch (InvalidArgumentException $exception) {
                 $this->assertStringContainsString('Invalid terminal block title', $exception->getMessage());
-                $this->assertStringContainsString('Expected a quoted value, like title="My title".', $exception->getMessage());
+                $this->assertStringContainsString('Expected syntax like title="My title".', $exception->getMessage());
             }
         }
     }

--- a/packages/framework/tests/Feature/TerminalCodeBlocksTest.php
+++ b/packages/framework/tests/Feature/TerminalCodeBlocksTest.php
@@ -112,6 +112,116 @@ class TerminalCodeBlocksTest extends TestCase
         $this->assertStringContainsString('Output', $html);
     }
 
+    public function testUnknownAttributesAreIgnored(): void
+    {
+        $html = Markdown::render("```terminal future=\"maybe\"\nOutput\n```");
+
+        $this->assertStringContainsString('<figure class="hyde-terminal ', $html);
+        $this->assertStringContainsString('<span>Terminal</span>', $html);
+        $this->assertStringContainsString('Output', $html);
+    }
+
+    public function testTerminalWindowUsesTheDefaultTitleWhenNoneIsSet(): void
+    {
+        $html = Markdown::render("```terminal\n\$ php hyde build\n```");
+
+        $this->assertStringContainsString('<span>Terminal</span>', $html);
+    }
+
+    public function testTitleModifierSetsTheTerminalWindowTitle(): void
+    {
+        $html = Markdown::render("```terminal title=\"Installing Hyde\"\n\$ composer require hyde/framework\n```");
+
+        $this->assertStringContainsString('<span>Installing Hyde</span>', $html);
+        $this->assertStringNotContainsString('<span>Terminal</span>', $html);
+        $this->assertStringNotContainsString('title=', $html);
+    }
+
+    public function testTitleModifierAcceptsSingleQuotes(): void
+    {
+        $html = Markdown::render("```terminal title='Build output'\nDone!\n```");
+
+        $this->assertStringContainsString('<span>Build output</span>', $html);
+    }
+
+    public function testTitleMayContainTheOtherQuoteCharacter(): void
+    {
+        $this->assertStringContainsString('<span>It&#039;s building</span>',
+            Markdown::render("```terminal title=\"It's building\"\nDone!\n```")
+        );
+
+        $this->assertStringContainsString('<span>The &quot;build&quot; command</span>',
+            Markdown::render("```terminal title='The \"build\" command'\nDone!\n```")
+        );
+    }
+
+    public function testTitleCasingIsPreserved(): void
+    {
+        $html = Markdown::render("```terminal TITLE=\"Build Output\"\nDone!\n```");
+
+        $this->assertStringContainsString('<span>Build Output</span>', $html);
+    }
+
+    public function testTitleIsEscaped(): void
+    {
+        $html = Markdown::render("```terminal title=\"<script>alert(1)</script>\"\nDone!\n```");
+
+        $this->assertStringNotContainsString('<script>', $html);
+        $this->assertStringContainsString('&lt;script&gt;alert(1)&lt;/script&gt;', $html);
+    }
+
+    public function testAnEmptyTitleRendersAnEmptyLabel(): void
+    {
+        $html = Markdown::render("```terminal title=\"\"\nDone!\n```");
+
+        $this->assertStringContainsString('<span></span>', $html);
+        $this->assertStringNotContainsString('<span>Terminal</span>', $html);
+    }
+
+    public function testModifiersAreOrderIndependent(): void
+    {
+        $expected = ['<span>Build output</span>', '<span class="hyde-terminal-info text-[#C3E88D]">Hyde was installed successfully.</span>'];
+
+        foreach (['xml title="Build output"', 'title="Build output" xml'] as $modifiers) {
+            $html = Markdown::render("```terminal $modifiers\n<info>Hyde was installed successfully.</info>\n```");
+
+            foreach ($expected as $needle) {
+                $this->assertStringContainsString($needle, $html, "The modifiers [$modifiers] did not render as expected.");
+            }
+        }
+    }
+
+    public function testMalformedTitlesAreRejected(): void
+    {
+        $malformed = [
+            'title=Build',
+            'title="Build output',
+            'title=\'Build output',
+            'title="Build\'',
+            'title=',
+            'xml title=Build',
+        ];
+
+        foreach ($malformed as $modifier) {
+            try {
+                Markdown::render("```terminal $modifier\nDone!\n```");
+
+                $this->fail("The malformed title [$modifier] was not rejected.");
+            } catch (InvalidArgumentException $exception) {
+                $this->assertStringContainsString('Invalid terminal block title', $exception->getMessage());
+                $this->assertStringContainsString('Expected a quoted value, like title="My title".', $exception->getMessage());
+            }
+        }
+    }
+
+    public function testTitlesAreOnlyParsedForTerminalBlocks(): void
+    {
+        $html = Markdown::render("```php title=Build\necho 'Hello World!';\n```");
+
+        $this->assertStringNotContainsString('hyde-terminal', $html);
+        $this->assertStringContainsString('<pre><code class="language-php', $html);
+    }
+
     public function testOrdinaryCodeBlocksAreUnaffected(): void
     {
         $html = Markdown::render("```php\n<h1>Hello</h1>\n```");

--- a/packages/framework/tests/Feature/TerminalCodeBlocksTest.php
+++ b/packages/framework/tests/Feature/TerminalCodeBlocksTest.php
@@ -199,12 +199,6 @@ class TerminalCodeBlocksTest extends TestCase
             'title=\'Build output',
             'title="Build\'',
             'title=',
-            'title',
-            'title = "Build"',
-            'title ="Build"',
-            'title= "Build"',
-            'title="Build"xml',
-            'title="Build"future="yes"',
             'xml title=Build',
         ];
 
@@ -218,23 +212,6 @@ class TerminalCodeBlocksTest extends TestCase
                 $this->assertStringContainsString('Expected a quoted value, like title="My title".', $exception->getMessage());
             }
         }
-    }
-
-    public function testModifiersMustBeSeparatedByWhitespace(): void
-    {
-        // A modifier running into the next one is a single token, which is not the modifier it looks like
-        $html = Markdown::render("```terminal xmlfuture=\"yes\"\n<info>Ready</info>\n```");
-
-        $this->assertStringContainsString('&lt;info&gt;Ready&lt;/info&gt;', $html);
-        $this->assertStringNotContainsString('hyde-terminal-info', $html);
-    }
-
-    public function testABlockCanOnlyHaveOneTitle(): void
-    {
-        $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('A terminal block can only have one title.');
-
-        Markdown::render("```terminal title=\"First\" title=\"Second\"\nDone!\n```");
     }
 
     public function testTitlesAreOnlyParsedForTerminalBlocks(): void

--- a/packages/framework/tests/Feature/TerminalCodeBlocksTest.php
+++ b/packages/framework/tests/Feature/TerminalCodeBlocksTest.php
@@ -199,6 +199,9 @@ class TerminalCodeBlocksTest extends TestCase
             'title=\'Build output',
             'title="Build\'',
             'title=',
+            'title',
+            'title = "Build"',
+            'title="Build"xml',
             'xml title=Build',
         ];
 
@@ -212,6 +215,15 @@ class TerminalCodeBlocksTest extends TestCase
                 $this->assertStringContainsString('Expected a quoted value, like title="My title".', $exception->getMessage());
             }
         }
+    }
+
+    public function testModifiersAreNotFoundInsideAnotherToken(): void
+    {
+        // Modifiers are whitespace separated, so this is one unknown token, not two modifiers
+        $html = Markdown::render("```terminal xmlfuture=\"yes\"\n<info>Ready</info>\n```");
+
+        $this->assertStringContainsString('&lt;info&gt;Ready&lt;/info&gt;', $html);
+        $this->assertStringNotContainsString('hyde-terminal-info', $html);
     }
 
     public function testTitlesAreOnlyParsedForTerminalBlocks(): void

--- a/packages/framework/tests/Feature/TerminalCodeBlocksTest.php
+++ b/packages/framework/tests/Feature/TerminalCodeBlocksTest.php
@@ -199,6 +199,12 @@ class TerminalCodeBlocksTest extends TestCase
             'title=\'Build output',
             'title="Build\'',
             'title=',
+            'title',
+            'title = "Build"',
+            'title ="Build"',
+            'title= "Build"',
+            'title="Build"xml',
+            'title="Build"future="yes"',
             'xml title=Build',
         ];
 
@@ -212,6 +218,23 @@ class TerminalCodeBlocksTest extends TestCase
                 $this->assertStringContainsString('Expected a quoted value, like title="My title".', $exception->getMessage());
             }
         }
+    }
+
+    public function testModifiersMustBeSeparatedByWhitespace(): void
+    {
+        // A modifier running into the next one is a single token, which is not the modifier it looks like
+        $html = Markdown::render("```terminal xmlfuture=\"yes\"\n<info>Ready</info>\n```");
+
+        $this->assertStringContainsString('&lt;info&gt;Ready&lt;/info&gt;', $html);
+        $this->assertStringNotContainsString('hyde-terminal-info', $html);
+    }
+
+    public function testABlockCanOnlyHaveOneTitle(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('A terminal block can only have one title.');
+
+        Markdown::render("```terminal title=\"First\" title=\"Second\"\nDone!\n```");
     }
 
     public function testTitlesAreOnlyParsedForTerminalBlocks(): void


### PR DESCRIPTION
Adds an optional title to terminal code blocks, so the window's title bar can describe what the block is showing instead of always reading "Terminal".

````markdown
```terminal title="Installing Hyde"
$ composer require hyde/framework
```
````

Combined with the existing `xml` modifier:

````markdown
```terminal xml title="Build output"
<info>Hyde was installed successfully.</info>
```
````

The info string grammar is now:

```
terminal [xml] [title="…"]
```

Modifiers are order-independent, so `terminal xml title="Build output"` and `terminal title="Build output" xml` are the same thing.

## Why

`title="…"` is the established convention for this exact thing. Docusaurus uses it for titled fenced code blocks, and Expressive Code uses it specifically for terminal window titles, so readers coming from other documentation generators recognize it without being taught. It also fits CommonMark, which treats the first word of the info string as the language and deliberately leaves the rest for implementations to interpret.

Within Hyde it is the same attribute syntax as the Blade Block component directive (#2574), which is what the extensibility argument there anticipated: the title sits next to the existing modifier rather than replacing or reshaping it.

## Quoting rules

Following the component directive: double quotes canonical, single quotes equivalent (useful when the title itself contains a double quote), and unquoted or unterminated values rejected rather than guessed at. Unlike a component name, a title may contain whitespace, which is exactly why it is quoted; the quotes keep the rest of the info string parseable as space-separated tokens.

| Input | Result |
|---|---|
| `terminal title="Build output"` | Canonical |
| `terminal title='Build output'` | Accepted |
| `terminal title='The "build" command'` | Accepted |
| `terminal title=""` | Accepted, renders an empty title bar |
| `terminal title=Build` | Throws |
| `terminal title="Build output` | Throws |

Rejecting a malformed title departs from how the block treats an unknown modifier, which is still ignored so that a modifier added in a future version does not break a page rendered by an older one. The asymmetry is deliberate: `title=Build` is not a modifier this version doesn't know about, it is one it does know about, written wrong, and silently discarding it would leave an author looking at a window still labelled "Terminal" with nothing to explain why.

## View contract

The title is passed to the view verbatim as a nullable string rather than pre-resolved to the default label, so a published view can define its own fallback for untitled blocks:

```blade
<span>{{ $title ?? 'Terminal' }}</span>
```

An explicitly empty title is therefore distinguishable from an omitted one. The documented customization example now edits this fallback instead of hardcoding a label, so per-block titles keep working in a customized view.

## Notes

Terminal blocks have not shipped in a release, so this is additive rather than a breaking change. A published view from earlier in the v3 cycle keeps working untouched; it simply ignores the new variable.

Documented on both the Advanced Markdown syntax reference and the composable blocks masterclass, with every new claim asserted in the documentation driven test. The commits are split so each one stands on its own: the feature with its tests, the documentation, then the planning note recording the rationale.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
