### PR TITLE
[3.x] Strip Markdown from sidebar table of contents

### DIFF
--- a/packages/framework/src/Framework/Actions/GeneratesTableOfContents.php
+++ b/packages/framework/src/Framework/Actions/GeneratesTableOfContents.php
@@ -147,7 +147,7 @@ class GeneratesTableOfContents
     protected function createTableItem(array $heading): array
     {
         return [
-            'title' => $heading['title'],
+            'title' => (new ConvertsMarkdownToPlainText($heading['title']))->execute(),
             'identifier' => $heading['identifier'],
             'children' => [],
         ];

--- a/packages/framework/tests/Unit/GeneratesSidebarTableOfContentsTest.php
+++ b/packages/framework/tests/Unit/GeneratesSidebarTableOfContentsTest.php
@@ -170,6 +170,19 @@ class GeneratesSidebarTableOfContentsTest extends UnitTestCase
         );
     }
 
+    public function testMarkdownIsStrippedFromHeadingTitles()
+    {
+        $markdown = '## To learn more, head over to the [Quickstart page](quickstart).';
+
+        $this->assertSame([
+            [
+                'title' => 'To learn more, head over to the Quickstart page.',
+                'identifier' => 'to-learn-more-head-over-to-the-quickstart-pagequickstart',
+                'children' => [],
+            ],
+        ], (new GeneratesTableOfContents($markdown))->execute());
+    }
+
     public function testWithNoLevelOneHeading()
     {
         $markdown = <<<'MARKDOWN'


### PR DESCRIPTION
Fixes #2591.

V3 counterpart to #2607.

## Summary

- convert Markdown heading titles to plain text before displaying them in the sidebar table of contents
- preserve the existing heading identifier used by the table of contents
- add a regression test using the linked-heading example from the issue

## Testing

- `php vendor/bin/phpunit packages/framework/tests/Unit/GeneratesSidebarTableOfContentsTest.php`
- `php vendor/bin/phpunit packages/framework/tests/Feature/Views/SidebarTableOfContentsViewTest.php`
- `php vendor/bin/phpstan analyse packages/framework/src/Framework/Actions/GeneratesTableOfContents.php packages/framework/tests/Unit/GeneratesSidebarTableOfContentsTest.php --no-progress`
- `git diff origin/master --check`