### PR TITLE
[2.x] Serve the sitemap and RSS feed from the realtime compiler

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,7 +42,7 @@ _Changes to the realtime compiler requires an update to v4.5 or later of the `hy
 - Fix build command trying to use Vite in site builds if server is running in https://github.com/hydephp/develop/issues/2483
 - Fixed missing content type headers for JSON and XML in the realtime compiler in https://github.com/hydephp/develop/pull/2496
 - Fixed dashboard links not resolving properly when there is a trailing slash in the URL in https://github.com/hydephp/develop/pull/2499
-- Fixed the realtime compiler serving a 404 for the sitemap and the RSS feed instead of generating them on the fly in https://github.com/hydephp/develop/pull/2603
+- Fixed the realtime compiler serving a 404 for the sitemap and the RSS feed during `php hyde serve`, even after building the site, by now generating them on the fly in https://github.com/hydephp/develop/pull/2603
 
 ### Security
 - in case of vulnerabilities.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,7 @@ _Changes to the realtime compiler requires an update to v4.5 or later of the `hy
 - Fix build command trying to use Vite in site builds if server is running in https://github.com/hydephp/develop/issues/2483
 - Fixed missing content type headers for JSON and XML in the realtime compiler in https://github.com/hydephp/develop/pull/2496
 - Fixed dashboard links not resolving properly when there is a trailing slash in the URL in https://github.com/hydephp/develop/pull/2499
+- Fixed the realtime compiler serving a 404 for the sitemap and the RSS feed instead of generating them on the fly in https://github.com/hydephp/develop/pull/2603
 
 ### Security
 - in case of vulnerabilities.

--- a/packages/realtime-compiler/src/Http/VirtualRouteController.php
+++ b/packages/realtime-compiler/src/Http/VirtualRouteController.php
@@ -4,9 +4,14 @@ declare(strict_types=1);
 
 namespace Hyde\RealtimeCompiler\Http;
 
+use Hyde\Facades\Features;
 use Desilva\Microserve\Request;
 use Desilva\Microserve\Response;
 use Desilva\Microserve\JsonResponse;
+use Hyde\Framework\Features\XmlGenerators\RssFeedGenerator;
+use Hyde\Framework\Features\XmlGenerators\SitemapGenerator;
+
+use function strlen;
 
 class VirtualRouteController
 {
@@ -30,5 +35,33 @@ class VirtualRouteController
     public static function openInEditor(Request $request): Response
     {
         return (new OpenInEditorController($request))->handle();
+    }
+
+    public static function sitemap(): Response
+    {
+        if (! Features::hasSitemap()) {
+            return new Response(404, 'Not Found');
+        }
+
+        return static::xmlResponse(SitemapGenerator::make(), 'application/xml');
+    }
+
+    public static function rssFeed(): Response
+    {
+        if (! Features::hasRss()) {
+            return new Response(404, 'Not Found');
+        }
+
+        return static::xmlResponse(RssFeedGenerator::make(), 'application/rss+xml');
+    }
+
+    protected static function xmlResponse(string $xml, string $contentType): Response
+    {
+        return (new Response(200, 'OK', [
+            'body' => $xml,
+        ]))->withHeaders([
+            'Content-Type' => $contentType,
+            'Content-Length' => (string) strlen($xml),
+        ]);
     }
 }

--- a/packages/realtime-compiler/src/RealtimeCompilerServiceProvider.php
+++ b/packages/realtime-compiler/src/RealtimeCompilerServiceProvider.php
@@ -13,6 +13,8 @@ use Hyde\Framework\Features\XmlGenerators\RssFeedGenerator;
 use Hyde\RealtimeCompiler\Console\Commands\HerdInstallCommand;
 use Hyde\RealtimeCompiler\Console\Commands\ServeCommand;
 
+use function Hyde\unslash;
+
 class RealtimeCompilerServiceProvider extends ServiceProvider
 {
     public function register(): void
@@ -48,6 +50,6 @@ class RealtimeCompilerServiceProvider extends ServiceProvider
         // Unlike the routes above, these are registered unconditionally, as the feature checks depend on the
         // site URL, which the router only overrides with the local preview URL after the application boots.
         $router->registerVirtualRoute('/sitemap.xml', [VirtualRouteController::class, 'sitemap']);
-        $router->registerVirtualRoute('/'.RssFeedGenerator::getFilename(), [VirtualRouteController::class, 'rssFeed']);
+        $router->registerVirtualRoute('/'.unslash(RssFeedGenerator::getFilename()), [VirtualRouteController::class, 'rssFeed']);
     }
 }

