### PR TITLE
[3.x] Make _media a passthrough directory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ This serves two purposes:
 - Pages with non-HTML output paths are now excluded from automatic navigation by default. Explicit navigation front matter now takes precedence over automatic navigation exclusions.
 - Fenced code blocks are now rendered through the publishable `components/markdown/code-block.blade.php` view, which changes the generated markup around the code. Syntax highlighting is unaffected, and the `hyde-code-block` and `hyde-code-block-label` classes are stable hooks for your own CSS.
 - Code block labels are now set with a `title="…"` modifier on the fence, replacing the `// filepath:` comment syntax, which is no longer recognized and must be replaced.
+- The `_media` directory is now a passthrough: every file it contains is discovered and copied to the built site, not just files with a recognized extension. `Thumbs.db` and `desktop.ini` are still skipped.
 
 ### Deprecated
 - for changes that will be removed in upcoming releases.
@@ -38,6 +39,7 @@ This serves two purposes:
 - Removed the `rebuild` command. It had no remaining internal consumers now that the realtime compiler renders pages in-memory, and single-page builds can silently leave aggregate outputs (sitemap, RSS, search index, navigation) stale. Use `Hyde\Framework\Actions\StaticPageBuilder::handle()` instead if you need to build a single page programmatically.
 - Removed the `InMemoryPage` instance macro API. Use a contents closure for dynamic output, or extend `InMemoryPage` to add custom methods and behavior.
 - Removed the `components/filepath-label.blade.php` view, as the label markup now lives in the code block view. If this was published, port any customizations into `components/markdown/code-block.blade.php`.
+- Removed the `hyde.media_extensions` config option, now that the media directory discovers files of every type.
 
 ### Fixed
 - Fixed Markdown-to-plain-text conversion consuming unrelated content after ATX headings and stripping literal trailing hashes in https://github.com/hydephp/develop/pull/2590

--- a/HYDEPHP_V3_PLANNING.md
+++ b/HYDEPHP_V3_PLANNING.md
@@ -74,6 +74,8 @@ Having this document in code lets us know the devlopment state at any given poin
 
   The undocumented `hyde.empty_output_directory` option is removed too. It was never present in the shipped `config/hyde.php` and never documented, so no upgrade step is needed for it.
 
+- The `_media` directory is now a passthrough for every file it contains, rather than only files matching the `hyde.media_extensions` allow-list. That option is removed, along with `MediaFile::EXTENSIONS` as anything more than a deprecated internal default kept so old published config files still load. `Thumbs.db` and `desktop.ini` are still skipped regardless of case, since Symfony Finder's dotfile and VCS exclusions were already relied on and remain unchanged. This lets media types Hyde never had an opinion about — PDFs, fonts, archives — pass through without a config change, at the cost of also copying files a project may have parked in `_media` for other reasons.
+
 ### Upgrade guide
 
 Please fill in UPGRADE.md as you make changes.
@@ -92,6 +94,7 @@ Please fill in UPGRADE.md as you make changes.
 - Compare a few pages against your old site if you have custom CSS for code blocks or their labels, since the generated markup changed. The `hyde-code-block` and `hyde-code-block-label` classes are stable hooks to target instead of the markup structure.
 - Port any customizations from a published `filepath-label.blade.php` to `markdown/code-block.blade.php`. The old file is ignored after upgrading, so the site renders with the shipped label until they are moved.
 - Move manually maintained files out of the output directory and into `_static`, since the whole output directory is now emptied before every build. Remove `safe_output_directories` from a published `config/hyde.php`.
+- Remove `media_extensions` from a published `config/hyde.php`, and move any non-asset files out of `_media` that you were relying on the extension allow-list to keep out of the build.
 
 ## `InMemoryPage` content-source motivation
 

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -439,6 +439,12 @@ Move those files into the `_static` directory, which is copied verbatim to the s
 
 The `hyde.safe_output_directories` option no longer exists, and the build no longer asks for confirmation before emptying an unfamiliar output directory. Delete the entry from your `config/hyde.php`. Take the chance to double-check your `hyde.output_directory` if you build somewhere other than `_site`, since everything in that directory is now removed on every build.
 
