### PR TITLE
[3.x] Fix Markdown heading conversion

### DIFF
--- a/packages/framework/src/Framework/Actions/ConvertsMarkdownToPlainText.php
+++ b/packages/framework/src/Framework/Actions/ConvertsMarkdownToPlainText.php
@@ -5,6 +5,9 @@ declare(strict_types=1);
 namespace Hyde\Framework\Actions;
 
 use function trim;
+use function strlen;
+use function strspn;
+use function ltrim;
 use function rtrim;
 use function is_numeric;
 use function str_ends_with;
@@ -22,7 +25,6 @@ use function preg_replace;
  */
 class ConvertsMarkdownToPlainText
 {
-    protected const ATX_HEADERS = ['/^(\n)?\s{0,}#{1,6}\s+| {0,}(\n)?\s{0,}#{0,} {0,}(\n)?\s{0,}$/m' => '$1$2$3'];
     protected const SETEXT_HEADERS = ['/\n={2,}/' => "\n"];
     protected const HORIZONTAL_RULES = ['/^(-\s*?|\*\s*?|_\s*?){3,}\s*/m' => ''];
     protected const HTML_TAGS = ['/<[^>]*>/' => ''];
@@ -63,7 +65,6 @@ class ConvertsMarkdownToPlainText
     {
         /** @var array<array-key, array<string, string>> $patterns */
         $patterns = [
-            static::ATX_HEADERS,
             static::SETEXT_HEADERS,
             static::HORIZONTAL_RULES,
             static::HTML_TAGS,
@@ -93,6 +94,7 @@ class ConvertsMarkdownToPlainText
     {
         $lines = explode("\n", $markdown);
         foreach ($lines as $line => $contents) {
+            $contents = $this->removeAtxHeading($contents);
             $contents = $this->removeTables($contents);
             $contents = $this->removeBlockquotes($contents);
             $contents = $this->trimWhitespace($contents);
@@ -101,6 +103,50 @@ class ConvertsMarkdownToPlainText
         }
 
         return implode("\n", $lines);
+    }
+
+    protected function removeAtxHeading(string $contents): string
+    {
+        $indent = strspn($contents, ' ');
+
+        if ($indent > 3) {
+            return $contents;
+        }
+
+        $offset = $indent;
+        $hashes = strspn($contents, '#', $offset);
+
+        if ($hashes === 0 || $hashes > 6) {
+            return $contents;
+        }
+
+        $offset += $hashes;
+
+        if ($offset === strlen($contents)) {
+            return '';
+        }
+
+        if ($contents[$offset] !== ' ' && $contents[$offset] !== "\t") {
+            return $contents;
+        }
+
+        $contents = rtrim(ltrim(substr($contents, $offset), " \t"), " \t");
+        $closingMarker = strlen($contents);
+
+        while ($closingMarker > 0 && $contents[$closingMarker - 1] === '#') {
+            $closingMarker--;
+        }
+
+        if ($closingMarker === 0) {
+            return '';
+        }
+
+        if ($closingMarker < strlen($contents)
+            && ($contents[$closingMarker - 1] === ' ' || $contents[$closingMarker - 1] === "\t")) {
+            $contents = rtrim(substr($contents, 0, $closingMarker), " \t");
+        }
+
+        return $contents;
     }
 
     protected function removeTables(string $contents): string

--- a/packages/framework/tests/Feature/Actions/ConvertsMarkdownToPlainTextTest.php
+++ b/packages/framework/tests/Feature/Actions/ConvertsMarkdownToPlainTextTest.php
@@ -33,6 +33,69 @@ class ConvertsMarkdownToPlainTextTest extends TestCase
         $this->assertSame($text, $this->convert($markdown));
     }
 
+    public function testItOnlyRemovesAtxMarkersFromHeadings()
+    {
+        $markdown = <<<'MD'
+        literal value #
+        ## Heading ##
+        ## Heading ########
+        ## Heading with a literal hash#
+        MD;
+
+        $text = <<<'TXT'
+        literal value #
+        Heading
+        Heading
+        Heading with a literal hash#
+        TXT;
+
+        $this->assertSame($text, $this->convert($markdown));
+    }
+
+    public function testItOnlyRecognizesValidAtxOpeningMarkers()
+    {
+        $markdown = <<<'MD'
+        # Heading
+           # Heading
+            # Code block
+        ####### Not a heading
+        #Not a heading
+        MD;
+
+        $text = <<<'TXT'
+        Heading
+        Heading
+        # Code block
+        ####### Not a heading
+        #Not a heading
+        TXT;
+
+        $this->assertSame($text, $this->convert($markdown));
+    }
+
+    public function testItRemovesEmptyAtxHeadings()
+    {
+        $this->assertSame("\n\n", $this->convert("#\n#   \n# ###"));
+    }
+
+    public function testItRemovesHeadingsFromLongMarkdownDocuments()
+    {
+        $markdown = <<<'MD'
+        # Customizing Your Site
+
+        ## Introduction
+
+        | Collection Type                       | Facade Method  | Returned Object Type                                                                                                                                     | File Extension        |
+        |---------------------------------------|----------------|----------------------------------------------------------------------------------------------------------------------------------------------------------|-----------------------|
+        MD;
+
+        $text = $this->convert($markdown);
+
+        $this->assertStringContainsString("Customizing Your Site\n\nIntroduction", $text);
+        $this->assertStringNotContainsString('# Customizing Your Site', $text);
+        $this->assertStringContainsString('Collection Type', $text);
+    }
+
     public function testItRemovesHeadingsAlternateSyntax()
     {
         $markdown = <<<'MD'
@@ -450,6 +513,22 @@ class ConvertsMarkdownToPlainTextTest extends TestCase
         $this->assertSame($text, $this->convert($markdown));
     }
 
+    public function testItContinuesTransformingMarkdownInsideFencedCodeBlocks()
+    {
+        $markdown = <<<'MD'
+        ```markdown
+        # not a heading
+        ```
+        MD;
+
+        $text = <<<'TXT'
+        not a heading
+
+        TXT;
+
+        $this->assertSame($text, $this->convert($markdown));
+    }
+
     public function testItRemovesFencedCodeBlocksAlternate()
     {
         $markdown = <<<'MD'
@@ -509,7 +588,7 @@ class ConvertsMarkdownToPlainTextTest extends TestCase
 
     public function testWithOnlyEmptyLines()
     {
-        $this->assertSame("\n", $this->convert("\n\n\n"));
+        $this->assertSame("\n\n", $this->convert("\n\n\n"));
     }
 
     protected function convert(string $markdown): string


### PR DESCRIPTION
## What changed

- Forward-port the Markdown heading conversion fix from #2590 to the v3 development branch.
- Replace the global ATX heading regex with explicit per-line heading handling.
- Recognize only headings with 0–3 leading spaces, 1–6 opening hashes, and the required whitespace or end-of-line separator.
- Remove optional closing hash sequences of any length only when separated from heading content by whitespace.
- Preserve ordinary text ending in a hash, literal hashes attached to heading content, invalid opening markers, and four-space-indented code.
- Add regression coverage for long documents, heading grammar edge cases, empty headings, indentation boundaries, and existing fenced-code behavior.

## Why

Master still contained the original cross-line regex fixed on the `2.x` branch. This ports the complete merged fix so v3 does not corrupt content following headings or strip hashes from ordinary text.

## Validation

- `php vendor/bin/phpunit packages/framework/tests/Feature/Actions/ConvertsMarkdownToPlainTextTest.php` (33 tests, 35 assertions)
- `php vendor/bin/phpstan analyse --no-progress --debug --level 1 packages/framework/src/Framework/Actions/ConvertsMarkdownToPlainText.php`
- `git diff --check origin/master...HEAD`

Forward-port of #2590.