--- a/packages/realtime-compiler/src/RealtimeCompilerServiceProvider.php
+++ b/packages/realtime-compiler/src/RealtimeCompilerServiceProvider.php
@@ -9,6 +9,7 @@ use Hyde\RealtimeCompiler\Http\DashboardController;
 use Hyde\RealtimeCompiler\Http\LiveEditController;
 use Hyde\RealtimeCompiler\Http\VirtualRouteController;
 use Hyde\RealtimeCompiler\Http\OpenInEditorController;
+use Hyde\Framework\Features\XmlGenerators\RssFeedGenerator;
 use Hyde\RealtimeCompiler\Console\Commands\HerdInstallCommand;
 use Hyde\RealtimeCompiler\Console\Commands\ServeCommand;
 
@@ -43,5 +44,10 @@ class RealtimeCompilerServiceProvider extends ServiceProvider
         if (OpenInEditorController::enabled()) {
             $router->registerVirtualRoute('/_hyde/open-in-editor', [VirtualRouteController::class, 'openInEditor']);
         }
+
+        // Unlike the routes above, these are registered unconditionally, as the feature checks depend on the
+        // site URL, which the router only overrides with the local preview URL after the application boots.
+        $router->registerVirtualRoute('/sitemap.xml', [VirtualRouteController::class, 'sitemap']);
+        $router->registerVirtualRoute('/'.RssFeedGenerator::getFilename(), [VirtualRouteController::class, 'rssFeed']);
     }
 }

--- a/packages/realtime-compiler/src/Routing/Router.php
+++ b/packages/realtime-compiler/src/Routing/Router.php
@@ -26,8 +26,16 @@ class Router
 
     public function handle(): Response
     {
-        if ($this->shouldProxy($this->request)) {
-            return $this->proxyStatic();
+        // An asset request without a matching file may still be served by a virtual
+        // route, as the sitemap and the RSS feed are generated on the fly.
+        $isAssetRequest = $this->isAssetRequest($this->request);
+
+        if ($isAssetRequest) {
+            $path = AssetFileLocator::find($this->request->path);
+
+            if ($path !== null) {
+                return $this->proxyStatic($path);
+            }
         }
 
         $this->bootApplication();
@@ -40,14 +48,14 @@ class Router
             return $virtualRoutes[$this->request->path]($this->request);
         }
 
-        return PageRouter::handle($this->request);
+        return $isAssetRequest ? $this->notFound() : PageRouter::handle($this->request);
     }
 
     /**
-     * If the request is not for a web page, we assume it's
-     * a static asset, which we instead want to proxy.
+     * If the request is not for a web page, we assume it's a static asset,
+     * which we want to proxy instead of compiling.
      */
-    protected function shouldProxy(Request $request): bool
+    protected function isAssetRequest(Request $request): bool
     {
         // Always proxy media files. This condition is just to improve performance
         // without having to check the file extension.
@@ -151,16 +159,10 @@ class Router
     }
 
     /**
-     * Proxy a static file or return a 404.
+     * Proxy a static file.
      */
