### PR TITLE
[3.x] Remove terminal header window controls

### DIFF
--- a/HYDEPHP_V3_PLANNING.md
+++ b/HYDEPHP_V3_PLANNING.md
@@ -143,8 +143,8 @@ recognized inside a larger malformed token such as `title="One"more`.
 
 The title is passed to the view verbatim as a nullable string rather than pre-resolved to the default label, so that a
 published view can define its own fallback for untitled blocks, which the shipped view demonstrates with
-`{{ $title ?? 'Terminal' }}`. An explicitly empty title is therefore distinguishable from an omitted one, and renders
-without a title bar.
+`{{ $title ?? 'Terminal' }}`. An explicitly empty title is therefore distinguishable from an omitted one, and omits
+the title bar entirely.
 
 ## Terminal formatting tag motivation
 

--- a/HYDEPHP_V3_PLANNING.md
+++ b/HYDEPHP_V3_PLANNING.md
@@ -144,7 +144,7 @@ recognized inside a larger malformed token such as `title="One"more`.
 The title is passed to the view verbatim as a nullable string rather than pre-resolved to the default label, so that a
 published view can define its own fallback for untitled blocks, which the shipped view demonstrates with
 `{{ $title ?? 'Terminal' }}`. An explicitly empty title is therefore distinguishable from an omitted one, and renders
-an empty title bar as written.
+without a title bar.
 
 ## Terminal formatting tag motivation
 

--- a/docs/digging-deeper/advanced-markdown.md
+++ b/docs/digging-deeper/advanced-markdown.md
@@ -145,7 +145,7 @@ can select and copy the command without including it.
 
 ### Window titles
 
-Add the `title` modifier to replace the default `Terminal` label in the window's title bar:
+Without a `title` modifier, the title bar displays `Terminal`. Add the modifier to replace that label:
 
 ````markdown
 ```terminal title="Installing Hyde"
@@ -161,6 +161,8 @@ $ composer require hyde/framework
 
 Double quotes are canonical, but single quotes are also accepted, which is useful when the title contains a double
 quote. The title is HTML-escaped when rendered.
+
+Set `title=""` to omit the title bar entirely.
 
 The `title` modifier must use a quoted value with no whitespace around the `=`, such as `title="Build output"`.
 Unquoted values, unclosed quotes, and whitespace around the `=` are reported as errors instead of being guessed at.

--- a/docs/digging-deeper/composable-markdown-blocks.md
+++ b/docs/digging-deeper/composable-markdown-blocks.md
@@ -238,9 +238,9 @@ $ composer require hyde/framework
 Double quotes are canonical, matching how attributes are written in HTML and Blade, but single quotes are also
 accepted, which is useful when the title contains a double quote. The title is HTML-escaped when rendered.
 
-An empty title (`title=""`) is respected as written, leaving the title bar empty. The `title` modifier must otherwise
-use a quoted value with no whitespace around the `=`. Malformed title syntax causes the build to fail rather than
-being silently ignored.
+An empty title (`title=""`) is respected as written, omitting the title bar. The `title` modifier must otherwise use a
+quoted value with no whitespace around the `=`. Malformed title syntax causes the build to fail rather than being
+silently ignored.
 
 #### Terminal formatting tags
 
@@ -305,9 +305,11 @@ Say you want blocks that set no title of their own to show the current working d
 
 ```blade title="resources/views/vendor/hyde/components/markdown/terminal.blade.php"
 <figure class="hyde-terminal not-prose my-4 overflow-hidden rounded-md bg-[#292D3E] text-[#A6ACCD]">
-    <figcaption class="hyde-terminal-header bg-[#212529] px-4 py-2.5 font-sans text-xs leading-none">
-        <span>{{ $title ?? '~/my-project' }}</span>
-    </figcaption>
+    @if (($title ?? '~/my-project') !== '')
+        <figcaption class="hyde-terminal-header bg-[#212529] px-4 py-2.5 font-sans text-xs leading-none">
+            <span>{{ $title ?? '~/my-project' }}</span>
+        </figcaption>
+    @endif
     <pre class="hyde-terminal-body m-0 overflow-x-auto rounded-none bg-[#292D3E] p-4 text-[#A6ACCD]"><code class="block whitespace-pre font-mono text-sm leading-relaxed">{!! $contents !!}</code></pre>
 </figure>
 ```

--- a/docs/digging-deeper/composable-markdown-blocks.md
+++ b/docs/digging-deeper/composable-markdown-blocks.md
@@ -238,9 +238,9 @@ $ composer require hyde/framework
 Double quotes are canonical, matching how attributes are written in HTML and Blade, but single quotes are also
 accepted, which is useful when the title contains a double quote. The title is HTML-escaped when rendered.
 
-An empty title (`title=""`) is respected as written, leaving the title bar with only the window controls. The `title`
-modifier must otherwise use a quoted value with no whitespace around the `=`. Malformed title syntax causes the build
-to fail rather than being silently ignored.
+An empty title (`title=""`) is respected as written, leaving the title bar empty. The `title` modifier must otherwise
+use a quoted value with no whitespace around the `=`. Malformed title syntax causes the build to fail rather than
+being silently ignored.
 
 #### Terminal formatting tags
 
@@ -287,7 +287,6 @@ untitled block falls back to. The shipped view escapes it with `{{ }}` and falls
 |---------------------------|----------------------------------------------------|
 | `hyde-terminal`           | The outer `<figure>` container                     |
 | `hyde-terminal-header`    | The title bar                                      |
-| `hyde-terminal-controls`  | The decorative window buttons                      |
 | `hyde-terminal-body`      | The `<pre>` output area                            |
 | `hyde-terminal-command`   | A line beginning with a `$ ` prompt                |
 | `hyde-terminal-prompt`    | The `$ ` prompt itself                             |
@@ -306,12 +305,7 @@ Say you want blocks that set no title of their own to show the current working d
 
 ```blade title="resources/views/vendor/hyde/components/markdown/terminal.blade.php"
 <figure class="hyde-terminal not-prose my-4 overflow-hidden rounded-md bg-[#292D3E] text-[#A6ACCD]">