+## Step 13: Review the Contents of Your Media Directory
+
+The `hyde.media_extensions` config option no longer exists, and `_media` now discovers every file it contains, not just files with a recognized extension. Delete the entry from your `config/hyde.php`.
+
+If you kept non-asset files in `_media` relying on the extension allow-list to exclude them from the build, such as design source files or notes, move them out of the directory, since they'll now be copied to the built site.
+
 ## Migration Checklist
 
 Use this checklist to track your upgrade progress:
@@ -456,6 +462,7 @@ Use this checklist to track your upgrade progress:
 - [ ] Compared pages against your old site if you have custom CSS for code blocks or their labels
 - [ ] Checked `_posts` for drafts and blog posts dated in the future, and set up recurring builds if scheduling posts
 - [ ] Moved manually maintained files out of the output directory and into `_static`
+- [ ] Removed `hyde.media_extensions` from `config/hyde.php` and moved any non-asset files out of `_media`
 
 ## Troubleshooting
 

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -445,6 +445,8 @@ The `hyde.media_extensions` config option no longer exists, and `_media` now dis
 
 If you kept non-asset files in `_media` relying on the extension allow-list to exclude them from the build, such as design source files or notes, move them out of the directory, since they'll now be copied to the built site.
 
+This can also surface a new collision with `_static`: if a file such as `_media/report.pdf` was never discovered before because `.pdf` wasn't on the allow-list, `_static/media/report.pdf` could coexist with it. Now that `_media/report.pdf` is discovered too, the build throws a `FileConflictException` for the collision. Rename or remove one of the two files.
+
 ## Migration Checklist
 
 Use this checklist to track your upgrade progress:

--- a/config/hyde.php
+++ b/config/hyde.php
@@ -483,10 +483,6 @@ return [
     |
     */
 
-    // Change the file extensions to be considered as media files and are copied to the output directory.
-    // If you want to add more extensions, add it to the empty merge array, or just override the entire array.
-    'media_extensions' => array_merge([], \Hyde\Support\Filesystem\MediaFile::EXTENSIONS),
-
     // Should a JSON build manifest with metadata about the build be generated?
     'generate_build_manifest' => true,
 

--- a/docs/creating-content/managing-assets.md
+++ b/docs/creating-content/managing-assets.md
@@ -99,7 +99,8 @@ to add your custom styles. It is also where we import HydeFront. If you compile 
 it will output the same file that's already included in Hyde.
 
 - The `_media` folder contains **compiled** (and usually minified) files. When Hyde compiles your static site,
-all asset files here will get copied as they are into the `_site/media` folder.
+every file here gets copied as-is into the `_site/media` folder, regardless of file type. The only files skipped
+are `Thumbs.db` and `desktop.ini`.
 
 - The `_site/media` folder contains the files that are served to the user.
 

--- a/docs/digging-deeper/customization.md
+++ b/docs/digging-deeper/customization.md
@@ -354,17 +354,6 @@ Learn more in the [Documentation Pages](documentation-pages#sidebar) documentati
 The following configuration options in the `config/hyde.php` file are intended for advanced users and
 should only be modified if you fully understand their impact. The code examples show the default values.
 
-### `media_extensions`
-
-This option allows you to specify file extensions considered as media files, which will be copied to the output directory.
-To add more extensions, either append them to the existing array or override the entire array.
-
-```php title="config/hyde.php"
-use \Hyde\Support\Filesystem\MediaFile;
-
-'media_extensions' => array_merge([], MediaFile::EXTENSIONS),
-```
-
 ### `generate_build_manifest`
 
 Determines whether a JSON build manifest with metadata about the build should be generated. Set to `true` to enable.

--- a/packages/framework/config/hyde.php
+++ b/packages/framework/config/hyde.php
@@ -483,10 +483,6 @@ return [
     |
     */
 
-    // Change the file extensions to be considered as media files and are copied to the output directory.
-    // If you want to add more extensions, add it to the empty merge array, or just override the entire array.
-    'media_extensions' => array_merge([], \Hyde\Support\Filesystem\MediaFile::EXTENSIONS),
-
     // Should a JSON build manifest with metadata about the build be generated?
     'generate_build_manifest' => true,
 

--- a/packages/framework/src/Foundation/Concerns/HasMediaFiles.php
+++ b/packages/framework/src/Foundation/Concerns/HasMediaFiles.php
@@ -21,7 +21,6 @@ use function strtolower;
  */
 trait HasMediaFiles
 {
-    /** Filenames that are never treated as media files, matched case-insensitively. */
     private const IGNORED_FILENAMES = ['thumbs.db', 'desktop.ini'];
 
     /** @var Collection<string, \Hyde\Support\Filesystem\MediaFile> The Collection keys are the filenames relative to the _media/ directory */

--- a/packages/framework/src/Foundation/Concerns/HasMediaFiles.php
+++ b/packages/framework/src/Foundation/Concerns/HasMediaFiles.php
@@ -5,12 +5,14 @@ declare(strict_types=1);
 namespace Hyde\Foundation\Concerns;
 
 use Hyde\Hyde;
-use Hyde\Facades\Config;
 use Hyde\Facades\Filesystem;
 use Hyde\Support\Filesystem\MediaFile;
 use Illuminate\Support\Collection;
 
 use function collect;
+use function basename;
+use function in_array;
+use function strtolower;
 
 /**
  * @internal Single-use trait for the Filesystem class.
@@ -19,6 +21,9 @@ use function collect;
  */
 trait HasMediaFiles
 {
+    /** Filenames that are never treated as media files, matched case-insensitively. */
+    private const IGNORED_FILENAMES = ['thumbs.db', 'desktop.ini'];
+
     /** @var Collection<string, \Hyde\Support\Filesystem\MediaFile> The Collection keys are the filenames relative to the _media/ directory */
     protected Collection $assets;
 
@@ -43,8 +48,8 @@ trait HasMediaFiles
 
     protected static function getMediaFiles(): array
     {
-        return Filesystem::findFiles(Hyde::getMediaDirectory(),
-            Config::getArray('hyde.media_extensions', MediaFile::EXTENSIONS), recursive: true
-        )->all();
+        return Filesystem::findFiles(Hyde::getMediaDirectory(), false, recursive: true)
+            ->reject(fn (string $path): bool => in_array(strtolower(basename($path)), self::IGNORED_FILENAMES, true))
+            ->values()->all();
     }
 }

--- a/packages/framework/src/Framework/Actions/PreBuildTasks/TransferMediaAssets.php
+++ b/packages/framework/src/Framework/Actions/PreBuildTasks/TransferMediaAssets.php
@@ -8,8 +8,12 @@ use RuntimeException;
 use Hyde\Facades\Config;
 use Hyde\Facades\Filesystem;
 use Hyde\Support\Filesystem\MediaFile;
-use Hyde\Framework\Concerns\InteractsWithDirectories;
+use Symfony\Component\Console\Command\Command;
 use Hyde\Framework\Features\BuildTasks\PreBuildTask;
+use Hyde\Framework\Concerns\InteractsWithDirectories;
+
+use function implode;
+use function array_map;
 
 class TransferMediaAssets extends PreBuildTask
 {
@@ -31,16 +35,25 @@ class TransferMediaAssets extends PreBuildTask
             $this->skip("No media files to transfer.\n");
         }
 
-        $this->withProgressBar($files, function (MediaFile $file): void {
+        $failures = [];
+
+        $this->withProgressBar($files, function (MediaFile $file) use (&$failures): void {
             $sitePath = $file->getOutputPath();
             $this->needsParentDirectory($sitePath);
 
             if (! Filesystem::copy($file->getPath(), $sitePath)) {
-                throw new RuntimeException("Failed to copy media file from [{$file->getPath()}] to [{$sitePath}]");
+                $failures[] = "[{$file->getPath()}] to [{$sitePath}]";
             }
         });
 
         $this->newLine();
+
+        if ($failures !== []) {
+            throw new RuntimeException(
+                "Failed to copy media file(s):\n".implode("\n", array_map(fn (string $failure): string => "- $failure", $failures)),
+                Command::FAILURE
+            );
+        }
     }
 
     public function printFinishMessage(): void

--- a/packages/framework/src/Framework/Actions/PreBuildTasks/TransferMediaAssets.php
+++ b/packages/framework/src/Framework/Actions/PreBuildTasks/TransferMediaAssets.php
@@ -4,11 +4,12 @@ declare(strict_types=1);
 
 namespace Hyde\Framework\Actions\PreBuildTasks;
 
+use RuntimeException;
 use Hyde\Facades\Config;
 use Hyde\Facades\Filesystem;
 use Hyde\Support\Filesystem\MediaFile;
-use Hyde\Framework\Features\BuildTasks\PreBuildTask;
 use Hyde\Framework\Concerns\InteractsWithDirectories;
+use Hyde\Framework\Features\BuildTasks\PreBuildTask;
 
 class TransferMediaAssets extends PreBuildTask
 {
@@ -33,7 +34,10 @@ class TransferMediaAssets extends PreBuildTask
         $this->withProgressBar($files, function (MediaFile $file): void {
             $sitePath = $file->getOutputPath();
             $this->needsParentDirectory($sitePath);
-            Filesystem::putContents($sitePath, $file->getContents());
+
+            if (! Filesystem::copy($file->getPath(), $sitePath)) {
+                throw new RuntimeException("Failed to copy media file from [{$file->getPath()}] to [{$sitePath}]");
+            }
         });
 
         $this->newLine();

--- a/packages/framework/src/Markdown/Processing/DynamicMarkdownLinkProcessor.php
+++ b/packages/framework/src/Markdown/Processing/DynamicMarkdownLinkProcessor.php
@@ -26,6 +26,10 @@ class DynamicMarkdownLinkProcessor implements MarkdownPostProcessorContract
         }
 
         foreach (static::assetMap() as $sourcePath => $mediaFile) {
+            if (! str_contains($html, $sourcePath)) {
+                continue;
+            }
+
             $patterns = [
                 sprintf('<img src="%s"', $sourcePath),
                 sprintf('<img src="/%s"', $sourcePath),

--- a/packages/framework/src/Support/Filesystem/MediaFile.php
+++ b/packages/framework/src/Support/Filesystem/MediaFile.php
@@ -24,7 +24,13 @@ use function array_merge;
  */
 class MediaFile extends ProjectFile implements Stringable
 {
-    /** @var array<string> The default extensions for media types */
+    /**
+     * @deprecated This is not Hyde's list of supported asset types; the media directory is a
+     * passthrough that discovers files of any type. It is retained only so that published
+     * config files referencing it still load.
+     *
+     * @var array<string>
+     */
     final public const EXTENSIONS = ['png', 'svg', 'jpg', 'jpeg', 'webp', 'gif', 'ico', 'css', 'js'];
 
     protected readonly int $length;

--- a/packages/framework/tests/Feature/DiscoveryServiceTest.php
+++ b/packages/framework/tests/Feature/DiscoveryServiceTest.php
@@ -103,10 +103,7 @@ class DiscoveryServiceTest extends UnitTestCase
     {
         $path = 'test.custom';
         $this->file("_media/$path");
-        $this->assertNotContains($path, MediaFile::files());
-        self::mockConfig(['hyde.media_extensions' => ['custom']]);
 
-        $this->resetKernel(); // Reboot to rediscover new files
         $this->assertContains($path, MediaFile::files());
     }
 
@@ -125,33 +122,6 @@ class DiscoveryServiceTest extends UnitTestCase
         $this->file("_media/$path");
         $this->assertContains($path, MediaFile::files());
         Filesystem::deleteDirectory('_media/foo');
-    }
-
-    public function testMediaAssetExtensionsCanBeAddedByCommaSeparatedValues()
-    {
-        self::mockConfig(['hyde.media_extensions' => []]);
-        $this->file('_media/test.1');
-        $this->file('_media/test.2');
-        $this->file('_media/test.3');
-
-        $this->assertSame([], MediaFile::files());
-
-        self::mockConfig(['hyde.media_extensions' => ['1,2,3']]);
-        $this->resetKernel(); // Reboot to rediscover new files
-        $this->assertSame(['test.1', 'test.2', 'test.3'], MediaFile::files());
-    }
-
-    public function testMediaAssetExtensionsCanBeAddedByArray()
-    {
-        self::mockConfig(['hyde.media_extensions' => []]);
-        $this->file('_media/test.1');
-        $this->file('_media/test.2');
-        $this->file('_media/test.3');
-
-        $this->assertSame([], MediaFile::files());
-        self::mockConfig(['hyde.media_extensions' => ['1', '2', '3']]);
-        $this->resetKernel(); // Reboot to rediscover new files
-        $this->assertSame(['test.1', 'test.2', 'test.3'], MediaFile::files());
     }
 
     public function testBladePageFilesStartingWithUnderscoreAreIgnored()

--- a/packages/framework/tests/Feature/StaticSiteServiceTest.php
+++ b/packages/framework/tests/Feature/StaticSiteServiceTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Hyde\Framework\Testing\Feature;
 
+use Mockery;
 use Hyde\Facades\Filesystem;
 use Hyde\Hyde;
 use Hyde\Support\BuildWarnings;
@@ -13,6 +14,7 @@ use Illuminate\Support\Facades\File;
 use Illuminate\Support\Facades\Process;
 use Hyde\Framework\HydeServiceProvider;
 use Hyde\Framework\Actions\StaticPageBuilder;
+use Illuminate\Filesystem\Filesystem as BaseFilesystem;
 use Hyde\Framework\Exceptions\InvalidConfigurationException;
 
 #[\PHPUnit\Framework\Attributes\CoversClass(\Hyde\Console\Commands\BuildSiteCommand::class)]
@@ -124,6 +126,23 @@ class StaticSiteServiceTest extends TestCase
         $this->assertFileDoesNotExist(Hyde::path('_site/media/.DS_Store'));
         $this->assertFileDoesNotExist(Hyde::path('_site/media/.env'));
         $this->assertDirectoryDoesNotExist(Hyde::path('_site/media/.git'));
+    }
+
+    public function testBuildCommandTransfersEveryFileBeforeReportingAFailedMediaCopy()
+    {
+        $this->file('_media/good.txt', 'ok');
+        $this->file('_media/bad.txt', 'nope');
+
+        $mock = Mockery::mock(BaseFilesystem::class)->makePartial();
+        $mock->shouldReceive('copy')->withArgs(fn (string $path): bool => str_contains($path, 'bad.txt'))->andReturn(false);
+        $mock->shouldReceive('copy')->withArgs(fn (string $path): bool => ! str_contains($path, 'bad.txt'))->passthru();
+        app()->instance(BaseFilesystem::class, $mock);
+
+        $this->artisan('build')->expectsOutputToContain('[_media/bad.txt] to ['.Hyde::path('_site/media/bad.txt').']');
+
+        $this->assertFileExists(Hyde::path('_site/media/good.txt'));
+
+        app()->forgetInstance(BaseFilesystem::class);
     }
 
     public function testBuildCommandSkipsMediaTransferWhenThereAreNoAssets()

--- a/packages/framework/tests/Feature/StaticSiteServiceTest.php
+++ b/packages/framework/tests/Feature/StaticSiteServiceTest.php
@@ -96,7 +96,9 @@ class StaticSiteServiceTest extends TestCase
 
     public function testBuildCommandSkipsMediaTransferWhenThereAreNoAssets()
     {
-        rename(Hyde::path('_media/app.css'), Hyde::path('_media/app.css.bak'));
+        // Since the media directory is a passthrough, the file must leave the directory
+        // entirely to make it empty, rather than just being renamed within it.
+        rename(Hyde::path('_media/app.css'), Hyde::path('app.css.bak'));
 
         $this->artisan('build')
             ->expectsOutputToContain('Transferring Media Assets... ')
@@ -104,7 +106,7 @@ class StaticSiteServiceTest extends TestCase
             ->expectsOutputToContain('> No media files to transfer.')
             ->assertExitCode(0);
 
-        rename(Hyde::path('_media/app.css.bak'), Hyde::path('_media/app.css'));
+        rename(Hyde::path('app.css.bak'), Hyde::path('_media/app.css'));
     }
 
     public function testBuildCommandDoesNotUseViteDevServerPathEvenWhenViteIsRunning()

--- a/packages/framework/tests/Feature/StaticSiteServiceTest.php
+++ b/packages/framework/tests/Feature/StaticSiteServiceTest.php
@@ -128,8 +128,7 @@ class StaticSiteServiceTest extends TestCase
 
     public function testBuildCommandSkipsMediaTransferWhenThereAreNoAssets()
     {
-        // Since the media directory is a passthrough, the file must leave the directory
-        // entirely to make it empty, rather than just being renamed within it.
+        // The file must leave the media directory entirely, since renaming it within a passthrough directory wouldn't empty it.
         rename(Hyde::path('_media/app.css'), Hyde::path('app.css.bak'));
 
         $this->artisan('build')

--- a/packages/framework/tests/Feature/StaticSiteServiceTest.php
+++ b/packages/framework/tests/Feature/StaticSiteServiceTest.php
@@ -94,6 +94,38 @@ class StaticSiteServiceTest extends TestCase
         $this->assertFileExists(Hyde::path('_site/media/foo/bar/3.png'));
     }
 
+    public function testBuildCommandDiscoversAndTransfersArbitraryFileTypesWithStructurePreserved()
+    {
+        $this->file('_media/document.pdf', 'pdf content');
+        $this->file('_media/font.woff2', 'font content');
+        $this->file('_media/archive.zip', 'zip content');
+        $this->file('_media/nested/deep/file.xyz', 'nested content');
+
+        $this->artisan('build')->assertExitCode(0);
+
+        $this->assertFileEquals(Hyde::path('_media/document.pdf'), Hyde::path('_site/media/document.pdf'));
+        $this->assertFileEquals(Hyde::path('_media/font.woff2'), Hyde::path('_site/media/font.woff2'));
+        $this->assertFileEquals(Hyde::path('_media/archive.zip'), Hyde::path('_site/media/archive.zip'));
+        $this->assertFileEquals(Hyde::path('_media/nested/deep/file.xyz'), Hyde::path('_site/media/nested/deep/file.xyz'));
+    }
+
+    public function testBuildCommandIgnoresThumbsDbAndHiddenOrVcsFiles()
+    {
+        $this->file('_media/Thumbs.db');
+        $this->file('_media/.gitkeep');
+        $this->file('_media/.DS_Store');
+        $this->file('_media/.env');
+        $this->file('_media/.git/config');
+
+        $this->artisan('build')->assertExitCode(0);
+
+        $this->assertFileDoesNotExist(Hyde::path('_site/media/Thumbs.db'));
+        $this->assertFileDoesNotExist(Hyde::path('_site/media/.gitkeep'));
+        $this->assertFileDoesNotExist(Hyde::path('_site/media/.DS_Store'));
+        $this->assertFileDoesNotExist(Hyde::path('_site/media/.env'));
+        $this->assertDirectoryDoesNotExist(Hyde::path('_site/media/.git'));
+    }
+
     public function testBuildCommandSkipsMediaTransferWhenThereAreNoAssets()
     {
         // Since the media directory is a passthrough, the file must leave the directory

--- a/packages/framework/tests/Feature/StaticSiteServiceTest.php
+++ b/packages/framework/tests/Feature/StaticSiteServiceTest.php
@@ -114,6 +114,7 @@ class StaticSiteServiceTest extends TestCase
     public function testBuildCommandIgnoresThumbsDbAndHiddenOrVcsFiles()
     {
         $this->file('_media/Thumbs.db');
+        $this->file('_media/desktop.ini');
         $this->file('_media/.gitkeep');
         $this->file('_media/.DS_Store');
         $this->file('_media/.env');
@@ -122,6 +123,7 @@ class StaticSiteServiceTest extends TestCase
         $this->artisan('build')->assertExitCode(0);
 
         $this->assertFileDoesNotExist(Hyde::path('_site/media/Thumbs.db'));
+        $this->assertFileDoesNotExist(Hyde::path('_site/media/desktop.ini'));
         $this->assertFileDoesNotExist(Hyde::path('_site/media/.gitkeep'));
         $this->assertFileDoesNotExist(Hyde::path('_site/media/.DS_Store'));
         $this->assertFileDoesNotExist(Hyde::path('_site/media/.env'));
@@ -150,13 +152,15 @@ class StaticSiteServiceTest extends TestCase
         // The file must leave the media directory entirely, since renaming it within a passthrough directory wouldn't empty it.
         rename(Hyde::path('_media/app.css'), Hyde::path('app.css.bak'));
 
-        $this->artisan('build')
-            ->expectsOutputToContain('Transferring Media Assets... ')
-            ->expectsOutputToContain('Skipped')
-            ->expectsOutputToContain('> No media files to transfer.')
-            ->assertExitCode(0);
-
-        rename(Hyde::path('app.css.bak'), Hyde::path('_media/app.css'));
+        try {
+            $this->artisan('build')
+                ->expectsOutputToContain('Transferring Media Assets... ')
+                ->expectsOutputToContain('Skipped')
+                ->expectsOutputToContain('> No media files to transfer.')
+                ->assertExitCode(0);
+        } finally {
+            rename(Hyde::path('app.css.bak'), Hyde::path('_media/app.css'));
+        }
     }
 
     public function testBuildCommandDoesNotUseViteDevServerPathEvenWhenViteIsRunning()

--- a/packages/framework/tests/Unit/Foundation/FilesystemHasMediaFilesTest.php
+++ b/packages/framework/tests/Unit/Foundation/FilesystemHasMediaFilesTest.php
@@ -82,7 +82,7 @@ class FilesystemHasMediaFilesTest extends UnitTestCase
 
         (new Filesystem(Hyde::getInstance()))->assets();
 
-        $mock->shouldHaveReceived('handle')->with('_media', MediaFile::EXTENSIONS, true);
+        $mock->shouldHaveReceived('handle')->with('_media', false, true);
     }
 
     public function testItSupportsCustomMediaDirectory()
@@ -93,18 +93,25 @@ class FilesystemHasMediaFilesTest extends UnitTestCase
 
         (new Filesystem(Hyde::getInstance()))->assets();
 
-        $mock->shouldHaveReceived('handle')->with('assets', MediaFile::EXTENSIONS, true);
+        $mock->shouldHaveReceived('handle')->with('assets', false, true);
     }
 
-    public function testItSupportsCustomExtensions()
+    public function testItIgnoresThumbsDbAndDesktopIniRegardlessOfCase()
     {
-        self::mockConfig(['hyde.media_extensions' => ['gif', 'svg']]);
+        $mock = Mockery::mock(FileFinder::class);
+        $mock->shouldReceive('handle')->andReturn(collect([
+            '_media/Thumbs.db',
+            '_media/thumbs.db',
+            '_media/Desktop.ini',
+            '_media/desktop.ini',
+            '_media/image.png',
+        ]));
+        app()->instance(FileFinder::class, $mock);
 
-        $mock = $this->mockFileFinder();
+        $assets = (new Filesystem(Hyde::getInstance()))->assets();
 
-        (new Filesystem(Hyde::getInstance()))->assets();
-
-        $mock->shouldHaveReceived('handle')->with('_media', ['gif', 'svg'], true);
+        $this->assertCount(1, $assets);
+        $this->assertTrue($assets->has('image.png'));
     }
 
     public function testDiscoverMediaFilesWithEmptyResult()

--- a/packages/framework/tests/Unit/Foundation/FilesystemHasMediaFilesTest.php
+++ b/packages/framework/tests/Unit/Foundation/FilesystemHasMediaFilesTest.php
@@ -98,15 +98,13 @@ class FilesystemHasMediaFilesTest extends UnitTestCase
 
     public function testItIgnoresThumbsDbAndDesktopIniRegardlessOfCase()
     {
-        $mock = Mockery::mock(FileFinder::class);
-        $mock->shouldReceive('handle')->andReturn(collect([
+        $this->mockFileFinder([
             '_media/Thumbs.db',
             '_media/thumbs.db',
             '_media/Desktop.ini',
             '_media/desktop.ini',
             '_media/image.png',
-        ]));
-        app()->instance(FileFinder::class, $mock);
+        ]);
 
         $assets = (new Filesystem(Hyde::getInstance()))->assets();
 
@@ -138,10 +136,10 @@ class FilesystemHasMediaFilesTest extends UnitTestCase
         $this->assertInstanceOf(MediaFile::class, $result->get('document.pdf'));
     }
 
-    protected function mockFileFinder(): MockInterface
+    protected function mockFileFinder(array $files = []): MockInterface
     {
         $mock = Mockery::mock(FileFinder::class);
-        $mock->shouldReceive('handle')->andReturn(collect());
+        $mock->shouldReceive('handle')->andReturn(collect($files));
         app()->instance(FileFinder::class, $mock);
 
         return $mock;

--- a/packages/framework/tests/Unit/MediaDirectoryCanBeChangedTest.php
+++ b/packages/framework/tests/Unit/MediaDirectoryCanBeChangedTest.php
@@ -25,6 +25,7 @@ class MediaDirectoryCanBeChangedTest extends TestCase
 
         $this->directory('_assets');
         $this->file('_assets/app.css');
+        $this->file('_assets/document.pdf');
 
         Hyde::setMediaDirectory('_assets');
 
@@ -33,6 +34,7 @@ class MediaDirectoryCanBeChangedTest extends TestCase
         $this->assertDirectoryDoesNotExist(Hyde::path('_site/media'));
         $this->assertDirectoryExists(Hyde::path('_site/assets'));
         $this->assertFileExists(Hyde::path('_site/assets/app.css'));
+        $this->assertFileExists(Hyde::path('_site/assets/document.pdf'));
 
         $this->resetSite();
     }

--- a/packages/framework/tests/Unit/Support/MediaFileUnitTest.php
+++ b/packages/framework/tests/Unit/Support/MediaFileUnitTest.php
@@ -15,6 +15,8 @@ use Hyde\Support\Filesystem\MediaFile;
 use Hyde\Testing\UnitTestCase;
 use Illuminate\Filesystem\Filesystem as BaseFilesystem;
 
+use function defined;
+
 /**
  * @see \Hyde\Framework\Testing\Feature\Support\MediaFileTest
  */
@@ -69,6 +71,12 @@ class MediaFileUnitTest extends UnitTestCase
     protected function tearDown(): void
     {
         $this->verifyMockeryExpectations();
+    }
+
+    public function testExtensionsConstantIsStillDefined()
+    {
+        // Published config files reference this constant at load time, so removing it fatals an upgrading app.
+        $this->assertTrue(defined(MediaFile::class.'::EXTENSIONS'));
     }
 
     public function testCanConstruct()


### PR DESCRIPTION
## Summary
- `_media` now discovers and copies every file it contains instead of filtering by the `hyde.media_extensions` allow-list; only `Thumbs.db` and `desktop.ini` are skipped (case-insensitive). Symfony Finder's existing dotfile/VCS exclusions are unchanged. `MediaFile::EXTENSIONS` is kept but deprecated, since published config files still reference it at load time.
- `TransferMediaAssets` now streams files with `Filesystem::copy()` instead of loading full contents into memory, needed now that `_media` can contain PDFs and archives, not just CSS/JS/images. It attempts every file before reporting: a failed copy no longer aborts the transfer of the remaining files, and a single exception afterward names every failure with both its source and target path.
- `DynamicMarkdownLinkProcessor` skips resolving (and CRC32-hashing) a media asset when its source path isn't present in the HTML, since discovery now covers a much larger set of files. Behavior-preserving; the existing dynamic-link test suites pass unchanged.
- `config/hyde.php` (both copies) drop the `media_extensions` option, and `docs/digging-deeper/customization.md` no longer documents it.

Closes #2539.

**Known gap, out of scope here:** the copy-failure exception carries `Command::FAILURE` as its code, but `BuildTask` catches it and `BuildTaskService` discards the returned exit code, so a failed media copy is reported in the build output but doesn't currently affect the process exit code. That's a pre-existing gap across all build tasks, not something this PR introduces or fixes.

## Test plan
- [x] `vendor/bin/pest --testsuite UnitFramework,FeatureFramework` — before/after baseline diff is clean (only the known pre-existing PHP 8.5 `FeaturedImageUnitTest` flake, confirmed flaky on baseline too)
- [x] `vendor/bin/pest --testsuite FeatureHyde` and `--testsuite "Realtime Compiler"` — green
- [x] `php monorepo/HydeStan/run.php` — no errors
- [x] Coverage: PDF/woff2/zip/nested-file discovery and copy with structure preserved; `Thumbs.db` and `desktop.ini` excluded (integration + unit, case-insensitive); `.gitkeep`, `.DS_Store`, `.env`, `.git/config` excluded; custom media source/output directory; `app.css` under `load_app_styles_from_cdn`; a failed copy is reported by both paths without aborting the rest of the transfer; `MediaFile::EXTENSIONS` stays defined
- [x] Fixed a real regression surfaced by the change: `StaticSiteServiceTest::testBuildCommandSkipsMediaTransferWhenThereAreNoAssets` relied on the old extension filter to simulate an empty media directory by renaming `app.css` to `app.css.bak` in place — now moves the file fully out of `_media`, wrapped in try/finally so a failure mid-test can't leave the project tree dirty
- [x] `UPGRADE.md` now also notes that a `_static` file can collide with a previously-undiscovered `_media` file (e.g. a `.pdf`), throwing a `FileConflictException` during the build

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0123tyfadjk86BHng4TjBPBH