-    protected function proxyStatic(): Response
+    protected function proxyStatic(string $path): Response
     {
-        $path = AssetFileLocator::find($this->request->path);
-
-        if ($path === null) {
-            return $this->notFound();
-        }
-
         $file = new FileObject($path);
 
         return (new Response(200, 'OK', [

--- a/packages/realtime-compiler/tests/RealtimeCompilerTest.php
+++ b/packages/realtime-compiler/tests/RealtimeCompilerTest.php
@@ -631,6 +631,21 @@ class RealtimeCompilerTest extends TestCase
         $this->assertStringContainsString('<title>Custom Filename Test</title>', $response->body);
     }
 
+    public function testRssFeedRouteNormalizesTheConfiguredFilename()
+    {
+        $this->mockCompilerRoute('posts.rss');
+        $_SERVER['HTTP_HOST'] = 'localhost:8080';
+
+        $this->markdown('_posts/slashed-filename-test.md', 'Hello World!', ['title' => 'Slashed Filename Test']);
+        $this->file('hyde.yml', "rss:\n  filename: /posts.rss");
+
+        $kernel = new HttpKernel();
+        $response = $kernel->handle(new Request());
+
+        $this->assertSame(200, $response->statusCode);
+        $this->assertStringContainsString('<title>Slashed Filename Test</title>', $response->body);
+    }
+
     public function testSitemapRouteIsNotServedWhenSavePreviewIsEnabledWithoutASiteUrl()
     {
         $siteUrlEnvironment = getenv('SITE_URL');

--- a/packages/realtime-compiler/tests/RealtimeCompilerTest.php
+++ b/packages/realtime-compiler/tests/RealtimeCompilerTest.php
@@ -511,6 +511,138 @@ class RealtimeCompilerTest extends TestCase
         putenv('SERVER_SAVE_PREVIEW=');
     }
 
+    public function testSitemapRouteRendersDynamicallyGeneratedSitemap()
+    {
+        $siteUrlEnvironment = getenv('SITE_URL');
+        putenv('SITE_URL=');
+
+        $this->mockCompilerRoute('sitemap.xml');
+        $_SERVER['HTTP_HOST'] = 'localhost:8080';
+
+        $this->file('_pages/dynamic-sitemap-test.md', '# Dynamic Sitemap Test');
+
+        try {
+            $kernel = new HttpKernel();
+            $response = $kernel->handle(new Request());
+
+            $this->assertSame(200, $response->statusCode);
+            $this->assertSame('OK', $response->statusMessage);
+
+            $headers = $this->getResponseHeaders($response);
+            $this->assertSame('application/xml', $headers['Content-Type']);
+            $this->assertSame((string) strlen($response->body), $headers['Content-Length']);
+
+            $this->assertStringContainsString('<loc>http://localhost:8080/dynamic-sitemap-test.html</loc>', $response->body);
+        } finally {
+            putenv($siteUrlEnvironment === false ? 'SITE_URL' : "SITE_URL=$siteUrlEnvironment");
+        }
+    }
+
+    public function testSitemapRouteIsNotServedFromAPreviouslyBuiltFile()
+    {
+        $this->mockCompilerRoute('sitemap.xml');
+        $_SERVER['HTTP_HOST'] = 'localhost:8080';
+
+        $this->file('_site/sitemap.xml', '<urlset><!-- Stale sitemap --></urlset>');
+        $this->file('_pages/fresh-sitemap-test.md', '# Fresh Sitemap Test');
+
+        $kernel = new HttpKernel();
+        $response = $kernel->handle(new Request());
+
+        $this->assertSame(200, $response->statusCode);
+        $this->assertStringNotContainsString('Stale sitemap', $response->body);
+        $this->assertStringContainsString('<loc>http://localhost:8080/fresh-sitemap-test.html</loc>', $response->body);
+    }
+
+    public function testRssFeedRouteRendersDynamicallyGeneratedFeed()
+    {
+        $siteUrlEnvironment = getenv('SITE_URL');
+        putenv('SITE_URL=');
+
+        $this->mockCompilerRoute('feed.xml');
+        $_SERVER['HTTP_HOST'] = 'localhost:8080';
+
+        $this->markdown('_posts/dynamic-feed-test.md', 'Hello World!', [
+            'title' => 'Dynamic Feed Test',
+            'description' => 'A post added while the server is running.',
+        ]);
+
+        try {
+            $kernel = new HttpKernel();
+            $response = $kernel->handle(new Request());
+
+            $this->assertSame(200, $response->statusCode);
+            $this->assertSame('OK', $response->statusMessage);
+
+            $headers = $this->getResponseHeaders($response);
+            $this->assertSame('application/rss+xml', $headers['Content-Type']);
+            $this->assertSame((string) strlen($response->body), $headers['Content-Length']);
+
+            $this->assertStringContainsString('<title>Dynamic Feed Test</title>', $response->body);
+            $this->assertStringContainsString('<link>http://localhost:8080/posts/dynamic-feed-test.html</link>', $response->body);
+            $this->assertStringContainsString('http://localhost:8080/feed.xml', $response->body);
+        } finally {
+            putenv($siteUrlEnvironment === false ? 'SITE_URL' : "SITE_URL=$siteUrlEnvironment");
+        }
+    }
+
+    public function testSitemapRouteIsNotServedWhenSitemapGenerationIsDisabled()
+    {
+        $this->mockCompilerRoute('sitemap.xml');
+        $_SERVER['HTTP_HOST'] = 'localhost:8080';
+
+        $this->file('hyde.yml', 'generate_sitemap: false');
+
+        $kernel = new HttpKernel();
+        $response = $kernel->handle(new Request());
+
+        $this->assertSame(404, $response->statusCode);
+        $this->assertSame('Not Found', $response->statusMessage);
+    }
+
+    public function testRssFeedRouteIsNotServedWhenRssGenerationIsDisabled()
+    {
+        $this->mockCompilerRoute('feed.xml');
+        $_SERVER['HTTP_HOST'] = 'localhost:8080';
+
+        $this->markdown('_posts/disabled-feed-test.md', 'Hello World!', ['title' => 'Disabled Feed Test']);
+        $this->file('hyde.yml', "rss:\n  enabled: false");
+
+        $kernel = new HttpKernel();
+        $response = $kernel->handle(new Request());
+
+        $this->assertSame(404, $response->statusCode);
+        $this->assertSame('Not Found', $response->statusMessage);
+    }
+
+    public function testRssFeedRouteUsesTheConfiguredFilename()
+    {
+        $this->mockCompilerRoute('posts.rss');
+        $_SERVER['HTTP_HOST'] = 'localhost:8080';
+
+        $this->markdown('_posts/custom-filename-test.md', 'Hello World!', ['title' => 'Custom Filename Test']);
+        $this->file('hyde.yml', "rss:\n  filename: posts.rss");
+
+        $kernel = new HttpKernel();
+        $response = $kernel->handle(new Request());
+
+        $this->assertSame(200, $response->statusCode);
+        $this->assertSame('application/rss+xml', $this->getResponseHeaders($response)['Content-Type']);
+        $this->assertStringContainsString('<title>Custom Filename Test</title>', $response->body);
+    }
+
+    public function testStaticXmlAssetsAreStillProxied()
+    {
+        $this->mockCompilerRoute('static-asset-test.xml');
+        $this->file('_media/static-asset-test.xml', '<static />');
+
+        $kernel = new HttpKernel();
+        $response = $kernel->handle(new Request());
+
+        $this->assertSame(200, $response->statusCode);
+        $this->assertSame('<static />', $response->body);
+    }
+
     protected function mockCompilerRoute(string $route, $method = 'GET'): void
     {
         $_SERVER['REQUEST_METHOD'] = $method;

--- a/packages/realtime-compiler/tests/RealtimeCompilerTest.php
+++ b/packages/realtime-compiler/tests/RealtimeCompilerTest.php
@@ -631,6 +631,29 @@ class RealtimeCompilerTest extends TestCase
         $this->assertStringContainsString('<title>Custom Filename Test</title>', $response->body);
     }
 
+    public function testSitemapRouteIsNotServedWhenSavePreviewIsEnabledWithoutASiteUrl()
+    {
+        $siteUrlEnvironment = getenv('SITE_URL');
+        putenv('SITE_URL=');
+        putenv('SERVER_SAVE_PREVIEW=true');
+
+        $this->mockCompilerRoute('sitemap.xml');
+        $_SERVER['HTTP_HOST'] = 'localhost:8080';
+
+        try {
+            $kernel = new HttpKernel();
+            $response = $kernel->handle(new Request());
+
+            // The local preview URL is not applied when the preview is saved to disk,
+            // so there is no site URL to generate the sitemap with.
+            $this->assertSame(404, $response->statusCode);
+            $this->assertSame('Not Found', $response->statusMessage);
+        } finally {
+            putenv('SERVER_SAVE_PREVIEW=');
+            putenv($siteUrlEnvironment === false ? 'SITE_URL' : "SITE_URL=$siteUrlEnvironment");
+        }
+    }
+
     public function testStaticXmlAssetsAreStillProxied()
     {
         $this->mockCompilerRoute('static-asset-test.xml');


### PR DESCRIPTION
## Problem

The sitemap and the RSS feed are only written by post-build tasks, so the realtime compiler had nothing to serve for them.
Requests like `/sitemap.xml` and `/feed.xml` have a file extension, so the router classified them as static assets and passed
them to the media proxy, which only ever resolves files in `_media/`. The result was a 404 for both resources during
`hyde serve`, no matter how many times the site had been built.

## Solution

Both resources are now registered as virtual routes that call the existing `SitemapGenerator` and `RssFeedGenerator`,
so the response is generated from the current project state on every request.

- The routes are registered unconditionally, and `Features::hasSitemap()` / `Features::hasRss()` are evaluated when the
  request is handled. The feature checks depend on the site URL, and the router only overrides that with the local preview
  URL after the application has booted, so checking at registration time would disable both resources for anyone who has
  not configured a production URL.
- Asset requests that have no matching file now fall through to the virtual routes before returning the same 404 as before.
  This is what lets a custom `hyde.rss.filename` be served regardless of its extension, such as `posts.rss`. The tradeoff is
  that a request for a missing asset now boots the application before it 404s; requests that do resolve to a file still
  short-circuit before the boot, which is what the lazy bootstrapping is there for.
- Since the local preview URL override already runs before the route is dispatched, the generated URLs point at the local
  server, and no production `hyde.url` is needed.

Production builds are untouched, and the post-build tasks that write the files remain as they are.

## Tests

Added to the realtime compiler test suite:

- The sitemap and the feed are served with `200`, the correct content type, and content generated from the current source files.
- Both use the local preview URL and work without a configured production site URL.
- A post created while the server is running appears in the feed.
- The sitemap is generated from source rather than from a previously built `_site/sitemap.xml`.
- Disabling `generate_sitemap` or `rss.enabled` returns a 404.
- A custom RSS feed filename is served.
- Static XML files in the media directory are still proxied.
- With `save_preview` enabled and no configured site URL, the sitemap is not served, since the local preview URL is
  deliberately not applied when the preview is written to disk.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