-    <figcaption class="hyde-terminal-header flex items-center gap-3 bg-[#212529] px-4 py-2.5 font-sans text-xs leading-none">
-        <span class="hyde-terminal-controls flex gap-1.5" aria-hidden="true">
-            <span class="size-2.5 rounded-full bg-[#FF5F57]"></span>
-            <span class="size-2.5 rounded-full bg-[#FEBC2E]"></span>
-            <span class="size-2.5 rounded-full bg-[#28C840]"></span>
-        </span>
+    <figcaption class="hyde-terminal-header bg-[#212529] px-4 py-2.5 font-sans text-xs leading-none">
         <span>{{ $title ?? '~/my-project' }}</span>
     </figcaption>
     <pre class="hyde-terminal-body m-0 overflow-x-auto rounded-none bg-[#292D3E] p-4 text-[#A6ACCD]"><code class="block whitespace-pre font-mono text-sm leading-relaxed">{!! $contents !!}</code></pre>

--- a/docs/digging-deeper/composable-markdown-blocks.md
+++ b/docs/digging-deeper/composable-markdown-blocks.md
@@ -223,7 +223,7 @@ terminal [title="…"]
 
 #### Window titles
 
-The `title` modifier replaces the `Terminal` label in the window's title bar.
+Without a `title` modifier, the title bar displays `Terminal`. The modifier replaces that label.
 
 ````markdown
 ```terminal title="Installing Hyde"
@@ -238,9 +238,8 @@ $ composer require hyde/framework
 Double quotes are canonical, matching how attributes are written in HTML and Blade, but single quotes are also
 accepted, which is useful when the title contains a double quote. The title is HTML-escaped when rendered.
 
-An empty title (`title=""`) is respected as written, omitting the title bar. The `title` modifier must otherwise use a
-quoted value with no whitespace around the `=`. Malformed title syntax causes the build to fail rather than being
-silently ignored.
+Set `title=""` to omit the title bar entirely. The `title` modifier must otherwise use a quoted value with no whitespace
+around the `=`. Malformed title syntax causes the build to fail rather than being silently ignored.
 
 #### Terminal formatting tags
 

--- a/packages/framework/resources/views/components/markdown/terminal.blade.php
+++ b/packages/framework/resources/views/components/markdown/terminal.blade.php
@@ -1,10 +1,5 @@
 <figure class="hyde-terminal not-prose my-4 overflow-hidden rounded-md bg-[#292D3E] text-[#A6ACCD]">
-    <figcaption class="hyde-terminal-header flex items-center gap-3 bg-[#212529] px-4 py-2.5 font-sans text-xs leading-none">
-        <span class="hyde-terminal-controls flex gap-1.5" aria-hidden="true">
-            <span class="size-2.5 rounded-full bg-[#FF5F57]"></span>
-            <span class="size-2.5 rounded-full bg-[#FEBC2E]"></span>
-            <span class="size-2.5 rounded-full bg-[#28C840]"></span>
-        </span>
+    <figcaption class="hyde-terminal-header bg-[#212529] px-4 py-2.5 font-sans text-xs leading-none">
         <span>{{ $title ?? 'Terminal' }}</span>
     </figcaption>
     <pre class="hyde-terminal-body m-0 overflow-x-auto rounded-none bg-[#292D3E] p-4 text-[#A6ACCD]"><code class="block whitespace-pre font-mono text-sm leading-relaxed">{!! $contents !!}</code></pre>

--- a/packages/framework/resources/views/components/markdown/terminal.blade.php
+++ b/packages/framework/resources/views/components/markdown/terminal.blade.php
@@ -1,6 +1,8 @@
 <figure class="hyde-terminal not-prose my-4 overflow-hidden rounded-md bg-[#292D3E] text-[#A6ACCD]">
-    <figcaption class="hyde-terminal-header bg-[#212529] px-4 py-2.5 font-sans text-xs leading-none">
-        <span>{{ $title ?? 'Terminal' }}</span>
-    </figcaption>
+    @if (($title ?? 'Terminal') !== '')
+        <figcaption class="hyde-terminal-header bg-[#212529] px-4 py-2.5 font-sans text-xs leading-none">
+            <span>{{ $title ?? 'Terminal' }}</span>
+        </figcaption>
+    @endif
     <pre class="hyde-terminal-body m-0 overflow-x-auto rounded-none bg-[#292D3E] p-4 text-[#A6ACCD]"><code class="block whitespace-pre font-mono text-sm leading-relaxed">{!! $contents !!}</code></pre>
 </figure>

--- a/packages/framework/tests/Feature/Documentation/ComposableMarkdownBlocksDocumentationTest.php
+++ b/packages/framework/tests/Feature/Documentation/ComposableMarkdownBlocksDocumentationTest.php
@@ -567,11 +567,11 @@ class ComposableMarkdownBlocksDocumentationTest extends TestCase
         $this->assertStringContainsString('&lt;script&gt;alert(1)&lt;/script&gt; &amp; &#039;more&#039;', $html);
     }
 
-    public function testAnEmptyTitleIsRespectedAsWritten()
+    public function testAnEmptyTitleOmitsTheHeader()
     {
         $html = Markdown::render("```terminal title=\"\"\nDone!\n```");
 
