### PR TITLE
[3.x] Set framework version to v3 development

### DIFF
--- a/packages/framework/src/Foundation/HydeKernel.php
+++ b/packages/framework/src/Foundation/HydeKernel.php
@@ -50,7 +50,7 @@ class HydeKernel implements SerializableContract
     use Serializable;
     use Macroable;
 
-    final public const VERSION = '2.0.3';
+    final public const VERSION = '3.0.0-dev';
 
     protected static self $instance;
 


### PR DESCRIPTION
Summary: HydeKernel::VERSION is now 3.0.0-dev for the unreleased v3 development line. Verification: targeted HydeKernelTest version tests passed (3 tests, 3 assertions).