### PR TITLE
[2.x] Strip Markdown from sidebar table of contents

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ _Changes to the realtime compiler requires an update to v4.5 or later of the `hy
 - for now removed features.
 
 ### Fixed
+- Fixed Markdown syntax being displayed in the sidebar table of contents in https://github.com/hydephp/develop/pull/2607
 - Fixed Markdown-to-plain-text conversion consuming unrelated content after ATX headings and stripping literal trailing hashes in https://github.com/hydephp/develop/pull/2590
 - Improved documentation page detection in MarkdownService so it works for child classes in https://github.com/hydephp/develop/pull/2332
 - Fixed bug causing build manifest to not generate when a site has dynamic pages in https://github.com/hydephp/develop/pull/2450

--- a/packages/framework/src/Framework/Actions/GeneratesTableOfContents.php
+++ b/packages/framework/src/Framework/Actions/GeneratesTableOfContents.php
@@ -147,7 +147,7 @@ class GeneratesTableOfContents
     protected function createTableItem(array $heading): array
     {
         return [
-            'title' => $heading['title'],
+            'title' => (new ConvertsMarkdownToPlainText($heading['title']))->execute(),
             'identifier' => $heading['identifier'],
             'children' => [],
         ];

--- a/packages/framework/tests/Unit/GeneratesSidebarTableOfContentsTest.php
+++ b/packages/framework/tests/Unit/GeneratesSidebarTableOfContentsTest.php
@@ -170,6 +170,19 @@ class GeneratesSidebarTableOfContentsTest extends UnitTestCase
         );
     }
 
+    public function testMarkdownIsStrippedFromHeadingTitles()
+    {
+        $markdown = '## To learn more, head over to the [Quickstart page](quickstart).';
+
+        $this->assertSame([
+            [
+                'title' => 'To learn more, head over to the Quickstart page.',
+                'identifier' => 'to-learn-more-head-over-to-the-quickstart-pagequickstart',
+                'children' => [],
+            ],
+        ], (new GeneratesTableOfContents($markdown))->execute());
+    }
+
     public function testWithNoLevelOneHeading()
     {
         $markdown = <<<'MARKDOWN'


### PR DESCRIPTION
Fixes #2591.

## Summary

- convert Markdown heading titles to plain text before displaying them in the sidebar table of contents
- preserve the existing heading identifier used by the table of contents
- add a regression test using the linked-heading example from the issue

## Testing

- `php vendor/bin/phpunit packages/framework/tests/Unit/GeneratesSidebarTableOfContentsTest.php`
- `php vendor/bin/phpunit packages/framework/tests/Feature/Views/SidebarTableOfContentsViewTest.php`
- `php vendor/bin/phpstan analyse packages/framework/src/Framework/Actions/GeneratesTableOfContents.php packages/framework/tests/Unit/GeneratesSidebarTableOfContentsTest.php --no-progress`
- `git diff --check`