-        $this->assertStringContainsString('<span></span>', $html);
+        $this->assertStringNotContainsString('<figcaption', $html);
         $this->assertStringNotContainsString('<span>Terminal</span>', $html);
     }
 

--- a/packages/framework/tests/Feature/Documentation/ComposableMarkdownBlocksDocumentationTest.php
+++ b/packages/framework/tests/Feature/Documentation/ComposableMarkdownBlocksDocumentationTest.php
@@ -573,9 +573,6 @@ class ComposableMarkdownBlocksDocumentationTest extends TestCase
 
         $this->assertStringContainsString('<span></span>', $html);
         $this->assertStringNotContainsString('<span>Terminal</span>', $html);
-
-        // The window buttons are still there
-        $this->assertStringContainsString('<span class="hyde-terminal-controls ', $html);
     }
 
     public function testATitleThatIsNotAQuotedValueIsRejectedInsteadOfBeingGuessedAt()
@@ -615,7 +612,6 @@ class ComposableMarkdownBlocksDocumentationTest extends TestCase
 
         $this->assertStringContainsString('<figure class="hyde-terminal ', $html);
         $this->assertStringContainsString('<figcaption class="hyde-terminal-header ', $html);
-        $this->assertStringContainsString('<span class="hyde-terminal-controls ', $html);
         $this->assertStringContainsString('<pre class="hyde-terminal-body ', $html);
         $this->assertStringContainsString('<span class="hyde-terminal-command"', $html);
         $this->assertStringContainsString('<span class="hyde-terminal-prompt"', $html);

--- a/packages/framework/tests/Feature/TerminalCodeBlocksTest.php
+++ b/packages/framework/tests/Feature/TerminalCodeBlocksTest.php
@@ -222,11 +222,11 @@ class TerminalCodeBlocksTest extends TestCase
         $this->assertStringContainsString('&lt;script&gt;alert(1)&lt;/script&gt;', $html);
     }
 
-    public function testAnEmptyTitleRendersAnEmptyLabel(): void
+    public function testAnEmptyTitleOmitsTheHeader(): void
     {
         $html = Markdown::render("```terminal title=\"\"\nDone!\n```");
 
-        $this->assertStringContainsString('<span></span>', $html);
+        $this->assertStringNotContainsString('<figcaption', $html);
         $this->assertStringNotContainsString('<span>Terminal</span>', $html);
     }
 


### PR DESCRIPTION
## Summary

- remove the decorative macOS-style dots from terminal block headers
- remove the now-unused controls markup and layout utilities
- omit the header entirely when a terminal block has an explicitly empty title
- update the terminal customization documentation and its synchronized tests

## Rationale

The decorative controls do not add enough value to the terminal component and should not be part of the final HydePHP v3 design. Terminal blocks keep their normal `Terminal` fallback and custom titles, while `title=""` now omits the otherwise empty header bar. Padding, borders, and terminal body styling remain intact.

Because v3 is unreleased, the documentation now presents the final design directly without preserving a removal history. No configuration option or replacement UI is introduced.

## Validation

- `vendor/bin/pest packages/framework/tests/Feature/TerminalCodeBlocksTest.php packages/framework/tests/Feature/Documentation/ComposableMarkdownBlocksDocumentationTest.php` — 125 passed, 1,257 assertions
- `vendor/bin/pest --testsuite FeatureFramework` — 1,879 passed and 1 skipped; the sole sandbox-related localhost socket failure passed when rerun with socket permission
- `php monorepo/HydeStan/run.php` — no errors
